### PR TITLE
Don't replay image attachments to models without image input

### DIFF
--- a/packages/workshop-backend/__tests__/chat-attachment-parts.test.ts
+++ b/packages/workshop-backend/__tests__/chat-attachment-parts.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { chatAttachmentModelParts } from "../src/chat-attachment-parts.js";
+
+// Verifies that an attachment the current model can't accept is replaced with a text marker
+// rather than sent as an image part; see the header of chat-attachment-parts.ts for why.
+
+function testModel(api: Api, input: ("text" | "image")[]): Model<Api> {
+  return {
+    id: "test-model",
+    name: "Test Model",
+    api,
+    provider: "anthropic",
+    baseUrl: "https://example.com",
+    reasoning: false,
+    input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+const PNG_BYTES = Uint8Array.fromBase64("iVBORw0KGgo=");
+const PDF_BYTES = Uint8Array.fromBase64("JVBERi0xLjQ=");
+
+describe("chatAttachmentModelParts", () => {
+  it("emits an image part for an image on a model with image input", () => {
+    const parts = chatAttachmentModelParts(
+        {mimeType: "image/png", name: "photo.png"}, PNG_BYTES,
+        testModel("anthropic-messages", ["text", "image"]));
+    expect(parts).toEqual([
+      {type: "image", data: PNG_BYTES.toBase64(), mimeType: "image/png"},
+    ]);
+  });
+
+  it("degrades an image to a text marker on a text-only model", () => {
+    const parts = chatAttachmentModelParts(
+        {mimeType: "image/png", name: "photo.png"}, PNG_BYTES,
+        testModel("anthropic-messages", ["text"]));
+    expect(parts).toEqual([{
+      type: "text",
+      text: "\n\n[Attached file (photo.png) (image/png) omitted — " +
+          "this file type is not supported by the current model]",
+    }]);
+  });
+
+  it("inlines a text-like attachment regardless of image support", () => {
+    const bytes = new TextEncoder().encode("a,b\n1,2\n");
+    const parts = chatAttachmentModelParts(
+        {mimeType: "text/csv", name: "data.csv"}, bytes,
+        testModel("openai-completions", ["text"]));
+    expect(parts).toEqual([{
+      type: "text",
+      text: "\n\n[Attached text file (data.csv)]\na,b\n1,2\n",
+    }]);
+  });
+
+  it("bridges a PDF over an image part on a document-capable API with image input", () => {
+    const parts = chatAttachmentModelParts(
+        {mimeType: "application/pdf", name: "doc.pdf"}, PDF_BYTES,
+        testModel("anthropic-messages", ["text", "image"]));
+    expect(parts).toEqual([
+      {type: "text", text: "\n\n[Attached PDF file (doc.pdf)]"},
+      {type: "image", data: PDF_BYTES.toBase64(), mimeType: "application/pdf"},
+    ]);
+  });
+
+  it("degrades a PDF to a text marker when the model lacks image input", () => {
+    // The API could take a document block, but the PDF rides an image content part, so a
+    // text-only model must not receive it.
+    const parts = chatAttachmentModelParts(
+        {mimeType: "application/pdf", name: "doc.pdf"}, PDF_BYTES,
+        testModel("anthropic-messages", ["text"]));
+    expect(parts).toEqual([{
+      type: "text",
+      text: "\n\n[Attached file (doc.pdf) (application/pdf) omitted — " +
+          "this file type is not supported by the current model]",
+    }]);
+  });
+
+  it("degrades a PDF to a text marker on an API without document input", () => {
+    const parts = chatAttachmentModelParts(
+        {mimeType: "application/pdf"}, PDF_BYTES,
+        testModel("openai-completions", ["text", "image"]));
+    expect(parts).toEqual([{
+      type: "text",
+      text: "\n\n[Attached file (application/pdf) omitted — " +
+          "this file type is not supported by the current model]",
+    }]);
+  });
+
+  it("degrades an unknown attachment type to a text marker", () => {
+    const parts = chatAttachmentModelParts(
+        {mimeType: "application/zip", name: "stuff.zip"}, new Uint8Array([0x50, 0x4B]),
+        testModel("anthropic-messages", ["text", "image"]));
+    expect(parts).toEqual([{
+      type: "text",
+      text: "\n\n[Attached file (stuff.zip) (application/zip) omitted — " +
+          "this file type is not supported by the current model]",
+    }]);
+  });
+});

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -1,5 +1,5 @@
-import { AiChatMessage, AiChatAuthorInfo, AiToolCall, AiChatMessageBody, AgentSpawnerConfig, AiChatStreamEvent, BlueprintOutput, WorkpieceId, type AiModelConfig, isTextLikeAttachmentMimeType, validateBindingName } from '@gadgets/workshop-shared/api';
-import { PDF_MIME_TYPE, modelApiSupportsPdfAttachments } from './chat-attachment-pdf';
+import { AiChatMessage, AiChatAuthorInfo, AiToolCall, AiChatMessageBody, AgentSpawnerConfig, AiChatStreamEvent, BlueprintOutput, WorkpieceId, type AiModelConfig, validateBindingName } from '@gadgets/workshop-shared/api';
+import { chatAttachmentModelParts } from './chat-attachment-parts';
 import { AgentCatalog, ObservationDescription } from '@gadgets/workshop-shared/gatekeeper';
 import { createWorkshopLogger } from "./observability";
 import * as Y from "yjs";
@@ -1453,39 +1453,8 @@ export async function runAgent(
               if (content) parts.push({type: "text", text: content});
               let attachmentParts = await Promise.all(msg.attachments.map(
                   async (attachment): Promise<(TextContent | ImageContent)[]> => {
-                let filename = attachment.name ? ` (${attachment.name})` : "";
                 let data = await hooks.getChatAttachmentData(chatId, attachment.id);
-                if (attachment.mimeType.startsWith("image/")) {
-                  return [{
-                    type: "image",
-                    data: data.toBase64(),
-                    mimeType: attachment.mimeType,
-                  }];
-                } else if (isTextLikeAttachmentMimeType(attachment.mimeType)) {
-                  return [{
-                    type: "text",
-                    text: `\n\n[Attached text file${filename}]\n${new TextDecoder().decode(data)}`,
-                  }];
-                } else if (attachment.mimeType === PDF_MIME_TYPE &&
-                           modelApiSupportsPdfAttachments(handle.model.api)) {
-                  // pi has no file/document content part, so a PDF rides an ImageContent part;
-                  // the model handle rewrites it into the provider's native document block just
-                  // before the request goes out (see chat-attachment-pdf.ts). The text part
-                  // carries the filename, which the disguised part cannot.
-                  return [
-                    {type: "text", text: `\n\n[Attached PDF file${filename}]`},
-                    {type: "image", data: data.toBase64(), mimeType: attachment.mimeType},
-                  ];
-                } else {
-                  // Attachment types the current model can't take -- a PDF after the chat moved
-                  // to a Workers AI/Ollama model, or types some providers accepted before the pi
-                  // migration -- degrade to a text marker rather than failing the whole replay.
-                  return [{
-                    type: "text",
-                    text: `\n\n[Attached file${filename} (${attachment.mimeType}) omitted — ` +
-                        `this file type is not supported by the current model]`,
-                  }];
-                }
+                return chatAttachmentModelParts(attachment, data, handle.model);
               }));
               parts.push(...attachmentParts.flat());
               modelMessage = { role: "user", content: parts, timestamp: msgTimestamp };

--- a/packages/workshop-backend/src/chat-attachment-parts.ts
+++ b/packages/workshop-backend/src/chat-attachment-parts.ts
@@ -1,0 +1,54 @@
+import type { Api, ImageContent, Model, TextContent } from "@earendil-works/pi-ai";
+import { isTextLikeAttachmentMimeType } from "@gadgets/workshop-shared/api";
+import { PDF_MIME_TYPE, modelApiSupportsPdfAttachments } from "./chat-attachment-pdf";
+
+// Converts a stored chat attachment into the content parts that represent it in the user message
+// sent to the model. This runs during history replay (agent.ts), which rebuilds the full message
+// history for every request -- so an attachment the current model can't accept (e.g. an image
+// after the chat switched to a text-only model) must be replaced with a text marker, not sent:
+// the provider would fail the request with a 400, and since every subsequent request replays the
+// same history, that single attachment would break the chat permanently.
+
+/**
+ * Convert one chat attachment into the content parts to splice into its user message, degrading
+ * anything `model` cannot accept to a text marker. `data` is the attachment's stored bytes.
+ */
+export function chatAttachmentModelParts(
+  attachment: { mimeType: string; name?: string },
+  data: Uint8Array,
+  model: Model<Api>,
+): (TextContent | ImageContent)[] {
+  let filename = attachment.name ? ` (${attachment.name})` : "";
+  let modelAcceptsImages = model.input.includes("image");
+  if (attachment.mimeType.startsWith("image/") && modelAcceptsImages) {
+    return [{
+      type: "image",
+      data: data.toBase64(),
+      mimeType: attachment.mimeType,
+    }];
+  } else if (isTextLikeAttachmentMimeType(attachment.mimeType)) {
+    return [{
+      type: "text",
+      text: `\n\n[Attached text file${filename}]\n${new TextDecoder().decode(data)}`,
+    }];
+  } else if (attachment.mimeType === PDF_MIME_TYPE &&
+             modelApiSupportsPdfAttachments(model.api) && modelAcceptsImages) {
+    // pi has no file/document content part, so a PDF rides an ImageContent part (hence the
+    // image modality check above); the model handle rewrites it into the provider's native
+    // document block just before the request goes out (see chat-attachment-pdf.ts). The text
+    // part carries the filename, which the disguised part cannot.
+    return [
+      {type: "text", text: `\n\n[Attached PDF file${filename}]`},
+      {type: "image", data: data.toBase64(), mimeType: attachment.mimeType},
+    ];
+  } else {
+    // Attachment types the current model can't take -- an image or PDF on a text-only model,
+    // or types some providers accepted before the pi migration -- degrade to a text marker
+    // rather than failing the whole replay.
+    return [{
+      type: "text",
+      text: `\n\n[Attached file${filename} (${attachment.mimeType}) omitted — ` +
+          `this file type is not supported by the current model]`,
+    }];
+  }
+}


### PR DESCRIPTION
Sending an image attachment to a model without image input fails with the provider's 400 — and because history replay rebuilds the model request from the chat log on every turn, the image is re-sent on every subsequent message, permanently wedging the chat.

This gates the image content part on the model's declared input modalities (`model.input`), degrading to the existing `[Attached file … omitted]` text marker instead — the same path other unsupported attachment types already take. PDFs get the same gate since they ride an image content part. The conversion is extracted into `chat-attachment-parts.ts` with tests, following the existing `chat-attachment-validation.ts` / `chat-attachment-pdf.ts` pattern.

Since replay rebuilds from the log each turn, chats that are already stuck recover on their next message.

Known limitation: custom/uncatalogued models default to `input: ["text", "image"]`, so a text-only custom model can still hit the 400. Discussion of how to handle that is on the issue.

Fixes #97