### PR TITLE
Trim suggested model list

### DIFF
--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -801,19 +801,14 @@ export const SUGGESTED_MODELS: Record<AiModelProvider, Record<string, string>> =
     "@cf/zai-org/glm-5.2": "GLM 5.2 (Workers AI)",
   },
   "anthropic": {
-    "claude-opus-4-8": "Claude Opus 4.8",
-    "claude-opus-4-7": "Claude Opus 4.7",
-    "claude-opus-4-6": "Claude Opus 4.6",
+    "claude-opus-5": "Claude Opus 5",
     "claude-sonnet-5": "Claude Sonnet 5",
-    "claude-sonnet-4-6": "Claude Sonnet 4.6",
   },
   "openai": {
     "gpt-5.6": "GPT 5.6",
     "gpt-5.6-sol": "GPT 5.6 Sol",
     "gpt-5.6-luna": "GPT 5.6 Luna",
     "gpt-5.6-terra": "GPT 5.6 Terra",
-    "gpt-5.5": "GPT 5.5",
-    "gpt-5.4": "GPT 5.4",
   },
   "google": {
     "gemini-3.1-pro-preview": "Gemini 3.1 Pro",


### PR DESCRIPTION
Keep only Opus 5, Sonnet 5, and the GPT 5.6 models. Workers AI and Gemini entries unchanged.