### PR TITLE
Let admins choose which built-in AI models are offered to users

### DIFF
--- a/packages/workshop-backend/__tests__/admin-config.test.ts
+++ b/packages/workshop-backend/__tests__/admin-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_ADMIN_CONFIG, defaultOutputFormatId, parseAdminConfig, reorderFormats, resolveFormatOutput, sanitizeOutputOverrides, serializeAdminConfig } from "../src/admin-config.js";
+import { DEFAULT_ADMIN_CONFIG, defaultOutputFormatId, isAiModelDisabled, parseAdminConfig, reorderFormats, resolveFormatOutput, sanitizeOutputOverrides, serializeAdminConfig } from "../src/admin-config.js";
 
 describe("parseAdminConfig", () => {
   it("backfills fields missing from a config persisted before they existed", () => {
@@ -30,6 +30,23 @@ describe("parseAdminConfig", () => {
       { blueprintId: "good", enabled: true, agentHint: "prefer me" },
       { blueprintId: "defaults-enabled", enabled: true },
     ]);
+  });
+
+  it("keeps disabled AI model ids case-sensitive and drops non-strings", () => {
+    // Model ids like "@cf/moonshotai/kimi-k2.7-code" are case-sensitive, unlike vendor ids, so
+    // parsing must not lowercase them or the disable would silently stop matching.
+    let config = parseAdminConfig(JSON.stringify({
+      disabledAiModels: ["@cf/moonshotai/Kimi-K2.7-code", 42, null, "gpt-5.6-sol"],
+    }));
+
+    expect(config.disabledAiModels).toEqual(["@cf/moonshotai/Kimi-K2.7-code", "gpt-5.6-sol"]);
+    expect(isAiModelDisabled(config, "gpt-5.6-sol")).toBe(true);
+    expect(isAiModelDisabled(config, "@cf/moonshotai/kimi-k2.7-code")).toBe(false);
+  });
+
+  it("survives a serialize/parse round trip with disabled AI models", () => {
+    let config = parseAdminConfig(JSON.stringify({ disabledAiModels: ["gpt-5.6-sol"] }));
+    expect(parseAdminConfig(serializeAdminConfig(config))).toEqual(config);
   });
 
   // Everything downstream keys formats by blueprint id; setFormatOrder() in particular treats the

--- a/packages/workshop-backend/__tests__/ai-gateway.test.ts
+++ b/packages/workshop-backend/__tests__/ai-gateway.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AiGatewayLogRetryableError,
+  getAiGatewayConfig,
   getAiGatewayLogCost,
 } from "../src/ai-gateway.js";
 
@@ -12,6 +13,24 @@ function env(overrides: Partial<Cloudflare.Env> = {}): Cloudflare.Env {
     ...overrides,
   } as Cloudflare.Env;
 }
+
+describe("getModelCatalog", () => {
+  it("lists every suggested model of the enabled providers, with its provider", () => {
+    let gwConfig = getAiGatewayConfig(env({
+      CF_AI_GATEWAY_ACCOUNT_ID: "account-id",
+      CF_AI_GATEWAY_API_TOKEN: "token",
+      CF_AI_GATEWAY_PROVIDERS: "cloudflare,openai",
+    }))!;
+
+    let catalog = gwConfig.getModelCatalog();
+    expect(catalog.length).toBeGreaterThan(0);
+    // Every entry belongs to an enabled provider; disabled providers contribute nothing.
+    expect(new Set(catalog.map(m => m.provider))).toEqual(new Set(["cloudflare", "openai"]));
+    // Matches what users are offered, entry for entry (the catalog only adds the provider).
+    expect(catalog.map(m => ({ type: "agent", id: m.id, name: m.name })))
+        .toEqual(gwConfig.getModelList());
+  });
+});
 
 describe("getAiGatewayLogCost", () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/packages/workshop-backend/src/admin-config.ts
+++ b/packages/workshop-backend/src/admin-config.ts
@@ -34,6 +34,10 @@ export type AdminConfig = {
   disabledResources: Record<string, string[]>;
   // Fully-disabled gatekeeper vendor ids.
   disabledGatekeepers: string[];
+  // Disabled AI Gateway built-in model ids (see SUGGESTED_MODELS). A disabled model is hidden from
+  // users and refused at resolution; user-added custom models are unaffected. Only meaningful in
+  // AI Gateway mode. Ids are case-sensitive (e.g. "@cf/moonshotai/kimi-k2.7-code").
+  disabledAiModels: string[];
   // Per-vendor provisioning mode for auto-provisioning ("ambient") gatekeepers (e.g. the Context
   // Library). Absent ⇒ the default ("optional", see provisioning-policy.ts). Only meaningful for
   // vendors that declare autoProvisionsAccount.
@@ -75,6 +79,7 @@ export const DEFAULT_ADMIN_CONFIG: AdminConfig = {
   accentColor: "",
   disabledResources: {},
   disabledGatekeepers: [],
+  disabledAiModels: [],
   ambientGatekeeperModes: {},
   formats: [],
 };
@@ -277,6 +282,8 @@ export function parseAdminConfig(raw: string | null): AdminConfig {
       accentColor: typeof p.accentColor === "string" ? p.accentColor : "",
       disabledResources,
       disabledGatekeepers: strings(p.disabledGatekeepers).map(v => v.toLowerCase()),
+      // Model ids are case-sensitive, unlike vendor ids.
+      disabledAiModels: strings(p.disabledAiModels),
       ambientGatekeeperModes,
       formats: parseFormats(p.formats),
     };
@@ -306,6 +313,12 @@ export function filterEnabledResources(
   let disabled = config.disabledResources[vendorId];
   if (!disabled || disabled.length === 0) return resources;
   return resources.filter(r => !disabled.includes(r.urlPattern));
+}
+
+// --- AI-model-disable helpers ---
+
+export function isAiModelDisabled(config: AdminConfig, modelId: string): boolean {
+  return config.disabledAiModels.includes(modelId);
 }
 
 // --- Agent system-prompt instructions ---

--- a/packages/workshop-backend/src/admin-settings.ts
+++ b/packages/workshop-backend/src/admin-settings.ts
@@ -1,4 +1,4 @@
-import { AdminApi, AdminFormat, AdminFormatPatch, AdminResourceVendor, AdminSettingsView, AmbientGatekeeperMode, BannerColor, BlueprintPublicInfo, MAX_ANNOUNCEMENT_LENGTH, MAX_INSTANCE_INSTRUCTIONS_LENGTH, MAX_SITE_NAME_LENGTH, isAmbientGatekeeperMode, isBannerColor, isHexColor } from '@gadgets/workshop-shared/api';
+import { AdminAiModel, AdminApi, AdminFormat, AdminFormatPatch, AdminResourceVendor, AdminSettingsView, AmbientGatekeeperMode, BannerColor, BlueprintPublicInfo, MAX_ANNOUNCEMENT_LENGTH, MAX_INSTANCE_INSTRUCTIONS_LENGTH, MAX_SITE_NAME_LENGTH, SUGGESTED_MODELS, isAmbientGatekeeperMode, isBannerColor, isHexColor } from '@gadgets/workshop-shared/api';
 import { GatekeeperVendor } from '@gadgets/workshop-shared/gatekeeper';
 import { DurableObject } from 'cloudflare:workers';
 import { RpcTarget } from 'capnweb';
@@ -9,6 +9,7 @@ import { ADMIN_CONFIG_KEY, FEATURED_BLUEPRINTS_KEY, isReservedBlueprintKey, pars
 import { AdminConfig, DEFAULT_ADMIN_CONFIG, FormatCuration, MAX_AGENT_HINT, defaultOutputFormatId, listPromotedFormats, reorderFormats, sanitizeOutputOverrides, serializeAdminConfig } from './admin-config.js';
 import { SITE_LOGO_R2_KEY, siteLogoImage, validateSiteLogo } from './site-logo.js';
 import { ambientGatekeeperMode, DEFAULT_AMBIENT_GATEKEEPER_MODE } from './provisioning-policy.js';
+import { getAiGatewayConfig } from './ai-gateway.js';
 import { buildGatekeeperVendorMap } from './auth/auth-vendors.js';
 import { UserDurableObject } from './user.js';
 import { formatBlueprintsManifestVersion, installFormatBlueprints } from './format-blueprints.js';
@@ -311,7 +312,21 @@ export class AdminSettings extends DurableObject<Cloudflare.Env> {
       accentColor: config.accentColor,
       resourceVendors: await this.#listResourceConfig(config, adminUserId),
       formats: await this.#listFormatConfig(config),
+      aiModels: this.#listAiModelConfig(config),
     };
+  }
+
+  // Admin view of the AI Gateway built-in models with their enabled state. Unlike the user-facing
+  // model list, this does NOT hide disabled models (so admins can re-enable them). Empty outside
+  // AI Gateway mode, where there are no deployment-managed models to curate.
+  #listAiModelConfig(config: AdminConfig): AdminAiModel[] {
+    let gwConfig = getAiGatewayConfig(this.env);
+    if (!gwConfig) return [];
+    let disabled = new Set(config.disabledAiModels);
+    return gwConfig.getModelCatalog().map(model => ({
+      ...model,
+      enabled: !disabled.has(model.id),
+    }));
   }
 
   // --- Standard output formats ---
@@ -422,6 +437,15 @@ export class AdminSettings extends DurableObject<Cloudflare.Env> {
       if (enabled) disabled.delete(urlPattern); else disabled.add(urlPattern);
       if (disabled.size === 0) delete map[vendorId]; else map[vendorId] = [...disabled];
       return { ...config, disabledResources: map };
+    });
+  }
+
+  // Enable/disable a single AI Gateway built-in model atomically (read-modify-write within the DO).
+  async setAiModelEnabled(modelId: string, enabled: boolean): Promise<void> {
+    await this.#mutateAdminConfig(config => {
+      let disabled = new Set(config.disabledAiModels);
+      if (enabled) disabled.delete(modelId); else disabled.add(modelId);
+      return { ...config, disabledAiModels: [...disabled] };
     });
   }
 
@@ -594,6 +618,15 @@ export class AdminApiImpl extends RpcTarget implements AdminApi {
       throw new Error(`Invalid gatekeeper mode: ${mode}`);
     }
     return this.admin.setGatekeeperMode(vendorId, mode);
+  }
+
+  setAiModelEnabled(modelId: string, enabled: boolean): Promise<void> {
+    // Validated against the full suggested catalog rather than the currently-enabled providers, so
+    // an admin's disable survives provider-list changes and can be set before enabling a provider.
+    if (!Object.values(SUGGESTED_MODELS).some(models => modelId in models)) {
+      throw new Error(`Unknown built-in model: ${modelId}`);
+    }
+    return this.admin.setAiModelEnabled(modelId, enabled);
   }
 
   async setAnnouncement(text: string): Promise<void> {

--- a/packages/workshop-backend/src/ai-gateway.ts
+++ b/packages/workshop-backend/src/ai-gateway.ts
@@ -39,6 +39,23 @@ export class AiGatewayConfig {
   }
 
   /**
+   * Every built-in model this gateway configuration offers, with its provider — the admin
+   * panel's view. Unlike the user-facing model list, this is never filtered by admin curation:
+   * the panel exists to show disabled models so they can be re-enabled.
+   */
+  getModelCatalog(): { id: string, name: string, provider: string }[] {
+    let result: { id: string, name: string, provider: string }[] = [];
+    for (let [provider, models] of Object.entries(SUGGESTED_MODELS)) {
+      if (this.providers.has(provider)) {
+        for (let [id, model] of Object.entries(models)) {
+          result.push({ id, name: model.name, provider });
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
    * Get the list of models available through AI Gateway, as AiChatAuthorInfo entries.
    */
   getModelList(): AiChatAuthorInfo[] {

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -10,7 +10,7 @@ import { getAiGatewayConfig } from "./ai-gateway.js";
 import { utcDayKey, nextUtcMidnightIso, DailyQuotaResult } from "./ai-gateway-billing/limits/config.js";
 import type { AdminSettings } from "./admin-settings.js";
 import { isReservedBlueprintKey, readBlueprintKvRecord } from "./blueprint-archive.js";
-import { filterEnabledResources, isResourceDisabled, readAdminConfig } from "./admin-config.js";
+import { filterEnabledResources, isAiModelDisabled, isResourceDisabled, readAdminConfig } from "./admin-config.js";
 import { buildGatekeeperVendorMap } from "./auth/auth-vendors.js";
 
 const logger = createWorkshopLogger("workshop.user");
@@ -505,11 +505,14 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
   async listModels(): Promise<AiChatAuthorInfo[]> {
     let result: AiChatAuthorInfo[] = [];
 
-    // When AI Gateway mode is active, include all suggested models for enabled providers.
+    // When AI Gateway mode is active, include all suggested models for enabled providers, except
+    // those the deployment admin has disabled.
     let gwConfig = getAiGatewayConfig(this.env);
     let gwModelIds = new Set<string>();
     if (gwConfig) {
+      let adminConfig = await readAdminConfig(this.env);
       for (let entry of gwConfig.getModelList()) {
+        if (isAiModelDisabled(adminConfig, entry.id)) continue;
         result.push(entry);
         gwModelIds.add(entry.id);
       }
@@ -528,6 +531,11 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     let gwConfig = getAiGatewayConfig(this.env);
     if (gwConfig && !gwConfig.providers.has(config.provider)) {
       throw new Error(`Provider "${config.provider}" is not available in AI Gateway mode.`);
+    }
+    // An admin-disabled built-in can't be re-added as a custom model: in AI Gateway mode a custom
+    // model routes through the platform gateway anyway, so allowing it would undo the disable.
+    if (isAiModelDisabled(await readAdminConfig(this.env), config.model)) {
+      throw new Error(`Model "${config.model}" has been disabled by the administrator.`);
     }
 
     profile.type = "agent";
@@ -567,10 +575,11 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
 
   async setPreferredModel(id: string | null): Promise<void> {
     if (id !== null) {
-      // Validate that the model exists in the user's configured models or as a gateway model.
+      // Validate that the model exists in the user's configured models or as a gateway model, and
+      // that the deployment admin has not disabled it.
       let gwConfig = getAiGatewayConfig(this.env);
       let exists = !!this.storage.aiModels.get(id) || !!gwConfig?.resolveModel(id);
-      if (!exists) {
+      if (!exists || isAiModelDisabled(await readAdminConfig(this.env), id)) {
         throw new Error(`No such model: ${id}`);
       }
     }
@@ -670,6 +679,11 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
       profile: this.storage.profile.get()
     };
     if (modelId) {
+      // Refuse a model the deployment admin has disabled, whether it resolves as a gateway
+      // built-in or as a user-added custom model: a chat pinned to it must pick another model.
+      if (isAiModelDisabled(await readAdminConfig(this.env), modelId)) {
+        throw new Error(`Model "${modelId}" has been disabled by the administrator.`);
+      }
       // In AI Gateway mode, resolve gateway models first.
       if (gwConfig) {
         result.aiModel = gwConfig.resolveModel(modelId);

--- a/packages/workshop-frontend/src/AdminPage.tsx
+++ b/packages/workshop-frontend/src/AdminPage.tsx
@@ -3,7 +3,7 @@ import { RpcStub } from 'capnweb'
 import { Switch, Textarea, Input, Button, Tabs, useKumoToastManager } from '@cloudflare/kumo'
 import { Hexagon, ShieldWarning, UserPlus } from '@phosphor-icons/react'
 import { useAuthenticatedApi } from './AuthContext'
-import { AdminApi, AdminFormat, AdminResourceVendor, AmbientGatekeeperMode, MAX_INSTANCE_INSTRUCTIONS_LENGTH, MAX_ANNOUNCEMENT_LENGTH, MAX_SITE_NAME_LENGTH, DEFAULT_SITE_NAME, BannerColor, BANNER_COLORS, DEFAULT_BANNER_COLOR } from '@gadgets/workshop-shared/api'
+import { AdminAiModel, AdminApi, AdminFormat, AdminResourceVendor, AmbientGatekeeperMode, MAX_INSTANCE_INSTRUCTIONS_LENGTH, MAX_ANNOUNCEMENT_LENGTH, MAX_SITE_NAME_LENGTH, DEFAULT_SITE_NAME, BannerColor, BANNER_COLORS, DEFAULT_BANNER_COLOR } from '@gadgets/workshop-shared/api'
 import { applyAccentColor, DEFAULT_ACCENT_COLOR } from './theme'
 import { cacheBustSiteLogoUrl, prepareSiteLogo } from './siteLogoUtils'
 import SiteLogo from './components/SiteLogo'
@@ -80,6 +80,9 @@ export default function AdminPage() {
   const [resourceVendors, setResourceVendors] = useState<AdminResourceVendor[]>([])
   const [resourceBusy, setResourceBusy] = useState<Set<string>>(new Set())
 
+  // AI Gateway built-in models with their enabled state (empty outside AI Gateway mode).
+  const [aiModels, setAiModels] = useState<AdminAiModel[]>([])
+
   const [activeTab, setActiveTab] = useState('general')
 
   // Promoted output formats, in menu order (see AdminFormatsPanel).
@@ -104,6 +107,7 @@ export default function AdminPage() {
     setSavedAccent(view.accentColor)
     setAccentDraft(view.accentColor)
     setFormats(view.formats)
+    setAiModels(view.aiModels)
   }
 
   // Mint the admin capability once (the access check happens server-side) and load settings.
@@ -150,12 +154,13 @@ export default function AdminPage() {
     return () => { applyAccentColor(savedAccent) }
   }, [accentDraft, savedAccent])
 
-  // Re-fetch just the gatekeeper/resource state (used to revert an optimistic toggle on error).
-  // Leaves the General-tab drafts untouched.
+  // Re-fetch just the gatekeeper/resource and AI-model state (used to revert an optimistic toggle
+  // on error). Leaves the General-tab drafts untouched.
   const reloadResources = async () => {
     if (!admin) return
     const view = await admin.api.getSettings()
     setResourceVendors(view.resourceVendors)
+    setAiModels(view.aiModels)
   }
 
   const handleResourceToggle = async (vendorId: string, urlPattern: string, enabled: boolean) => {
@@ -216,6 +221,27 @@ export default function AdminPage() {
     )
     try {
       await admin.api.setGatekeeperMode(vendorId, mode)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Update failed'
+      toasts.add({ title: message, variant: 'error' })
+      await reloadResources().catch(() => {})
+    } finally {
+      setResourceBusy((prev) => {
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+    }
+  }
+
+  const handleAiModelToggle = async (modelId: string, enabled: boolean) => {
+    if (!admin) return
+    const key = `model ${modelId}`
+    setResourceBusy((prev) => new Set(prev).add(key))
+    // Optimistic update.
+    setAiModels((prev) => prev.map((m) => (m.id === modelId ? { ...m, enabled } : m)))
+    try {
+      await admin.api.setAiModelEnabled(modelId, enabled)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Update failed'
       toasts.add({ title: message, variant: 'error' })
@@ -402,6 +428,7 @@ export default function AdminPage() {
         tabs={[
           { value: 'general', label: 'General' },
           { value: 'gatekeepers', label: 'Gatekeepers' },
+          { value: 'models', label: 'AI models' },
           { value: 'formats', label: 'Formats' },
           { value: 'access', label: 'Access' },
         ]}
@@ -948,6 +975,63 @@ export default function AdminPage() {
                 )}
               </div>
             )})}
+          </div>
+        </div>
+      )}
+
+      {/* Built-in AI model curation */}
+      {activeTab === 'models' && (
+        <div className="bg-kumo-elevated border border-kumo-line rounded-xl p-6">
+          <h2 className="text-lg font-semibold text-kumo-strong mb-1">AI models</h2>
+          <p className="text-sm text-kumo-subtle mb-5">
+            Turn built-in models on or off for your users. A disabled model disappears from model
+            pickers and can no longer be used, so you can offer a provider without offering every
+            one of its models. Custom models users add with their own API tokens are not affected.
+          </p>
+
+          {aiModels.length === 0 && (
+            <p className="text-sm text-kumo-subtle">
+              This deployment has no built-in models to curate. Built-in models exist only in AI
+              Gateway mode; users add their own models from the AI providers page.
+            </p>
+          )}
+
+          <div className="space-y-2">
+            {aiModels.map((model) => {
+              const key = `model ${model.id}`
+              return (
+                <div
+                  key={model.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => !resourceBusy.has(key) && handleAiModelToggle(model.id, !model.enabled)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      if (!resourceBusy.has(key)) handleAiModelToggle(model.id, !model.enabled)
+                    }
+                  }}
+                  className="flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer hover:bg-kumo-tint"
+                >
+                  <div className="flex-1 min-w-0">
+                    <span className={`block text-sm font-medium ${model.enabled ? 'text-kumo-default' : 'text-kumo-subtle'}`}>
+                      {model.name}
+                    </span>
+                    <span className="block text-xs text-kumo-subtle font-mono truncate">{model.id}</span>
+                  </div>
+                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-md bg-kumo-tint text-kumo-subtle border border-kumo-line">
+                    {model.provider}
+                  </span>
+                  <span onClick={(e) => e.stopPropagation()}>
+                    <Switch
+                      checked={model.enabled}
+                      disabled={resourceBusy.has(key)}
+                      onCheckedChange={(enabled) => handleAiModelToggle(model.id, enabled)}
+                    />
+                  </span>
+                </div>
+              )
+            })}
           </div>
         </div>
       )}

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -651,6 +651,19 @@ export type AdminResourceVendor = {
   | { autoProvisions: true; ambientMode: AmbientGatekeeperMode }
 );
 
+// One AI Gateway built-in model, as the admin AI-models panel sees it. Only present in AI Gateway
+// mode; custom models users add with their own tokens are not curated here.
+export type AdminAiModel = {
+  // The model id (e.g. "@cf/moonshotai/kimi-k2.7-code").
+  id: string;
+  name: string;
+  // The gateway provider offering it (e.g. "cloudflare", "openai").
+  provider: string;
+  // Offered to users. Disabling hides the model from model lists and refuses new use of it, so an
+  // org can offer a provider without offering every one of its models.
+  enabled: boolean;
+};
+
 // A connectable third-party service: its vendor id, display metadata, and the resource types it
 // offers (empty for an auto-provisioning gatekeeper like the Context Library). Returned by both
 // listGatekeeperVendors and listAddableGatekeepers so the connect UI treats both uniformly.
@@ -705,6 +718,9 @@ export type AdminSettingsView = {
   resourceVendors: AdminResourceVendor[];
   // The blueprints promoted as standard output formats, in menu order (including disabled ones).
   formats: AdminFormat[];
+  // AI Gateway built-in models with their enabled state (not hidden when disabled). Empty outside
+  // AI Gateway mode, where there are no deployment-managed models to curate.
+  aiModels: AdminAiModel[];
 };
 
 // One promoted blueprint, as the admin Formats panel sees it: the deployment's curation plus
@@ -777,6 +793,11 @@ export interface AdminApi {
   // gadget already holds, and 'disabled' leaves an ambient account's data dormant rather than deleting
   // it.
   setGatekeeperMode(vendorId: string, mode: AmbientGatekeeperMode): Promise<void>;
+
+  // Enable or disable one AI Gateway built-in model for users. Disabling hides it from model lists
+  // and refuses new use of it (chats pinned to it must pick another model); user-added custom
+  // models are unaffected. Throws for an id that is not a known built-in model.
+  setAiModelEnabled(modelId: string, enabled: boolean): Promise<void>;
 
   // Set the top-bar notice (centered text in the top navigation bar). Pass "" to clear. Rejects over
   // MAX_ANNOUNCEMENT_LENGTH.


### PR DESCRIPTION
Adds a disabledAiModels set to the deployment admin config. Built-in AI Gateway models can now be disabled individually from a new "AI models" tab in /admin, so a deployment can offer a provider without offering every one of its models (resolves the SUGGESTED_MODELS TODO about needing an admin option to disable specific models).

A disabled model is hidden from user model lists, refused as a chat or preferred model, and cannot be re-added as a custom model (which would otherwise route through the platform gateway and undo the disable). User-added custom models are otherwise unaffected, as is the internal quick model. Follows the disabledGatekeepers pattern: everything stays enabled by default and the admin UI opts models out.