### PR TITLE
Swap regex for dedicated trailing slash stripper function

### DIFF
--- a/packages/gatekeeper-cloudflare/src/cloudflare.ts
+++ b/packages/gatekeeper-cloudflare/src/cloudflare.ts
@@ -3,7 +3,7 @@ import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import {
   GatekeeperVendor as GatekeeperVendorIface, Gatekeeper, GatekeeperUserVerifier, VendorDescription,
   GatekeeperConnectCallback, GatekeeperConnectOptions, AccountDescription,
-  SupportedResource, ResourceConfiguratorFrame,
+  SupportedResource, ResourceConfiguratorFrame, stripTrailingSlashes,
 } from "@gadgets/workshop-shared/gatekeeper";
 import { CloudflareGatekeeperUser } from "@gadgets/workshop-shared/cloudflare-gatekeeper";
 import { getOAuthConfig, buildAuthorizeUrl, generatePkce, exchangeCode, refreshTokens, AUTH_SCOPES, FULL_SCOPES } from "./oauth";
@@ -67,7 +67,7 @@ type Env = Cloudflare.Env & {
 };
 
 function getBaseUrl(env: Env) {
-  return (env.BASE_URL || "http://localhost:8787/gatekeeper/cloudflare").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/cloudflare");
 }
 
 function getBasePath(env: Env) {

--- a/packages/gatekeeper-confluence/src/confluence-markdown.ts
+++ b/packages/gatekeeper-confluence/src/confluence-markdown.ts
@@ -121,13 +121,16 @@ function renderMacro(el: HTMLElement): string | null {
 }
 
 const tableRow = (vals: string[]): string => `| ${vals.join(" | ")} |`;
+// Escape backslashes as well as pipes so an existing backslash cannot neutralize the pipe escape.
+const escapeTableCell = (value: string): string =>
+  value.replace(/[\\|]/g, character => `\\${character}`);
 
 function renderTable(el: HTMLElement): string {
   const rows = el.querySelectorAll("tr");
   if (rows.length === 0) return "";
   const cells = (row: HTMLElement) =>
     (row.childNodes.filter(n => isElement(n) && ["td", "th"].includes(tagOf(n))) as HTMLElement[])
-      .map(c => renderInline(c.childNodes).trim().replace(/\|/g, "\\|"));
+      .map(c => escapeTableCell(renderInline(c.childNodes).trim()));
 
   const header = cells(rows[0]);
   const lines = [tableRow(header), tableRow(header.map(() => "---"))];

--- a/packages/gatekeeper-email/src/email.ts
+++ b/packages/gatekeeper-email/src/email.ts
@@ -15,6 +15,7 @@ import {
   AccountDescription,
   SupportedResource,
   ResourceConfiguratorFrame,
+  stripTrailingSlashes,
 } from '@gadgets/workshop-shared/gatekeeper';
 import {
   EmailSession,
@@ -64,7 +65,7 @@ type Env = Cloudflare.Env & {
 }
 
 function getBaseUrl(env: Env) {
-  return (env.BASE_URL || "http://localhost:8787/gatekeeper/email").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/email");
 }
 
 function getBasePath(env: Env) {

--- a/packages/gatekeeper-github/src/github.ts
+++ b/packages/gatekeeper-github/src/github.ts
@@ -2,6 +2,7 @@ import { DurableObject, RpcStub, RpcTarget, WorkerEntrypoint } from "cloudflare:
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import {
   ApprovalQueue,
+  stripTrailingSlashes,
   type ActionDescription,
   type AccountDescription,
   type Cursor,
@@ -355,7 +356,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/github").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/github");
 }
 
 function getBasePath(env: Env): string {

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -1,6 +1,6 @@
 import { WorkerEntrypoint, DurableObject, RpcTarget, RpcStub } from "cloudflare:workers";
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
-import { GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor as GatekeeperVendorIface, Gatekeeper, ResourceDescription, ApprovalQueue, ObservationDescription, VendorDescription, GatekeeperConnectCallback, GatekeeperConnectOptions, AccountDescription, SupportedResource, ResourceConfiguratorFrame, Cursor, ActionKind } from '@gadgets/workshop-shared/gatekeeper';
+import { GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor as GatekeeperVendorIface, Gatekeeper, ResourceDescription, ApprovalQueue, ObservationDescription, VendorDescription, GatekeeperConnectCallback, GatekeeperConnectOptions, AccountDescription, SupportedResource, ResourceConfiguratorFrame, Cursor, ActionKind, stripTrailingSlashes } from '@gadgets/workshop-shared/gatekeeper';
 import { exchangeAuthCode, getAccessToken, getGoogleAccountDescription, getGoogleVerifiedEmail, GmailApi, GmailMessageRaw, GmailOutboundMessage, GoogleAccessToken, normalizeEmailRecipients, revokeGoogleToken } from "./google-api";
 import {
   GmailSession, GmailThread, GmailMessage,
@@ -158,7 +158,7 @@ function validateGmailQueryForGrouping(query: string): void {
 }
 
 function getBaseUrl(env: Env) {
-  return (env.BASE_URL || "http://localhost:8787/gatekeeper/google").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/google");
 }
 
 function getBasePath(env: Env) {

--- a/packages/gatekeeper-homeassistant/src/homeassistant.ts
+++ b/packages/gatekeeper-homeassistant/src/homeassistant.ts
@@ -2,6 +2,7 @@ import { DurableObject, RpcStub, RpcTarget, WorkerEntrypoint } from "cloudflare:
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import {
   ApprovalQueue,
+  stripTrailingSlashes,
   type AccountDescription,
   type AvatarImage,
   type Gatekeeper,
@@ -104,7 +105,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/homeassistant").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/homeassistant");
 }
 
 function getBasePath(env: Env): string {
@@ -318,8 +319,7 @@ export default {
             throw new Error("URL must use http:// or https://");
           }
           // Strip trailing slash
-          normalizedUrl = `${u.protocol}//${u.host}${u.pathname.replace(/\/+$/, "")}`;
-          if (normalizedUrl.endsWith("/")) normalizedUrl = normalizedUrl.slice(0, -1);
+          normalizedUrl = `${u.protocol}//${u.host}${stripTrailingSlashes(u.pathname)}`;
         } catch (e: any) {
           return new Response(
             CONNECT_FORM_HTML({ actionUrl: req.url, error: `Invalid URL: ${e.message}` }),

--- a/packages/gatekeeper-linear/src/linear.ts
+++ b/packages/gatekeeper-linear/src/linear.ts
@@ -2,6 +2,7 @@ import { WorkerEntrypoint, DurableObject, RpcTarget, RpcStub } from "cloudflare:
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import {
   GatekeeperUser,
+  stripTrailingSlashes,
   GatekeeperUserVerifier,
   GatekeeperVendor as GatekeeperVendorIface,
   Gatekeeper,
@@ -176,7 +177,7 @@ function badRequest(message: string): Response {
 }
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/linear").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/linear");
 }
 
 function getBasePath(env: Env): string {

--- a/packages/gatekeeper-mcp-portal/src/portal.ts
+++ b/packages/gatekeeper-mcp-portal/src/portal.ts
@@ -10,6 +10,7 @@ import { validateRpc, skipRpcValidation } from "capnweb-validate";
 import { createLogger } from "@gadgets/backend-utils/logger";
 import {
   matchesResourceUrlPattern,
+  stripTrailingSlashes,
   type AvatarImage,
   type Gatekeeper,
   type GatekeeperConnectCallback,
@@ -99,7 +100,7 @@ const PORTAL_COLOR = "#f6821f";
 // Helpers
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/mcp-portal").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/mcp-portal");
 }
 
 async function fetchPortalServers(

--- a/packages/gatekeeper-mcp/src/mcp.ts
+++ b/packages/gatekeeper-mcp/src/mcp.ts
@@ -10,6 +10,7 @@ import { RpcStub, RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
 import { validateRpc, skipRpcValidation } from "capnweb-validate";
 import { createLogger } from "@gadgets/backend-utils/logger";
 import {
+  stripTrailingSlashes,
   type AvatarImage,
   type Gatekeeper,
   type GatekeeperConnectCallback,
@@ -84,7 +85,7 @@ const MCP_AVATAR: AvatarImage = { url: MCP_LOGO_URL };
 // Helpers
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/mcp").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/mcp");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gatekeeper-notion/src/notion.ts
+++ b/packages/gatekeeper-notion/src/notion.ts
@@ -16,6 +16,7 @@
 import { DurableObject, RpcStub, RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import {
+  stripTrailingSlashes,
   type AccountDescription,
   type ApprovalQueue,
   type Gatekeeper,
@@ -122,7 +123,7 @@ type StoredAccountInfo = {
 };
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL || "http://localhost:8787/gatekeeper/notion").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/notion");
 }
 
 function getBasePath(env: Env): string {
@@ -204,7 +205,7 @@ function idFromResourceUrl(url: string): string | null {
     return null;
   }
   if (!/(^|\.)notion\.so$/i.test(parsed.hostname)) return null;
-  if (parsed.pathname.replace(/\/+$/, "").length === 0) return null;
+  if (stripTrailingSlashes(parsed.pathname).length === 0) return null;
   try {
     return parseNotionId(url);
   } catch {

--- a/packages/gatekeeper-slack/src/slack-api.ts
+++ b/packages/gatekeeper-slack/src/slack-api.ts
@@ -646,6 +646,8 @@ function mentionedUserIds(text: string): string[] {
   return ids;
 }
 
+const SLACK_TEXT_ENTITIES: Record<string, string> = { amp: "&", lt: "<", gt: ">" };
+
 /** Converts Slack mention/link markup and HTML entities to readable text. */
 export function resolveText(text: string, userName: (id: string) => string): string {
   let out = text
@@ -660,8 +662,5 @@ export function resolveText(text: string, userName: (id: string) => string): str
           (_m, url: string, label?: string) => label ? `${label} (${url})` : url)
       .replace(/<(mailto:[^|>]+)(?:\|([^>]*))?>/g,
           (_m, url: string, label?: string) => label || url.replace(/^mailto:/, ""));
-  return out
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">");
+  return out.replace(/&(amp|lt|gt);/g, (_match, name: string) => SLACK_TEXT_ENTITIES[name]);
 }

--- a/packages/gatekeeper-slack/src/slack.ts
+++ b/packages/gatekeeper-slack/src/slack.ts
@@ -5,6 +5,7 @@ import {
   ApprovalQueue, VendorDescription, GatekeeperConnectCallback, GatekeeperConnectOptions,
   AccountDescription, SupportedResource, ResourceConfiguratorFrame, ActionKind, Cursor,
   GatekeeperUserVerifier, ObservationDescription,
+  stripTrailingSlashes,
 } from "@gadgets/workshop-shared/gatekeeper";
 import {
   SlackApi, SlackApiError, SlackAccessToken, SlackConversationTypeFilter, exchangeAuthCode,
@@ -59,7 +60,7 @@ type Env = Cloudflare.Env & {
 };
 
 function getBaseUrl(env: Env) {
-  return (env.BASE_URL || "http://localhost:8787/gatekeeper/slack").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/slack");
 }
 
 function getBasePath(env: Env) {

--- a/packages/gatekeeper-spotify/src/spotify.ts
+++ b/packages/gatekeeper-spotify/src/spotify.ts
@@ -2,6 +2,7 @@ import { DurableObject, RpcStub, RpcTarget, WorkerEntrypoint } from "cloudflare:
 import { validateRpc, skipRpcValidation } from "capnweb-validate";
 import {
   ApprovalQueue,
+  stripTrailingSlashes,
   type AccountDescription,
   type ActionDescription,
   type Gatekeeper,
@@ -181,7 +182,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/spotify").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/spotify");
 }
 
 function getBasePath(env: Env): string {

--- a/packages/gatekeeper-supabase/src/supabase.ts
+++ b/packages/gatekeeper-supabase/src/supabase.ts
@@ -2,6 +2,7 @@ import { DurableObject, RpcStub, RpcTarget, WorkerEntrypoint } from "cloudflare:
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import {
   ApprovalQueue,
+  stripTrailingSlashes,
   type AccountDescription,
   type Gatekeeper,
   type GatekeeperConnectCallback,
@@ -181,7 +182,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/supabase").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/supabase");
 }
 
 function getBasePath(env: Env): string {

--- a/packages/gatekeeper-zoominfo/src/zoominfo-api.ts
+++ b/packages/gatekeeper-zoominfo/src/zoominfo-api.ts
@@ -1,4 +1,5 @@
 import "cloudflare:workers";
+import { stripTrailingSlashes } from "@gadgets/workshop-shared/gatekeeper";
 
 // ---------------------------------------------------------------------------
 // OAuth (Authorization Code + PKCE) and a thin HTTP wrapper around the ZoomInfo GTM API.
@@ -36,7 +37,7 @@ export function resolveOAuthConfig(env: {
   return {
     authorizeUrl: env.ZOOMINFO_AUTHORIZE_URL || DEFAULT_AUTHORIZE_URL,
     tokenUrl: env.ZOOMINFO_TOKEN_URL || DEFAULT_TOKEN_URL,
-    apiBaseUrl: (env.ZOOMINFO_API_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/+$/, ""),
+    apiBaseUrl: stripTrailingSlashes(env.ZOOMINFO_API_BASE_URL || DEFAULT_API_BASE_URL),
   };
 }
 
@@ -229,7 +230,7 @@ export class ZoomInfoApi {
 
   constructor(getToken: () => Promise<string>, baseUrl: string = DEFAULT_API_BASE_URL) {
     this.#getToken = getToken;
-    this.#baseUrl = baseUrl.replace(/\/+$/, "");
+    this.#baseUrl = stripTrailingSlashes(baseUrl);
   }
 
   async #request(

--- a/packages/gatekeeper-zoominfo/src/zoominfo.ts
+++ b/packages/gatekeeper-zoominfo/src/zoominfo.ts
@@ -2,6 +2,7 @@ import { DurableObject, RpcStub, RpcTarget, WorkerEntrypoint } from "cloudflare:
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import {
   ApprovalQueue,
+  stripTrailingSlashes,
   type AccountDescription,
   type Gatekeeper,
   type GatekeeperConnectCallback,
@@ -204,7 +205,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 function getBaseUrl(env: Env): string {
-  return (env.BASE_URL ?? "http://localhost:8787/gatekeeper/zoominfo").replace(/\/+$/, "");
+  return stripTrailingSlashes(env.BASE_URL ?? "http://localhost:8787/gatekeeper/zoominfo");
 }
 
 function getBasePath(env: Env): string {

--- a/packages/mcp-shared/src/http.ts
+++ b/packages/mcp-shared/src/http.ts
@@ -1,3 +1,4 @@
+import { stripTrailingSlashes } from "@gadgets/workshop-shared/gatekeeper";
 import { NONCE_BYTES } from "./connect-nonce.js";
 import { htmlResponse, INVALID_LINK_HTML } from "./html.js";
 import type { McpLog } from "./log.js";
@@ -18,7 +19,7 @@ export async function handleMcpHttpRequest<A extends OAuthCallbackAccount>(
   },
 ): Promise<Response> {
   const url = new URL(request.url);
-  const basePath = new URL(options.baseUrl).pathname.replace(/\/+$/, "");
+  const basePath = stripTrailingSlashes(new URL(options.baseUrl).pathname);
   if (!url.pathname.startsWith(`${basePath}/`) && url.pathname !== basePath) {
     return new Response("Not Found", { status: 404 });
   }

--- a/packages/mcp-shared/src/portal.ts
+++ b/packages/mcp-shared/src/portal.ts
@@ -93,19 +93,58 @@ export function groupToolsByServer<T extends Pick<McpTool, "name">>(
 //
 // Display metadata only, so an unrecognized line is skipped rather than raised;
 // `reconcilePortalServers` recovers any server the prose failed to describe.
-const PORTAL_SERVER_LINE = /^\s*[-*\u2022]\s*(.+?)\s*\(([^()\s]+)\)\s*:\s*(.*)$/;
+function parseServerLine(line: string): PortalServer | null {
+  const bulletLine = line.trimStart();
+  if (bulletLine[0] !== "-" && bulletLine[0] !== "*" && bulletLine[0] !== "\u2022") return null;
+
+  const content = bulletLine.slice(1);
+  let nameStart = 0;
+  while (nameStart < content.length && content[nameStart].trim().length === 0) ++nameStart;
+
+  let open = -1;
+  let closedOpen = -1;
+  let close = -1;
+  for (let index = nameStart; index < content.length; ++index) {
+    const character = content[index];
+    if (close >= 0) {
+      if (character === ":") {
+        const name = content.slice(nameStart, closedOpen).trimEnd();
+        if (!name && nameStart === 0) return null;
+        const id = content.slice(closedOpen + 1, close);
+        return {
+          id,
+          name: name || id,
+          enabled: !/disabled|\u2717|\u2718/i.test(content.slice(index + 1)),
+        };
+      }
+      if (character.trim().length === 0) continue;
+      close = -1;
+      closedOpen = -1;
+    }
+
+    if (character === "(") {
+      open = index;
+    } else if (open >= 0 && character === ")") {
+      if (index > open + 1) {
+        closedOpen = open;
+        close = index;
+      }
+      open = -1;
+    } else if (open >= 0 && character.trim().length === 0) {
+      open = -1;
+    }
+  }
+  return null;
+}
 
 function parseServerLines(text: string): PortalServer[] {
   const servers: PortalServer[] = [];
   const seen = new Set<string>();
   for (const line of text.split(/\r?\n/)) {
-    const match = PORTAL_SERVER_LINE.exec(line);
-    if (!match) continue;
-    const [, name, id, status] = match;
-    if (seen.has(id)) continue;
-    seen.add(id);
-    // Enabled unless the portal says otherwise, so unrecognized wording shows the server.
-    servers.push({ id, name: name.trim() || id, enabled: !/disabled|\u2717|\u2718/i.test(status) });
+    const server = parseServerLine(line);
+    if (!server || seen.has(server.id)) continue;
+    seen.add(server.id);
+    servers.push(server);
   }
   return servers;
 }

--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -12,7 +12,7 @@ import { ANTHROPIC_MODELS } from "@earendil-works/pi-ai/providers/anthropic.mode
 import { CLOUDFLARE_WORKERS_AI_MODELS } from "@earendil-works/pi-ai/providers/cloudflare-workers-ai.models";
 import { GOOGLE_MODELS } from "@earendil-works/pi-ai/providers/google.models";
 import { OPENAI_MODELS } from "@earendil-works/pi-ai/providers/openai.models";
-import { ApprovalQueue, Gatekeeper, ResourceDescription } from '@gadgets/workshop-shared/gatekeeper';
+import { ApprovalQueue, Gatekeeper, ResourceDescription, stripTrailingSlashes } from '@gadgets/workshop-shared/gatekeeper';
 import { LanguageModelBinding } from "./ai-model-binding";
 import AI_MODEL_BINDING_TYPES from "./ai-model-binding.txt";
 import { AiChatAuthorInfo, AiModelConfig, SUGGESTED_MODELS, WORKERS_AI_OUTPUT_LIMIT }
@@ -557,8 +557,8 @@ function getModelDirect(config: AiModelConfig, sessionAffinity?: string): ModelH
           name: config.model,
           api: "openai-completions",
           provider: "ollama",
-          baseUrl: `${(config.apiUrl ?? "http://localhost:11434")
-              .replace(/\/+$/, "").replace(/\/(api|v1)$/, "")}/v1`,
+          baseUrl: `${stripTrailingSlashes(config.apiUrl ?? "http://localhost:11434")
+              .replace(/\/(api|v1)$/, "")}/v1`,
           reasoning: true,
           input: ["text", "image"],
           cost: ZERO_COST,

--- a/packages/workshop-shared/src/gatekeeper.ts
+++ b/packages/workshop-shared/src/gatekeeper.ts
@@ -222,6 +222,13 @@ export type SupportedResource = {
   grantable?: boolean;
 }
 
+/** Removes every trailing slash from a string in linear time. */
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) --end;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 // Tests whether a resource URL matches a SupportedResource `urlPattern` (a URLPattern string).
 //
 // This is deliberately tolerant of trivial URL variations that a strict URLPattern test would
@@ -245,7 +252,7 @@ export function matchesResourceUrlPattern(pattern: string, url: string): boolean
   }
   // Try the URL as given plus the trailing-slash-toggled variant, since URLPattern distinguishes
   // them and we don't know which form the pattern expects.
-  const candidates = url.endsWith('/') ? [url, url.replace(/\/+$/, '')] : [url, url + '/'];
+  const candidates = url.endsWith('/') ? [url, stripTrailingSlashes(url)] : [url, url + '/'];
   return candidates.some(candidate => {
     try {
       return compiled.test(candidate);


### PR DESCRIPTION
Addresses a few issues flagged by codeql, mostly the same fix applied across the gatekeeper suite