### PR TITLE
Don't send the developer role from the Ollama provider slot

### DIFF
--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -563,6 +563,11 @@ function getModelDirect(config: AiModelConfig, sessionAffinity?: string): ModelH
           input: ["text", "image"],
           cost: ZERO_COST,
           ...window,
+          // pi detects the `developer` system role from the hostname, so an OpenAI-compatible
+          // gateway on an unrecognized domain is assumed to accept it. Most don't — they reject
+          // the request with "developer is not one of [...] - 'messages.[0].role'". Reasoning is
+          // hardcoded on above, which is the other half of pi's condition, so pin the role here.
+          compat: { supportsDeveloperRole: false },
         },
         ...(config.apiToken === ""
             ? { apiKey: "unused", headers: { Authorization: null } }


### PR DESCRIPTION
Fixes #36.

A model added through the **Ollama** provider slot against a self-hosted OpenAI-compatible endpoint fails on the very first message:

```
400 {"message":"developer is not one of ['system', 'assistant', 'user', 'tool', 'function'] - 'messages.[0].role'","type":"invalid_request_error"}
```

pi chooses the system-prompt role with

```js
const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
```

and `detectCompat()` infers `supportsDeveloperRole` from the provider id and base URL. `ollama` is not in its `isNonStandard` list, and a self-hosted base URL matches none of its hostname checks, so the endpoint is assumed to accept `role: "developer"`. The branch also hardcodes `reasoning: true`, which supplies the other half of the condition — so the developer role went out on every request.

This slot is the only one in `AddModelModal` that pairs a user-supplied base URL with the chat-completions API (`openai` uses `openai-responses`, `google` uses `google-generative-ai`, `cloudflare` is account-scoped), so it is what vLLM, LM Studio, llama.cpp and self-hosted gateways get added through, not just Ollama itself. Any of them that validates message roles strictly was unusable.

`workersAiCompat()` in the same file already pins this flag; this brings the ollama branch in line.

## Verification

Against an internal OpenAI-compatible gateway serving a DeepSeek model, before the change every chat failed with the 400 above. After it:

- plain chat ✅
- streaming, including `reasoning_content` deltas rendered as thinking ✅
- `executeCode` tool calls ✅
- multi-turn with tool-result replay ✅ (asked it to compute the sum of squares 1..100 in code; it ran `executeCode` and returned 338350)

`pnpm --filter @gadgets/workshop-backend types:check` passes.

I also checked with `curl` that the endpoint itself accepts everything else pi sends — non-streaming, streaming, assistant-message replay with and without `reasoning_content`, and function calling all return 200. The `developer` role was the only rejected part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
