### PR TITLE
Revoke only this account's GitHub token, not the whole app grant

### DIFF
--- a/packages/gatekeeper-github/src/github-api.ts
+++ b/packages/gatekeeper-github/src/github-api.ts
@@ -340,14 +340,18 @@ export async function exchangeAuthCode(
   };
 }
 
-export async function revokeOAuthGrant(
+// Revokes one access token. Deliberately the token-scoped endpoint: deleting the *grant*
+// (`/applications/{client_id}/grant`) revokes every token the user holds for this OAuth app, so
+// revoking one account would also invalidate the others sharing it -- including the fresh grant a
+// re-authorization just issued.
+export async function revokeOAuthToken(
   accessToken: string,
   clientId: string,
   clientSecret: string,
 ): Promise<void> {
   await request<void>(
     "DELETE",
-    `/applications/${encodeURIComponent(clientId)}/grant`,
+    `/applications/${encodeURIComponent(clientId)}/token`,
     {
       auth: "basic",
       basicAuth: {

--- a/packages/gatekeeper-github/src/github.ts
+++ b/packages/gatekeeper-github/src/github.ts
@@ -21,7 +21,7 @@ import {
   GitHubApi,
   GitHubApiError,
   exchangeAuthCode,
-  revokeOAuthGrant,
+  revokeOAuthToken,
   type ConditionalRequestResult,
   type GitHubIssueCommentResponse,
   type GitHubIssueResponse,
@@ -1179,10 +1179,10 @@ export class UserAccount extends DurableObject<Env> {
     const accessToken = this.ctx.storage.kv.get<string>("accessToken");
     if (accessToken && this.env.CLIENT_ID && this.env.CLIENT_SECRET) {
       try {
-        await revokeOAuthGrant(accessToken, this.env.CLIENT_ID, this.env.CLIENT_SECRET);
+        await revokeOAuthToken(accessToken, this.env.CLIENT_ID, this.env.CLIENT_SECRET);
       } catch (error) {
-        logger.error("failed to revoke GitHub OAuth grant", {
-          event: "oauth.grant.revoke.failed", error,
+        logger.error("failed to revoke GitHub OAuth token", {
+          event: "oauth.token.revoke.failed", error,
         });
       }
     }


### PR DESCRIPTION
`UserAccount.revoke()` in the GitHub gatekeeper calls `DELETE /applications/{client_id}/grant`.
That endpoint deletes the app *authorization*: GitHub documents that it revokes **every** OAuth
token the user holds for that app, not just the one in the request body. Those sibling tokens are
real — GitHub issues a new token on each authorization, up to ten concurrent per
user/application/scope.

`putConnectedAccount()` depends on the opposite. When a user adds a second account and the provider
returns the identity they are already connected as — the case its own comment calls out — it keeps
the existing record and revokes "the newly-created duplicate grant":

https://github.com/cloudflare/cloudflare-os/blob/aedcda8/packages/workshop-backend/src/user.ts#L1586-L1595

Under a grant-wide revoke that call also destroys the **existing** account's still-valid token and
drops the app from the user's GitHub authorizations, so trying to add a duplicate silently breaks a
working connection.

`DELETE /applications/{client_id}/token` is the token-scoped counterpart. It takes the identical
basic auth and `{ access_token }` body, so the change is the path plus a rename for accuracy.

This is also what the rest of the codebase already does. `github.ts` avoids the revoke endpoint
entirely on the ephemeral sign-in path for exactly this reason ("it could invalidate the user's
other grants for this OAuth app"), and among the other connectors Linear (`/oauth/revoke`), Google
(`oauth2.googleapis.com/revoke`) and Slack (`auth.revoke`) are token-scoped, while Cloudflare,
Spotify and Confluence only drop local state. `gatekeeper-github` is the only one that deauthorizes
the app.

Related to #10, but deliberately **not** claimed as fixing it: that reporter also needed
`putConnectedAccount()` to replace the capability in place, which is a separate change. This PR is
just the endpoint, which breaks a working connection on its own.

One judgement call worth flagging: `disconnectAccount()` also goes through `revoke()`, and there a
full deauthorization is arguably what the user wants. `user.ts` describes `revoke()` as the
gatekeeper's cleanup hook rather than a deauthorization, and no other connector deauthorizes, so
this PR keeps them consistent — happy to add a separate call for disconnect instead if you would
rather keep that behaviour.

Verified: `pnpm lint:check` and `pnpm --filter @gadgets/github-gatekeeper types:check` pass. Not
exercised against a live GitHub OAuth app.
