### PR TITLE
Auto-title chats/workspaces without requiring a manual "Quick model"

### DIFF
--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -692,6 +692,12 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
           result.quickModel = quickModel.config;
         }
       }
+      // Fall back to the chat's own model when the user hasn't explicitly picked a "Quick
+      // model" in settings, so title generation works out of the box (matching AI Gateway
+      // mode, which always has a quick model) instead of silently never firing.
+      if (!result.quickModel) {
+        result.quickModel = result.aiModel?.config;
+      }
     }
     return result;
   }


### PR DESCRIPTION
Title generation (generateThreadTitle/generateGadgetTitle) was gated on userMeta.quickModel, which is null until a user finds the "Quick model" toggle on the Providers settings page. AI Gateway mode already sidesteps this by always resolving a hardcoded quick model; direct/BYOK mode had no equivalent fallback, so titles silently stayed "New Chat"/"Untitled Workspace" forever unless a user opted in.

Falls back to the chat's own model when no quick model has been explicitly chosen, mirroring AI Gateway mode's behavior.