### PR TITLE
fix(chat): ignore Enter key while IME is composing

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -1835,6 +1835,7 @@ export const ChatInput = ({
 }) => {
   const toasts = useKumoToastManager();
   const [inputValue, setInputValue] = useState("");
+  const [isComposing, setIsComposing] = useState(false);
   const [capsules, setCapsules] = useState<InputCapsule[]>([]);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [isSending, setIsSending] = useState(false);
@@ -3099,6 +3100,8 @@ export const ChatInput = ({
               onSelect={handleCursorChange}
               onClick={handleCursorChange}
               onKeyUp={handleCursorChange}
+              onCompositionStart={() => setIsComposing(true)}
+              onCompositionEnd={() => setIsComposing(false)}
 
               onMouseDown={(e) => {
                 if (e.button !== 0) return;
@@ -3199,8 +3202,8 @@ export const ChatInput = ({
                     return;
                   }
                 }
-                // Enter sends message (unless Shift is held)
-                if (e.key === "Enter" && !e.shiftKey) {
+                // Enter sends message unless Shift is held or IME is composing
+                if (e.key === "Enter" && !e.shiftKey && !isComposing && !e.nativeEvent?.isComposing) {
                   e.preventDefault();
                   if (!isAgentActive && !isBlocked) submitMessage();
                   return;


### PR DESCRIPTION
## Summary
I noticed this while using Cloudflare OS with a Japanese IME.

The chat composer sent a message on every unmodified Enter press, including the Enter key used to confirm an IME composition. This caused accidental sends while the user was still converting text.

## Change
Track the IME composition state using `compositionstart` and `compositionend` on the composer textarea, and ignore Enter `keydown` events while `isComposing` is true. Also check `event.nativeEvent.isComposing` for environments where the compositionend/event ordering differs.

## Verification
- `pnpm lint` passes
- `pnpm build` passes
- `pnpm test` passes
- Confirmed locally that pressing Enter to confirm a Japanese IME conversion no longer sends the message.