### PR TITLE
Add a generic OpenAI-compatible "custom" AI model provider

### DIFF
--- a/packages/workshop-backend/__tests__/ai-models.test.ts
+++ b/packages/workshop-backend/__tests__/ai-models.test.ts
@@ -366,6 +366,41 @@ describe("getModel direct routing (no gateway)", () => {
   });
 });
 
+describe("custom OpenAI-compatible provider", () => {
+  it("uses the configured base URL verbatim (no legacy-suffix normalization)", () => {
+    const handle = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "custom",
+      model: "anthropic/claude-sonnet-5",
+      apiToken: "sk-or-test",
+      apiUrl: "https://openrouter.ai/api/v1",
+    }, INITIATOR);
+
+    expect(handle.model.api).toBe("openai-completions");
+    expect(handle.model.baseUrl).toBe("https://openrouter.ai/api/v1");
+  });
+
+  it("sends the configured API key as a bearer token", async () => {
+    const handle = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "custom",
+      model: "anthropic/claude-sonnet-5",
+      apiToken: "sk-or-test",
+      apiUrl: "https://openrouter.ai/api/v1",
+    }, INITIATOR);
+
+    const request = await captureRequest(handle);
+    expect(request.url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(request.headers.get("authorization")).toBe("Bearer sk-or-test");
+  }, 15000);
+
+  it("throws a clear error when no API URL is configured", () => {
+    expect(() => getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "custom",
+      model: "anthropic/claude-sonnet-5",
+      apiToken: "sk-or-test",
+    }, INITIATOR)).toThrow("This custom model has no API URL configured.");
+  });
+});
+
 describe("PDF attachment bridging", () => {
   beforeEach(() => {
     capturedRequests.length = 0;

--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -124,6 +124,7 @@ function catalogModel(provider: AiModelConfig["provider"], modelId: string): Mod
     case "google": return (GOOGLE_MODELS as Record<string, Model<Api>>)[modelId];
     case "cloudflare": return (CLOUDFLARE_WORKERS_AI_MODELS as Record<string, Model<Api>>)[modelId];
     case "ollama": return undefined;
+    case "custom": return undefined;
     default: return undefined;
   }
 }
@@ -567,6 +568,31 @@ function getModelDirect(config: AiModelConfig, sessionAffinity?: string): ModelH
         ...(config.apiToken === ""
             ? { apiKey: "unused", headers: { Authorization: null } }
             : { apiKey: config.apiToken }),
+        sessionAffinity,
+      });
+    case "custom":
+      // Any OpenAI Chat-Completions-compatible endpoint (OpenRouter, OpenCode Zen, a self-hosted
+      // proxy, etc.). Unlike "ollama" this has no default URL and no legacy-suffix normalization:
+      // the user supplies the exact base URL the provider documents (e.g.
+      // "https://openrouter.ai/api/v1").
+      if (!config.apiUrl) {
+        throw new Error(
+            "This custom model has no API URL configured. Re-add it with the base URL of an " +
+            "OpenAI-compatible endpoint (e.g. https://openrouter.ai/api/v1).");
+      }
+      return makeHandle({
+        model: {
+          id: config.model,
+          name: config.model,
+          api: "openai-completions",
+          provider: "custom",
+          baseUrl: stripTrailingSlashes(config.apiUrl),
+          reasoning: true,
+          input: ["text", "image"],
+          cost: ZERO_COST,
+          ...window,
+        },
+        apiKey: config.apiToken,
         sessionAffinity,
       });
     case "openai":

--- a/packages/workshop-backend/src/chat-attachment-validation.ts
+++ b/packages/workshop-backend/src/chat-attachment-validation.ts
@@ -38,6 +38,9 @@ const ATTACHMENT_SUPPORT_BY_PROVIDER = {
   google: isTextImageOrPdfMime,
   cloudflare: isTextOrImageMime,
   ollama: isTextOrImageMime,
+  // Generic OpenAI Chat-Completions endpoints (see ai-models.ts): same "openai-completions" API
+  // shape as Workers AI/Ollama, with no document input.
+  custom: isTextOrImageMime,
 } satisfies Record<AiModelProvider, (mimeType: string) => boolean>;
 
 function sanitizeChatAttachmentMimeType(mimeType: string | undefined): string {

--- a/packages/workshop-frontend/src/AddModelModal.tsx
+++ b/packages/workshop-frontend/src/AddModelModal.tsx
@@ -22,6 +22,7 @@ const PROVIDER_LABELS: Record<AiModelProvider, string> = {
   google: 'Google',
   cloudflare: 'Cloudflare Workers AI',
   ollama: 'Ollama',
+  custom: 'Custom (OpenAI-compatible)',
 }
 
 // Placeholder hinting at the shape of each provider's API token.
@@ -31,6 +32,7 @@ const API_TOKEN_PLACEHOLDERS: Record<AiModelProvider, string> = {
   google: 'AIza...',
   cloudflare: 'Cloudflare API token',
   ollama: '(optional)',
+  custom: 'sk-...',
 }
 
 // Example used in the custom-model placeholders for providers that have no suggested models
@@ -160,6 +162,7 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
     }
 
     const isOllama = selection?.provider === 'ollama'
+    const isCustom = selection?.provider === 'custom'
     const isCloudflare = selection?.provider === 'cloudflare'
     const showCredentials = !gatewayMode
 
@@ -173,6 +176,10 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
 
     if (showCredentials && isOllama && !apiUrl.trim()) {
       newErrors.apiUrl = 'Please enter the Ollama API URL'
+    }
+
+    if (showCredentials && isCustom && !apiUrl.trim()) {
+      newErrors.apiUrl = 'Please enter the API URL'
     }
 
     setErrors(newErrors)
@@ -217,6 +224,7 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
   const showCustomFields = selection?.type === 'custom'
   const example = selection ? exampleModel(selection.provider) : null
   const isOllama = selection?.provider === 'ollama'
+  const isCustom = selection?.provider === 'custom'
   const isCloudflare = selection?.provider === 'cloudflare'
   const showCredentials = !gatewayMode
 
@@ -317,6 +325,8 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
                   ? 'Optional for local Ollama access'
                   : isCloudflare
                   ? 'An API token with Workers AI Read + Edit permissions (in the dashboard: Workers AI > Use REST API > Create a Workers AI API Token)'
+                  : isCustom
+                  ? 'API key for this endpoint'
                   : `Your ${PROVIDER_LABELS[selection.provider]} API token for billing`
               }
               value={apiToken}
@@ -339,8 +349,21 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
             />
           )}
 
-          {/* Advanced Settings for non-Ollama, non-Cloudflare providers */}
-          {showCredentials && selection && !isOllama && !isCloudflare && (
+          {/* API URL (always visible and required for a generic custom endpoint) */}
+          {showCredentials && isCustom && (
+            <Input
+              label="API URL"
+              placeholder="https://openrouter.ai/api/v1"
+              description="Base URL of an OpenAI Chat-Completions-compatible endpoint (e.g. OpenRouter, OpenCode Zen)"
+              value={apiUrl}
+              onChange={(e) => { setApiUrl(e.target.value); setErrors(prev => ({ ...prev, apiUrl: '' })) }}
+              error={errors.apiUrl}
+              variant={errors.apiUrl ? 'error' : 'default'}
+            />
+          )}
+
+          {/* Advanced Settings for non-Ollama, non-Cloudflare, non-custom providers */}
+          {showCredentials && selection && !isOllama && !isCustom && !isCloudflare && (
             <Collapsible.Root
               open={advancedOpen}
               onOpenChange={setAdvancedOpen}

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -917,7 +917,7 @@ export type CloudflareAccountOption = {
 };
 
 // Supported AI providers.
-export type AiModelProvider = "openai" | "anthropic" | "google" | "cloudflare" | "ollama";
+export type AiModelProvider = "openai" | "anthropic" | "google" | "cloudflare" | "ollama" | "custom";
 
 // Information about the AI gateway configuration. Returned by `AuthenticatedApi.getAiConfig()`.
 export type AiGatewayInfo = {
@@ -984,6 +984,8 @@ export const SUGGESTED_MODELS: Record<
     "gemini-3.6-flash": {name: "Gemini 3.6 Flash", contextWindow: 1048576},
   },
   "ollama": {
+  },
+  "custom": {
   },
 };
 


### PR DESCRIPTION
## Summary

- Adds a `custom` AI model provider — any OpenAI Chat-Completions-compatible endpoint (OpenRouter, OpenCode Zen, self-hosted proxies, etc.) can now be added directly instead of misusing the `ollama` provider as a workaround.
- Same direct-routing shape as `ollama` (`openai-completions` API, `getModelDirect`), but with a required, always-visible API URL field and no legacy `/api`/`/v1` suffix normalization — the user supplies the exact base URL their provider documents.
- New UI entry in Add Model: "Other Custom (OpenAI-compatible)...", with its own label/placeholder instead of piggybacking on Ollama's copy.

Follows up on #29 (cc @Tmeister).

## Test plan

- [x] `pnpm --filter @gadgets/workshop-backend exec vitest run __tests__/ai-models.test.ts` — 24/24 passing, including 3 new tests for the custom provider (base URL used verbatim, bearer auth, clear error when no API URL is configured)
- [x] `pnpm --filter @gadgets/workshop-backend exec tsc --noEmit` — clean (also caught and fixed a missed `Record<AiModelProvider, ...>` exhaustiveness case in `chat-attachment-validation.ts`)
- [x] `pnpm --filter @gadgets/workshop-shared exec tsc --noEmit` / `pnpm --filter @gadgets/workshop-frontend exec tsc --noEmit` — clean
- [x] Manually verified end-to-end against a local `pnpm run-local` instance: added a model with provider "Custom", pointed at an OpenAI-compatible base URL, confirmed it appears and the Add Model flow validates the URL as required