### PR TITLE
Seed Linear and Spotify OAuth creds in local dev

### DIFF
--- a/scripts/run-dev-server.ts
+++ b/scripts/run-dev-server.ts
@@ -415,6 +415,8 @@ const SHARED_GATEKEEPER_CREDS: Record<string, { id: string; secret: string }> = 
   "gatekeeper-zoominfo": { id: "ZOOMINFO_CLIENT_ID", secret: "ZOOMINFO_CLIENT_SECRET" },
   "gatekeeper-confluence": { id: "CONFLUENCE_CLIENT_ID", secret: "CONFLUENCE_CLIENT_SECRET" },
   "gatekeeper-slack": { id: "SLACK_CLIENT_ID", secret: "SLACK_CLIENT_SECRET" },
+  "gatekeeper-linear": { id: "LINEAR_CLIENT_ID", secret: "LINEAR_CLIENT_SECRET" },
+  "gatekeeper-spotify": { id: "SPOTIFY_CLIENT_ID", secret: "SPOTIFY_CLIENT_SECRET" },
 };
 
 // Deployment-configured vars a gatekeeper reads that its committed `wrangler.jsonc` deliberately


### PR DESCRIPTION
## Problem

`run-dev-server.js` injects `CLIENT_ID` / `CLIENT_SECRET` into each OAuth gatekeeper's generated `wrangler.dev.jsonc` via the `SHARED_GATEKEEPER_CREDS` table, but the table covers only 8 of the 10 gatekeepers that read `env.CLIENT_ID` — **Linear and Spotify are missing**.

So in a local run (`pnpm run-local`), putting `LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET` (or the `SPOTIFY_*` equivalents) in the root `.dev.vars` silently does nothing, and connecting either service always lands on the "Configuration Required" page — while the identical setup works for the other eight gatekeepers.


## Fix

Add the two missing rows. Verified locally: after this change the generated `packages/gatekeeper-linear/wrangler.dev.jsonc` contains the injected `CLIENT_ID`, and the Linear connect flow proceeds past the configuration check exactly like the already-covered gatekeepers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-os/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->