### PR TITLE
Keep webFetch's timeout armed until the response body has been read

### DIFF
--- a/packages/workshop-backend/src/web-fetch.ts
+++ b/packages/workshop-backend/src/web-fetch.ts
@@ -283,6 +283,7 @@ export async function webFetch(
       signal: abortController.signal,
     });
   } catch (err) {
+    clearTimeout(timeoutId);
     if (
       err instanceof Error &&
       (err.name === "AbortError" || /abort/i.test(err.message))
@@ -290,9 +291,10 @@ export async function webFetch(
       throw new Error(`Fetch timed out after ${FETCH_TIMEOUT_MS}ms`, { cause: err });
     }
     throw err;
-  } finally {
-    clearTimeout(timeoutId);
   }
+  // NB: the timer deliberately stays armed past this point. `fetch` resolves once the response
+  // headers arrive, so clearing it here would leave the body read below unbounded, and a server
+  // that answers promptly and then stalls could hold the agent open indefinitely.
 
   // `response.url` is set by the runtime to the final URL after any redirects. Fall back
   // to the original URL if it happens to be empty.
@@ -302,6 +304,7 @@ export async function webFetch(
   // Respect the Content-Signal header (https://contentsignals.org/). If the site
   // explicitly sets `ai-input=no`, we must not feed its content to the AI agent.
   if (contentSignalDenies(response, "ai-input")) {
+    clearTimeout(timeoutId);
     try {
       await response.body?.cancel();
     } catch {
@@ -313,7 +316,14 @@ export async function webFetch(
     );
   }
 
-  const { bytes, truncated } = await readBodyCapped(response, maxBytes);
+  const { bytes, truncated } = await readBodyCapped(response, maxBytes)
+    .catch((err: unknown) => {
+      if (abortController.signal.aborted) {
+        throw new Error(`Fetch timed out after ${FETCH_TIMEOUT_MS}ms`, { cause: err });
+      }
+      throw err;
+    })
+    .finally(() => clearTimeout(timeoutId));
 
   let body: string;
   if (input.raw) {


### PR DESCRIPTION
Refs #27 — this covers the timeout half only, so please keep that issue open for the rest (see the
list at the bottom).

`fetch()` resolves as soon as the response headers arrive, and the `finally` cleared
`FETCH_TIMEOUT_MS` right there — before `readBodyCapped()` ran. The declared 30s bound therefore
only covered connect and time-to-headers, and the body read had no deadline at all.
`readBodyCapped` is a bare `while (true) { await reader.read() }` with no signal, so a server that
answers promptly and then stalls holds the agent turn open with nothing to stop it.

The 1 MiB cap does not substitute for a deadline: it bounds total bytes, so a server trickling
below the cap never trips it.

**Measured on workerd**, against a server that flushes headers then writes one byte every 2s, with
the timeout shortened to 5s:

| variant | result |
| --- | --- |
| before this PR | still pending when the client gave up at **25s** |
| just keeping the timer armed | `AbortError` after **5057ms** |
| this PR | `Error: Fetch timed out after 5000ms` after **5039ms** |

The middle row is why the diff is not a one-line move: the abort does reach an in-flight
`reader.read()`, but the `catch` that produces the friendly message wraps only the `fetch` call, so
a timeout during the body read would otherwise surface as a bare `AbortError`. The change clears
the timer on each exit path and maps an abort during the body read onto the same error.

Two things this deliberately leaves alone, both because they change the function's signature or its
caller, and both noted in #27:

- The `AbortSignal` `pi-agent-core` passes to a tool as `execute`'s third argument is still dropped
  by the `webFetch` tool, so Stop still cannot cancel a slow fetch.
- `convertToMarkdown` runs after the body read, so it stays outside the deadline.

Verified: `pnpm lint:check` and `pnpm --filter @gadgets/workshop-backend types:check` pass.
