### PR TITLE
Fix Cloudflare Access logout

### DIFF
--- a/packages/workshop-frontend/src/useAuth.ts
+++ b/packages/workshop-frontend/src/useAuth.ts
@@ -94,6 +94,11 @@ export function useAuth(publicApi: RpcStub<PublicApi>) {
   }
 
   const logout = () => {
+    if (CF_ACCESS_MODE) {
+      window.location.assign('/cdn-cgi/access/logout')
+      return
+    }
+
     // Use functional updater to read current state (avoids stale closure).
     setAuthState(prev => {
       if (prev.authenticatedApi) {
@@ -107,9 +112,7 @@ export function useAuth(publicApi: RpcStub<PublicApi>) {
       }
     })
 
-    if (!CF_ACCESS_MODE) {
-      localStorage.removeItem('authToken')
-    }
+    localStorage.removeItem('authToken')
   }
 
   return {


### PR DESCRIPTION
Fixes logout for deployments behind Cloudflare Access. Clicking "Sign out" currently drops users into an infinite "Authenticating..." state without actually logging them out:
<img width="341" height="269" alt="image" src="https://github.com/user-attachments/assets/f77ec368-3ac6-45a6-8f15-d792eaca1166" />

<img width="341" height="269" alt="image" src="https://github.com/user-attachments/assets/e34c03f8-418d-44e4-925a-b24b4c24e7e3" />

Instead, we should send them to the [Access logout URL](/cdn-cgi/access/logout) so their session is properly revoked:
<img width="650" height="472" alt="image" src="https://github.com/user-attachments/assets/448ab8dc-5f4c-4503-8484-06584aa70b1c" />
