### PR TITLE
fix: execute pnpm with shell on Windows

### DIFF
--- a/packages/gatekeeper-context/build-app.mjs
+++ b/packages/gatekeeper-context/build-app.mjs
@@ -15,5 +15,5 @@ console.log(
 execFileSync(
   "pnpm",
   ["exec", "vite", "build", "-c", "vite.config.ts", ...(watch ? ["--watch"] : [])],
-  { cwd: pkgDir, stdio: "inherit" },
+  { cwd: pkgDir, stdio: "inherit", shell: process.platform === "win32" },
 );

--- a/packages/gatekeeper-scheduler/build-app.mjs
+++ b/packages/gatekeeper-scheduler/build-app.mjs
@@ -8,5 +8,5 @@ const watch = process.argv.includes("--watch");
 execFileSync(
   "pnpm",
   ["exec", "vite", "build", "-c", "vite.config.ts", ...(watch ? ["--watch"] : [])],
-  { cwd: packageDirectory, stdio: "inherit" },
+  { cwd: packageDirectory, stdio: "inherit", shell: process.platform === "win32" },
 );

--- a/run-dev-server.js
+++ b/run-dev-server.js
@@ -323,7 +323,7 @@ console.log(`\nStarting: wrangler dev ${args.join(" ")}\n`);
 
 try {
   execFileSync("pnpm", ["exec", "wrangler", "dev", ...args],
-      { stdio: "inherit", cwd: ROOT });
+      { stdio: "inherit", cwd: ROOT, shell: process.platform === "win32" });
 } catch (e) {
   // wrangler was killed or exited with an error; the output was already shown
   // via stdio: "inherit", so just propagate the exit code.

--- a/scripts/release/build-release.mjs
+++ b/scripts/release/build-release.mjs
@@ -42,7 +42,7 @@ function parseArgs(argv) {
 
 function run(command, argv, options = {}) {
   console.log(`running: ${command} ${argv.join(" ")} ${options.cwd ? `(in ${options.cwd})` : ""}`);
-  execFileSync(command, argv, { stdio: "inherit", cwd: ROOT, ...options });
+  execFileSync(command, argv, { stdio: "inherit", cwd: ROOT, shell: process.platform === "win32", ...options });
 }
 
 function gitCommit() {

--- a/scripts/run-local.mjs
+++ b/scripts/run-local.mjs
@@ -115,7 +115,7 @@ const needsInstall = needsBuild || !existsSync(NODE_MODULES);
 
 function run(cmd, args) {
   console.log(`\n> ${cmd} ${args.join(" ")}`);
-  execFileSync(cmd, args, { stdio: "inherit", cwd: ROOT });
+  execFileSync(cmd, args, { stdio: "inherit", cwd: ROOT, shell: process.platform === "win32" });
 }
 
 if (needsInstall) {


### PR DESCRIPTION
Fixes ENOENT and EINVAL errors when running pnpm via child_process execFileSync on Windows by ensuring it runs with shell: true.

This fixes an issue where running `pnpm run-local` fails immediately on Windows with `ENOENT` or `EINVAL` errors coming from `child_process.execFileSync`.

**Why it was broken**
On Windows, `pnpm` is installed as a batch script (`pnpm.cmd`). Node.js's `execFileSync` cannot execute `.cmd` files natively without invoking a shell (like `cmd.exe`).

**The fix**
I updated the 5 instances of `execFileSync("pnpm", ...)` across the codebase to include `{ shell: process.platform === "win32" }`.