### PR TITLE
Fix gatekeeper app navigation after OAuth

### DIFF
--- a/packages/workshop-frontend/src/routes/gatekeepers.tsx
+++ b/packages/workshop-frontend/src/routes/gatekeepers.tsx
@@ -540,6 +540,8 @@ function ConnectorsPage() {
           credentialsValid,
         })
         setAccounts(Array.from(accountMap.values()))
+        // OAuth connections arrive through this subscription, after the connect popup opens.
+        if (description.providesUi) refreshGatekeeperApps(authenticatedApi)
       }
       remove(id: number) {
         accountMap.delete(id)


### PR DESCRIPTION
## What

Refresh the cached gatekeeper app list when the connected-account subscription adds an account that provides a management UI.

OAuth connections arrive through this subscription after the connect popup opens. Without the refresh, the account appears under Gatekeepers but its app remains absent from navigation until a full page reload. The ambient provisioning path already performs the same cache invalidation explicitly.

## Verification

- `pnpm --filter @gadgets/workshop-frontend types:check`
- `pnpm --filter @gadgets/workshop-frontend test` (24 files, 115 tests)
- `pnpm lint:check`