### PR TITLE
fix: run pnpm through a shell in execFileSync/spawnSync on Windows

### DIFF
--- a/packages/gatekeeper-context/build-app.mjs
+++ b/packages/gatekeeper-context/build-app.mjs
@@ -15,5 +15,5 @@ console.log(
 execFileSync(
   "pnpm",
   ["exec", "vite", "build", "-c", "vite.config.ts", ...(watch ? ["--watch"] : [])],
-  { cwd: pkgDir, stdio: "inherit" },
+  { cwd: pkgDir, stdio: "inherit", shell: process.platform === "win32" },
 );

--- a/packages/gatekeeper-scheduler/build-app.mjs
+++ b/packages/gatekeeper-scheduler/build-app.mjs
@@ -8,5 +8,5 @@ const watch = process.argv.includes("--watch");
 execFileSync(
   "pnpm",
   ["exec", "vite", "build", "-c", "vite.config.ts", ...(watch ? ["--watch"] : [])],
-  { cwd: packageDirectory, stdio: "inherit" },
+  { cwd: packageDirectory, stdio: "inherit", shell: process.platform === "win32" },
 );

--- a/run-dev-server.js
+++ b/run-dev-server.js
@@ -323,7 +323,7 @@ console.log(`\nStarting: wrangler dev ${args.join(" ")}\n`);
 
 try {
   execFileSync("pnpm", ["exec", "wrangler", "dev", ...args],
-      { stdio: "inherit", cwd: ROOT });
+      { stdio: "inherit", cwd: ROOT, shell: process.platform === "win32" });
 } catch (e) {
   // wrangler was killed or exited with an error; the output was already shown
   // via stdio: "inherit", so just propagate the exit code.

--- a/scripts/run-local.mjs
+++ b/scripts/run-local.mjs
@@ -115,7 +115,7 @@ const needsInstall = needsBuild || !existsSync(NODE_MODULES);
 
 function run(cmd, args) {
   console.log(`\n> ${cmd} ${args.join(" ")}`);
-  execFileSync(cmd, args, { stdio: "inherit", cwd: ROOT });
+  execFileSync(cmd, args, { stdio: "inherit", cwd: ROOT, shell: process.platform === "win32" });
 }
 
 if (needsInstall) {


### PR DESCRIPTION
## What

On Windows, `pnpm` is a `.CMD` shim, not a real executable. Node's `execFileSync` does not apply `PATHEXT`, so `execFileSync("pnpm", ...)` fails with `spawnSync pnpm ENOENT`. (`git`/`node` calls are unaffected because they resolve to real `.exe` files.)

This breaks `pnpm run-local` on Windows: the first `pnpm install` succeeds, but every later step that shells out to `pnpm` aborts.

## Fix

Pass `shell: process.platform === "win32"` at the four `pnpm` call sites so the shim resolves on Windows. POSIX behavior is unchanged (`shell` stays `false` off-Windows).

- `scripts/run-local.mjs` — `pnpm install` + typed-storage/frontend builds
- `run-dev-server.js` — `pnpm exec wrangler dev`
- `packages/gatekeeper-context/build-app.mjs` — `pnpm exec vite build` (incl. `--watch`)
- `packages/gatekeeper-scheduler/build-app.mjs` — `pnpm exec vite build` (incl. `--watch`)

## Testing

With this patch, `pnpm run-local -- --use-workers-ai-binding` completes install + build and serves at `http://localhost:8787` on Windows 11 (Node 23, pnpm 11.17.0). Verified the app loads, a Workers AI model can be configured, and the agent builds and runs a gadget end to end.