### PR TITLE
fix: expand oauth scopes for observer verification if needed

### DIFF
--- a/packages/workshop-frontend/src/ObserverConfigModal.test.tsx
+++ b/packages/workshop-frontend/src/ObserverConfigModal.test.tsx
@@ -3,14 +3,15 @@
 
 import { act, type ComponentProps, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 import type { RpcStub } from 'capnweb'
 import type {
   AuthenticatedApi,
   ConnectedAccountsSubscriber,
+  ObserverAccountChoice,
   ObserverBindingNeed,
 } from '@gadgets/workshop-shared/api'
-import type { AccountDescription, VendorDescription } from '@gadgets/workshop-shared/gatekeeper'
+import type { AccountDescription, SupportedResource, VendorDescription } from '@gadgets/workshop-shared/gatekeeper'
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -50,6 +51,15 @@ const VENDOR = {
   color: '#4285f4',
 } as VendorDescription
 
+const DOC_RESOURCE: SupportedResource = {
+  urlPattern: 'https://docs.google.com/document/d/:docId/*',
+  title: 'Google Doc',
+  description: 'Read and edit documents you choose.',
+  grantable: true,
+}
+
+const GMAIL_RESOURCE_PATTERN = 'https://mail.google.com/*'
+
 const NEED: ObserverBindingNeed = {
   gatekeeperId: 12,
   vendorId: 'google',
@@ -57,24 +67,50 @@ const NEED: ObserverBindingNeed = {
   resourceUrl: 'https://docs.google.com/document/d/quarterly',
 }
 
-function account(id: number, uniqueName: string) {
+function account(id: number, uniqueName: string, grantedResourceUrlPatterns?: string[]) {
   return {
     id,
-    description: { displayName: uniqueName, uniqueName } as AccountDescription,
+    description: {
+      displayName: uniqueName,
+      uniqueName,
+      grantedResourceUrlPatterns,
+    } as AccountDescription,
   }
 }
 
-function fakeApi(accountEntries: ReturnType<typeof account>[]): RpcStub<AuthenticatedApi> {
+type ApiOverrides = {
+  connectAccount?: Mock<(vendorId: string, resourceUrlPatterns?: string[]) => Promise<{ url: string }>>
+  ensureAccountResources?: Mock<(
+    accountId: number,
+    resourceUrlPatterns: string[],
+  ) => Promise<{ url?: string }>>
+  reconnectAccount?: Mock<(accountId: number) => Promise<{ url: string }>>
+}
+
+function fakeApi(
+  accountEntries: ReturnType<typeof account>[],
+  overrides: ApiOverrides = {},
+): RpcStub<AuthenticatedApi> {
   return {
     subscribeConnectedAccounts: async (subscriber: ConnectedAccountsSubscriber) => {
       for (const entry of accountEntries) {
-        subscriber.add(entry.id, entry.description, VENDOR, [], true, 'google')
+        subscriber.add(entry.id, entry.description, VENDOR, [DOC_RESOURCE], true, 'google')
       }
       subscriber.ready()
       return { [Symbol.dispose]() {} }
     },
-    listGatekeeperVendors: async () => [{ id: 'google', description: VENDOR }],
+    listGatekeeperVendors: async () => [{
+      id: 'google',
+      description: VENDOR,
+      supportedResources: [DOC_RESOURCE],
+    }],
     listAddableGatekeepers: async () => [],
+    connectAccount: overrides.connectAccount ??
+      vi.fn<(vendorId: string, resourceUrlPatterns?: string[]) => Promise<{ url: string }>>(),
+    ensureAccountResources: overrides.ensureAccountResources ??
+      vi.fn<(accountId: number, resourceUrlPatterns: string[]) => Promise<{ url?: string }>>(),
+    reconnectAccount: overrides.reconnectAccount ??
+      vi.fn<(accountId: number) => Promise<{ url: string }>>(),
   } as unknown as RpcStub<AuthenticatedApi>
 }
 
@@ -85,11 +121,18 @@ describe('ObserverConfigModal account selection', () => {
   afterEach(() => {
     act(() => root?.unmount())
     container?.remove()
+    vi.restoreAllMocks()
     root = undefined
     container = undefined
   })
 
-  async function render(accountEntries: ReturnType<typeof account>[]) {
+  async function render(
+    accountEntries: ReturnType<typeof account>[],
+    options: {
+      api?: RpcStub<AuthenticatedApi>
+      onConfirm?: (choices: ObserverAccountChoice[]) => void
+    } = {},
+  ) {
     container = document.createElement('div')
     document.body.append(container)
     root = createRoot(container)
@@ -97,8 +140,8 @@ describe('ObserverConfigModal account selection', () => {
       root!.render(
         <ObserverConfigModal
           needs={[NEED]}
-          authenticatedApi={fakeApi(accountEntries)}
-          onConfirm={() => {}}
+          authenticatedApi={options.api ?? fakeApi(accountEntries)}
+          onConfirm={options.onConfirm ?? (() => {})}
           onCancel={() => {}}
         />,
       )
@@ -121,5 +164,66 @@ describe('ObserverConfigModal account selection', () => {
     ])
 
     expect(rendered.querySelectorAll('[data-testid="account-select"]')).toHaveLength(1)
+  })
+
+  it('requests the resource scope when connecting a new account', async () => {
+    const connectAccount = vi.fn<
+      (vendorId: string, resourceUrlPatterns?: string[]) => Promise<{ url: string }>
+    >().mockResolvedValue({ url: 'https://accounts.google.test/oauth' })
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+    const rendered = await render([], {
+      api: fakeApi([], { connectAccount }),
+    })
+
+    const connect = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Connect')
+    expect(connect).toBeDefined()
+    await act(async () => connect!.click())
+
+    expect(connectAccount).toHaveBeenCalledWith('google', [DOC_RESOURCE.urlPattern])
+    expect(window.open).toHaveBeenCalledWith(
+      'https://accounts.google.test/oauth', '_blank', 'noopener,noreferrer',
+    )
+  })
+
+  it('expands an existing account grant before allowing verification', async () => {
+    const ensureAccountResources = vi.fn<
+      (accountId: number, resourceUrlPatterns: string[]) => Promise<{ url?: string }>
+    >()
+      .mockResolvedValue({ url: 'https://accounts.google.test/oauth' })
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+    const underScoped = account(1, 'dan@cloudflare.com', [GMAIL_RESOURCE_PATTERN])
+    const rendered = await render([underScoped], {
+      api: fakeApi([underScoped], { ensureAccountResources }),
+    })
+
+    const verify = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Verify and open')
+    const grant = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Grant the access needed to verify this resource')
+    expect(verify?.disabled).toBe(true)
+    expect(grant).toBeDefined()
+    expect(rendered.textContent).not.toContain('Ready')
+
+    await act(async () => grant!.click())
+
+    expect(ensureAccountResources).toHaveBeenCalledWith(1, [DOC_RESOURCE.urlPattern])
+    expect(window.open).toHaveBeenCalledWith(
+      'https://accounts.google.test/oauth', '_blank', 'noopener,noreferrer',
+    )
+  })
+
+  it('allows verification when the account already has the required grant', async () => {
+    const onConfirm = vi.fn<(choices: ObserverAccountChoice[]) => void>()
+    const granted = account(1, 'dan@cloudflare.com', [DOC_RESOURCE.urlPattern])
+    const rendered = await render([granted], { onConfirm })
+
+    const verify = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Verify and open')
+    expect(verify?.disabled).toBe(false)
+    expect(rendered.textContent).toContain('Ready')
+
+    await act(async () => verify!.click())
+    expect(onConfirm).toHaveBeenCalledWith([{ gatekeeperId: 12, accountId: 1 }])
   })
 })

--- a/packages/workshop-frontend/src/ObserverConfigModal.tsx
+++ b/packages/workshop-frontend/src/ObserverConfigModal.tsx
@@ -43,13 +43,10 @@ function accountLabel(account: AccountInfo | undefined, accountId: number): stri
   return account?.description.uniqueName || account?.description.displayName || `Account ${accountId}`
 }
 
-/**
- * Returns the grantable resource type needed to verify one observer binding.
- *
- * Account metadata is preferred because it reflects the resources currently available to that
- * account; vendor metadata is the fallback used before an account has been connected. Non-grantable
- * resources require no OAuth scope expansion.
- */
+// Return the grantable resource type needed to verify one observer binding. Account metadata is
+// preferred because it reflects the resources currently available to that account; vendor metadata
+// is the fallback used before an account has been connected. Non-grantable resources require no
+// OAuth scope expansion.
 function requiredResourceUrlPatterns(
   need: ObserverBindingNeed,
   vendor: GatekeeperVendorInfo | undefined,
@@ -63,12 +60,9 @@ function requiredResourceUrlPatterns(
   return resolved.ok && resolved.resource.grantable ? [resolved.resource.urlPattern] : []
 }
 
-/**
- * Filters required resource types down to those the account has not granted yet.
- *
- * An omitted granted-resource list denotes a legacy or full-scope account and is therefore treated
- * as satisfying every requirement.
- */
+// Filter required resource types down to those the account has not granted yet. An omitted
+// granted-resource list denotes a legacy or full-scope account and therefore satisfies every
+// requirement.
 function missingResourceUrlPatterns(account: AccountInfo, required: string[]): string[] {
   const granted = account.description.grantedResourceUrlPatterns
   return granted === undefined ? [] : required.filter(pattern => !granted.includes(pattern))
@@ -255,7 +249,10 @@ export default function ObserverConfigModal({
 
   const handleGrantResourceAccess = async (need: ObserverBindingNeed, account: AccountInfo) => {
     const required = requiredResourceUrlPatterns(
-      need, vendorsById.get(need.vendorId), account)
+      need,
+      vendorsById.get(need.vendorId),
+      account,
+    )
     const missing = missingResourceUrlPatterns(account, required)
     if (missing.length === 0) return
     setGranting(account.id)
@@ -279,7 +276,10 @@ export default function ObserverConfigModal({
   const accountSatisfies = (need: ObserverBindingNeed, account: AccountInfo | undefined) => {
     if (!account?.credentialsValid) return false
     const required = requiredResourceUrlPatterns(
-      need, vendorsById.get(need.vendorId), account)
+      need,
+      vendorsById.get(need.vendorId),
+      account,
+    )
     return missingResourceUrlPatterns(account, required).length === 0
   }
   const allSatisfied = needs.every(need => accountSatisfies(need, accountFor(need.gatekeeperId)))
@@ -411,6 +411,8 @@ export default function ObserverConfigModal({
                         </Select>
                       )}
 
+                      {/* Scope expansion also replaces expired credentials, so prefer this over the
+                          plain re-authentication path when both apply. */}
                       {chosen && missing.length > 0 && (
                         <button
                           type="button"

--- a/packages/workshop-frontend/src/ObserverConfigModal.tsx
+++ b/packages/workshop-frontend/src/ObserverConfigModal.tsx
@@ -5,10 +5,16 @@ import { RpcStub, RpcTarget } from 'capnweb'
 import {
   AuthenticatedApi,
   ConnectedAccountsSubscriber,
+  GatekeeperVendorInfo,
   ObserverBindingNeed,
   ObserverAccountChoice,
 } from '@gadgets/workshop-shared/api'
-import { AccountDescription, VendorDescription, SupportedResource } from '@gadgets/workshop-shared/gatekeeper'
+import {
+  AccountDescription,
+  VendorDescription,
+  SupportedResource,
+  resolveRequestedResource,
+} from '@gadgets/workshop-shared/gatekeeper'
 import { WorkshopButton } from './components/WorkshopControls'
 import Avatar from './components/Avatar'
 
@@ -27,6 +33,7 @@ interface AccountInfo {
   description: AccountDescription
   vendor: VendorDescription
   vendorId: string
+  supportedResources: SupportedResource[]
   credentialsValid: boolean
 }
 
@@ -34,6 +41,37 @@ interface AccountInfo {
 // for an account that has since been disconnected (so `accounts` no longer has it).
 function accountLabel(account: AccountInfo | undefined, accountId: number): string {
   return account?.description.uniqueName || account?.description.displayName || `Account ${accountId}`
+}
+
+/**
+ * Returns the grantable resource type needed to verify one observer binding.
+ *
+ * Account metadata is preferred because it reflects the resources currently available to that
+ * account; vendor metadata is the fallback used before an account has been connected. Non-grantable
+ * resources require no OAuth scope expansion.
+ */
+function requiredResourceUrlPatterns(
+  need: ObserverBindingNeed,
+  vendor: GatekeeperVendorInfo | undefined,
+  account?: AccountInfo,
+): string[] {
+  const supportedResources = account?.supportedResources.length
+    ? account.supportedResources
+    : vendor?.supportedResources
+  if (!supportedResources) return []
+  const resolved = resolveRequestedResource(supportedResources, need.resourceUrl)
+  return resolved.ok && resolved.resource.grantable ? [resolved.resource.urlPattern] : []
+}
+
+/**
+ * Filters required resource types down to those the account has not granted yet.
+ *
+ * An omitted granted-resource list denotes a legacy or full-scope account and is therefore treated
+ * as satisfying every requirement.
+ */
+function missingResourceUrlPatterns(account: AccountInfo, required: string[]): string[] {
+  const granted = account.description.grantedResourceUrlPatterns
+  return granted === undefined ? [] : required.filter(pattern => !granted.includes(pattern))
 }
 
 interface ObserverConfigModalProps {
@@ -55,11 +93,13 @@ export default function ObserverConfigModal({
   const [ready, setReady] = useState(false)
   // gatekeeperId -> chosen accountId (undefined = not yet chosen).
   const [choices, setChoices] = useState<Record<number, number | undefined>>({})
-  // Vendor descriptions keyed by vendorId, for display (name + logo) even when no account exists.
-  const [vendorsById, setVendorsById] = useState<Map<string, VendorDescription>>(new Map())
+  // Vendor metadata keyed by vendorId, used both for display and to resolve the resource scopes each
+  // observer binding needs.
+  const [vendorsById, setVendorsById] = useState<Map<string, GatekeeperVendorInfo>>(new Map())
   const [vendorsReady, setVendorsReady] = useState(false)
   const [connecting, setConnecting] = useState<string | null>(null)
   const [reconnecting, setReconnecting] = useState<number | null>(null)
+  const [granting, setGranting] = useState<number | null>(null)
 
   // The subscriber closure (created once) reads the in-flight connect target through this ref so it
   // can clear it when the freshly-connected account arrives.
@@ -75,17 +115,18 @@ export default function ObserverConfigModal({
         id: number,
         description: AccountDescription,
         vendor: VendorDescription,
-        _supportedResources: SupportedResource[] = [],
+        supportedResources: SupportedResource[] = [],
         credentialsValid: boolean = true,
         vendorId: string = '',
       ) {
         setAccounts(prev => {
           const next = new Map(prev)
-          next.set(id, { id, description, vendor, vendorId, credentialsValid })
+          next.set(id, { id, description, vendor, vendorId, supportedResources, credentialsValid })
           return next
         })
         if (credentialsValid) {
           setReconnecting(r => (r === id ? null : r))
+          setGranting(g => (g === id ? null : g))
           // If we were waiting on a connect for this vendor, it's done.
           if (connectingRef.current === vendorId) {
             connectingRef.current = null
@@ -125,7 +166,7 @@ export default function ObserverConfigModal({
     }
   }, [authenticatedApi])
 
-  // ── load vendor descriptions for display (names + logos) ──────────────────────
+  // ── load vendor metadata for display and resource-scope resolution ─────────────
   useEffect(() => {
     let cancelled = false
     Promise.all([
@@ -134,8 +175,8 @@ export default function ObserverConfigModal({
     ])
       .then(([vendors, addable]) => {
         if (cancelled) return
-        const map = new Map<string, VendorDescription>()
-        for (const v of [...vendors, ...addable]) map.set(v.id, v.description)
+        const map = new Map<string, GatekeeperVendorInfo>()
+        for (const vendor of [...vendors, ...addable]) map.set(vendor.id, vendor)
         setVendorsById(map)
         setVendorsReady(true)
       })
@@ -180,10 +221,15 @@ export default function ObserverConfigModal({
     connectingRef.current = vendorId
     setConnecting(vendorId)
     try {
-      if (vendorsById.get(vendorId)?.autoProvisionsAccount) {
+      const vendor = vendorsById.get(vendorId)
+      if (vendor?.description.autoProvisionsAccount) {
         await authenticatedApi.provisionAmbientAccount(vendorId)
       } else {
-        const { url } = await authenticatedApi.connectAccount(vendorId)
+        const required = requiredResourceUrlPatterns(need, vendor)
+        const { url } = await authenticatedApi.connectAccount(
+          vendorId,
+          required.length > 0 ? required : undefined,
+        )
         window.open(url, '_blank', 'noopener,noreferrer')
       }
     } catch (err) {
@@ -207,12 +253,36 @@ export default function ObserverConfigModal({
     }
   }
 
-  // A binding is satisfied only when its chosen account exists and its credentials are valid.
+  const handleGrantResourceAccess = async (need: ObserverBindingNeed, account: AccountInfo) => {
+    const required = requiredResourceUrlPatterns(
+      need, vendorsById.get(need.vendorId), account)
+    const missing = missingResourceUrlPatterns(account, required)
+    if (missing.length === 0) return
+    setGranting(account.id)
+    try {
+      const { url } = await authenticatedApi.ensureAccountResources(account.id, missing)
+      if (url) window.open(url, '_blank', 'noopener,noreferrer')
+      else setGranting(null)
+    } catch (err) {
+      console.error('Failed to request additional access:', err)
+      toasts.add({ title: 'Failed to request additional access', variant: 'error' })
+      setGranting(null)
+    }
+  }
+
+  // A binding is satisfied only when its chosen account has valid credentials and every grantable
+  // resource type needed for observer verification.
   const accountFor = (gatekeeperId: number): AccountInfo | undefined => {
     const id = choices[gatekeeperId]
     return id === undefined ? undefined : accounts.get(id)
   }
-  const allSatisfied = needs.every(n => accountFor(n.gatekeeperId)?.credentialsValid)
+  const accountSatisfies = (need: ObserverBindingNeed, account: AccountInfo | undefined) => {
+    if (!account?.credentialsValid) return false
+    const required = requiredResourceUrlPatterns(
+      need, vendorsById.get(need.vendorId), account)
+    return missingResourceUrlPatterns(account, required).length === 0
+  }
+  const allSatisfied = needs.every(need => accountSatisfies(need, accountFor(need.gatekeeperId)))
 
   const handleConfirm = () => {
     const result: ObserverAccountChoice[] = []
@@ -250,9 +320,12 @@ export default function ObserverConfigModal({
           <div className="flex flex-col gap-4 mt-5">
             {needs.map(need => {
               const matching = [...accounts.values()].filter(a => a.vendorId === need.vendorId)
-              const vendor = matching[0]?.vendor ?? vendorsById.get(need.vendorId)
+              const vendorInfo = vendorsById.get(need.vendorId)
+              const vendor = matching[0]?.vendor ?? vendorInfo?.description
               const vendorName = vendor?.displayName || need.vendorId || 'service'
               const chosen = accountFor(need.gatekeeperId)
+              const required = requiredResourceUrlPatterns(need, vendorInfo, chosen)
+              const missing = chosen ? missingResourceUrlPatterns(chosen, required) : []
 
               return (
                 <div key={need.gatekeeperId} className="rounded-xl border border-kumo-line bg-kumo-base p-4">
@@ -309,7 +382,7 @@ export default function ObserverConfigModal({
                               {accountLabel(matching[0], matching[0].id)}
                             </div>
                           </div>
-                          {matching[0].credentialsValid && (
+                          {accountSatisfies(need, matching[0]) && (
                             <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-kumo-success">
                               <CheckCircle size={15} weight="fill" /> Ready
                             </span>
@@ -338,12 +411,31 @@ export default function ObserverConfigModal({
                         </Select>
                       )}
 
+                      {chosen && missing.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={() => handleGrantResourceAccess(need, chosen)}
+                          disabled={granting === chosen.id}
+                          className="flex items-center gap-1.5 text-xs text-kumo-warning hover:underline disabled:opacity-60"
+                        >
+                          {granting === chosen.id ? (
+                            <ArrowClockwise size={12} className="animate-spin" />
+                          ) : (
+                            <Warning size={12} />
+                          )}
+                          {granting === chosen.id
+                            ? 'Waiting for access…'
+                            : 'Grant the access needed to verify this resource'}
+                        </button>
+                      )}
+
                       {/* Offer re-authentication when we know the credentials are stale, and also
                           when this is the account that just failed verification: a gatekeeper that
                           rejects an observer on an auth error doesn't always tell the Workshop, so
                           `credentialsValid` can still read true. reconnectAccount() is documented as
                           safe for an account that merely *may* be expiring. */}
-                      {chosen && (!chosen.credentialsValid || chosen.id === need.failure?.accountId) && (
+                      {chosen && missing.length === 0 &&
+                        (!chosen.credentialsValid || chosen.id === need.failure?.accountId) && (
                         <button
                           type="button"
                           onClick={() => handleReconnect(chosen.id)}


### PR DESCRIPTION
Ensures that the OAuth scopes requested during observer verification cover the resource types that need to be verified.

Fixes situations like these:
1. A user receives a shared Gadget that has observed data from a Google service such as Sheets or Docs
2. The user reaches the observer verification page without an existing Google authentication grant
3. The authentication flow requests only the Gmail scope
4. Observer verification attempts to check the Sheets, Docs, or other relevant Google resource using that insufficient grant
5. The user is rejected as having no access, even though their Google account does have access to the observed resource