### PR TITLE
Send system role, not developer, to Ollama-compatible endpoints

### DIFF
--- a/packages/workshop-backend/__tests__/ai-models.test.ts
+++ b/packages/workshop-backend/__tests__/ai-models.test.ts
@@ -364,6 +364,39 @@ describe("getModel direct routing (no gateway)", () => {
       expect(handle.model.baseUrl).toBe("http://my-ollama:11434/v1");
     }
   });
+
+  it("pins supportsDeveloperRole off for Ollama's OpenAI-compatible endpoint", () => {
+    // The Ollama slot is what users point at self-hosted OpenAI-compatible endpoints (vLLM,
+    // LM Studio, self-hosted gateways). pi defaults supportsDeveloperRole on for providers it
+    // doesn't recognize, and reasoning: true then sends the system prompt as role "developer",
+    // which strictly-validating endpoints reject with a 400. Mirrors workersAiCompat().
+    const handle = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "ollama",
+      model: "qwen3:8b",
+      apiToken: "",
+      apiUrl: "http://my-ollama:11434",
+    }, INITIATOR);
+
+    expect(handle.model.compat).toMatchObject({ supportsDeveloperRole: false });
+  });
+
+  it("sends the system prompt as role \"system\", not \"developer\", to an Ollama endpoint", async () => {
+    const handle = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "ollama",
+      model: "qwen3:8b",
+      apiToken: "",
+      apiUrl: "http://my-ollama:11434",
+    }, INITIATOR);
+
+    const stream = await handle.stream(handle.model, {
+      systemPrompt: "You are a helpful assistant.",
+      messages: [{ role: "user", content: "hello", timestamp: 0 }],
+    }, { fetch: fetchStub, maxRetries: 0 });
+    await stream.result();
+    expect(capturedRequests.length).toBeGreaterThan(0);
+    const body = JSON.parse(capturedRequests[0].body) as { messages: { role: string }[] };
+    expect(body.messages[0].role).toBe("system");
+  }, 15000);
 });
 
 describe("PDF attachment bridging", () => {

--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -551,6 +551,11 @@ function getModelDirect(config: AiModelConfig, sessionAffinity?: string): ModelH
       // local proxy may reject an unexpected bearer token): the OpenAI SDK requires *some* key,
       // so give it a placeholder while a null default header deletes the Authorization header
       // the SDK derives from it.
+      // Compat: supportsDeveloperRole off. The Ollama slot is what users point at arbitrary
+      // OpenAI-compatible endpoints (vLLM, LM Studio, self-hosted gateways); pi defaults the
+      // flag on for providers it doesn't recognize, and reasoning: true then sends the system
+      // prompt as role "developer", which strictly-validating endpoints reject. Mirrors
+      // workersAiCompat().
       return makeHandle({
         model: {
           id: config.model,
@@ -563,6 +568,7 @@ function getModelDirect(config: AiModelConfig, sessionAffinity?: string): ModelH
           input: ["text", "image"],
           cost: ZERO_COST,
           ...window,
+          compat: { supportsDeveloperRole: false },
         },
         ...(config.apiToken === ""
             ? { apiKey: "unused", headers: { Authorization: null } }


### PR DESCRIPTION
Fixes #36.

## Problem

A model added through the Ollama provider slot pointing at a self-hosted OpenAI-compatible endpoint fails on the first message with HTTP 400: the system prompt goes out with `role: "developer"`, which strictly-validating endpoints (vLLM, LM Studio, llama.cpp, self-hosted gateways) reject.

pi's `openai-completions` API picks the system-prompt role from `model.reasoning && compat.supportsDeveloperRole`. `detectCompat()` doesn't recognize the `ollama` provider or an arbitrary self-hosted hostname, so the flag defaults on — and the ollama branch hardcodes `reasoning: true`, supplying the other half of the condition.

## Fix

Pin `compat: { supportsDeveloperRole: false }` on the ollama branch in `getModelDirect()`, mirroring what `workersAiCompat()` already does for the sibling Workers AI branch.

## Tests

Two regression tests in `__tests__/ai-models.test.ts` (which drives the real pi-ai stack with an injected fetch stub):

- the ollama model descriptor carries `supportsDeveloperRole: false`;
- the captured request body sends the system prompt as `role: "system"` — red before the fix (it captured `"developer"`, exactly the issue's repro), green after.

`pnpm exec vitest run` (workshop-backend, 281 tests), `pnpm lint:check`, and `tsc --noEmit` all pass.