### PR TITLE
fix: don't send the developer role to Ollama

### DIFF
--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -563,6 +563,9 @@ function getModelDirect(config: AiModelConfig, sessionAffinity?: string): ModelH
           input: ["text", "image"],
           cost: ZERO_COST,
           ...window,
+          // Ollama Cloud 500s when a request carries both a `developer` message and an image; pi
+          // picks that role because we report reasoning: true above, so pin the role, not the flag.
+          compat: { supportsDeveloperRole: false } satisfies OpenAICompletionsCompat,
         },
         ...(config.apiToken === ""
             ? { apiKey: "unused", headers: { Authorization: null } }


### PR DESCRIPTION
Fixes an opaque 500 from Ollama Cloud when a request carries both a `developer` role message and an image :

    500: {"message":"Internal Server Error (ref: …)","type":"api_error","param":null,"code":null}

The same request with `system` succeeds, and `developer` with text only succeeds. 

Reproduced with plain curl outside the app, so the payload we send is valid. Streaming, `tools`, `store` and `stream_options` were each ruled out the same way.

| endpoint           | model              | `developer` + image |
| ------------------ | ------------------ | ------------------- |
| Ollama Cloud       | `gemma4:31b-cloud` | 500                 |
| local ollama serve | `gemma4:31b`       | OK                  |
| local ollama serve | `qwen3.6:35b-a3b`  | OK                  |

So this looks specific to Ollama Cloud's hosted inference rather than to ollama itself or to a given model. 

pi picks the `developer` role whenever a model reports reasoning support (`model.reasoning && compat.supportsDeveloperRole`). The ollama case reports `reasoning: true` for every model and supplied no `compat`, so it inherited pi's OpenAI-shaped defaults where `supportsDeveloperRole` is detected as `true`.

**So the solution is to pin `supportsDeveloperRole: false` for ollama** (the same flag `workersAiCompat` already sets just above). It's a oneliner, or 3 lines with the comments.

With this fix, both a local ollama server and Ollama Cloud work with images. And because `gemma4:31b-cloud` is free, it's a nice way to try cloudflare-os :)

