### PR TITLE
Make the scheduler delivery-bound assertion deterministic

### DIFF
--- a/packages/gatekeeper-scheduler/__tests__/schedule-driver.test.ts
+++ b/packages/gatekeeper-scheduler/__tests__/schedule-driver.test.ts
@@ -30,6 +30,7 @@ type TestHooks = HookInitiator<ScheduleHookTarget> & {
   }>;
   release(): Promise<void>;
   reset(): Promise<void>;
+  setCallbackBarrier(size: number, limit: number): Promise<void>;
   waitUntilBlocked(): Promise<void>;
 };
 
@@ -696,6 +697,9 @@ describe("ScheduleDriver", () => {
   it("bounds callback concurrency and immediately continues a due backlog", async () => {
     const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
     const driver = testEnv.SCHEDULE_DRIVER.getByName("batching");
+    // The batch of 20 delivers as five full sets of lanes; hold each set so the observed peak is
+    // the runner's bound and not RPC timing. The 21st, a round of one, is left unbarriered.
+    await testEnv.TEST_HOOKS.setCallbackBarrier(4, 20);
     const activationTime = Date.now();
     for (let index = 0; index < 21; index++) {
       await enableSchedule(

--- a/packages/gatekeeper-scheduler/__tests__/worker.ts
+++ b/packages/gatekeeper-scheduler/__tests__/worker.ts
@@ -24,6 +24,19 @@ let disposedApprovalQueues = 0;
 let disposedCallbacks = 0;
 let blockPoint: BlockPoint | null = null;
 let blockedPoint: BlockPoint | null = null;
+let callbackBarrier = 1;
+let callbackBarrierLimit = 0;
+
+// Holds a callback until `callbackBarrier` of them are in flight, so a test observing peak
+// concurrency measures the delivery bound rather than how RPC round-trips happened to interleave.
+// It applies only to the first `callbackBarrierLimit` callbacks, which the caller sizes to a whole
+// number of full rounds -- a partial round could never reach the barrier, and waiting on a count
+// that will arrive keeps this free of any wall-clock assumption.
+async function waitForCallbackBarrier(): Promise<void> {
+  if (callbackScheduleIds.length > callbackBarrierLimit) return;
+  // eslint-disable-next-line no-unmodified-loop-condition -- sibling callbacks mutate this.
+  while (activeCallbacks < callbackBarrier) await new Promise((resolve) => setTimeout(resolve, 1));
+}
 
 async function pauseIfBlocked(point: BlockPoint): Promise<void> {
   if (blockPoint !== point) return;
@@ -54,6 +67,7 @@ class TestCallback extends RpcTarget {
     try {
       await pauseIfBlocked("callback");
       if (mode === "callback-reject") throw new Error("callback rejected");
+      await waitForCallbackBarrier();
       await new Promise((resolve) => setTimeout(resolve, 10));
     } finally {
       activeCallbacks--;
@@ -81,6 +95,11 @@ export class TestHooks extends WorkerEntrypoint {
   blockAt(nextBlockPoint: BlockPoint): void {
     blockPoint = nextBlockPoint;
     blockedPoint = null;
+  }
+
+  setCallbackBarrier(size: number, limit: number): void {
+    callbackBarrier = size;
+    callbackBarrierLimit = limit;
   }
 
   async waitUntilBlocked(): Promise<void> {
@@ -112,6 +131,8 @@ export class TestHooks extends WorkerEntrypoint {
     disposedApprovalQueues = 0;
     disposedCallbacks = 0;
     blockedPoint = null;
+    callbackBarrier = 1;
+    callbackBarrierLimit = 0;
   }
 }
 


### PR DESCRIPTION
`ScheduleDriver > bounds callback concurrency and immediately continues a due backlog` asserts `maxActiveCallbacks === DELIVERY_CONCURRENCY`, but the observed peak is a function of timing rather than of the bound: each of the four `runBounded` lanes runs `startHook -> authorizeObservation -> onSchedule` over RPC, and the callback only holds for 10ms. When the lanes drift apart the peak lands below 4 even though the runner never exceeds it.

Reproducible on macOS/arm64 (M-series):

```
AssertionError: expected 3 to be 4 // Object.is equality
 ❯ __tests__/schedule-driver.test.ts:735:41
```

Rather than weaken the assertion to an upper bound — which would stop proving the bound is reached — this holds each callback until a full set of lanes has arrived, so the peak is the runner's bound and not RPC scheduling.

The batch of 20 delivers as exactly five full rounds of four, so the barrier waits on a count that is guaranteed to arrive and needs no timeout of its own; the tail round of one is excluded by the `limit` argument. The barrier is off by default, leaving every other test untouched.

### Verification

Four consecutive runs of `schedule-driver.test.ts`, alternated on the same machine with nothing else running:

| | run 1 | run 2 | run 3 | run 4 |
| --- | --- | --- | --- | --- |
| `main` | fail | fail | pass | fail |
| this branch | pass | pass | pass | pass |

`pnpm test` for the package is 102 passed / 3 skipped, and `pnpm types:check` is clean.

Unrelated, and untouched here: `permanently fences mutations and cleans revoked storage in bounded alarm passes` occasionally exceeds the 5s vitest timeout under CPU contention (it showed up on `main` run 4 above, and on this branch too when the whole monorepo suite runs in parallel). That is a separate load sensitivity, not the assertion this PR is about.