### PR TITLE
Fix Enter during IME composition sending the message

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -3146,6 +3146,10 @@ export const ChatInput = ({
                 }
               }}
               onKeyDown={(e) => {
+                // While an IME composition is active (e.g. Japanese input), Enter confirms
+                // the conversion and must not send the message. keyCode 229 covers browsers
+                // that fire the confirming keydown without isComposing set (e.g. Safari).
+                if (e.nativeEvent.isComposing || e.keyCode === 229) return;
                 if (slashCommandPicker.open && e.key === "Escape") {
                   e.preventDefault();
                   slashCommandPicker.dismiss();
@@ -6511,6 +6515,7 @@ function ChatInterface({
                             onChange={(e) => setRenamingInput(e.target.value)}
                             onClick={(e) => e.stopPropagation()}
                             onKeyDown={(e) => {
+                              if (e.nativeEvent.isComposing || e.keyCode === 229) return;
                               if (e.key === "Enter") {
                                 e.preventDefault();
                                 handleSaveListRename(chat.id);
@@ -6730,6 +6735,7 @@ function ChatInterface({
                         value={titleInput}
                         onChange={(e) => setTitleInput(e.target.value)}
                         onKeyDown={(e) => {
+                          if (e.nativeEvent.isComposing || e.keyCode === 229) return;
                           if (e.key === "Enter") handleSaveChatTitle();
                           if (e.key === "Escape") handleCancelTitleEdit();
                         }}


### PR DESCRIPTION
## Problem

When typing with an IME (Japanese, Chinese, Korean input methods), pressing Enter to confirm a text conversion is interpreted as a send action. This makes the chat input nearly unusable for CJK users: every conversion confirmation sends a half-written message.

## Fix

Guard the `onKeyDown` handlers with the standard IME check:

```ts
if (e.nativeEvent.isComposing || e.keyCode === 229) return;
```

`keyCode === 229` covers browsers (notably Safari) that fire the confirming keydown without `isComposing` set.

Applied to the three text inputs in `ChatInterface.tsx` that submit on Enter:
- the main chat message input
- the chat list rename input
- the chat title edit input

## Testing

- With a Japanese IME: type text, press Enter to confirm the conversion → message is not sent; press Enter again → message sends.
- Without an IME: Enter sends, Shift+Enter inserts a newline, slash-command picker Enter/Tab/arrow behavior unchanged (the guard returns before those branches only during active composition).
- `tsc --noEmit` passes in `packages/workshop-frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)