### PR TITLE
Absorb user-DO resets in the Worker and self-heal subscriptions

### DIFF
--- a/packages/workshop-backend/__integration__/open-gadget-rpc.test.ts
+++ b/packages/workshop-backend/__integration__/open-gadget-rpc.test.ts
@@ -1,5 +1,6 @@
+import { abortAllDurableObjects } from "cloudflare:test";
 import { exports } from "cloudflare:workers";
-import { newWebSocketRpcSession, type RpcStub } from "capnweb";
+import { newWebSocketRpcSession, RpcTarget, type RpcStub } from "capnweb";
 import {
   createOpenGadgetError,
   getOpenGadgetErrorCode,
@@ -8,7 +9,7 @@ import {
   type OpenGadgetErrorCode,
   type PublicApi,
 } from "@gadgets/workshop-shared/api";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 type CodedError = Error & { code?: unknown };
 
@@ -131,5 +132,139 @@ describe.skip("openGadget errors across native RPC and Cap'n Web", () => {
 
     const browserError = await openRejection(intruder, metadata.id);
     expectRpcCode(browserError, OPEN_GADGET_ERROR_CODES.workspaceAccessDenied);
+  });
+});
+
+// In production, workerd tags rejections from a reset DO with the structured flags do-retry.ts
+// reads. Locally, vitest-pool-workers aborts reject FLAGLESS — this test pins that, so if a
+// future pool upgrade starts attaching the production flags, it fails and the flag paths can
+// graduate from synthetic unit tests to real-reset integration tests. abortAllDurableObjects()
+// is the non-graceful teardown (deliberately not evictDurableObject(), which never breaks a
+// stub).
+describe("user-DO reset flags", () => {
+  it("local aborts reject flagless — flag-based recovery is untestable locally", async () => {
+    using publicApi = await connect();
+    const account = await createAccount(publicApi, "probe");
+    using authenticated = await publicApi.authenticate(account.token);
+
+    expect(await authenticated.listModels()).toBeInstanceOf(Array);
+
+    // Bind a native stub to the current DO incarnation BEFORE the reset — a stub minted after
+    // the abort would simply restart the object and succeed. This poisoned-stub rejection is
+    // the exact shape AuthenticatedApiImpl sees when one of its calls loses the reset race.
+    const userStub = exports.UserDurableObject.get(
+      exports.UserDurableObject.idFromName(account.username));
+    expect(await userStub.listModels()).toBeInstanceOf(Array);
+
+    await abortAllDurableObjects();
+
+    // The session recovers: AuthenticatedApiImpl resolves a fresh stub per call, so the
+    // restarted object serves this read — the browser never sees the reset.
+    expect(await authenticated.listModels()).toBeInstanceOf(Array);
+
+    const nativeErr = await rejection(userStub.listModels());
+    expect({
+      message: nativeErr.message,
+      durableObjectReset: (nativeErr as Record<string, unknown>).durableObjectReset,
+      retryable: (nativeErr as Record<string, unknown>).retryable,
+      overloaded: (nativeErr as Record<string, unknown>).overloaded,
+    }).toEqual({
+      message: "Application called abortAllDurableObjects().",
+      durableObjectReset: undefined,
+      retryable: undefined,
+      overloaded: undefined,
+    });
+
+    // Permanently broken, not fail-once: the fresh-stub-per-call design rests on this.
+    const nativeErr2 = await rejection(userStub.listModels());
+    expect(nativeErr2.message).toBe("Application called abortAllDurableObjects().");
+  });
+});
+
+// Recovery of live connected-accounts subscriptions across a reset: the session re-subscribes
+// the browser's own subscriber stub when it detects incarnation drift, and the restarted
+// object's catch-up replay is pure upsert (repeat adds, then a second ready()). Local aborts
+// reject flagless (see above), so the drift path is the one exercised here. With no OAuth
+// vendors bound there is no way to mutate accounts, so recovery is asserted as: the subscriber
+// receives the replay's second ready() without errors. Manual fault injection against a dev
+// server remains the full-stack check.
+describe("user-DO subscription recovery", () => {
+  class RecordingSubscriber extends RpcTarget {
+    adds: number[] = [];
+    removes: number[] = [];
+    readyCount = 0;
+
+    add(id: number): void { this.adds.push(id); }
+    remove(id: number): void { this.removes.push(id); }
+    ready(): void { this.readyCount++; }
+  }
+
+  // The DO fires subscriber callbacks without awaiting them, so arrival lags the subscribe
+  // call's return by a beat; recovery additionally runs in a background waitUntil. Conditions
+  // MUST be >= (never ===): a recovery replay can bump readyCount past the target between
+  // polls, so an equality check races its own success.
+  const waitFor = (condition: () => boolean, what: string) =>
+    vi.waitFor(() => { expect(condition(), what).toBe(true); }, { timeout: 10_000 });  // CI margin
+
+  it("changes the DO incarnation id on reset (the drift-detection primitive)", async () => {
+    const id = exports.UserDurableObject.idFromName(username("incarnation"));
+    const before = await exports.UserDurableObject.get(id).getIncarnationId();
+    await abortAllDurableObjects();
+    const after = await exports.UserDurableObject.get(id).getIncarnationId();
+    expect(before).toMatch(/[0-9a-f-]{36}/);
+    expect(after).toMatch(/[0-9a-f-]{36}/);
+    expect(after).not.toBe(before);
+  });
+
+  it("re-subscribes across a reset (subscribers see the catch-up replay), no errors", async () => {
+    using publicApi = await connect();
+    const account = await createAccount(publicApi, "resub");
+    using authenticated = await publicApi.authenticate(account.token);
+
+    const first = new RecordingSubscriber();
+    using firstSub = await authenticated.subscribeConnectedAccounts(first);
+    await waitFor(() => first.readyCount >= 1, "first subscriber's ready()");
+
+    await abortAllDurableObjects();
+
+    // A second subscribe lands on the restarted incarnation; the session notices the stamp
+    // mismatch and re-subscribes the DEAD registrations in the background. The first
+    // subscriber receiving the replay's second ready() is the proof recovery reached it; the
+    // second subscriber is already live on the new incarnation, so its stamp makes the pass
+    // skip it (no spurious replay).
+    const second = new RecordingSubscriber();
+    using secondSub = await authenticated.subscribeConnectedAccounts(second);
+    await waitFor(() => second.readyCount >= 1, "second subscriber's ready()");
+
+    await waitFor(() => first.readyCount >= 2, "first subscriber's post-recovery replay");
+    expect(await authenticated.listModels()).toBeInstanceOf(Array);
+
+    expect(first.removes).toEqual([]);  // empty replay of an empty account list: no removes
+    // Exact === is safe here (unlike the polled waitFor conditions above): this is a
+    // post-condition checked after recovery completed, and the pass skips entries whose stamp
+    // is current, so the second subscriber never gets a replay.
+    expect(second.readyCount).toBe(1);
+
+    // Both disposers are Worker-minted and must tear down cleanly even though the DO-side
+    // registration they originally wrapped died with the old incarnation.
+    firstSub[Symbol.dispose]();
+    secondSub[Symbol.dispose]();
+    expect(await authenticated.listModels()).toBeInstanceOf(Array);
+  });
+
+  it("disposing a subscription whose DO registration died with a reset is safe", async () => {
+    using publicApi = await connect();
+    const account = await createAccount(publicApi, "dispose");
+    using authenticated = await publicApi.authenticate(account.token);
+
+    const subscriber = new RecordingSubscriber();
+    const sub = await authenticated.subscribeConnectedAccounts(subscriber);
+    await waitFor(() => subscriber.readyCount >= 1, "subscriber's ready()");
+
+    await abortAllDurableObjects();
+
+    sub[Symbol.dispose]();
+    // The session must remain fully usable after disposing across the reset.
+    expect(await authenticated.listModels()).toBeInstanceOf(Array);
   });
 });

--- a/packages/workshop-backend/__tests__/do-retry.test.ts
+++ b/packages/workshop-backend/__tests__/do-retry.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { isDoResetError, retryOnDoReset } from "../src/do-retry";
+
+// Synthetic errors shaped like workerd's tagged rejections (jsg/util.c++). Local aborts reject
+// flagless (pinned by the "user-DO reset flags" integration test), so the predicate and retry
+// paths are exercised here with the production shapes.
+function resetError(flags: Record<string, unknown>): Error {
+  return Object.assign(new Error("Durable Object reset."), flags);
+}
+
+describe("isDoResetError", () => {
+  it("matches the durableObjectReset flag", () => {
+    expect(isDoResetError(resetError({ durableObjectReset: true }))).toBe(true);
+  });
+
+  it("matches the retryable flag (connection lost)", () => {
+    expect(isDoResetError(resetError({ retryable: true }))).toBe(true);
+  });
+
+  it("matches the production storage-timeout shape (overloaded reset)", () => {
+    expect(isDoResetError(
+      resetError({ remote: true, overloaded: true, durableObjectReset: true }))).toBe(true);
+  });
+
+  it("rejects overload without a reset — retrying adds load to a live object", () => {
+    expect(isDoResetError(resetError({ remote: true, overloaded: true }))).toBe(false);
+  });
+
+  it("rejects unflagged and malformed values", () => {
+    expect(isDoResetError(new Error("some app error"))).toBe(false);
+    expect(isDoResetError(resetError({ durableObjectReset: "yes" }))).toBe(false);
+    expect(isDoResetError(resetError({ retryable: 1 }))).toBe(false);
+    expect(isDoResetError(null)).toBe(false);
+    expect(isDoResetError(undefined)).toBe(false);
+    expect(isDoResetError("boom")).toBe(false);
+  });
+});
+
+describe("retryOnDoReset", () => {
+  const immediate: readonly [number, number] = [0, 0];
+
+  it("passes through a first-try success without retrying", async () => {
+    const onRetry = vi.fn();
+    const fn = vi.fn<() => Promise<string>>().mockResolvedValue("ok");
+    expect(await retryOnDoReset(fn, onRetry, immediate)).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("retries once after a reset and reports the retry", async () => {
+    const failure = resetError({ durableObjectReset: true });
+    const onRetry = vi.fn();
+    const fn = vi.fn<() => Promise<string>>()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce("ok");
+    expect(await retryOnDoReset(fn, onRetry, immediate)).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledExactlyOnceWith({ error: failure, delayMs: 0 });
+  });
+
+  it("gives up after the second failure and propagates it unchanged", async () => {
+    const second = resetError({ durableObjectReset: true });
+    const fn = vi.fn<() => Promise<string>>()
+      .mockRejectedValueOnce(resetError({ durableObjectReset: true }))
+      .mockRejectedValueOnce(second);
+    await expect(retryOnDoReset(fn, undefined, immediate)).rejects.toBe(second);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-reset failures", async () => {
+    const failure = new Error("Workspace not found.");
+    const onRetry = vi.fn();
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValue(failure);
+    await expect(retryOnDoReset(fn, onRetry, immediate)).rejects.toBe(failure);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("does not retry overload without a reset", async () => {
+    const failure = resetError({ overloaded: true });
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValue(failure);
+    await expect(retryOnDoReset(fn, undefined, immediate)).rejects.toBe(failure);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("delays within the configured range", async () => {
+    const onRetry = vi.fn();
+    const fn = vi.fn<() => Promise<string>>()
+      .mockRejectedValueOnce(resetError({ retryable: true }))
+      .mockResolvedValueOnce("ok");
+    expect(await retryOnDoReset(fn, onRetry, [1, 3])).toBe("ok");
+    const { delayMs } = onRetry.mock.calls[0][0] as { delayMs: number };
+    expect(delayMs).toBeGreaterThanOrEqual(1);
+    expect(delayMs).toBeLessThanOrEqual(3);
+  });
+});

--- a/packages/workshop-backend/src/do-retry.ts
+++ b/packages/workshop-backend/src/do-retry.ts
@@ -1,0 +1,47 @@
+// Server-side classification and retry for Durable Object resets.
+//
+// workerd tags rejections from a reset or disconnected DO with structured flags (jsg/util.c++):
+// `retryable` ⇔ connection lost, `overloaded` ⇔ load shedding, and `durableObjectReset`
+// whenever the object's incarnation died — the production storage-timeout reset arrives as
+// `{remote, overloaded, durableObjectReset}`. The flags are attached natively in the calling
+// Worker, so no message matching is needed. Local vitest-pool-workers aborts reject FLAGLESS
+// (pinned by the "user-DO reset flags" integration test), so these paths are unit-tested with
+// synthetic errors and integration tests assert recovery behaviorally.
+
+/** True for rejections caused by a DO reset or lost connection — cases where a retry of an
+ * IDEMPOTENT call through a fresh stub is expected to succeed against the restarted object.
+ * `overloaded` alone is deliberately excluded (the object is alive and shedding load; a retry
+ * adds to it — the docs' "never retry .overloaded" case). An overloaded RESET is retried
+ * despite that blanket wording: the overloaded queue died with the incarnation, and one
+ * jittered attempt is not a retry loop. */
+export function isDoResetError(e: unknown): boolean {
+  if (typeof e !== "object" || e === null) return false;
+  const flags = e as { durableObjectReset?: unknown; retryable?: unknown };
+  return flags.durableObjectReset === true || flags.retryable === true;
+}
+
+export interface DoRetryInfo {
+  /** The initial call's rejection that is about to be retried. */
+  error: unknown;
+  delayMs: number;
+}
+
+/** Runs `fn`, retrying ONCE after a short jittered delay if it rejects with a DO-reset error.
+ * `fn` MUST be idempotent and MUST mint a fresh stub per invocation (a stub is permanently
+ * broken once its incarnation resets). `onRetry` fires before the delay. A second failure
+ * propagates unchanged — the client's socket-level recovery is the backstop, not a retry
+ * loop. */
+export async function retryOnDoReset<T>(
+    fn: () => Promise<T>,
+    onRetry?: (info: DoRetryInfo) => void,
+    delayRangeMs: readonly [number, number] = [150, 400]): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    if (!isDoResetError(e)) throw e;
+    const delayMs = delayRangeMs[0] + Math.random() * (delayRangeMs[1] - delayRangeMs[0]);
+    onRetry?.({ error: e, delayMs });
+    await scheduler.wait(delayMs);
+    return await fn();
+  }
+}

--- a/packages/workshop-backend/src/observability.ts
+++ b/packages/workshop-backend/src/observability.ts
@@ -9,6 +9,8 @@ export type WorkshopObservabilityFields = {
   blueprintId: string;
   callbackInitiated: boolean;
   chatId: number;
+  delayMs: number;
+  durableObjectId: string;
   durationMs: number;
   eventName: string;
   executionId: string;

--- a/packages/workshop-backend/src/server.ts
+++ b/packages/workshop-backend/src/server.ts
@@ -78,6 +78,18 @@ type Env = Cloudflare.Env & {
  * type-system gap as the Overseer stub casts). */
 type UserSubscription = Awaited<ReturnType<UserDurableObject["subscribeConnectedAccounts"]>>;
 
+type UserStub = DurableObjectStub<UserDurableObject>;
+
+/** Async-method view of the user stub, backing the #query/#command sugar: the same method
+ * surface and (Unstubify-transformed) types a direct stub call has, minus the Fetcher members
+ * and symbol keys the proxy doesn't dispatch. */
+type UserDoProxy = {
+  [K in Exclude<keyof UserStub, keyof Fetcher | symbol>
+      as UserStub[K] extends (...args: never) => unknown ? K : never]:
+    UserStub[K] extends (...args: infer A) => infer R
+        ? (...args: A) => Promise<Awaited<R>> : never;
+};
+
 /** One browser subscription, held in the session's Worker context (which survives DO resets)
  * so the DO-side registration can be re-created after the object's in-memory state dies.
  * Re-subscribing triggers the DO's normal catch-up replay (`add` per current account, then
@@ -120,23 +132,27 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
   // A stub is permanently poisoned once its incarnation resets, so re-resolve per call instead
   // of caching one for the session (stub creation is local — not a network call). The trade:
-  // e-order is per stub, so cross-call delivery ordering is gone; #userWrite restores it for
-  // writes, but nothing orders a read against an in-flight write — a call site that depends on
-  // a prior user-DO call must await it. `#`-private because RpcTarget members are
+  // e-order is per stub, so cross-call delivery ordering is gone; #userCommand restores it for
+  // commands, but nothing orders a query against an in-flight command — a call site that
+  // depends on a prior user-DO call must await it. `#`-private because RpcTarget members are
   // runtime-visible and TS `private` is erased.
   get #user(): DurableObjectStub<UserDurableObject> {
     return this.users.get(this.#userId);
   }
 
-  // Every RPC into the user DO goes through #userRead, #userWrite, or #userCall (the recovery
-  // internals below are the one exception) — a naked `this.#user.x()` elsewhere is a review
-  // defect. This choke point keeps routine DO resets from surfacing in the browser: workerd
-  // tags those rejections with flags right here in the Worker, one same-colo hop from the
-  // object, so recovery is cheap and needs no message matching.
+  // Every RPC into the user DO goes through #userQuery, #userCommand, or #userCall (the
+  // recovery internals below are the one exception) — a naked `this.#user.x()` elsewhere is a
+  // review defect. The #query/#command proxies below are sugar routing plain delegations
+  // through these same chokepoints. Query vs command is a retry-safety split, not a
+  // storage-semantics one: a query is idempotent (safe to replay against the restarted
+  // object), a command is not — see listProvidedAccounts for a "list" that is a command. This
+  // choke point keeps routine DO resets from surfacing in the browser: workerd tags those
+  // rejections with flags right here in the Worker, one same-colo hop from the object, so
+  // recovery is cheap and needs no message matching.
 
-  /** Idempotent read against the user DO: fresh stub per attempt, one retry on reset. */
-  async #userRead<T>(operation: string,
-               fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
+  /** Idempotent query against the user DO: fresh stub per attempt, one retry on reset. */
+  async #userQuery<T>(operation: string,
+                      fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
     let result: T;
     try {
       result = await retryOnDoReset(
@@ -151,25 +167,25 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
     return result;
   }
 
-  /** Non-idempotent call: NO retry — a reset can land after the write committed but before the
-   * response, so a retry could double-apply. Writes also serialize on a per-session chain:
-   * unguarded optimistic UI (e.g. the quick-model row toggle) can issue overlapping writes
-   * whose reversed cross-stub arrival would invert the final state. Reads stay concurrent.
+  /** Effectful command: NO retry — a reset can land after the write committed but before the
+   * response, so a retry could double-apply. Commands also serialize on a per-session chain:
+   * unguarded optimistic UI (e.g. the quick-model row toggle) can issue overlapping commands
+   * whose reversed cross-stub arrival would invert the final state. Queries stay concurrent.
    *
-   * Never call #userWrite from inside another #userWrite closure: the inner call chains behind
-   * the outer's own unresolved result and self-deadlocks. A write needing two DO calls uses
-   * one closure (see getGatekeeperApp). */
-  async #userWrite<T>(operation: string,
-                      fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
-    let result = this.#writeChain.then(() => this.#userCall(operation, fn));
-    this.#writeChain = result.then(() => {}, () => {});
+   * Never call #userCommand from inside another #userCommand closure: the inner call chains
+   * behind the outer's own unresolved result and self-deadlocks. A command needing two DO
+   * calls uses one closure (see getGatekeeperApp). */
+  async #userCommand<T>(operation: string,
+                        fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
+    let result = this.#commandChain.then(() => this.#userCall(operation, fn));
+    this.#commandChain = result.then(() => {}, () => {});
     return result;
   }
 
-  #writeChain: Promise<void> = Promise.resolve();
+  #commandChain: Promise<void> = Promise.resolve();
 
-  /** Non-retrying dispatch shared by #userWrite; also used directly for subscription
-   * registration, which must not retry but must not stall behind writes either (its replay
+  /** Non-retrying dispatch shared by #userCommand; also used directly for subscription
+   * registration, which must not retry but must not stall behind commands either (its replay
    * awaits vendor describes). Observes reset flags and rethrows unchanged. */
   async #userCall<T>(operation: string,
                      fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
@@ -183,7 +199,28 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
     }
   }
 
-  /** Central reset observation point. `retrying` = a read retry is about to absorb it;
+  /** Builds the #query/#command sugar: `this.#query.listGadgets()` routes through #userQuery
+   * with the DO method name as the telemetry operation (so the logged operation names the DO
+   * method that was hit, which for a handful of endpoints differs from the API method —
+   * `dismissSharedGadget` logs as `forgetSharedGadget`). Sites whose closure does more than a
+   * single same-args delegation (multi-call closures, helpers that take the stub) use the
+   * chokepoints directly. */
+  #doProxy(dispatch: (operation: string,
+                      fn: (user: UserStub) => Promise<unknown>) => Promise<unknown>): UserDoProxy {
+    return new Proxy({}, {
+      get: (_target, prop) => typeof prop === "string"
+          ? (...args: unknown[]) => dispatch(prop, user => {
+              let methods = user as unknown as Record<string, (...a: unknown[]) => Promise<unknown>>;
+              return methods[prop](...args);
+            })
+          : undefined,
+    }) as UserDoProxy;
+  }
+
+  #query = this.#doProxy((op, fn) => this.#userQuery(op, fn));
+  #command = this.#doProxy((op, fn) => this.#userCommand(op, fn));
+
+  /** Central reset observation point. `retrying` = a query retry is about to absorb it;
    * `surfaced` = the error reaches the client. The split is what lets the absorption thesis be
    * checked in telemetry. Kicks off subscription recovery either way. */
   #onUserDoReset(operation: string, error: unknown, outcome: "retrying" | "surfaced",
@@ -367,60 +404,60 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   whoami(): Promise<AiChatAuthorInfo> {
-    return this.#userRead("whoami", u => u.whoami());
+    return this.#query.whoami();
   }
   setOwnDisplayName(name: string): Promise<void> {
-    return this.#userWrite("setOwnDisplayName", u => u.setOwnDisplayName(name));
+    return this.#command.setOwnDisplayName(name);
   }
   changePassword(oldHash: Uint8Array, newHash: Uint8Array): Promise<void> {
-    return this.#userWrite("changePassword", u => u.changePassword(oldHash, newHash));
+    return this.#command.changePassword(oldHash, newHash);
   }
   hasPasswordLogin(): Promise<boolean> {
-    return this.#userRead("hasPasswordLogin", u => u.hasPasswordLogin());
+    return this.#query.hasPasswordLogin();
   }
   listModels(): Promise<AiChatAuthorInfo[]> {
-    return this.#userRead("listModels", u => u.listModels());
+    return this.#query.listModels();
   }
   addModel(profile: AiChatAuthorInfo, config: AiModelConfig): Promise<void> {
-    return this.#userWrite("addModel", u => u.addModel(profile, config));
+    return this.#command.addModel(profile, config);
   }
   deleteModel(id: string): Promise<void> {
-    return this.#userWrite("deleteModel", u => u.deleteModel(id));
+    return this.#command.deleteModel(id);
   }
   setQuickModel(id: string | null): Promise<void> {
-    return this.#userWrite("setQuickModel", u => u.setQuickModel(id));
+    return this.#command.setQuickModel(id);
   }
   getQuickModel(): Promise<null | string> {
-    return this.#userRead("getQuickModel", u => u.getQuickModel());
+    return this.#query.getQuickModel();
   }
 
   getPreferredModel(): Promise<string | null> {
-    return this.#userRead("getPreferredModel", u => u.getPreferredModel());
+    return this.#query.getPreferredModel();
   }
   setPreferredModel(id: string | null): Promise<void> {
-    return this.#userWrite("setPreferredModel", u => u.setPreferredModel(id));
+    return this.#command.setPreferredModel(id);
   }
   isOnboardingCompleted(): Promise<boolean> {
-    return this.#userRead("isOnboardingCompleted", u => u.isOnboardingCompleted());
+    return this.#query.isOnboardingCompleted();
   }
   completeOnboarding(): Promise<void> {
-    return this.#userWrite("completeOnboarding", u => u.completeOnboarding());
+    return this.#command.completeOnboarding();
   }
 
   getCloudflareUsage(): Promise<CloudflareUsageInfo> {
-    // #userCall: not an idempotent read — the closure can fetch OAuth tokens and write back
+    // #userCall: not an idempotent query — the closure can fetch OAuth tokens and write back
     // account selection / credit snapshots (connection-service.ts), so no retry — and it is
-    // slow (token fetch), so it must not queue the write chain either. A reset surfaces to the
-    // usage panel's fallback.
+    // slow (token fetch), so it must not queue the command chain either. A reset surfaces to
+    // the usage panel's fallback.
     return this.#userCall("getCloudflareUsage", u => getUsageInfo(this.env, u));
   }
 
   listCloudflareAccounts(): Promise<CloudflareAccountOption[]> {
-    return this.#userRead("listCloudflareAccounts", u => listConnectedAccounts(this.env, u));
+    return this.#userQuery("listCloudflareAccounts", u => listConnectedAccounts(this.env, u));
   }
 
   selectCloudflareAccount(accountId: string): Promise<void> {
-    return this.#userWrite("selectCloudflareAccount", u => selectAccount(this.env, u, accountId));
+    return this.#userCommand("selectCloudflareAccount", u => selectAccount(this.env, u, accountId));
   }
 
   async setAvatar(data: Uint8Array | null): Promise<void> {
@@ -511,7 +548,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
       // (refreshAffectedCollaboratorListings), but that push is best-effort. Only catches entries
       // they click; others stay frozen at revocation, as a disconnected collaborator gets no pushes.
       if (getOpenGadgetErrorCode(err) === OPEN_GADGET_ERROR_CODES.workspaceAccessDenied) {
-        await this.#userWrite("forgetSharedGadget", u => u.forgetSharedGadget(id));
+        await this.#command.forgetSharedGadget(id);
       }
       throw err;
     }
@@ -535,7 +572,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
   async newGadget(): Promise<RpcStub<Overseer>> {
     let id = this.overseers.newUniqueId().toString();
-    await this.#userWrite("newGadget", u => u.newGadget(id, "Untitled Workspace"));
+    await this.#command.newGadget(id, "Untitled Workspace");
     recordAnalytics(this.ctx, this.env, {
       event_name: "gadget_created",
       user_id: this.#userId.toString(),
@@ -550,14 +587,14 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   async listGadgets(): Promise<GadgetMetadataWithTimestamps[]> {
-    return this.#userRead("listGadgets", u => u.listGadgets());
+    return this.#query.listGadgets();
   }
 
   listOutputs(): Promise<ListOutputsResult> {
-    // A read despite the backfill inside: the DO sweeps one page whose cursor only advances
+    // A #query despite the backfill inside: the DO sweeps one page whose cursor only advances
     // after it completes, and workspace pushes are whole-workspace replaces, so a retry re-runs
     // the same page idempotently.
-    return this.#userRead("listOutputs", u => u.listOutputs());
+    return this.#query.listOutputs();
   }
 
   async listOutputFormats(): Promise<OutputFormatOffer[]> {
@@ -567,24 +604,23 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   listGatekeeperVendors(filter?: GatekeeperVendorFilter): Promise<GatekeeperVendorInfo[]> {
-    return this.#userRead("listGatekeeperVendors", u => u.listGatekeeperVendors(filter));
+    return this.#query.listGatekeeperVendors(filter);
   }
 
   connectAccount(vendorId: string, resourceUrlPatterns?: string[]): Promise<{url: string}> {
-    return this.#userWrite("connectAccount", u => u.connectAccount(vendorId, resourceUrlPatterns));
+    return this.#command.connectAccount(vendorId, resourceUrlPatterns);
   }
 
   ensureAccountResources(accountId: number, resourceUrlPatterns: string[]): Promise<{url?: string}> {
-    return this.#userWrite("ensureAccountResources",
-        u => u.ensureAccountResources(accountId, resourceUrlPatterns));
+    return this.#command.ensureAccountResources(accountId, resourceUrlPatterns);
   }
 
   listAddableGatekeepers(): Promise<GatekeeperVendorInfo[]> {
-    return this.#userRead("listAddableGatekeepers", u => u.listAddableGatekeepers());
+    return this.#query.listAddableGatekeepers();
   }
 
   provisionAmbientAccount(vendorId: string): Promise<void> {
-    return this.#userWrite("provisionAmbientAccount", u => u.provisionAmbientAccount(vendorId));
+    return this.#command.provisionAmbientAccount(vendorId);
   }
 
   async subscribeConnectedAccounts(
@@ -598,7 +634,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
     try {
       // #userCall: registration is not retry-safe (a retry after a lost response duplicates
       // it, and the includeForcedAutoProvisionedAccounts filter provisions accounts — see
-      // listGatekeeperApps), and it must not stall the write chain (its replay awaits vendor
+      // listGatekeeperApps), and it must not stall the command chain (its replay awaits vendor
       // describes). A subscribe raced by a reset surfaces to the component's fallback.
       subscription = await this.#userCall("subscribeConnectedAccounts",
           () => this.#registerSubscriber(kept.dup(), filter));
@@ -629,42 +665,41 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   disconnectAccount(accountId: number): Promise<void> {
-    return this.#userWrite("disconnectAccount", u => u.disconnectAccount(accountId));
+    return this.#command.disconnectAccount(accountId);
   }
 
   reconnectAccount(accountId: number): Promise<{url: string}> {
-    return this.#userWrite("reconnectAccount", u => u.reconnectAccount(accountId));
+    return this.#command.reconnectAccount(accountId);
   }
 
   startResourceConfigurator(
       accountId: number,
       resourceUrlPattern: string) {
-    return this.#userWrite("startResourceConfigurator",
-        u => u.startResourceConfigurator(accountId, resourceUrlPattern));
+    return this.#command.startResourceConfigurator(accountId, resourceUrlPattern);
   }
 
   async dismissSharedGadget(gadgetId: string): Promise<void> {
-    return this.#userWrite("dismissSharedGadget", u => u.forgetSharedGadget(gadgetId));
+    return this.#command.forgetSharedGadget(gadgetId);
   }
 
   async listOwnBlueprints(): Promise<BlueprintUserSummary[]> {
-    return this.#userRead("listOwnBlueprints", u => u.listBlueprints());
+    return this.#query.listBlueprints();
   }
 
   async getOwnBlueprint(blueprintId: string): Promise<BlueprintUserSummary | null> {
-    return this.#userRead("getOwnBlueprint", u => u.getBlueprint(blueprintId));
+    return this.#query.getBlueprint(blueprintId);
   }
 
   async listLibraryBlueprints(): Promise<BlueprintLibrarySummary[]> {
-    return this.#userRead("listLibraryBlueprints", u => u.listLibraryBlueprints());
+    return this.#query.listLibraryBlueprints();
   }
 
   async setBlueprintPinned(blueprintId: string, pinned: boolean): Promise<void> {
-    return this.#userWrite("setBlueprintPinned", u => u.setBlueprintPinned(blueprintId, pinned));
+    return this.#command.setBlueprintPinned(blueprintId, pinned);
   }
 
   async isBlueprintPinned(blueprintId: string): Promise<boolean> {
-    return this.#userRead("isBlueprintPinned", u => u.isBlueprintPinned(blueprintId));
+    return this.#query.isBlueprintPinned(blueprintId);
   }
 
   async listFeaturedBlueprints(): Promise<BlueprintPublicInfo[]> {
@@ -673,16 +708,15 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   async addBlueprintToLibrary(blueprintId: string): Promise<void> {
-    return this.#userWrite("addBlueprintToLibrary", u => u.addBlueprintToLibrary(blueprintId));
+    return this.#command.addBlueprintToLibrary(blueprintId);
   }
 
   async removeBlueprintFromLibrary(blueprintId: string): Promise<void> {
-    return this.#userWrite("removeBlueprintFromLibrary",
-        u => u.removeBlueprintFromLibrary(blueprintId));
+    return this.#command.removeBlueprintFromLibrary(blueprintId);
   }
 
   isBlueprintInLibrary(blueprintId: string): Promise<{ uploaded: boolean } | null> {
-    return this.#userRead("isBlueprintInLibrary", u => u.isBlueprintInLibrary(blueprintId));
+    return this.#query.isBlueprintInLibrary(blueprintId);
   }
 
   async importBlueprint(archive: ReadableStream<Uint8Array>): Promise<string> {
@@ -706,7 +740,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
       await this.env.BLUEPRINTS.put(blueprintId, JSON.stringify(kvRecord));
 
-      await this.#userWrite("importBlueprint", u => u.importBlueprint(blueprintId, metadata));
+      await this.#command.importBlueprint(blueprintId, metadata);
 
       recordAnalytics(this.ctx, this.env, {
         event_name: "blueprint_imported",
@@ -738,7 +772,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
     // 3. Create new Overseer DO (same as newGadget()).
     let id = this.overseers.newUniqueId().toString();
-    await this.#userWrite("newGadgetFromBlueprint", u => u.newGadget(id, kvRecord.metadata.title));
+    await this.#command.newGadget(id, kvRecord.metadata.title);
     let overseerResult = await this.#openGadgetInternal(id);
 
     // 4. Initialize from blueprint code.
@@ -844,7 +878,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   async deleteOrphanedBlueprint(blueprintId: string): Promise<void> {
-    return this.#userWrite("deleteOrphanedBlueprint", u => u.deleteOwnedBlueprint(blueprintId));
+    return this.#command.deleteOwnedBlueprint(blueprintId);
   }
 
   // --- Gatekeeper management apps ---
@@ -855,10 +889,10 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   // accounts are auto-provisioned singletons (one per vendor), so the vendor id identifies them.
   async listGatekeeperApps(): Promise<GatekeeperAppInfo[]> {
     // listProvidedAccounts provisions auto-provisioned accounts first, so their apps appear in
-    // the nav before the user opens a gadget. #userWrite, not #userRead: provisioning calls the
+    // the nav before the user opens a gadget. #command, not #query: provisioning calls the
     // vendor's createAccount before the record persists, so a reset-then-retry in that window
     // would create a duplicate vendor-side account. Same in getGatekeeperApp.
-    let accounts = await this.#userWrite("listGatekeeperApps", u => u.listProvidedAccounts());
+    let accounts = await this.#command.listProvidedAccounts();
     return accounts
         .filter(account => account.description.providesUi)
         .map(account => ({
@@ -871,9 +905,9 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   async getGatekeeperApp(id: string): Promise<GatekeeperUiFrame | null> {
     // Self-sufficient: listProvidedAccounts provisions auto-provisioned accounts first, so a
     // direct URL load of /gatekeepers/$id works without racing the Header's listGatekeeperApps.
-    // #userWrite for the provisioning side effect (see there); one closure so both DO calls
+    // #userCommand for the provisioning side effect (see there); one closure so both DO calls
     // share a stub.
-    return this.#userWrite("getGatekeeperApp", async u => {
+    return this.#userCommand("getGatekeeperApp", async u => {
       let accounts = await u.listProvidedAccounts();
       let app = accounts.find(account => account.vendorId === id && account.description.providesUi);
       if (!app) return null;

--- a/packages/workshop-backend/src/server.ts
+++ b/packages/workshop-backend/src/server.ts
@@ -28,6 +28,7 @@ import { verifyCfAccessJwt } from "./access.js";
 import { resolveUiFeatureFlags } from "./feature-flags";
 import { serveSiteLogo, SITE_LOGO_PATH } from "./site-logo.js";
 import { createWorkshopLogger } from "./observability";
+import { isDoResetError, retryOnDoReset } from "./do-retry";
 
 const logger = createWorkshopLogger("workshop.server");
 
@@ -71,13 +72,41 @@ type Env = Cloudflare.Env & {
 
 // =======================================================================================
 
+/** What UserDurableObject.subscribeConnectedAccounts returns, as seen from the Worker. Derived
+ * from the method rather than hand-written because the native stub's Unstubify type transform
+ * mangles capnweb stubs nested in returns, so the two call sites cast through this (same known
+ * type-system gap as the Overseer stub casts). */
+type UserSubscription = Awaited<ReturnType<UserDurableObject["subscribeConnectedAccounts"]>>;
+
+/** One browser subscription, held in the session's Worker context (which survives DO resets)
+ * so the DO-side registration can be re-created after the object's in-memory state dies.
+ * Re-subscribing triggers the DO's normal catch-up replay (`add` per current account, then
+ * `ready()`), which subscribers absorb as upserts. Accepted staleness: an account REMOVED
+ * while the registration was dead ghosts until the component next re-subscribes — removes
+ * have exactly one source today (see the census note in user.ts), and pruning against the
+ * replay was tried and deleted (the replay is lossy by design, so the prune removed live
+ * accounts more often than ghosts). */
+interface SubscriptionEntry {
+  /** Worker-held dup of the browser's subscriber stub; passed to the DO on each (re-)subscribe. */
+  subscriber: RpcStub<ConnectedAccountsSubscriber>;
+  filter?: ConnectedAccountsFilter;
+  /** DO-minted disposer for the current registration; poisoned by a reset, replaced on
+   * re-subscribe. Disposal is always best-effort. */
+  doDisposer: RpcStub<{}>;
+  /** Incarnation the current registration was made under; recovery skips entries already at
+   * the target incarnation, so a subscribe that raced the trigger is not replayed twice. */
+  incarnation: string;
+  disposed: boolean;
+}
+
 @validateRpc()
 class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   constructor(private ctx: ExecutionContext, private env: Env,
-      private user: DurableObjectStub<UserDurableObject>,
+      userId: DurableObjectId,
       private abortSession: (reason: Error) => void) {
     super();
 
+    this.#userId = userId;
     this.overseers = this.ctx.exports.OverseerDurableObject;
     this.adminSettings = this.ctx.exports.AdminSettings;
     this.users = this.ctx.exports.UserDurableObject;
@@ -87,8 +116,239 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   private adminSettings: DurableObjectNamespace<AdminSettings>;
   private users: DurableObjectNamespace<UserDurableObject>;
 
+  #userId: DurableObjectId;
+
+  // A stub is permanently poisoned once its incarnation resets, so re-resolve per call instead
+  // of caching one for the session (stub creation is local — not a network call). The trade:
+  // e-order is per stub, so cross-call delivery ordering is gone; #userWrite restores it for
+  // writes, but nothing orders a read against an in-flight write — a call site that depends on
+  // a prior user-DO call must await it. `#`-private because RpcTarget members are
+  // runtime-visible and TS `private` is erased.
+  get #user(): DurableObjectStub<UserDurableObject> {
+    return this.users.get(this.#userId);
+  }
+
+  // Every RPC into the user DO goes through #userRead, #userWrite, or #userCall (the recovery
+  // internals below are the one exception) — a naked `this.#user.x()` elsewhere is a review
+  // defect. This choke point keeps routine DO resets from surfacing in the browser: workerd
+  // tags those rejections with flags right here in the Worker, one same-colo hop from the
+  // object, so recovery is cheap and needs no message matching.
+
+  /** Idempotent read against the user DO: fresh stub per attempt, one retry on reset. */
+  async #userRead<T>(operation: string,
+               fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
+    let result: T;
+    try {
+      result = await retryOnDoReset(
+          () => fn(this.#user),
+          info => this.#onUserDoReset(operation, info.error, "retrying", info.delayMs));
+    } catch (e) {
+      // The retry also failed: this reset reaches the client.
+      if (isDoResetError(e)) this.#onUserDoReset(operation, e, "surfaced");
+      throw e;
+    }
+    this.#maybeRevalidateSubscriptions();
+    return result;
+  }
+
+  /** Non-idempotent call: NO retry — a reset can land after the write committed but before the
+   * response, so a retry could double-apply. Writes also serialize on a per-session chain:
+   * unguarded optimistic UI (e.g. the quick-model row toggle) can issue overlapping writes
+   * whose reversed cross-stub arrival would invert the final state. Reads stay concurrent.
+   *
+   * Never call #userWrite from inside another #userWrite closure: the inner call chains behind
+   * the outer's own unresolved result and self-deadlocks. A write needing two DO calls uses
+   * one closure (see getGatekeeperApp). */
+  async #userWrite<T>(operation: string,
+                      fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
+    let result = this.#writeChain.then(() => this.#userCall(operation, fn));
+    this.#writeChain = result.then(() => {}, () => {});
+    return result;
+  }
+
+  #writeChain: Promise<void> = Promise.resolve();
+
+  /** Non-retrying dispatch shared by #userWrite; also used directly for subscription
+   * registration, which must not retry but must not stall behind writes either (its replay
+   * awaits vendor describes). Observes reset flags and rethrows unchanged. */
+  async #userCall<T>(operation: string,
+                     fn: (user: DurableObjectStub<UserDurableObject>) => Promise<T>): Promise<T> {
+    try {
+      let result = await fn(this.#user);
+      this.#maybeRevalidateSubscriptions();
+      return result;
+    } catch (e) {
+      if (isDoResetError(e)) this.#onUserDoReset(operation, e, "surfaced");
+      throw e;
+    }
+  }
+
+  /** Central reset observation point. `retrying` = a read retry is about to absorb it;
+   * `surfaced` = the error reaches the client. The split is what lets the absorption thesis be
+   * checked in telemetry. Kicks off subscription recovery either way. */
+  #onUserDoReset(operation: string, error: unknown, outcome: "retrying" | "surfaced",
+                 delayMs?: number) {
+    logger.warn("user DO reset observed", {
+      event: `user_do.reset.${outcome}`,
+      operation, delayMs,
+      durableObjectId: this.#userId.toString(),
+      error,
+    });
+    this.#triggerRecovery();
+  }
+
+  // ── subscription recovery ─────────────────────────────────────────────────────────────────
+  //
+  // The DO holds subscriber registrations in memory only, so a reset destroys them while the
+  // browser's WebSocket stays healthy. Triggers feeding #triggerRecovery:
+  //  1. a call rejecting with reset flags (#onUserDoReset);
+  //  2. throttled drift checks after successful calls — a call issued after the reset just
+  //     restarts the object and succeeds, so there is no error to observe;
+  //  3. a subscribe returning an incarnation that differs from an existing entry's stamp.
+  //
+  // TODO(stopgap): all of this exists because native JSRPC stubs have no brokenness callback
+  // (capnweb's `onRpcBroken` exists browser-side only, as of 2026-08). Given one,
+  // `doDisposer.onRpcBroken(() => this.#triggerRecovery())` deletes getIncarnationId(), the
+  // throttled check, and the idle window. Disposal-detection (the overseer's notifyClosed
+  // HACK: a sentinel whose dispose fires when the holder dies) was considered and rejected for
+  // now — it rests on undocumented teardown ordering plus per-registration sentinel plumbing,
+  // while the stamp is atomic and self-describing — but it would close the idle window and the
+  // blind spot below, so it is the strongest candidate shape for a follow-up.
+  //
+  // Accepted costs: live registrations pin the user DO resident (pre-existing — Workers RPC
+  // keeps the callee alive while stubs are live); a fully idle session learns nothing
+  // until its next user-DO call, so its connected-accounts list silently stops updating
+  // (worst case: watching for an OAuth connect completing in a popup); and the stamp is not a
+  // COMPLETE death signal — the DO tears down its own registration when a delivery to the
+  // browser rejects (catch(unsubscribe) in user.ts) without changing incarnation, a death this
+  // machinery cannot see. The client's socket-level reconnect is the backstop for all three.
+
+  #subscriptions = new Set<SubscriptionEntry>();
+  /** Serializes recovery passes. Triggers are not deduplicated — every trigger queues a pass —
+   * but redundant passes coalesce into cheap no-ops (one incarnation read, every entry's
+   * stamp already current). */
+  #recoveryChain: Promise<void> = Promise.resolve();
+  #lastIncarnationCheck = 0;
+  static readonly #INCARNATION_CHECK_INTERVAL_MS = 30_000;
+  /** Consecutive drifted passes; bounds the self-re-queue in #recoverSubscriptions. Reset by
+   * any pass that completes without drift. */
+  #driftRequeues = 0;
+  static readonly #MAX_DRIFT_REQUEUES = 3;
+
+  /** Cheap, throttled, fire-and-forget drift check — call after any successful user-DO RPC.
+   * Sync on purpose so callers never pay latency for it; the recovery pass itself compares
+   * incarnations and no-ops when the registrations are still live. */
+  #maybeRevalidateSubscriptions() {
+    if (this.#subscriptions.size === 0) return;
+    let now = Date.now();
+    if (now - this.#lastIncarnationCheck < AuthenticatedApiImpl.#INCARNATION_CHECK_INTERVAL_MS) {
+      return;
+    }
+    this.#lastIncarnationCheck = now;
+    this.#triggerRecovery();
+  }
+
+  /** Queues a recovery pass behind any in-flight one. Best-effort: a failed pass leaves the
+   * affected entries' stamps stale, so the next trigger (flags or throttled check) retries. */
+  #triggerRecovery() {
+    this.#recoveryChain = this.#recoveryChain.then(() => this.#recoverSubscriptions());
+    // Guarded: this runs on the success path of the chokepoints (and in their catch blocks),
+    // and recovery is fire-and-forget bookkeeping — a waitUntil() rejection during context
+    // teardown must not replace a call's result or strip a flagged error of its flags.
+    try { this.ctx.waitUntil(this.#recoveryChain); } catch {}
+  }
+
+  /** Registers a subscriber with the DO and unwraps the result envelope, which owns its nested
+   * stubs — so the retained disposer is dup()'d and the envelope disposed. The subscriber stub
+   * is consumed by the send, so callers pass a dup(). */
+  async #registerSubscriber(subscriber: RpcStub<ConnectedAccountsSubscriber>,
+                            filter?: ConnectedAccountsFilter): Promise<UserSubscription> {
+    let result = await this.#user.subscribeConnectedAccounts(subscriber, filter) as unknown as
+        UserSubscription & Partial<Disposable>;
+    try {
+      return { disposer: result.disposer.dup(), incarnationId: result.incarnationId };
+    } finally {
+      result[Symbol.dispose]?.();
+    }
+  }
+
+  /** Re-subscribes every registration whose incarnation stamp is no longer the object's
+   * current one. Entry stamps are the only recovery state, each returned atomically by the
+   * subscribe that created it. Runs serialized via #triggerRecovery, never rejects. */
+  async #recoverSubscriptions(): Promise<void> {
+    if (this.#subscriptions.size === 0) return;
+    try {
+      let incarnation = await this.#user.getIncarnationId();
+      let recovered = 0;
+      let drifted = false;
+      // Iterating the live Set across the awaits is safe: an entry unsubscribed mid-pass is
+      // skipped via the disposed check; one added mid-pass carries an up-to-date stamp.
+      for (let entry of this.#subscriptions) {
+        if (entry.disposed || entry.incarnation === incarnation) continue;
+        // Dispose the old registration first: a no-op on a dead incarnation, and on a
+        // false-positive trigger it prevents double-delivery from two live registrations.
+        try { entry.doDisposer[Symbol.dispose](); } catch {}
+        let subscription = await this.#registerSubscriber(entry.subscriber.dup(), entry.filter);
+        if (entry.disposed) {
+          // Unsubscribed while the re-subscribe was in flight: tear down the orphan.
+          try { subscription.disposer[Symbol.dispose](); } catch {}
+          continue;
+        }
+        entry.doDisposer = subscription.disposer;
+        entry.incarnation = subscription.incarnationId;
+        recovered++;
+        if (subscription.incarnationId !== incarnation) drifted = true;
+      }
+      if (drifted) {
+        // The object reset AGAIN mid-pass, so some stamps are stale again. Re-queue after a
+        // jittered pause — a hot loop would hammer an already-failing object with replay work —
+        // and capped: a crashlooping object falls back to the ordinary triggers instead.
+        if (++this.#driftRequeues <= AuthenticatedApiImpl.#MAX_DRIFT_REQUEUES) {
+          logger.info("user DO reset again during subscription recovery", {
+            event: "user_do.subscription.recover_requeued",
+            durableObjectId: this.#userId.toString(),
+          });
+          await scheduler.wait(500 + Math.random() * 1000);
+          this.#triggerRecovery();
+        } else {
+          this.#lastIncarnationCheck = 0;
+          logger.warn("user DO kept resetting during subscription recovery; deferring", {
+            event: "user_do.subscription.recover_deferred",
+            durableObjectId: this.#userId.toString(),
+          });
+        }
+        return;
+      }
+      this.#driftRequeues = 0;
+      if (recovered > 0) {
+        logger.info("re-subscribed after user DO reset", {
+          event: "user_do.subscription.recovered",
+          durableObjectId: this.#userId.toString(),
+        });
+      }
+    } catch (e) {
+      // Un-stamp the throttle: it was stamped before this pass ran, and the pass may have
+      // disposed a registration it then failed to replace — the next successful call must be
+      // able to re-trigger immediately rather than in 30s.
+      this.#lastIncarnationCheck = 0;
+      logger.warn("re-subscribe after user DO reset failed", {
+        event: "user_do.subscription.recover_failed",
+        durableObjectId: this.#userId.toString(),
+        error: e,
+      });
+    }
+  }
+
+  #unsubscribeEntry(entry: SubscriptionEntry) {
+    if (entry.disposed) return;
+    entry.disposed = true;
+    this.#subscriptions.delete(entry);
+    try { entry.doDisposer[Symbol.dispose](); } catch {}
+    entry.subscriber[Symbol.dispose]();
+  }
+
   #isAdmin(): boolean {
-    let name = this.user.id.name;
+    let name = this.#userId.name;
     let admins = this.env.ADMINS;
 
     if (!name || !admins) return false;
@@ -107,56 +367,60 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   whoami(): Promise<AiChatAuthorInfo> {
-    return this.user.whoami();
+    return this.#userRead("whoami", u => u.whoami());
   }
   setOwnDisplayName(name: string): Promise<void> {
-    return this.user.setOwnDisplayName(name);
+    return this.#userWrite("setOwnDisplayName", u => u.setOwnDisplayName(name));
   }
   changePassword(oldHash: Uint8Array, newHash: Uint8Array): Promise<void> {
-    return this.user.changePassword(oldHash, newHash);
+    return this.#userWrite("changePassword", u => u.changePassword(oldHash, newHash));
   }
   hasPasswordLogin(): Promise<boolean> {
-    return this.user.hasPasswordLogin();
+    return this.#userRead("hasPasswordLogin", u => u.hasPasswordLogin());
   }
   listModels(): Promise<AiChatAuthorInfo[]> {
-    return this.user.listModels();
+    return this.#userRead("listModels", u => u.listModels());
   }
   addModel(profile: AiChatAuthorInfo, config: AiModelConfig): Promise<void> {
-    return this.user.addModel(profile, config);
+    return this.#userWrite("addModel", u => u.addModel(profile, config));
   }
   deleteModel(id: string): Promise<void> {
-    return this.user.deleteModel(id);
+    return this.#userWrite("deleteModel", u => u.deleteModel(id));
   }
   setQuickModel(id: string | null): Promise<void> {
-    return this.user.setQuickModel(id);
+    return this.#userWrite("setQuickModel", u => u.setQuickModel(id));
   }
   getQuickModel(): Promise<null | string> {
-    return this.user.getQuickModel();
+    return this.#userRead("getQuickModel", u => u.getQuickModel());
   }
 
   getPreferredModel(): Promise<string | null> {
-    return this.user.getPreferredModel();
+    return this.#userRead("getPreferredModel", u => u.getPreferredModel());
   }
   setPreferredModel(id: string | null): Promise<void> {
-    return this.user.setPreferredModel(id);
+    return this.#userWrite("setPreferredModel", u => u.setPreferredModel(id));
   }
   isOnboardingCompleted(): Promise<boolean> {
-    return this.user.isOnboardingCompleted();
+    return this.#userRead("isOnboardingCompleted", u => u.isOnboardingCompleted());
   }
   completeOnboarding(): Promise<void> {
-    return this.user.completeOnboarding();
+    return this.#userWrite("completeOnboarding", u => u.completeOnboarding());
   }
 
   getCloudflareUsage(): Promise<CloudflareUsageInfo> {
-    return getUsageInfo(this.env, this.user);
+    // #userCall: not an idempotent read — the closure can fetch OAuth tokens and write back
+    // account selection / credit snapshots (connection-service.ts), so no retry — and it is
+    // slow (token fetch), so it must not queue the write chain either. A reset surfaces to the
+    // usage panel's fallback.
+    return this.#userCall("getCloudflareUsage", u => getUsageInfo(this.env, u));
   }
 
   listCloudflareAccounts(): Promise<CloudflareAccountOption[]> {
-    return listConnectedAccounts(this.env, this.user);
+    return this.#userRead("listCloudflareAccounts", u => listConnectedAccounts(this.env, u));
   }
 
   selectCloudflareAccount(accountId: string): Promise<void> {
-    return selectAccount(this.env, this.user, accountId);
+    return this.#userWrite("selectCloudflareAccount", u => selectAccount(this.env, u, accountId));
   }
 
   async setAvatar(data: Uint8Array | null): Promise<void> {
@@ -173,7 +437,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
     }
     // Avatar data lives in KV (global), not the user's DO storage, so we
     // read/write it directly here to avoid routing through the DO location.
-    let userId = this.user.id.name!;
+    let userId = this.#userId.name!;
     if (data) {
       await this.env.AVATARS.put(userId, data);
     } else {
@@ -199,14 +463,14 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   getUiFeatureFlags(): Promise<UiFeatureFlags> {
-    return resolveUiFeatureFlags(this.env, this.user.id.name!);
+    return resolveUiFeatureFlags(this.env, this.#userId.name!);
   }
 
   async #openGadgetInternal(id: string, shareKey?: string,
                             configureObservers?: RpcStub<ObserverConfigCallback>)
       : Promise<NativeRpcStub<Overseer>> {
-    let userId = this.user.id.toString();
-    let profileId = this.user.id.name!;
+    let userId = this.#userId.toString();
+    let profileId = this.#userId.name!;
     let overseerId;
     try {
       overseerId = this.overseers.idFromString(id);
@@ -247,7 +511,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
       // (refreshAffectedCollaboratorListings), but that push is best-effort. Only catches entries
       // they click; others stay frozen at revocation, as a disconnected collaborator gets no pushes.
       if (getOpenGadgetErrorCode(err) === OPEN_GADGET_ERROR_CODES.workspaceAccessDenied) {
-        await this.user.forgetSharedGadget(id);
+        await this.#userWrite("forgetSharedGadget", u => u.forgetSharedGadget(id));
       }
       throw err;
     }
@@ -271,10 +535,10 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
   async newGadget(): Promise<RpcStub<Overseer>> {
     let id = this.overseers.newUniqueId().toString();
-    await this.user.newGadget(id, "Untitled Workspace");
+    await this.#userWrite("newGadget", u => u.newGadget(id, "Untitled Workspace"));
     recordAnalytics(this.ctx, this.env, {
       event_name: "gadget_created",
-      user_id: this.user.id.toString(),
+      user_id: this.#userId.toString(),
       gadget_id: id,
       source: "blank",
     });
@@ -286,11 +550,14 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   async listGadgets(): Promise<GadgetMetadataWithTimestamps[]> {
-    return this.user.listGadgets();
+    return this.#userRead("listGadgets", u => u.listGadgets());
   }
 
   listOutputs(): Promise<ListOutputsResult> {
-    return this.user.listOutputs();
+    // A read despite the backfill inside: the DO sweeps one page whose cursor only advances
+    // after it completes, and workspace pushes are whole-workspace replaces, so a retry re-runs
+    // the same page idempotently.
+    return this.#userRead("listOutputs", u => u.listOutputs());
   }
 
   async listOutputFormats(): Promise<OutputFormatOffer[]> {
@@ -300,67 +567,104 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   listGatekeeperVendors(filter?: GatekeeperVendorFilter): Promise<GatekeeperVendorInfo[]> {
-    return this.user.listGatekeeperVendors(filter);
+    return this.#userRead("listGatekeeperVendors", u => u.listGatekeeperVendors(filter));
   }
 
   connectAccount(vendorId: string, resourceUrlPatterns?: string[]): Promise<{url: string}> {
-    return this.user.connectAccount(vendorId, resourceUrlPatterns);
+    return this.#userWrite("connectAccount", u => u.connectAccount(vendorId, resourceUrlPatterns));
   }
 
   ensureAccountResources(accountId: number, resourceUrlPatterns: string[]): Promise<{url?: string}> {
-    return this.user.ensureAccountResources(accountId, resourceUrlPatterns);
+    return this.#userWrite("ensureAccountResources",
+        u => u.ensureAccountResources(accountId, resourceUrlPatterns));
   }
 
   listAddableGatekeepers(): Promise<GatekeeperVendorInfo[]> {
-    return this.user.listAddableGatekeepers();
+    return this.#userRead("listAddableGatekeepers", u => u.listAddableGatekeepers());
   }
 
   provisionAmbientAccount(vendorId: string): Promise<void> {
-    return this.user.provisionAmbientAccount(vendorId);
+    return this.#userWrite("provisionAmbientAccount", u => u.provisionAmbientAccount(vendorId));
   }
 
-  subscribeConnectedAccounts(
+  async subscribeConnectedAccounts(
       subscriber: RpcStub<ConnectedAccountsSubscriber>, filter?: ConnectedAccountsFilter)
       : Promise<RpcStub<{}>> {
-    return this.user.subscribeConnectedAccounts(subscriber, filter);
+    // Dup the browser's subscriber stub: the param handle dies when this call returns, but
+    // re-subscribing after a reset needs it for the life of the subscription. Each
+    // (re-)subscribe sends its own dup(); the master is disposed only by #unsubscribeEntry.
+    let kept = subscriber.dup();
+    let subscription: UserSubscription;
+    try {
+      // #userCall: registration is not retry-safe (a retry after a lost response duplicates
+      // it, and the includeForcedAutoProvisionedAccounts filter provisions accounts — see
+      // listGatekeeperApps), and it must not stall the write chain (its replay awaits vendor
+      // describes). A subscribe raced by a reset surfaces to the component's fallback.
+      subscription = await this.#userCall("subscribeConnectedAccounts",
+          () => this.#registerSubscriber(kept.dup(), filter));
+    } catch (e) {
+      kept[Symbol.dispose]();
+      throw e;
+    }
+    let entry: SubscriptionEntry = {
+      subscriber: kept, filter, doDisposer: subscription.disposer,
+      incarnation: subscription.incarnationId, disposed: false,
+    };
+    this.#subscriptions.add(entry);
+
+    // A stamp mismatch among live entries means the object reset between an earlier subscribe
+    // and this one: the older registrations are already dead. This fresh entry's own stamp
+    // makes the recovery pass skip it and re-subscribe only the dead ones.
+    for (let other of this.#subscriptions) {
+      if (!other.disposed && other.incarnation !== entry.incarnation) {
+        this.#triggerRecovery();
+        break;
+      }
+    }
+
+    // Worker-minted disposer: unlike the DO-minted one it wraps, it survives resets, so the
+    // browser's dispose always cleanly tears down whichever registration is current.
+    let unsubscribe = () => this.#unsubscribeEntry(entry);
+    return new RpcStub<{}>({ [Symbol.dispose]() { unsubscribe(); } });
   }
 
   disconnectAccount(accountId: number): Promise<void> {
-    return this.user.disconnectAccount(accountId);
+    return this.#userWrite("disconnectAccount", u => u.disconnectAccount(accountId));
   }
 
   reconnectAccount(accountId: number): Promise<{url: string}> {
-    return this.user.reconnectAccount(accountId);
+    return this.#userWrite("reconnectAccount", u => u.reconnectAccount(accountId));
   }
 
   startResourceConfigurator(
       accountId: number,
       resourceUrlPattern: string) {
-    return this.user.startResourceConfigurator(accountId, resourceUrlPattern);
+    return this.#userWrite("startResourceConfigurator",
+        u => u.startResourceConfigurator(accountId, resourceUrlPattern));
   }
 
   async dismissSharedGadget(gadgetId: string): Promise<void> {
-    return this.user.forgetSharedGadget(gadgetId);
+    return this.#userWrite("dismissSharedGadget", u => u.forgetSharedGadget(gadgetId));
   }
 
   async listOwnBlueprints(): Promise<BlueprintUserSummary[]> {
-    return this.user.listBlueprints();
+    return this.#userRead("listOwnBlueprints", u => u.listBlueprints());
   }
 
   async getOwnBlueprint(blueprintId: string): Promise<BlueprintUserSummary | null> {
-    return this.user.getBlueprint(blueprintId);
+    return this.#userRead("getOwnBlueprint", u => u.getBlueprint(blueprintId));
   }
 
   async listLibraryBlueprints(): Promise<BlueprintLibrarySummary[]> {
-    return this.user.listLibraryBlueprints();
+    return this.#userRead("listLibraryBlueprints", u => u.listLibraryBlueprints());
   }
 
   async setBlueprintPinned(blueprintId: string, pinned: boolean): Promise<void> {
-    return this.user.setBlueprintPinned(blueprintId, pinned);
+    return this.#userWrite("setBlueprintPinned", u => u.setBlueprintPinned(blueprintId, pinned));
   }
 
   async isBlueprintPinned(blueprintId: string): Promise<boolean> {
-    return this.user.isBlueprintPinned(blueprintId);
+    return this.#userRead("isBlueprintPinned", u => u.isBlueprintPinned(blueprintId));
   }
 
   async listFeaturedBlueprints(): Promise<BlueprintPublicInfo[]> {
@@ -369,15 +673,16 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   async addBlueprintToLibrary(blueprintId: string): Promise<void> {
-    return this.user.addBlueprintToLibrary(blueprintId);
+    return this.#userWrite("addBlueprintToLibrary", u => u.addBlueprintToLibrary(blueprintId));
   }
 
   async removeBlueprintFromLibrary(blueprintId: string): Promise<void> {
-    return this.user.removeBlueprintFromLibrary(blueprintId);
+    return this.#userWrite("removeBlueprintFromLibrary",
+        u => u.removeBlueprintFromLibrary(blueprintId));
   }
 
   isBlueprintInLibrary(blueprintId: string): Promise<{ uploaded: boolean } | null> {
-    return this.user.isBlueprintInLibrary(blueprintId);
+    return this.#userRead("isBlueprintInLibrary", u => u.isBlueprintInLibrary(blueprintId));
   }
 
   async importBlueprint(archive: ReadableStream<Uint8Array>): Promise<string> {
@@ -396,16 +701,16 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
       let kvRecord: BlueprintKvRecord = {
         metadata,
-        ownerId: this.user.id.toString(),
+        ownerId: this.#userId.toString(),
       };
 
       await this.env.BLUEPRINTS.put(blueprintId, JSON.stringify(kvRecord));
 
-      await this.user.importBlueprint(blueprintId, metadata);
+      await this.#userWrite("importBlueprint", u => u.importBlueprint(blueprintId, metadata));
 
       recordAnalytics(this.ctx, this.env, {
         event_name: "blueprint_imported",
-        user_id: this.user.id.toString(),
+        user_id: this.#userId.toString(),
         blueprint_id: blueprintId,
       });
 
@@ -433,7 +738,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
     // 3. Create new Overseer DO (same as newGadget()).
     let id = this.overseers.newUniqueId().toString();
-    await this.user.newGadget(id, kvRecord.metadata.title);
+    await this.#userWrite("newGadgetFromBlueprint", u => u.newGadget(id, kvRecord.metadata.title));
     let overseerResult = await this.#openGadgetInternal(id);
 
     // 4. Initialize from blueprint code.
@@ -527,7 +832,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
 
     recordAnalytics(this.ctx, this.env, {
       event_name: "gadget_created",
-      user_id: this.user.id.toString(),
+      user_id: this.#userId.toString(),
       gadget_id: id,
       blueprint_id: blueprintId,
       source: "blueprint",
@@ -539,7 +844,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   async deleteOrphanedBlueprint(blueprintId: string): Promise<void> {
-    return this.user.deleteOwnedBlueprint(blueprintId);
+    return this.#userWrite("deleteOrphanedBlueprint", u => u.deleteOwnedBlueprint(blueprintId));
   }
 
   // --- Gatekeeper management apps ---
@@ -549,9 +854,11 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   // vendor id, e.g. "context"), so each app is hosted at /gatekeepers/<vendorId>. UI-providing
   // accounts are auto-provisioned singletons (one per vendor), so the vendor id identifies them.
   async listGatekeeperApps(): Promise<GatekeeperAppInfo[]> {
-    // listProvidedAccounts provisions auto-provisioned accounts first (idempotent), so their apps
-    // appear in the nav even before the user opens a gadget — in a single round trip.
-    let accounts = await this.user.listProvidedAccounts();
+    // listProvidedAccounts provisions auto-provisioned accounts first, so their apps appear in
+    // the nav before the user opens a gadget. #userWrite, not #userRead: provisioning calls the
+    // vendor's createAccount before the record persists, so a reset-then-retry in that window
+    // would create a duplicate vendor-side account. Same in getGatekeeperApp.
+    let accounts = await this.#userWrite("listGatekeeperApps", u => u.listProvidedAccounts());
     return accounts
         .filter(account => account.description.providesUi)
         .map(account => ({
@@ -562,13 +869,17 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   async getGatekeeperApp(id: string): Promise<GatekeeperUiFrame | null> {
-    // Self-sufficient: listProvidedAccounts provisions auto-provisioned accounts first (idempotent),
-    // so a direct URL load of /gatekeepers/$id works without racing the Header's listGatekeeperApps.
-    let accounts = await this.user.listProvidedAccounts();
-    let app = accounts.find(account => account.vendorId === id && account.description.providesUi);
-    if (!app) return null;
-    // isAdmin is supplied fresh per open so admin-gated features reflect the user's current status.
-    return this.user.startAccountAppUi(app.accountId, { isAdmin: this.#isAdmin() });
+    // Self-sufficient: listProvidedAccounts provisions auto-provisioned accounts first, so a
+    // direct URL load of /gatekeepers/$id works without racing the Header's listGatekeeperApps.
+    // #userWrite for the provisioning side effect (see there); one closure so both DO calls
+    // share a stub.
+    return this.#userWrite("getGatekeeperApp", async u => {
+      let accounts = await u.listProvidedAccounts();
+      let app = accounts.find(account => account.vendorId === id && account.description.providesUi);
+      if (!app) return null;
+      // isAdmin is supplied fresh per open so admin-gated features reflect the user's current status.
+      return u.startAccountAppUi(app.accountId, { isAdmin: this.#isAdmin() });
+    });
   }
 
   // --- Deployment admin ---
@@ -581,7 +892,7 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
     if (!this.#isAdmin()) return null;
     // #isAdmin() guarantees a non-empty user id name. Forwarded to gatekeepers when listing the
     // resource catalog so RBAC-gated ones still surface for this admin.
-    let adminUserId = this.user.id.name!;
+    let adminUserId = this.#userId.name!;
     // @ts-expect-error Cap'n Web RPC stubs and native RPC targets are compatible but the type
     //     system doesn't know this.
     return new AdminApiImpl(this.adminSettings.getByName(""), adminUserId);
@@ -668,14 +979,14 @@ class PublicApiImpl extends RpcTarget implements PublicApi {
     }
 
     let userId = this.users.idFromName(split[0]);
-    let stub = this.users.get(userId);
-    await stub.authenticate(split[1]);
+    // Token verification is an idempotent read; fresh stub per attempt.
+    await retryOnDoReset(() => this.users.get(userId).authenticate(split[1]));
     recordAnalytics(this.ctx, this.env, {
       event_name: "user_authenticated",
       user_id: userId.toString(),
       source: "session_token",
     });
-    return new AuthenticatedApiImpl(this.ctx, this.env, stub, this.abortSession);
+    return new AuthenticatedApiImpl(this.ctx, this.env, userId, this.abortSession);
   }
 
   async authenticateFromCfAccess(): Promise<AuthenticatedApi> {
@@ -685,9 +996,9 @@ class PublicApiImpl extends RpcTarget implements PublicApi {
 
     let email = this.accessPayload.email as string;
     let userId = this.users.idFromName(email);
-    let stub = this.users.get(userId);
     let signupsEnabled = (await readAdminConfig(this.env)).signupsEnabled;
-    let accountCreated = await stub.authenticateFromCfAccess(email, signupsEnabled);
+    let accountCreated =
+        await this.users.get(userId).authenticateFromCfAccess(email, signupsEnabled);
     if (accountCreated) {
       recordAnalytics(this.ctx, this.env, {
         event_name: "account_created",
@@ -700,7 +1011,7 @@ class PublicApiImpl extends RpcTarget implements PublicApi {
       user_id: userId.toString(),
       source: "cf_access",
     });
-    return new AuthenticatedApiImpl(this.ctx, this.env, stub, this.abortSession);
+    return new AuthenticatedApiImpl(this.ctx, this.env, userId, this.abortSession);
   }
 
   async login(username: string, passwordHash: Uint8Array): Promise<string | null> {
@@ -714,9 +1025,12 @@ class PublicApiImpl extends RpcTarget implements PublicApi {
     username = normalizeUsername(username);
 
     let id = this.users.idFromName(username);
-    let user = this.users.get(id);
-
-    let token = await user.login(passwordHash);
+    // Retried on reset even though it mints a token: the worst case of a double-run is an
+    // orphaned session token in the DO, while the login banner renders raw errors — this is
+    // the one page where a reset would still show the user the raw workerd message.
+    // createAccount and authenticateFromCfAccess stay unwrapped: retrying account CREATION is
+    // not known to be safe, so a reset there surfaces once and the user retries.
+    let token = await retryOnDoReset(() => this.users.get(id).login(passwordHash));
     if (!token) return null;
 
     recordAnalytics(this.ctx, this.env, {

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -278,6 +278,11 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
   private vendors: Map<string, Service<GatekeeperVendor>>;
   private adminSettings: DurableObjectNamespace<AdminSettings>;
 
+  // Fresh per incarnation, never persisted. In-memory subscription state dies with the
+  // incarnation, so a caller that remembers the incarnation it subscribed against can detect
+  // "my subscription is gone" by comparing — resets are otherwise invisible to callers.
+  #incarnationId = crypto.randomUUID();
+
   constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
     super(ctx, env);
 
@@ -296,7 +301,14 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
   }
 
   async authenticate(token: string): Promise<void> {
-    let tokenBytes = Uint8Array.fromBase64(token);
+    let tokenBytes: Uint8Array;
+    try {
+      tokenBytes = Uint8Array.fromBase64(token);
+    } catch {
+      // A corrupt (non-Base64) token must classify as an auth failure like any other bad token,
+      // not surface as the decoder's SyntaxError.
+      throw createAuthError(AUTH_ERROR_CODES.invalidSessionToken);
+    }
     let hash = await crypto.subtle.digest('SHA-256', tokenBytes);
     let tokenId = new Uint8Array(hash).toHex();
     let session = this.storage.sessions.get(tokenId);
@@ -1332,9 +1344,14 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     return record.account.ensureResources(resourceUrlPatterns);
   }
 
+  /** The id of this in-memory incarnation of the object; changes on every reset/eviction. */
+  getIncarnationId(): string {
+    return this.#incarnationId;
+  }
+
   async subscribeConnectedAccounts(
       subscriber: RpcStub<ConnectedAccountsSubscriber>, filter?: ConnectedAccountsFilter)
-      : Promise<RpcStub<{}>> {
+      : Promise<{disposer: RpcStub<{}>, incarnationId: string}> {
     if (filter?.includeForcedAutoProvisionedAccounts) await this.#ensureAutoProvisionedAccounts();
 
     let connectedAccounts = this.storage.connectedAccounts;
@@ -1424,6 +1441,13 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
       async update(oldRecord: ConnectedAccountRecord, newRecord: ConnectedAccountRecord) {
         await notifyAdd(newRecord);
       },
+      // Census note (load-bearing for the server's subscription recovery): every remove
+      // funnels through here, and deletion has exactly one source today — the owner's own
+      // disconnectAccount (credential expiry, dedup, and re-login all put(), i.e. re-add).
+      // A remove missed while a registration is dead is NOT reconciled and ghosts until the
+      // next re-subscribe; the same ghost occurs inside a HEALTHY registration when a remove
+      // lands mid-replay, before notifyAdd records the id in seenIds (pre-existing). A new
+      // remove-emitting path silently widens the window — revisit reconciliation then.
       remove(record: ConnectedAccountRecord): void {
         if (seenIds.has(record.id)) {
           subscriber.remove(record.id);
@@ -1447,12 +1471,15 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
 
     subscriber.ready().catch(unsubscribe);
 
-    return new RpcStub<{}>({
+    let disposer = new RpcStub<{}>({
       [Symbol.dispose]() {
         unsubscribe();
         subscriber[Symbol.dispose]();
       }
     });
+    // Returned atomically so the caller's incarnation stamp can't race a reset between the
+    // subscribe and a separate incarnation read.
+    return { disposer, incarnationId: this.#incarnationId };
   }
 
   async disconnectAccount(accountId: number): Promise<void> {

--- a/packages/workshop-backend/vitest.integration.config.ts
+++ b/packages/workshop-backend/vitest.integration.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
     onUnhandledError(error) {
       const code = "code" in error ? error.code : undefined;
       if (typeof code === "string" && EXPECTED_OPEN_ERROR_CODES.has(code)) return false;
+      // The reset-recovery tests abort every Durable Object mid-session; capabilities that were
+      // held across the abort (e.g. the fire-and-forget AdminSettings install kicked off by the
+      // fetch handler) reject on their own schedule, independent of any awaited call.
+      if (error.message?.includes("abortAllDurableObjects")) return false;
     },
   },
 });

--- a/packages/workshop-frontend/src/ResourcePicker.test.tsx
+++ b/packages/workshop-frontend/src/ResourcePicker.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+/* eslint-disable react/react-in-jsx-scope */
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcStub } from 'capnweb'
+import type { AuthenticatedApi } from '@gadgets/workshop-shared/api'
+import ResourcePicker from './ResourcePicker'
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@cloudflare/kumo', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  useKumoToastManager: () => ({ add: vi.fn<(toast: unknown) => void>() }),
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(next => { resolve = next })
+  return { promise, resolve }
+}
+
+describe('ResourcePicker', () => {
+  let root: Root | undefined
+  let container: HTMLDivElement | undefined
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    container?.remove()
+    vi.restoreAllMocks()
+  })
+
+  it('disposes a connected-account subscription that resolves after unmount', async () => {
+    const pendingSubscription = deferred<{ [Symbol.dispose](): void }>()
+    const dispose = vi.fn<() => void>()
+    const authenticatedApi = {
+      subscribeConnectedAccounts: () => pendingSubscription.promise,
+      listGatekeeperVendors: async () => [],
+    } as unknown as RpcStub<AuthenticatedApi>
+
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => root!.render(
+      <ResourcePicker
+        authenticatedApi={authenticatedApi}
+        searchText="https://example.com"
+        onSelectAccount={() => {}}
+      />,
+    ))
+
+    act(() => root!.unmount())
+    root = undefined
+    await act(async () => {
+      pendingSubscription.resolve({ [Symbol.dispose]: dispose })
+      await Promise.resolve()
+    })
+
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/workshop-frontend/src/ResourcePicker.tsx
+++ b/packages/workshop-frontend/src/ResourcePicker.tsx
@@ -1,14 +1,16 @@
+import { logRpcFailure } from './rpcErrors'
 import { useState, useEffect, useRef, useMemo, useCallback, type MutableRefObject } from 'react'
 import { Tooltip, useKumoToastManager } from '@cloudflare/kumo'
 import { Plus, CaretRight, Warning } from '@phosphor-icons/react'
-import { RpcStub, RpcTarget } from 'capnweb'
-import { AuthenticatedApi, ConnectedAccountsSubscriber } from '@gadgets/workshop-shared/api'
+import { RpcStub } from 'capnweb'
+import { AuthenticatedApi } from '@gadgets/workshop-shared/api'
 import { AccountDescription, SupportedResource, VendorDescription } from '@gadgets/workshop-shared/gatekeeper'
 import { extractHostname, extractBaseUrl, matchesResource, matchesResourceText, classifyMatch, getPlaceholderRanges } from './resourceMatching'
 import { GatekeeperIcon } from './components/GatekeeperIcon'
 import {
   PICKER_CAPTION, PICKER_EMPTY, PICKER_ROW, PICKER_ROW_ACTIVE, TabHint,
 } from './components/pickerRows'
+import { AccountsSubscriberAdapter } from './accountsSubscriber'
 
 export interface VendorOption {
   id: string
@@ -107,15 +109,12 @@ export default function ResourcePicker({
   const [grantingAccount, setGrantingAccount] = useState<number | null>(null)
 
   const subscriptionRef = useRef<{ stub: { [Symbol.dispose](): void } } | null>(null)
-  const seenAccountIdsRef = useRef(new Set<number>())
-
   // Subscribe to connected accounts on mount.
   useEffect(() => {
-    seenAccountIdsRef.current = new Set()
+    let cancelled = false
 
-    class AccountsSubscriber extends RpcTarget implements ConnectedAccountsSubscriber {
-      add(id: number, description: AccountDescription, vendor: VendorDescription, supportedResources: SupportedResource[] = [], credentialsValid: boolean = true, _vendorId: string = '') {
-        seenAccountIdsRef.current.add(id)
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id, description, vendor, supportedResources, credentialsValid }) {
         setAllAccounts(prev => {
           const next = new Map(prev)
           next.set(id, { description, vendor, supportedResources, credentialsValid })
@@ -125,49 +124,33 @@ export default function ResourcePicker({
         if (credentialsValid) {
           setReconnectingAccount(prev => prev === id ? null : prev)
         }
-      }
-
-      remove(id: number) {
-        seenAccountIdsRef.current.delete(id)
+      },
+      remove(id) {
         setAllAccounts(prev => {
           const next = new Map(prev)
           next.delete(id)
           return next
         })
-      }
-
+      },
       ready() {
         setAccountsLoaded(true)
-        const seen = seenAccountIdsRef.current
-        seenAccountIdsRef.current = new Set()
-        setAllAccounts(prev => {
-          let changed = false
-          const next = new Map(prev)
-          for (const id of next.keys()) {
-            if (!seen.has(id)) {
-              next.delete(id)
-              changed = true
-            }
-          }
-          return changed ? next : prev
-        })
-      }
-    }
-
-    const subscriber = new AccountsSubscriber()
+      },
+    })
     const subscribe = async () => {
       try {
         const stub = await authenticatedApi.subscribeConnectedAccounts(subscriber)
-        subscriptionRef.current = { stub }
+        if (cancelled) stub[Symbol.dispose]()
+        else subscriptionRef.current = { stub }
       } catch (error) {
-        console.error('Failed to subscribe to connected accounts:', error)
+        logRpcFailure('Failed to subscribe to connected accounts:', error)
         // Nothing more is coming, so show what we have rather than hiding forever.
-        setAccountsLoaded(true)
+        if (!cancelled) setAccountsLoaded(true)
       }
     }
     subscribe()
 
     return () => {
+      cancelled = true
       if (subscriptionRef.current) {
         subscriptionRef.current.stub[Symbol.dispose]()
         subscriptionRef.current = null

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -118,7 +118,9 @@ export interface ConnectedAccountsSubscriber {
       supportedResources: SupportedResource[], credentialsValid: boolean, vendorId: string): void;
   remove(id: number): void;
 
-  // Called after add() has been called for all accounts known so far.
+  // Called after add() has been called for all accounts known so far. Re-fires at the end of
+  // every catch-up replay when the server re-registers this subscriber after a Durable Object
+  // reset, so implementations must keep it idempotent (and treat repeat add() as an upsert).
   ready(): void;
 }
 


### PR DESCRIPTION
Supersedes #58 — same goal, restarted and reworked. #56 (the observability groundwork) is already on main, and the client-side half of this work — error classification, quieting, auth error codes, and the shared connected-accounts subscriber adapter — was extracted and merged separately as #110. This PR is the Worker-side recovery half, plus one small frontend subscription-hygiene fix.

Routine Durable Object resets — storage timeouts, overload aborts; ~3k over a recent 4-day window in production logs — were surfacing in the frontend as scary terminal errors, and anything subscribed to the user DO stayed silently broken until a page reload. The reject frames carry structured flags (`durableObjectReset`, `retryable`, … thanks to `enhanced_error_serialization`), but nothing read them.

<img width="1251" height="835" alt="terminal error screenshot" src="https://github.com/user-attachments/assets/0655824f-9df2-4c4d-bc3e-dded7c1b4c9a" />
<img width="1251" height="835" alt="terminal error screenshot" src="https://github.com/user-attachments/assets/ccb8e6b9-f943-422f-8667-1d8fa710eaab" />

## What changed

**The Worker absorbs user-DO resets.** Stubs are resolved fresh per call (a stub dies with its incarnation), and every user-DO RPC goes through one of three chokepoints: reads retry once on reset (jittered, same-colo), writes never retry — the reset can land after the commit — and serialize per session to keep their order, and subscription registration gets neither.

**Subscriptions self-heal.** The DO holds registrations in memory only, so the session stamps each with the DO's incarnation id and re-subscribes any whose stamp goes stale (detected via error flags, a throttled check after successful calls, or a mismatched new subscribe). The catch-up replay is pure upsert; the shared client adapter that consumes it landed in #110.

**ResourcePicker disposes subscriptions that resolve after unmount** — a small standalone fix for a leaked registration the self-heal work surfaced.

## Accepted gaps (deliberate)

- An account disconnected during the seconds a registration is dead ghosts in the UI until the next re-subscribe. Removes have exactly one source today (the owner's own disconnect), and the alternative was worse: a replay-reconciliation protocol was built and then deleted, because the DO's replay is lossy by design and pruning against it removed live accounts more often than ghosts.
- A fully idle session learns nothing until its next user-DO call; the client's socket-level reconnect remains the backstop.
- Workspace (Overseer) DO resets keep their pre-existing session-abort handling — out of scope here; a follow-up PR (workspace reopen) addresses them client-side.

## Testing

- **Integration** (`abortAllDurableObjects()`, the non-graceful teardown): the same session recovers transparently after a reset, live subscriptions recover via incarnation drift, and the local-aborts-reject-flagless shape is pinned so the flag paths can graduate to real integration tests if a future pool upgrade attaches the production flags.
- **Unit**: reset predicate/retry and the incarnation/replay behavior. (The frontend classifier canaries and subscriber-adapter contract tests merged with #110.) 290 backend unit + 4 integration + 136 frontend green on this branch.
- **Manual fault injection** (chrome-devtools against a local dev stack, temporary `debugAbort()` injector, composed with the #110 client): 72 aborts across idle, live-subscription, reload-race, and SPA-navigation-storm scenarios — every page functional, zero application console output, and an OAuth connect performed after an abort arrived live through the recovered subscription (no remount). A chat send racing a workspace-DO abort showed the inline hint (#110's UI), preserved the draft, and did not double-send. Server logs: 3× `subscription.recovered`, 0× `recover_failed`.
