### PR TITLE
Fix GitHub issue search repository scope

### DIFF
--- a/packages/gatekeeper-github/__tests__/cloudflare-workers.ts
+++ b/packages/gatekeeper-github/__tests__/cloudflare-workers.ts
@@ -1,1 +1,0 @@
-// Node test shim for github-api.ts's Workers runtime import.

--- a/packages/gatekeeper-github/__tests__/cloudflare-workers.ts
+++ b/packages/gatekeeper-github/__tests__/cloudflare-workers.ts
@@ -1,0 +1,1 @@
+// Node test shim for github-api.ts's Workers runtime import.

--- a/packages/gatekeeper-github/__tests__/github-api.test.ts
+++ b/packages/gatekeeper-github/__tests__/github-api.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GitHubApi,
+  type GitHubIssueResponse,
+} from "../src/github-api";
+import {
+  assertIssueSearchResultsInRepo,
+  buildIssueSearchQuery,
+} from "../src/github-search";
+
+function issueAt(htmlUrl: string): Pick<GitHubIssueResponse, "html_url"> {
+  return { html_url: htmlUrl };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("assertIssueSearchResultsInRepo", () => {
+  it("accepts exact repository path segments case-insensitively", () => {
+    expect(() => assertIssueSearchResultsInRepo("Cloudflare", "Workerd", [
+      issueAt("https://github.com/cloudflare/workerd/issues/1"),
+    ])).not.toThrow();
+  });
+
+  it("rejects results from another repository", () => {
+    expect(() => assertIssueSearchResultsInRepo("cloudflare", "workerd", [
+      issueAt("https://github.com/cloudflare/quiche/issues/1"),
+    ])).toThrow("outside the connected repository");
+  });
+
+  it("does not accept repository names that only share a prefix", () => {
+    expect(() => assertIssueSearchResultsInRepo("cloudflare", "workerd", [
+      issueAt("https://github.com/cloudflare/workerd-private/issues/1"),
+    ])).toThrow("outside the connected repository");
+  });
+
+  it("rejects pull requests returned by an injected search expression", () => {
+    expect(() => assertIssueSearchResultsInRepo("cloudflare", "workerd", [
+      issueAt("https://github.com/cloudflare/workerd/pull/1"),
+    ])).toThrow("non-issue result");
+  });
+
+  it("rejects malformed and non-GitHub result URLs", () => {
+    expect(() => assertIssueSearchResultsInRepo("cloudflare", "workerd", [
+      issueAt("not a URL"),
+    ])).toThrow("outside the connected repository");
+    expect(() => assertIssueSearchResultsInRepo("cloudflare", "workerd", [
+      issueAt("https://example.com/cloudflare/workerd/issues/1"),
+    ])).toThrow("outside the connected repository");
+  });
+});
+
+describe("buildIssueSearchQuery", () => {
+  it("builds a benign literal phrase search with structured filters", () => {
+    expect(buildIssueSearchQuery("cloudflare", "workerd", {
+      text: "durable objects",
+      state: "open",
+      labels: ["bug"],
+      author: "jasnell",
+    })).toBe(
+      '"durable objects" repo:cloudflare/workerd is:issue state:open label:"bug" author:"jasnell"',
+    );
+  });
+
+  it("quotes every caller-controlled query fragment", () => {
+    expect(buildIssueSearchQuery("cloudflare", "workerd", {
+      text: "repo:cloudflare/quiche OR scheduler",
+      author: "jasnell OR repo:cloudflare/quiche",
+      assignee: "octocat OR repo:cloudflare/quiche",
+    })).toBe(
+      '"repo:cloudflare/quiche OR scheduler" repo:cloudflare/workerd is:issue '
+      + 'author:"jasnell OR repo:cloudflare/quiche" assignee:"octocat OR repo:cloudflare/quiche"',
+    );
+  });
+
+  it("escapes quotes inside plain search text", () => {
+    expect(buildIssueSearchQuery("cloudflare", "workerd", {
+      text: 'bug" OR repo:cloudflare/quiche OR "',
+    })).toBe('"bug\\" OR repo:cloudflare/quiche OR \\"" repo:cloudflare/workerd is:issue');
+  });
+});
+
+describe("GitHubApi.searchIssuesConditional", () => {
+  it("enables GitHub advanced search parsing", async () => {
+    let requestUrl: URL | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      requestUrl = new URL(String(input));
+      return new Response(JSON.stringify({ items: [] }), {
+        headers: { "content-type": "application/json" },
+      });
+    }));
+
+    const api = new GitHubApi(async () => "test-token");
+    await api.searchIssuesConditional(
+      "repo:cloudflare/quiche OR repo:cloudflare/workerd is:issue",
+      1,
+      100,
+    );
+
+    expect(requestUrl?.searchParams.get("advanced_search")).toBe("true");
+  });
+});

--- a/packages/gatekeeper-github/package.json
+++ b/packages/gatekeeper-github/package.json
@@ -9,6 +9,7 @@
     "deploy": "pnpm run build:configurator && wrangler deploy",
     "build": "pnpm run build:configurator && tsc",
     "types:check": "pnpm run build:configurator && tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist src/generated"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "typescript": "^5.9.3",
+    "vitest": "^4.1.10",
     "wrangler": "^4.119.0"
   }
 }

--- a/packages/gatekeeper-github/src/github-api.ts
+++ b/packages/gatekeeper-github/src/github-api.ts
@@ -1,5 +1,3 @@
-import "cloudflare:workers";
-
 export type GitHubOAuthGrant = {
   accessToken: string;
   scopes: string[];

--- a/packages/gatekeeper-github/src/github-api.ts
+++ b/packages/gatekeeper-github/src/github-api.ts
@@ -596,6 +596,7 @@ export class GitHubApi {
       "/search/issues",
       {
         q: query,
+        advanced_search: true,
         page,
         per_page: perPage,
         sort,

--- a/packages/gatekeeper-github/src/github-search.ts
+++ b/packages/gatekeeper-github/src/github-search.ts
@@ -1,0 +1,40 @@
+import type { GitHubIssueResponse } from "./github-api";
+import type { GitHubIssueSearch } from "./types";
+
+export function buildIssueSearchQuery(owner: string, repo: string, query: GitHubIssueSearch): string {
+  const parts = [query.text ? JSON.stringify(query.text) : "", `repo:${owner}/${repo}`, "is:issue"];
+  if (query.state && query.state !== "all") parts.push(`state:${query.state}`);
+  for (const label of query.labels ?? []) {
+    parts.push(`label:${JSON.stringify(label)}`);
+  }
+  if (query.author) parts.push(`author:${JSON.stringify(query.author)}`);
+  if (query.assignee) parts.push(`assignee:${JSON.stringify(query.assignee)}`);
+  return parts.filter(Boolean).join(" ");
+}
+
+export function assertIssueSearchResultsInRepo(
+  owner: string,
+  repo: string,
+  results: readonly Pick<GitHubIssueResponse, "html_url">[],
+): void {
+  const expectedOwner = owner.toLowerCase();
+  const expectedRepo = repo.toLowerCase();
+
+  for (const result of results) {
+    let url: URL | undefined;
+    try {
+      url = new URL(result.html_url);
+    } catch {
+      // Handled by the scope check below.
+    }
+
+    const [resultOwner, resultRepo, resultKind] = url?.pathname.split("/").filter(Boolean) ?? [];
+    if (url?.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com"
+        || resultOwner?.toLowerCase() !== expectedOwner || resultRepo?.toLowerCase() !== expectedRepo) {
+      throw new Error("GitHub returned an issue outside the connected repository.");
+    }
+    if (resultKind !== "issues") {
+      throw new Error("GitHub returned a non-issue result for an issue search.");
+    }
+  }
+}

--- a/packages/gatekeeper-github/src/github.ts
+++ b/packages/gatekeeper-github/src/github.ts
@@ -30,6 +30,7 @@ import {
   type GitHubPullRequestResponse,
   type GitHubPullRequestReviewCommentResponse,
 } from "./github-api";
+import { assertIssueSearchResultsInRepo, buildIssueSearchQuery } from "./github-search";
 import GITHUB_LOGO_SVG from "./github-logo.svg";
 import type {
   GitHubActor,
@@ -109,6 +110,11 @@ type Cached<T> = {
   value: T;
   etag?: string;
   generation: number;
+};
+
+type CachedIssueSearchResult = {
+  html_url: string;
+  summary: GitHubIssueSummary;
 };
 
 type GitHubDiscussionCommentEntry = Extract<GitHubDiscussionEntry, { kind: "comment" }>;
@@ -695,17 +701,6 @@ function pullComparator(
     }
     return delta * factor;
   };
-}
-
-function buildIssueSearchQuery(owner: string, repo: string, query: GitHubIssueSearch): string {
-  const parts = [query.text, `repo:${owner}/${repo}`, "is:issue"];
-  if (query.state && query.state !== "all") parts.push(`state:${query.state}`);
-  for (const label of query.labels ?? []) {
-    parts.push(`label:${JSON.stringify(label)}`);
-  }
-  if (query.author) parts.push(`author:${query.author}`);
-  if (query.assignee) parts.push(`assignee:${query.assignee}`);
-  return parts.filter(Boolean).join(" ");
 }
 
 function parseDiffSide(side?: "LEFT" | "RIGHT" | null): "old" | "new" {
@@ -2563,10 +2558,20 @@ export class GitHubGatekeeperImpl extends DurableObject<Env, GitHubGatekeeperImp
     const owner = this.ctx.props.owner;
     const repo = this.ctx.props.repo;
     const searchQuery = buildIssueSearchQuery(owner, repo, query);
+    const assertSearchScope = (results: readonly Pick<GitHubIssueResponse, "html_url">[]) => {
+      try {
+        assertIssueSearchResultsInRepo(owner, repo, results);
+      } catch (error) {
+        logger.warn("GitHub issue search scope validation failed", {
+          event: "issue.search.scope.validation.failed", error,
+        });
+        throw error;
+      }
+    };
     return new StreamingCursor<GitHubIssueSummary>({
       fetchPage: async (page, perPage) => {
-        const cacheKey = this.#cacheKey("search-issues", stableKey(query), `p${page}`);
-        return await this.#loadCachedWithEtag<GitHubIssueSummary[]>(cacheKey, LIST_CACHE_TTL_MS, async etag => {
+        const cacheKey = this.#cacheKey("search-issues-scoped-v1", stableKey(query), `p${page}`);
+        const results = await this.#loadCachedWithEtag<CachedIssueSearchResult[]>(cacheKey, LIST_CACHE_TTL_MS, async etag => {
           const raw = await this.#withApi(api =>
             api.searchIssuesConditional(searchQuery, page, perPage, remoteSort, remoteDirection, { ifNoneMatch: etag })
           );
@@ -2574,17 +2579,21 @@ export class GitHubGatekeeperImpl extends DurableObject<Env, GitHubGatekeeperImp
             return raw;
           }
 
+          assertSearchScope(raw.data.items);
           return {
             status: 200,
             headers: raw.headers,
-            data: raw.data.items
-              .filter(item => !item.pull_request)
-              .map(item => normalizeIssueSummary(owner, repo, item)),
+            data: raw.data.items.map(item => ({
+              html_url: item.html_url,
+              summary: normalizeIssueSummary(owner, repo, item),
+            })),
           };
         });
+        assertSearchScope(results);
+        return results.map(item => item.summary);
       },
       overlay: item => this.#overlayIssueLike(item, "issue", item.id),
-      filter: () => true,  // Remote search results are already filtered by GitHub's search API.
+      filter: () => true,  // Search scope was validated before results entered the cursor.
       comparator: compare,
       injectedItems: provisionals,
       pageSize,

--- a/packages/gatekeeper-github/src/types.d.ts
+++ b/packages/gatekeeper-github/src/types.d.ts
@@ -53,8 +53,8 @@ export interface GitHubRepo {
   /**
    * Searches issues in this repository.
    *
-   * The search is limited to this repository. `query.text` is a plain-text search
-   * string; the remaining fields are structured filters.
+   * The search is limited to this repository. `query.text` is matched as a literal phrase;
+   * search qualifiers in it are not interpreted. The remaining fields are structured filters.
    */
   searchIssues(query: GitHubIssueSearch): Promise<Cursor<GitHubIssueSummary>>;
 

--- a/packages/gatekeeper-github/storage-schema.md
+++ b/packages/gatekeeper-github/storage-schema.md
@@ -125,7 +125,7 @@ Implemented TTL cache families:
 - `cache:issue:<realId>` -> `GitHubIssueDetails`
 - `cache:pull:<realId>` -> `GitHubPullRequestDetails`
 - `cache:list-issues:<encodedQuery>` -> `GitHubIssueSummary[]`
-- `cache:search-issues:<encodedQuery>` -> `GitHubIssueSummary[]`
+- `cache:search-issues-scoped-v1:<encodedQuery>` -> validated source URLs and `GitHubIssueSummary` values
 - `cache:list-pulls:<encodedQuery>` -> `GitHubPullRequestSummary[]`
 - `cache:search-pulls:<encodedQuery>` -> `GitHubPullRequestSummary[]`
 - `cache:discussion-reviews:<realId>:p<page>` -> `GitHubDiscussionEntry[]` review-summary pages for pull discussions

--- a/packages/gatekeeper-github/vitest.config.ts
+++ b/packages/gatekeeper-github/vitest.config.ts
@@ -1,12 +1,6 @@
-import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      "cloudflare:workers": fileURLToPath(new URL("./__tests__/cloudflare-workers.ts", import.meta.url)),
-    },
-  },
   test: {
     include: ["__tests__/*.test.ts"],
     environment: "node",

--- a/packages/gatekeeper-github/vitest.config.ts
+++ b/packages/gatekeeper-github/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "cloudflare:workers": fileURLToPath(new URL("./__tests__/cloudflare-workers.ts", import.meta.url)),
+    },
+  },
+  test: {
+    include: ["__tests__/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(jsdom@26.1.0(supports-color@10.2.2))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.119.0
         version: 4.119.0(@cloudflare/workers-types@5.20260804.1)


### PR DESCRIPTION
GitHub issue search was relying on an appended `repo:` qualifier, but caller-controlled search syntax could escape that scope.

This keeps the repository boundary local by quoting search inputs, validating results before caching or returning them, and retaining the source URL for cache revalidation. It also logs blocked scope mismatches and avoids caching issue bodies.

Added focused regression tests for injection attempts, case handling, and malformed result URLs.

Tested with the full test suite, type checks, and lint.