### PR TITLE
fix: reject unsupported URLs before Gmail fallthrough in Google Gatekeeper

### DIFF
--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -927,6 +927,15 @@ export class GatekeeperUserImpl extends WorkerEntrypoint<Env, GatekeeperUserImpl
       };
     }
 
+    // Reject URLs that don't belong to Gmail before falling through to the default.
+    // Without this check, any URL that doesn't match Docs/Sheets/Calendar/BigQuery
+    // silently receives a Gmail capability, which weakens the resource-URL boundary.
+    if (parsed.hostname !== "mail.google.com") {
+      throw new Error(
+        `Unsupported Google resource URL: ${parsed.hostname}${parsed.pathname}. ` +
+        "Supported resources are Google Docs, Sheets, Calendar, BigQuery, and Gmail.");
+    }
+
     // Default: Gmail
     let props: GmailGatekeeperImplProps = {...this.ctx.props};
 


### PR DESCRIPTION
Fixes #63

### Problem
\getGatekeeperClassFor()\ falls through to the Gmail branch for **any** URL that doesn't match Docs, Sheets, Calendar, or BigQuery — including non-Google URLs like \https://evil.example/resource\. This silently returns a Gmail capability for an unrelated resource URL, weakening the resource-URL boundary and making audit records misleading.

### Fix
Add a hostname check for \mail.google.com\ before the Gmail fallthrough. Unsupported URLs now get a clear error listing the supported resources.

9 insertions, 0 deletions.

cc @jonesphillip @kentonv