### PR TITLE
Add per-package Vitest configs to anchor test resolution

### DIFF
--- a/packages/configurator-ui/vitest.config.ts
+++ b/packages/configurator-ui/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Anchor Vitest to this package. Without a local config, Vitest walks up
+// parent directories looking for one, so when this repo is embedded inside a
+// larger monorepo it would load the host repo's vitest config instead.
+export default defineConfig({
+  test: {
+    include: ["__tests__/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/gatekeeper-mcp-portal/vitest.config.ts
+++ b/packages/gatekeeper-mcp-portal/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Anchor Vitest to this package. Without a local config, Vitest walks up
+// parent directories looking for one, so when this repo is embedded inside a
+// larger monorepo it would load the host repo's vitest config instead.
+export default defineConfig({
+  test: {
+    include: ["__tests__/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/gatekeeper-mcp/vitest.config.ts
+++ b/packages/gatekeeper-mcp/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Anchor Vitest to this package. Without a local config, Vitest walks up
+// parent directories looking for one, so when this repo is embedded inside a
+// larger monorepo it would load the host repo's vitest config instead.
+export default defineConfig({
+  test: {
+    include: ["__tests__/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Problem

`packages/gatekeeper-mcp`, `packages/gatekeeper-mcp-portal`, and `packages/configurator-ui` run `vitest run` with no local config file. Vitest searches upward through parent directories for a `vitest.config.*`/`vite.config.*`, so when this repository is embedded inside a larger monorepo — the "make it *Your Company* OS" fork case the README encourages — it silently loads the **host repository's** vitest config. The gatekeeper-mcp/mcp-portal tests then fail outright (the host's `include` patterns don't match `__tests__/`), and configurator-ui only survives because of `--passWithNoTests`.

The sibling packages are already immune: `mcp-shared` has its own `vitest.config.ts`, and `gatekeeper-context` / `workshop-frontend` have a `vite.config.ts` that stops the search.

## Fix

A minimal `vitest.config.ts` in each of the three packages. `include: ["__tests__/*.test.ts"]` and `environment: "node"` match what Vitest's defaults already resolve to for these packages standalone, so upstream behavior is unchanged — the config exists purely to stop the upward search.

Verified with `pnpm test` both standalone and embedded in a host monorepo that carries its own root vitest config (29 + 3 previously-broken tests pass embedded).

Made with [Cursor](https://cursor.com)