### PR TITLE
security: fix SSRF blocklist bypass, Markdown injection in approval prompts, and reflected error params

### DIFF
--- a/packages/gatekeeper-cloudflare/src/cloudflare.ts
+++ b/packages/gatekeeper-cloudflare/src/cloudflare.ts
@@ -123,7 +123,10 @@ export default {
     } else if (relPath === "/oauth") {
       const error = url.searchParams.get("error");
       if (error) {
-        return new Response(`${error}: ${url.searchParams.get("error_description")}`);
+        // Security fix: Set Content-Type to text/plain to prevent XSS via reflected parameters
+        return new Response(`${error}: ${url.searchParams.get("error_description")}`, {
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        });
       }
       const state = url.searchParams.get("state");
       if (!state) return new Response("Error: no 'state' provided");

--- a/packages/mcp-shared/src/endpoint.ts
+++ b/packages/mcp-shared/src/endpoint.ts
@@ -33,12 +33,33 @@ const BLOCKED_HOST_PATTERNS = [
 // spellings of the same address: `http://2130706433/` and `http://0x7f000001/` are both 127.0.0.1,
 // and `[::ffff:127.0.0.1]` is its IPv4-mapped IPv6 form. Each becomes dotted-quad.
 function normalizeHost(hostname: string): string {
+  // Security fix: Strip IPv6 zone IDs and handle IPv4-compatible IPv6 to prevent SSRF bypass
+  hostname = hostname.replace(/(%25|%)[^\]]+\]$/, "]");
+  const compat = /^\[::([^\]]+)\]$/i.exec(hostname);
+  if (compat && compat[1].includes(".")) {
+    hostname = compat[1];
+  }
+
   // `URL` rewrites an IPv4-mapped IPv6 address into hex groups, so `[::ffff:127.0.0.1]` arrives as
   // `[::ffff:7f00:1]` and the dotted-quad spelling is never what we see.
   const mapped = /^\[::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})\]$/i.exec(hostname);
   if (mapped) {
     const [high, low] = [parseInt(mapped[1], 16), parseInt(mapped[2], 16)];
     return [high >>> 8, high & 0xff, low >>> 8, low & 0xff].join(".");
+  }
+
+  // Security fix: Parse each octet individually to handle mixed/hex/octal dotted notation
+  const octets = hostname.split(".");
+  if (octets.length === 4) {
+    const parsedOctets = octets.map(octet => {
+      if (/^0[xX][0-9a-fA-F]+$/.test(octet)) return parseInt(octet, 16);
+      if (/^0[0-7]+$/.test(octet)) return parseInt(octet, 8);
+      if (/^(0|[1-9][0-9]*)$/.test(octet)) return parseInt(octet, 10);
+      return NaN;
+    });
+    if (parsedOctets.every(o => Number.isInteger(o) && o >= 0 && o <= 255)) {
+      return parsedOctets.join(".");
+    }
   }
 
   // A bare integer (decimal, hex, or octal) is a valid IPv4 address to most resolvers.

--- a/packages/mcp-shared/src/tools.ts
+++ b/packages/mcp-shared/src/tools.ts
@@ -159,9 +159,14 @@ function defuseFences(text: string): string {
 // and headings are neutralized, the text is capped, and the rest is block-quoted.
 function quoteUntrusted(text: string, max: number): string {
   const cleaned = defuseFences(text)
+    // Security fix: strip HTML tags and bidirectional control chars to prevent injection/spoofing
+    .replace(/<[^>]*>/g, "")
+    .replace(/[\u200E-\u200F\u202A-\u202E\u2066-\u2069\u061C]/g, "")
     // Repeated, since one strip leaves `##` as `#` -- still a heading, at heading weight, in the
-    // prompt the approver reads.
+    // prompt the approver reads. Also strip horizontal rules and strikethrough.
     .replace(/^[ \t]*[#>]+[ \t]*/gm, "")
+    .replace(/^[ \t]*(?:-{3,}|\*{3,})[ \t]*/gm, "")
+    .replace(/~~/g, "")
     .trim();
   const clipped = cleaned.length > max ? `${cleaned.slice(0, max)}\u2026` : cleaned;
   return clipped.split("\n").map(line => `> ${line}`).join("\n");


### PR DESCRIPTION
## Security Fixes

This PR addresses 3 security issues found during a code audit of the cloudflare-os repository.

### 1. SSRF Blocklist Bypass via Incomplete IPv4 Normalization
**File**: `packages/mcp-shared/src/endpoint.ts`
**Severity**: Medium

`normalizeHost()` handles bare integer IPs and IPv4-mapped IPv6, but missed:
- **Dotted hex**: `0x7f.0x00.0x00.0x01` → not normalized → bypasses blocklist
- **Dotted octal**: `0177.0.0.01` → not normalized → bypasses blocklist  
- **IPv4-compatible IPv6**: `[::127.0.0.1]` → only `::ffff:` form handled
- **IPv6 zone IDs**: `[::1%25eth0]` → not stripped

**Fix**: Extended `normalizeHost()` to parse each dotted octet (handling hex `0x` and octal `0` prefixes), strip zone IDs, and handle IPv4-compatible IPv6.

This is the same class of bug as CVE-2025-59436 (node `ip` package).

### 2. Markdown/HTML Injection in Approval Prompts
**File**: `packages/mcp-shared/src/tools.ts`
**Severity**: Low-Medium

`quoteUntrusted()` strips headings and blockquotes but not:
- HTML tags (`<img>`, `<details>`, etc.)
- Unicode bidirectional override characters (U+202E etc.)
- Horizontal rules (`---`/`***`) and strikethrough (`~~`)

A malicious MCP server could craft tool descriptions that inject tracking pixels, visually reverse text, or mislead the approval prompt.

**Fix**: Added HTML tag stripping, Unicode bidi control removal, and horizontal rule/strikethrough neutralization.

### 3. Reflected Error Parameters Without Content-Type
**File**: `packages/gatekeeper-cloudflare/src/cloudflare.ts`
**Severity**: Low

OAuth error callback reflects `error` and `error_description` query params directly into the response body without an explicit `Content-Type` header.

**Fix**: Set `Content-Type: text/plain; charset=utf-8` explicitly.

---

cc @jonesphillip @kentonv @Kieran-Hulsman — you authored the affected files and would be best positioned to review these changes.

All changes are minimal (31 lines added, 2 removed) and preserve existing functionality.