### PR TITLE
Classify RPC errors client-side and quiet recoverable failures

### DIFF
--- a/packages/workshop-backend/src/server.ts
+++ b/packages/workshop-backend/src/server.ts
@@ -1,7 +1,7 @@
 import { RpcStub, RpcTarget, newWorkersRpcResponse } from "capnweb";
 import { validateRpc } from "capnweb-validate";
 import type { JWTPayload } from "jose";
-import { PublicApi, AuthenticatedApi, Overseer, GadgetMetadataWithTimestamps, AiChatAuthorInfo, AiModelConfig, AiGatewayInfo, AiModelProvider, ConnectedAccountsSubscriber, ConnectedAccountsFilter, GatekeeperVendorFilter, ObserverConfigCallback, BlueprintLibrarySummary, BlueprintPublicInfo, BlueprintUserSummary, BlueprintBindingAssignment, AgentSpawnerConfig, WorkpieceId, BLUEPRINT_SCREENSHOT_PATH_PREFIX, BLUEPRINT_SCREENSHOT_R2_PREFIX, blueprintScreenshotUrl, ServerConfig, CloudflareUsageInfo, CloudflareAccountOption, LoginAttempt, GatekeeperAppInfo, AdminApi, GatekeeperVendorInfo, OutputFormatOffer, ListOutputsResult, createOpenGadgetError, getOpenGadgetErrorCode, OPEN_GADGET_ERROR_CODES } from '@gadgets/workshop-shared/api';
+import { PublicApi, AuthenticatedApi, Overseer, GadgetMetadataWithTimestamps, AiChatAuthorInfo, AiModelConfig, AiGatewayInfo, AiModelProvider, ConnectedAccountsSubscriber, ConnectedAccountsFilter, GatekeeperVendorFilter, ObserverConfigCallback, BlueprintLibrarySummary, BlueprintPublicInfo, BlueprintUserSummary, BlueprintBindingAssignment, AgentSpawnerConfig, WorkpieceId, BLUEPRINT_SCREENSHOT_PATH_PREFIX, BLUEPRINT_SCREENSHOT_R2_PREFIX, blueprintScreenshotUrl, ServerConfig, CloudflareUsageInfo, CloudflareAccountOption, LoginAttempt, GatekeeperAppInfo, AdminApi, GatekeeperVendorInfo, OutputFormatOffer, ListOutputsResult, createOpenGadgetError, getOpenGadgetErrorCode, OPEN_GADGET_ERROR_CODES, AUTH_ERROR_CODES, createAuthError } from '@gadgets/workshop-shared/api';
 import type { UiFeatureFlags } from "@gadgets/workshop-shared/feature-flags";
 import { getServerConfig } from "./deployment-config.js";
 import { isPasswordAuthEnabled, getAuthGatekeeperAllowlist } from "./auth/config.js";
@@ -664,7 +664,7 @@ class PublicApiImpl extends RpcTarget implements PublicApi {
   async authenticate(token: string): Promise<AuthenticatedApi> {
     let split = token.split(':');
     if (split.length !== 2) {
-      throw new Error("Invalid session token.");
+      throw createAuthError(AUTH_ERROR_CODES.invalidSessionToken);
     }
 
     let userId = this.users.idFromName(split[0]);
@@ -680,7 +680,7 @@ class PublicApiImpl extends RpcTarget implements PublicApi {
 
   async authenticateFromCfAccess(): Promise<AuthenticatedApi> {
     if (!this.accessPayload) {
-      throw new Error("Not authenticated with Access.");
+      throw createAuthError(AUTH_ERROR_CODES.notAuthenticatedWithAccess);
     }
 
     let email = this.accessPayload.email as string;

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -1,5 +1,5 @@
 import { RpcStub } from "capnweb";
-import { GadgetMetadataWithTimestamps, AiChatAuthorInfo, AiModelConfig, SUGGESTED_MODELS, CollaboratorRole, ConnectedAccountsSubscriber, ConnectedAccountsFilter, GatekeeperVendorFilter, GadgetMetadata, BlueprintMetadata, BlueprintLibrarySummary, BlueprintSource, BlueprintUserSummary, BLUEPRINT_SCREENSHOT_R2_PREFIX, GatekeeperVendorInfo, BlueprintOutput, OutputSummary, WorkpieceId, ListOutputsResult } from '@gadgets/workshop-shared/api';
+import { GadgetMetadataWithTimestamps, AiChatAuthorInfo, AiModelConfig, SUGGESTED_MODELS, CollaboratorRole, ConnectedAccountsSubscriber, ConnectedAccountsFilter, GatekeeperVendorFilter, GadgetMetadata, BlueprintMetadata, BlueprintLibrarySummary, BlueprintSource, BlueprintUserSummary, BLUEPRINT_SCREENSHOT_R2_PREFIX, GatekeeperVendorInfo, BlueprintOutput, OutputSummary, WorkpieceId, ListOutputsResult, AUTH_ERROR_CODES, createAuthError } from '@gadgets/workshop-shared/api';
 import { Gatekeeper, GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor, AccountDescription, VendorDescription, GatekeeperConnectCallback, SupportedResource, ResourceConfiguratorFrame, AppUiContext, GatekeeperUiFrame } from "@gadgets/workshop-shared/gatekeeper";
 import { shouldAutoProvisionAccount, ambientGatekeeperMode } from "./provisioning-policy.js";
 import { CloudflareGatekeeperUser } from "@gadgets/workshop-shared/cloudflare-gatekeeper";
@@ -301,7 +301,7 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     let tokenId = new Uint8Array(hash).toHex();
     let session = this.storage.sessions.get(tokenId);
     if (!session) {
-      throw new Error("invalid session token");
+      throw createAuthError(AUTH_ERROR_CODES.invalidSessionToken);
     }
   }
 

--- a/packages/workshop-frontend/src/BlueprintLandingPage.tsx
+++ b/packages/workshop-frontend/src/BlueprintLandingPage.tsx
@@ -1,8 +1,9 @@
+import { logRpcFailure } from './rpcErrors'
 import { useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react'
 import { useNavigate, useParams, useRouter } from '@tanstack/react-router'
-import { RpcStub, RpcTarget } from 'capnweb'
-import { PublicApi, AuthenticatedApi, AdminApi, BlueprintPublicInfo, BlueprintBinding, BlueprintBindingAssignment, BlueprintUserSummary, AiChatAuthorInfo, ConnectedAccountsSubscriber } from '@gadgets/workshop-shared/api'
-import { AccountDescription, SupportedResource, VendorDescription, ResourceConfiguratorFrame } from '@gadgets/workshop-shared/gatekeeper'
+import { RpcStub } from 'capnweb'
+import { PublicApi, AuthenticatedApi, AdminApi, BlueprintPublicInfo, BlueprintBinding, BlueprintBindingAssignment, BlueprintUserSummary, AiChatAuthorInfo } from '@gadgets/workshop-shared/api'
+import { SupportedResource, VendorDescription, ResourceConfiguratorFrame } from '@gadgets/workshop-shared/gatekeeper'
 import { Button, Dialog, DropdownMenu, Select, Tooltip, useKumoToastManager } from '@cloudflare/kumo'
 import { ArrowsOutSimple, ArrowLeft, ArrowSquareOut, DotsThree, DownloadSimple, Lightning, Plus, Robot, Sparkle, Star, Trash, X } from '@phosphor-icons/react'
 
@@ -19,6 +20,7 @@ import ResourceConfiguratorHost from './ResourceConfiguratorHost'
 import { WorkshopButton, WorkshopIconButton } from './components/WorkshopControls'
 import { MENU_CONTENT, MENU_ITEM, MENU_ITEM_DANGER } from './components/menuStyles'
 import { useDocumentTitle } from './useDocumentTitle'
+import { AccountsSubscriberAdapter } from './accountsSubscriber'
 
 interface Props {
   rpcStub: RpcStub<PublicApi>
@@ -120,7 +122,9 @@ export default function BlueprintLandingPage({ rpcStub }: Props) {
   // When authenticated, fetch models for binding assignment.
   useEffect(() => {
     if (isAuthenticated && authenticatedApi) {
-      authenticatedApi.listModels().then(setModels).catch(console.error)
+      authenticatedApi.listModels()
+        .then(setModels)
+        .catch(err => logRpcFailure('Failed to load models:', err))
     } else {
       setModels([])
     }
@@ -154,15 +158,8 @@ export default function BlueprintLandingPage({ rpcStub }: Props) {
     const accountMap = new Map<number, AccountOption>()
     let subStub: { [Symbol.dispose](): void } | null = null
 
-    class AccountsSubscriber extends RpcTarget implements ConnectedAccountsSubscriber {
-      add(
-        accountId: number,
-        description: AccountDescription,
-        vendor: VendorDescription,
-        supportedResources: SupportedResource[] = [],
-        credentialsValid: boolean = true,
-        vendorId: string = '',
-      ) {
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id: accountId, description, vendor, supportedResources, credentialsValid, vendorId }) {
         if (cancelled) return
         accountMap.set(accountId, {
           id: accountId, description, vendorId, vendorDescription: vendor,
@@ -172,16 +169,15 @@ export default function BlueprintLandingPage({ rpcStub }: Props) {
         if (credentialsValid) {
           setReconnectingAccountId(prev => prev === accountId ? null : prev)
         }
-      }
-      remove(accountId: number) {
+      },
+      remove(accountId) {
         if (cancelled) return
         accountMap.delete(accountId)
         setAccounts(Array.from(accountMap.values()))
-      }
-      ready() {}
-    }
+      },
+    })
 
-    authenticatedApi.subscribeConnectedAccounts(new AccountsSubscriber())
+    authenticatedApi.subscribeConnectedAccounts(subscriber)
       .then(stub => {
         if (cancelled) {
           stub[Symbol.dispose]()
@@ -190,7 +186,7 @@ export default function BlueprintLandingPage({ rpcStub }: Props) {
         }
       })
       .catch(err => {
-        console.error('Failed to subscribe to connected accounts:', err)
+        logRpcFailure('Failed to subscribe to connected accounts:', err)
       })
 
     return () => {

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -1,3 +1,4 @@
+import { isTransientRpcError, logRpcFailure } from "./rpcErrors";
 import {
   Fragment,
   memo,
@@ -1780,6 +1781,7 @@ export const ChatInput = ({
   attachLabel,
   draftUpdateBanner,
   blockedReason,
+  chatKey,
   onStop,
   showThinkingTraces = true,
   onToggleThinkingTraces,
@@ -1825,6 +1827,8 @@ export const ChatInput = ({
   /** When set, the composer is disabled and shows this message — the user must resolve something
    * (e.g. accept/deny a pending connection request) before they can type or send. */
   blockedReason?: string;
+  /** Identity of the chat the composer is bound to; a change clears chat-scoped hints. */
+  chatKey?: number | null;
   onStop?: () => void;
   showThinkingTraces?: boolean;
   onToggleThinkingTraces?: () => void;
@@ -1838,6 +1842,10 @@ export const ChatInput = ({
   const [capsules, setCapsules] = useState<InputCapsule[]>([]);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [isSending, setIsSending] = useState(false);
+  // The chat the "may not have been sent" hint belongs to; the render condition scopes it, and
+  // leaving the chat dismisses it.
+  const [sendHiccup, setSendHiccup] = useState<{ chatKey?: number | null } | null>(null);
+  useEffect(() => setSendHiccup(null), [chatKey]);
   const [isAttachmentDragActive, setIsAttachmentDragActive] = useState(false);
   const [selectedSlashCommand, setSelectedSlashCommand] = useState<SelectedSlashCommand | null>(null);
   // The caret the slash command picker parses at. Deliberately updated only when it moves to a
@@ -2276,6 +2284,7 @@ export const ChatInput = ({
 
   const handleSend = async () => {
     if (sendInFlightRef.current || isSending || isBlocked) return;
+    setSendHiccup(null);
     const attachmentsSnapshot = pendingAttachments;
     const readyAttachments = attachmentsSnapshot
       .filter((attachment) => attachment.uploadState === "ready" && attachment.ref)
@@ -2454,8 +2463,15 @@ export const ChatInput = ({
   };
 
   const submitMessage = () => {
+    const submittedChatKey = chatKey;
     void handleSend().catch((err) => {
-      console.error("Failed to send chat message:", err);
+      if (isTransientRpcError(err)) {
+        setSendHiccup({ chatKey: submittedChatKey });
+      } else {
+        // The onSend handlers log the RPC failures they see; this is the only report for
+        // anything handleSend itself throws before reaching them.
+        console.error("Failed to send chat message:", err);
+      }
     });
   };
 
@@ -3050,6 +3066,14 @@ export const ChatInput = ({
           </div>
         )}
         {draftUpdateBanner}
+        {sendHiccup && sendHiccup.chatKey === chatKey && (
+          <div className="px-4 pt-2 text-xs text-kumo-warning">
+            {/* Composers without a chatKey (new-chat, home page) have no thread to check. */}
+            {chatKey != null
+              ? "Connection hiccup — your message may not have been sent. Check the thread, then try again; if it keeps failing, reload the page."
+              : "Connection hiccup — your message may not have been sent. Try again; if it keeps failing, reload the page."}
+          </div>
+        )}
         {/* Textarea */}
         <div className="relative px-4 pb-1 pt-3">
           {slashCommandPicker.popup}
@@ -5213,9 +5237,10 @@ function ChatInterface({
           forceUpdate();
         }
       } catch (err) {
-        console.error("Failed to subscribe to chats:", err);
-        reportIssue('chat.subscription-load', err)
-        toasts.add({ title: "Unable to load conversations", variant: "error" });
+        if (!logRpcFailure("Failed to subscribe to chats:", err)) {
+          reportIssue('chat.subscription-load', err)
+          toasts.add({ title: "Unable to load conversations", variant: "error" });
+        }
       }
     };
 
@@ -5366,8 +5391,9 @@ function ChatInterface({
         );
       }
     } catch (err) {
-      console.error("Failed to send message:", err);
-      toasts.add({ title: "Failed to send message", variant: "error" });
+      if (!logRpcFailure("Failed to send message:", err, { reportSite: "chat.send" })) {
+        toasts.add({ title: "Failed to send message", variant: "error" });
+      }
       throw err;
     }
   };
@@ -5388,8 +5414,9 @@ function ChatInterface({
           message, model, capsules, attachments, formats);
       onNavigateToChatRef.current(newChatId);
     } catch (err) {
-      console.error("Failed to create new chat:", err);
-      toasts.add({ title: "Failed to start conversation", variant: "error" });
+      if (!logRpcFailure("Failed to create new chat:", err, { reportSite: "chat.new" })) {
+        toasts.add({ title: "Failed to start conversation", variant: "error" });
+      }
       throw err;
     }
   };
@@ -7576,6 +7603,7 @@ function ChatInterface({
               <div className={`flex-shrink-0 bg-kumo-base ${sidebarMode ? "" : "border-t border-kumo-line"}`}>
                 <div className={useConstrainedChatWidth ? "mx-auto w-full max-w-[920px]" : ""}>
                   <ChatInput
+                    chatKey={selectedChatId}
                     createCapsuleGatekeeper={(accountId, url) =>
                       overseer.newGatekeeper(accountId, url)
                     }

--- a/packages/workshop-frontend/src/Connections.tsx
+++ b/packages/workshop-frontend/src/Connections.tsx
@@ -70,6 +70,8 @@ export default function Connections({ overseer, gadget, chatId, authenticatedApi
       setHooks(hookList.filter((hook) => hook.gadgetId === id))
       onHasGatekeepersChange?.(bindingList.length > 0)
     } catch (err) {
+      // Loud on purpose: this panel has no retry path, so a quieted transient failure would
+      // silently render "no connected resources".
       console.error('Failed to load gatekeepers:', err)
       reportIssue('connections.load', err)
       toasts.add({ title: 'Failed to load connections', variant: 'error' })

--- a/packages/workshop-frontend/src/GatekeeperModal.tsx
+++ b/packages/workshop-frontend/src/GatekeeperModal.tsx
@@ -1,3 +1,4 @@
+import { logRpcFailure } from './rpcErrors'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Dialog, useKumoToastManager, type PortalContainer } from '@cloudflare/kumo'
 import {
@@ -10,15 +11,14 @@ import {
   Sparkle,
   X,
 } from '@phosphor-icons/react'
-import { RpcStub, RpcTarget } from 'capnweb'
+import { RpcStub } from 'capnweb'
 import {
   AgentSpawnerConfig,
   AiChatAuthorInfo,
-  ConnectedAccountsSubscriber,
   GatekeeperClient,
   Overseer,
 } from '@gadgets/workshop-shared/api'
-import { AccountDescription, SupportedResource, VendorDescription, matchesResourceUrlPattern } from '@gadgets/workshop-shared/gatekeeper'
+import { SupportedResource, VendorDescription, matchesResourceUrlPattern } from '@gadgets/workshop-shared/gatekeeper'
 import { ResourceConfiguratorFrame } from '@gadgets/workshop-shared/gatekeeper'
 import { useAuthenticatedApi } from './AuthContext'
 import { WorkshopButton, WorkshopIconButton } from './components/WorkshopControls'
@@ -34,6 +34,7 @@ import { AccountChooser, AccountOption } from './gatekeeper-modal/AccountChooser
 import { matchesResourceUrl } from './resourceMatching'
 import { reportIssue } from './errorReporting'
 import { useSiteName } from './ServerConfigContext'
+import { AccountsSubscriberAdapter } from './accountsSubscriber'
 
 export interface GatekeeperModalProps {
   open: boolean
@@ -407,30 +408,18 @@ export default function GatekeeperModal({
     let cancelled = false
     const accountMap = new Map<number, AccountOption>()
 
-    class AccountsSubscriber extends RpcTarget implements ConnectedAccountsSubscriber {
-      add(
-        id: number,
-        description: AccountDescription,
-        vendor: VendorDescription,
-        supportedResources: SupportedResource[] = [],
-        credentialsValid: boolean = true,
-        vendorId: string = '',
-      ) {
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id, description, vendor, supportedResources, credentialsValid, vendorId }) {
         if (cancelled) return
         accountMap.set(id, { id, description, vendorId, vendorDescription: vendor, supportedResources, credentialsValid })
         setAccounts(Array.from(accountMap.values()))
-      }
-
-      remove(id: number) {
+      },
+      remove(id) {
         if (cancelled) return
         accountMap.delete(id)
         setAccounts(Array.from(accountMap.values()))
-      }
-
-      ready() {}
-    }
-
-    const subscriber = new AccountsSubscriber()
+      },
+    })
     authenticatedApi.subscribeConnectedAccounts(subscriber)
       .then(stub => {
         if (cancelled) {
@@ -440,7 +429,7 @@ export default function GatekeeperModal({
         }
       })
       .catch(error => {
-        console.error('Failed to subscribe to connected accounts:', error)
+        logRpcFailure('Failed to subscribe to connected accounts:', error)
       })
 
     return () => {

--- a/packages/workshop-frontend/src/ObserverConfigModal.tsx
+++ b/packages/workshop-frontend/src/ObserverConfigModal.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
 import { Dialog, Select, Loader, Text, useKumoToastManager } from '@cloudflare/kumo'
 import { Warning, Plus, ArrowClockwise, CheckCircle } from '@phosphor-icons/react'
-import { RpcStub, RpcTarget } from 'capnweb'
+import { RpcStub } from 'capnweb'
 import {
   AuthenticatedApi,
-  ConnectedAccountsSubscriber,
   GatekeeperVendorInfo,
   ObserverBindingNeed,
   ObserverAccountChoice,
@@ -17,6 +16,7 @@ import {
 } from '@gadgets/workshop-shared/gatekeeper'
 import { WorkshopButton } from './components/WorkshopControls'
 import Avatar from './components/Avatar'
+import { AccountsSubscriberAdapter } from './accountsSubscriber'
 
 // Shown when a non-owner opens a shared Gadget that reads data through one or more gatekeeper
 // bindings, and they haven't yet chosen which of their own connected accounts to use for each one.
@@ -104,15 +104,8 @@ export default function ObserverConfigModal({
     let subStub: { [Symbol.dispose](): void } | null = null
     let cancelled = false
 
-    class Subscriber extends RpcTarget implements ConnectedAccountsSubscriber {
-      add(
-        id: number,
-        description: AccountDescription,
-        vendor: VendorDescription,
-        supportedResources: SupportedResource[] = [],
-        credentialsValid: boolean = true,
-        vendorId: string = '',
-      ) {
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id, description, vendor, supportedResources, credentialsValid, vendorId }) {
         setAccounts(prev => {
           const next = new Map(prev)
           next.set(id, { id, description, vendor, vendorId, supportedResources, credentialsValid })
@@ -127,29 +120,29 @@ export default function ObserverConfigModal({
             setConnecting(null)
           }
         }
-      }
-
-      remove(id: number) {
+      },
+      remove(id) {
         setAccounts(prev => {
           if (!prev.has(id)) return prev
           const next = new Map(prev)
           next.delete(id)
           return next
         })
-      }
-
+      },
       ready() {
         setReady(true)
-      }
-    }
+      },
+    })
 
     authenticatedApi
-      .subscribeConnectedAccounts(new Subscriber(), { includeForcedAutoProvisionedAccounts: true })
+      .subscribeConnectedAccounts(subscriber, { includeForcedAutoProvisionedAccounts: true })
       .then(stub => {
         if (cancelled) { stub[Symbol.dispose](); return }
         subStub = stub
       })
       .catch(err => {
+        // Loud on purpose: the modal has no retry path, so a quieted transient failure would
+        // strand the user on a permanent loader.
         console.error('Failed to subscribe to connected accounts:', err)
         toasts.add({ title: 'Failed to load your connected accounts', variant: 'error' })
       })

--- a/packages/workshop-frontend/src/OnboardingWizard.tsx
+++ b/packages/workshop-frontend/src/OnboardingWizard.tsx
@@ -1,16 +1,13 @@
+import { logRpcFailure } from './rpcErrors'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useKumoToastManager } from '@cloudflare/kumo'
-import { RpcTarget } from 'capnweb'
 import { useAuthenticatedApi } from './AuthContext'
 import {
   AiChatAuthorInfo,
   AiGatewayInfo,
-  ConnectedAccountsSubscriber,
 } from '@gadgets/workshop-shared/api'
 import {
   VendorDescription,
-  AccountDescription,
-  SupportedResource,
 } from '@gadgets/workshop-shared/gatekeeper'
 import {
   Camera,
@@ -34,6 +31,7 @@ import { useTheme } from './ThemeContext'
 import { useSiteName } from './ServerConfigContext'
 import SiteLogo from './components/SiteLogo'
 import { useDocumentTitle } from './useDocumentTitle'
+import { AccountsSubscriberAdapter } from './accountsSubscriber'
 
 // ─── constants ──────────────────────────────────────────────────────────────────
 
@@ -186,15 +184,8 @@ export default function OnboardingWizard({
         if (!cancelled) setVendorsLoading(false)
       })
 
-    class AccountsSubscriber extends RpcTarget implements ConnectedAccountsSubscriber {
-      add(
-        id: number,
-        _description: AccountDescription,
-        vendor: VendorDescription,
-        _supportedResources: SupportedResource[] = [],
-        _credentialsValid: boolean = true,
-        _vendorId: string = '',
-      ) {
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id, vendor }) {
         if (cancelled) return
         const url = vendor.url
         accountIdToUrl.set(id, url)
@@ -204,8 +195,8 @@ export default function OnboardingWizard({
         } else {
           pendingUrls.push(url)
         }
-      }
-      remove(id: number) {
+      },
+      remove(id) {
         const url = accountIdToUrl.get(id)
         if (url) {
           accountIdToUrl.delete(id)
@@ -213,15 +204,11 @@ export default function OnboardingWizard({
           if (!stillHas) connectedUrls.delete(url)
           refreshConnectedIds()
         }
-      }
-      ready() {}
-    }
-
-    const subscriber = new AccountsSubscriber()
+      },
+    })
     let subscriptionStub: { [Symbol.dispose](): void } | null = null
 
-    authenticatedApi
-      .subscribeConnectedAccounts(subscriber)
+    authenticatedApi.subscribeConnectedAccounts(subscriber)
       .then((stub) => {
         if (cancelled) {
           stub[Symbol.dispose]()
@@ -230,7 +217,7 @@ export default function OnboardingWizard({
         }
       })
       .catch((err) => {
-        console.error('Failed to subscribe to connected accounts:', err)
+        logRpcFailure('Failed to subscribe to connected accounts:', err)
       })
 
     return () => {

--- a/packages/workshop-frontend/src/accountsSubscriber.test.ts
+++ b/packages/workshop-frontend/src/accountsSubscriber.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { AccountDescription, VendorDescription } from '@gadgets/workshop-shared/gatekeeper'
+import { AccountsSubscriberAdapter } from './accountsSubscriber'
+
+const DESCRIPTION = { displayName: 'acct' } as AccountDescription
+const VENDOR = { displayName: 'vendor' } as VendorDescription
+
+type Event = { kind: 'add'; id: number } | { kind: 'remove'; id: number } | { kind: 'ready' }
+
+function recording() {
+  const events: Event[] = []
+  const subscriber = new AccountsSubscriberAdapter({
+    add: ({ id }) => events.push({ kind: 'add', id }),
+    remove: (id) => events.push({ kind: 'remove', id }),
+    ready: () => events.push({ kind: 'ready' }),
+  })
+  const add = (id: number) => subscriber.add(id, DESCRIPTION, VENDOR, [], true, 'vendor')
+  return { events, subscriber, add }
+}
+
+describe('AccountsSubscriberAdapter', () => {
+  it('forwards adds, removes, and ready', () => {
+    const { events, subscriber, add } = recording()
+    add(1)
+    add(2)
+    subscriber.remove(1)
+    subscriber.ready()
+    expect(events).toEqual([
+      { kind: 'add', id: 1 },
+      { kind: 'add', id: 2 },
+      { kind: 'remove', id: 1 },
+      { kind: 'ready' },
+    ])
+  })
+
+  // A post-reset catch-up replay (repeat adds + second ready) must be forwarded verbatim — no
+  // synthesized removes; reconciliation was deliberately deleted (see the class comment).
+  it('forwards a recovery replay (repeat adds + second ready) without synthesizing events', () => {
+    const { events, subscriber, add } = recording()
+    add(1)
+    add(2)
+    subscriber.ready()
+
+    add(1)
+    add(2)
+    subscriber.ready()
+
+    expect(events.filter(e => e.kind === 'remove')).toEqual([])
+    expect(events.filter(e => e.kind === 'ready')).toHaveLength(2)
+    expect(events.filter(e => e.kind === 'add')).toHaveLength(4)
+  })
+})

--- a/packages/workshop-frontend/src/accountsSubscriber.ts
+++ b/packages/workshop-frontend/src/accountsSubscriber.ts
@@ -1,0 +1,54 @@
+import { RpcTarget } from 'capnweb'
+import type { ConnectedAccountsSubscriber } from '@gadgets/workshop-shared/api'
+import type {
+  AccountDescription, SupportedResource, VendorDescription,
+} from '@gadgets/workshop-shared/gatekeeper'
+
+/** Everything the backend sends about one connected account. */
+export interface AccountEvent {
+  id: number
+  description: AccountDescription
+  vendor: VendorDescription
+  supportedResources: SupportedResource[]
+  credentialsValid: boolean
+  vendorId: string
+}
+
+export interface AccountHandlers {
+  add(event: AccountEvent): void
+  remove(id: number): void
+  ready?(): void
+}
+
+// The one client-side implementation of the connected-accounts subscription protocol. After a
+// Durable Object reset the session re-registers this subscriber and the restarted object
+// replays `add` per current account, then `ready()` — so handlers must treat `add` as an
+// upsert and keep `ready` (optional) idempotent.
+//
+// Accepted staleness: an account removed while the registration was dead ghosts until the
+// component re-subscribes. Removes have exactly one source today, the owner's own disconnect
+// (census note at dbSubscriber.remove in workshop-backend's user.ts). A replay-boundary prune
+// lived here once and was deleted: the DO's replay is lossy by design, so pruning against it
+// removed live accounts more often than ghosts. Reconsider if a new remove path appears.
+export class AccountsSubscriberAdapter extends RpcTarget implements ConnectedAccountsSubscriber {
+  #handlers: AccountHandlers
+
+  constructor(handlers: AccountHandlers) {
+    super()
+    this.#handlers = handlers
+  }
+
+  add(id: number, description: AccountDescription, vendor: VendorDescription,
+      supportedResources: SupportedResource[] = [], credentialsValid: boolean = true,
+      vendorId: string = ''): void {
+    this.#handlers.add({ id, description, vendor, supportedResources, credentialsValid, vendorId })
+  }
+
+  remove(id: number): void {
+    this.#handlers.remove(id)
+  }
+
+  ready(): void {
+    this.#handlers.ready?.()
+  }
+}

--- a/packages/workshop-frontend/src/components/AppShell/SidebarWorkspaces.tsx
+++ b/packages/workshop-frontend/src/components/AppShell/SidebarWorkspaces.tsx
@@ -1,3 +1,4 @@
+import { logRpcFailure } from '../../rpcErrors'
 import {
   createContext,
   useCallback,
@@ -89,15 +90,14 @@ export function SidebarWorkspacesProvider({ children }: { children: ReactNode })
   useEffect(() => {
     let cancelled = false
     setGadgetsLoading(true)
-    authenticatedApi
-      .listGadgets()
+    authenticatedApi.listGadgets()
       .then((list) => {
         if (cancelled) return
         setGadgets(list)
         setGadgetsLoading(false)
       })
       .catch((err) => {
-        console.error('Failed to load workspaces for sidebar:', err)
+        logRpcFailure('Failed to load workspaces for sidebar:', err)
         if (!cancelled) setGadgetsLoading(false)
       })
     return () => { cancelled = true }

--- a/packages/workshop-frontend/src/components/ConnectionChips.tsx
+++ b/packages/workshop-frontend/src/components/ConnectionChips.tsx
@@ -5,9 +5,7 @@ import { useState, useEffect } from 'react'
 import { logoComponents } from './ConnectionLogos'
 import { getVendorIconBackground } from './vendorColors'
 import { useTheme } from '../ThemeContext'
-import { ConnectedAccountsSubscriber } from '@gadgets/workshop-shared/api'
-import { AccountDescription, VendorDescription, SupportedResource } from '@gadgets/workshop-shared/gatekeeper'
-import { RpcTarget } from 'capnweb'
+import { AccountsSubscriberAdapter } from '../accountsSubscriber'
 
 interface ConnectedAccount {
   id: number
@@ -26,25 +24,21 @@ export default function ConnectionChips() {
 
     const accountMap = new Map<number, ConnectedAccount>()
 
-    class ChipsSubscriber extends RpcTarget implements ConnectedAccountsSubscriber {
-      add(id: number, description: AccountDescription, vendor: VendorDescription, _supportedResources: SupportedResource[] = [], _credentialsValid: boolean = true, vendorId: string = '') {
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id, description, vendor, vendorId }) {
         if (cancelled) return
-        const logoKey = vendorId
         accountMap.set(id, {
           id,
           name: description.displayName ?? description.uniqueName ?? vendor.displayName,
-          logo: logoKey,
+          logo: vendorId,
         })
-        if (!cancelled) setAccounts(Array.from(accountMap.values()))
-      }
-      remove(id: number) {
+        setAccounts(Array.from(accountMap.values()))
+      },
+      remove(id) {
         accountMap.delete(id)
         if (!cancelled) setAccounts(Array.from(accountMap.values()))
-      }
-      ready() {}
-    }
-
-    const subscriber = new ChipsSubscriber()
+      },
+    })
     const subPromise = authenticatedApi.subscribeConnectedAccounts(subscriber)
     subPromise.then((stub) => {
       if (cancelled) {

--- a/packages/workshop-frontend/src/routes/__root.tsx
+++ b/packages/workshop-frontend/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+import { logRpcFailure } from '../rpcErrors'
 import { useState, useEffect } from 'react'
 import { createRootRoute, Outlet, useRouterState } from '@tanstack/react-router'
 import { TooltipProvider, Toasty } from '@cloudflare/kumo'
@@ -154,7 +155,7 @@ function AuthenticatedShell({
     authenticatedApi.isOnboardingCompleted().then((completed) => {
       if (!cancelled) setOnboardingNeeded(!completed)
     }).catch((err) => {
-      console.error('Failed to check onboarding status:', err)
+      logRpcFailure('Failed to check onboarding status:', err)
       // If the check fails, skip onboarding to avoid blocking the user
       if (!cancelled) setOnboardingNeeded(false)
     })

--- a/packages/workshop-frontend/src/routes/gatekeepers.tsx
+++ b/packages/workshop-frontend/src/routes/gatekeepers.tsx
@@ -1,3 +1,4 @@
+import { logRpcFailure } from '../rpcErrors'
 import { createFileRoute } from '@tanstack/react-router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useKumoToastManager } from '@cloudflare/kumo'
@@ -11,7 +12,6 @@ import {
   Plugs,
 } from '@phosphor-icons/react'
 import ViewToggle from '../components/ViewToggle'
-import { RpcTarget } from 'capnweb'
 import { useAuthenticatedApi } from '../AuthContext'
 import { refreshGatekeeperApps } from '../useGatekeeperApps'
 import { EmptyState } from '../components/EmptyState'
@@ -21,9 +21,10 @@ import {
   SupportedResource,
   VendorDescription,
 } from '@gadgets/workshop-shared/gatekeeper'
-import { ConnectedAccountsSubscriber, GatekeeperVendorInfo } from '@gadgets/workshop-shared/api'
+import { GatekeeperVendorInfo } from '@gadgets/workshop-shared/api'
 import { useDocumentTitle } from '../useDocumentTitle'
 import { useSiteName } from '../ServerConfigContext'
+import { AccountsSubscriberAdapter } from '../accountsSubscriber'
 
 export const Route = createFileRoute('/gatekeepers')({
   component: ConnectorsPage,
@@ -482,17 +483,15 @@ function ConnectorsPage() {
     setAccountsLoaded(false)
     setVendorsLoaded(false)
 
-    authenticatedApi
-      .listAddableGatekeepers()
+    authenticatedApi.listAddableGatekeepers()
       .then((list) => {
         if (!cancelled) setAddable(list)
       })
       .catch((err) => {
-        console.error('Failed to load addable gatekeepers:', err)
+        logRpcFailure('Failed to load addable gatekeepers:', err)
       })
 
-    authenticatedApi
-      .listGatekeeperVendors()
+    authenticatedApi.listGatekeeperVendors()
       .then((vendorList) => {
         if (cancelled) return
         const unavailable = vendorList.filter((v) => v.unavailable)
@@ -514,22 +513,12 @@ function ConnectorsPage() {
         setVendorsLoaded(true)
       })
       .catch((err) => {
-        console.error('Failed to load available services:', err)
+        logRpcFailure('Failed to load available services:', err)
         if (!cancelled) setLoadError(true)
       })
 
-    class AccountsSubscriber
-      extends RpcTarget
-      implements ConnectedAccountsSubscriber
-    {
-      add(
-        id: number,
-        description: AccountDescription,
-        vendor: VendorDescription,
-        supportedResources: SupportedResource[] = [],
-        credentialsValid: boolean = true,
-        vendorId: string = '',
-      ) {
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id, description, vendor, supportedResources, credentialsValid, vendorId }) {
         if (cancelled) return
         accountMap.set(id, {
           id,
@@ -540,20 +529,17 @@ function ConnectorsPage() {
           credentialsValid,
         })
         setAccounts(Array.from(accountMap.values()))
-      }
-      remove(id: number) {
+      },
+      remove(id) {
         accountMap.delete(id)
         if (!cancelled) setAccounts(Array.from(accountMap.values()))
-      }
+      },
       ready() {
         if (!cancelled) setAccountsLoaded(true)
-      }
-    }
+      },
+    })
 
-    const subscriber = new AccountsSubscriber()
-
-    authenticatedApi
-      .subscribeConnectedAccounts(subscriber)
+    authenticatedApi.subscribeConnectedAccounts(subscriber)
       .then((stub) => {
         if (cancelled) {
           stub[Symbol.dispose]()
@@ -562,7 +548,7 @@ function ConnectorsPage() {
         }
       })
       .catch((err) => {
-        console.error('Failed to subscribe to connected accounts:', err)
+        logRpcFailure('Failed to subscribe to connected accounts:', err)
         if (!cancelled) setLoadError(true)
       })
 

--- a/packages/workshop-frontend/src/routes/index.tsx
+++ b/packages/workshop-frontend/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { classifyRpcError, logRpcFailure } from "../rpcErrors";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useKumoToastManager } from "@cloudflare/kumo";
@@ -57,16 +58,19 @@ export function HomePageContent({ prompt }: HomeSearch) {
 
   useEffect(() => {
     let cancelled = false;
-    authenticatedApi
-      .listModels()
+    authenticatedApi.listModels()
       .then((list) => {
         if (cancelled) return;
         setModels(list);
         setSelectedModel(getStoredSelectedModel(list));
       })
       .catch((err) => {
-        console.error("Failed to fetch models:", err);
-        toasts.add({ title: "Couldn't load AI models", variant: "error" });
+        logRpcFailure("Failed to fetch models:", err);
+        // Toast unless it's a connection error (reconnect refetches); a do-reset here already
+        // survived the Worker's same-colo retry, so the user should hear about it.
+        if (classifyRpcError(err) !== "connection") {
+          toasts.add({ title: "Couldn't load AI models", variant: "error" });
+        }
       });
     return () => {
       cancelled = true;
@@ -117,13 +121,16 @@ export function HomePageContent({ prompt }: HomeSearch) {
         // Open the conversation we just started.
         navigate({ to: "/workspace/$id", params: { id }, search: { chat } });
       } catch (err) {
-        console.error("Failed to create gadget:", err);
+        const transient = logRpcFailure("Failed to create gadget:", err,
+            { reportSite: "workspace.create" });
         // A retry reuses the provisional gadget while the draft contains gadget-scoped references.
         if (!attachments?.length && !capsules?.length) {
           provisionalOverseerRef.current?.stub[Symbol.dispose]();
           provisionalOverseerRef.current = null;
         }
-        toasts.add({ title: "Failed to create workspace", variant: "error" });
+        if (!transient) {
+          toasts.add({ title: "Failed to create workspace", variant: "error" });
+        }
         throw err;
       }
     },

--- a/packages/workshop-frontend/src/rpcErrors.test.ts
+++ b/packages/workshop-frontend/src/rpcErrors.test.ts
@@ -1,0 +1,160 @@
+// Vitest runs under node, but the src/ tsconfig only has browser types — hence the suppressions.
+// @ts-expect-error node builtin without @types/node
+import { readFileSync } from 'node:fs'
+// @ts-expect-error node builtin without @types/node
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+import { deserialize, serialize } from 'capnweb'
+import { AUTH_ERROR_CODES, createAuthError } from '@gadgets/workshop-shared/api'
+
+vi.mock('./errorReporting', () => ({ reportIssue: vi.fn<(site: string, err: unknown, options?: object) => void>() }))
+
+import { reportIssue } from './errorReporting'
+import {
+  classifyRpcError, getDurableObjectId, isDurableObjectResetError, isOverloadedError,
+  CONNECTION_MESSAGES, isTransientRpcError, logRpcFailure, reportDoResetError,
+} from './rpcErrors'
+
+const rpcError = (message: string, props?: object) => Object.assign(new Error(message), props)
+
+// The reject frame observed in prod for a DO storage-timeout reset.
+function storageTimeoutReset() {
+  return rpcError(
+    'Durable Object storage operation exceeded timeout which caused object to be reset.',
+    { remote: true, overloaded: true, durableObjectReset: true, durableObjectId: 'eed0859e' },
+  )
+}
+
+describe('classifyRpcError', () => {
+  it('classifies reset flags as do-reset', () => {
+    expect(classifyRpcError(storageTimeoutReset())).toBe('do-reset')
+  })
+
+  it('trusts the durableObjectReset flag over an unrecognized message', () => {
+    expect(classifyRpcError(rpcError('internal error', { durableObjectReset: true }))).toBe('do-reset')
+  })
+
+  it('falls back to known reset messages without flags', () => {
+    for (const message of [
+      'Durable Object reset because its code was updated.',
+      "Durable Object's isolate exceeded its memory limit and was reset.",
+      'Durable Object exceeded its CPU time limit and was reset.',
+      // What later calls on an already-dead capability reject with (flagless).
+      'The execution context which hosts this callback is no longer running.',
+    ]) {
+      expect(classifyRpcError(new Error(message))).toBe('do-reset')
+    }
+  })
+
+  it('prefers do-reset when both reset and retryable flags are set', () => {
+    expect(classifyRpcError(rpcError('x', { durableObjectReset: true, retryable: true }))).toBe('do-reset')
+  })
+
+  it('classifies the retryable flag as do-reset (backend-side, not browser transport)', () => {
+    expect(classifyRpcError(rpcError('x', { retryable: true }))).toBe('do-reset')
+  })
+
+  it('classifies capnweb transport messages as connection', () => {
+    expect(classifyRpcError(new Error('Peer closed WebSocket: 1006 '))).toBe('connection')
+    expect(classifyRpcError(new Error('WebSocket connection failed.'))).toBe('connection')
+    expect(classifyRpcError(new Error('RPC session was shut down by disposing the main stub')))
+        .toBe('connection')
+    expect(classifyRpcError(new Error('Attempted to use RPC stub after it has been disposed.')))
+        .toBe('connection')
+  })
+
+  it('classifies auth failures, which must never be retried or quieted', () => {
+    // Coded errors are authoritative; bare messages are the fallback for older deployments.
+    expect(classifyRpcError(createAuthError(AUTH_ERROR_CODES.invalidSessionToken))).toBe('auth')
+    expect(classifyRpcError(rpcError('nope', { code: 'INVALID_SESSION_TOKEN' }))).toBe('auth')
+    expect(classifyRpcError(new Error('invalid session token'))).toBe('auth')
+    expect(classifyRpcError(new Error('Not authenticated with Access.'))).toBe('auth')
+  })
+
+  it('classifies everything else as other', () => {
+    expect(classifyRpcError(new Error('Workspace not found.'))).toBe('other')
+    expect(classifyRpcError('boom')).toBe('other')
+    expect(classifyRpcError(null)).toBe('other')
+    expect(classifyRpcError(undefined)).toBe('other')
+  })
+})
+
+describe('isTransientRpcError', () => {
+  it('is true for do-reset and connection, false otherwise', () => {
+    expect(isTransientRpcError(storageTimeoutReset())).toBe(true)
+    expect(isTransientRpcError(new Error('Peer closed WebSocket: 1006 '))).toBe(true)
+    expect(isTransientRpcError(new Error('invalid session token'))).toBe(false)
+    expect(isTransientRpcError(new Error('Workspace not found.'))).toBe(false)
+  })
+})
+
+describe('flag accessors', () => {
+  it('reads reset, overload, and DO id from the enriched error', () => {
+    const err = storageTimeoutReset()
+    expect(isDurableObjectResetError(err)).toBe(true)
+    expect(isOverloadedError(err)).toBe(true)
+    expect(getDurableObjectId(err)).toBe('eed0859e')
+  })
+
+  it('handles errors without flags', () => {
+    expect(isOverloadedError(new Error('x'))).toBe(false)
+    expect(getDurableObjectId(new Error('x'))).toBeUndefined()
+    expect(getDurableObjectId(null)).toBeUndefined()
+  })
+})
+
+describe('reportDoResetError', () => {
+  it('forwards to reportIssue with a namespaced site', () => {
+    const err = storageTimeoutReset()
+    reportDoResetError('chat.send', err, { gadgetId: 'g1' })
+    expect(reportIssue).toHaveBeenCalledWith('do-reset.chat.send', err,
+        { severity: 'warning', handled: true, gadgetId: 'g1' })
+  })
+})
+
+describe('logRpcFailure', () => {
+  it('logs transient errors at debug level and returns true', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      expect(logRpcFailure('failed:', storageTimeoutReset())).toBe(true)
+      expect(debug).toHaveBeenCalledOnce()
+      expect(error).not.toHaveBeenCalled()
+
+      expect(logRpcFailure('failed:', new Error('Workspace not found.'))).toBe(false)
+      expect(error).toHaveBeenCalledOnce()
+    } finally {
+      debug.mockRestore()
+      error.mockRestore()
+    }
+  })
+})
+
+// Canary: these client-local errors carry no flags, so the classifier matches capnweb's message
+// strings. Pin them to the installed build so an upgrade fails here, not silently in the UX.
+describe('capnweb transport messages', () => {
+  it('still exist in the installed capnweb build', () => {
+    const require = createRequire(import.meta.url)
+    const source = readFileSync(require.resolve('capnweb'), 'utf8')
+    for (const message of CONNECTION_MESSAGES) {
+      expect(source, `capnweb no longer raises "${message}"`).toContain(message)
+    }
+  })
+})
+
+// Canary: the classifier's primary path reads flags/codes off the deserialized error, so pin
+// capnweb's custom-property round-trip too (serialize/deserialize use the same wire frame as
+// RPC rejections). A regression here would silently demote every classification to the message
+// fallback and drop auth codes entirely.
+describe('capnweb error serialization', () => {
+  it('round-trips the custom properties the classifier reads', () => {
+    const sent = Object.assign(storageTimeoutReset(), { code: AUTH_ERROR_CODES.invalidSessionToken })
+    const received = deserialize(serialize(sent)) as Error & Record<string, unknown>
+    expect(received).toBeInstanceOf(Error)
+    expect(received.durableObjectReset).toBe(true)
+    expect(received.overloaded).toBe(true)
+    expect(received.durableObjectId).toBe('eed0859e')
+    expect(received.code).toBe(AUTH_ERROR_CODES.invalidSessionToken)
+    expect(classifyRpcError(received)).toBe('do-reset')
+  })
+})

--- a/packages/workshop-frontend/src/rpcErrors.ts
+++ b/packages/workshop-frontend/src/rpcErrors.ts
@@ -1,0 +1,108 @@
+import { AUTH_ERROR_MESSAGES, getAuthErrorCode } from '@gadgets/workshop-shared/api'
+import { reportIssue } from './errorReporting'
+
+// Classifies errors surfaced through capnweb RPC. The backend runs with
+// `enhanced_error_serialization`, so remote failures carry structured flags (workerd
+// jsg/util.c++): `retryable` ⇔ the connection was lost, `overloaded` ⇔ the target pushed
+// back, `durableObjectReset` ⇔ the target Durable Object was reset. Flags are authoritative;
+// message matching is a fallback for errors that lose them in transit.
+
+export type RpcErrorClass = 'do-reset' | 'connection' | 'auth' | 'other'
+
+// What calls on a capability whose hosting Durable Object already reset reject with — always
+// flagless; only calls in flight at reset time get the flagged error. A workerd runtime string
+// nothing pins, so drift degrades gracefully: those errors reclassify from quiet do-reset to
+// loud other. Lives here (not workshop-shared) because this classifier is its only consumer.
+const WORKERD_DEAD_CAPABILITY_MESSAGE =
+  'The execution context which hosts this callback is no longer running'
+
+// Fallbacks: the first four strings only matter when something re-wrapped the error and lost
+// its flags; the dead-capability string is inherently flagless (above).
+const DO_RESET_MESSAGES = [
+  'Durable Object reset because its code was updated',
+  'Durable Object storage operation exceeded timeout',
+  "Durable Object's isolate exceeded its memory limit",
+  'Durable Object exceeded its CPU time limit',
+  WORKERD_DEAD_CAPABILITY_MESSAGE,
+]
+
+// Transport failures raised locally by capnweb, plus its own-session teardown message. These
+// carry no flags, so matching messages is all we have; a canary test pins them to the installed
+// capnweb build so an upgrade fails loudly here instead of silently in the UX.
+export const CONNECTION_MESSAGES = [
+  'Peer closed WebSocket',
+  'WebSocket connection failed.',
+  'RPC session was shut down by disposing the main stub',
+  // What RPCs on an already-disposed stub reject with — e.g. the zombie the connection manager
+  // disposes while an outage is being recovered.
+  'Attempted to use RPC stub after it has been disposed',
+]
+
+// Fallback for auth errors thrown without a code (older deployments); codes are authoritative.
+const AUTH_MESSAGES = Object.values(AUTH_ERROR_MESSAGES)
+
+const messageOf = (err: unknown) => (err instanceof Error ? err.message : String(err))
+
+const flag = (err: unknown, name: string) =>
+  (err as Record<string, unknown> | null | undefined)?.[name] === true
+
+export function isDurableObjectResetError(err: unknown): boolean {
+  return flag(err, 'durableObjectReset') || DO_RESET_MESSAGES.some(m => messageOf(err).includes(m))
+}
+
+export function isOverloadedError(err: unknown): boolean {
+  return flag(err, 'overloaded')
+}
+
+export function getDurableObjectId(err: unknown): string | undefined {
+  const id = (err as { durableObjectId?: unknown } | null | undefined)?.durableObjectId
+  return typeof id === 'string' ? id : undefined
+}
+
+export function classifyRpcError(err: unknown): RpcErrorClass {
+  // A flagged `retryable` (the WORKER's connection to the object was lost) is backend trouble,
+  // not browser transport — it arrived over a healthy socket, so the reconnect path would never
+  // observe it. It classifies with do-reset, whose callers own that recovery.
+  if (isDurableObjectResetError(err) || flag(err, 'retryable')) return 'do-reset'
+  const message = messageOf(err)
+  if (CONNECTION_MESSAGES.some(m => message.includes(m))) {
+    return 'connection'
+  }
+  // 'auth' is deliberately terminal — never quieted, never retried, and there is no missing
+  // re-auth handler: the session is invalid and only a fresh login cures it.
+  if (getAuthErrorCode(err) !== undefined || AUTH_MESSAGES.some(m => message.includes(m))) {
+    return 'auth'
+  }
+  return 'other'
+}
+
+// True for failures that a healthy retry or reconnect is expected to cure.
+export function isTransientRpcError(err: unknown): boolean {
+  const cls = classifyRpcError(err)
+  return cls === 'do-reset' || cls === 'connection'
+}
+
+// Logs an RPC failure: quietly for transient errors (a retry or reconnect is expected to cure
+// them), loudly otherwise. Returns true when transient so call sites can skip their toasts.
+// Pass `reportSite` from action paths (sends, creates) to also report do-reset errors to the
+// client-errors endpoint, so resets that cost the user an action stay visible in telemetry.
+export function logRpcFailure(
+  message: string, err: unknown, options?: { reportSite?: string },
+): boolean {
+  const cls = classifyRpcError(err)
+  if (cls === 'do-reset' && options?.reportSite) reportDoResetError(options.reportSite, err)
+  const transient = cls === 'do-reset' || cls === 'connection'
+  if (transient) console.debug(message, err)
+  else console.error(message, err)
+  return transient
+}
+
+// No client-side retry lives here on purpose: the Worker owns DO-reset recovery (fresh stubs,
+// one same-colo retry for idempotent reads — see workshop-backend's do-retry.ts), so a do-reset
+// error that reaches the browser already survived that and is worth surfacing. Connection-class
+// errors are owned by the connection manager's reconnect.
+
+/** Reports a DO-reset error to the client-errors endpoint (no-op unless reporting is enabled). */
+export function reportDoResetError(site: string, err: unknown, options?: { gadgetId?: string }) {
+  reportIssue(`do-reset.${site}`, err, { severity: 'warning', handled: true, ...options })
+}

--- a/packages/workshop-frontend/src/useVendorBranding.ts
+++ b/packages/workshop-frontend/src/useVendorBranding.ts
@@ -1,3 +1,4 @@
+import { logRpcFailure } from './rpcErrors'
 import { useEffect, useState } from 'react'
 import { RpcStub } from 'capnweb'
 import { AuthenticatedApi } from '@gadgets/workshop-shared/api'
@@ -50,7 +51,7 @@ export function useVendorBranding(
     promise
       .then((map) => { if (!cancelled) setBranding(map) })
       .catch((err) => {
-        console.error('Failed to load vendor branding:', err)
+        logRpcFailure('Failed to load vendor branding:', err)
       })
 
     return () => { cancelled = true }

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -251,6 +251,22 @@ export interface ObserverConfigCallback extends RpcTarget {
   configure(needs: ObserverBindingNeed[]): Promise<ObserverAccountChoice[]>;
 }
 
+/** Builds the create/read helpers for a family of expected errors carrying stable
+ * machine-readable codes. The per-code messages double as the classification fallback for errors
+ * from older deployments that lost the code in transit, so changing one is a compatibility break. */
+function codedErrorFamily<Code extends string>(messages: Record<Code, string>) {
+  const codes = new Set<unknown>(Object.keys(messages));
+  return {
+    create: (code: Code): Error & { code: Code } =>
+        Object.assign(new Error(messages[code]), { code }),
+    getCode: (error: unknown): Code | undefined => {
+      const candidate = typeof error === "object" && error !== null && "code" in error
+          ? error.code : undefined;
+      return codes.has(candidate) ? candidate as Code : undefined;
+    },
+  };
+}
+
 /** Stable error codes attached to expected failures from `AuthenticatedApi.openGadget()`. */
 export const OPEN_GADGET_ERROR_CODES = {
   workspaceNotFound: "WORKSPACE_NOT_FOUND",
@@ -261,29 +277,40 @@ export const OPEN_GADGET_ERROR_CODES = {
 export type OpenGadgetErrorCode =
     typeof OPEN_GADGET_ERROR_CODES[keyof typeof OPEN_GADGET_ERROR_CODES];
 
-const OPEN_GADGET_ERROR_MESSAGES: Record<OpenGadgetErrorCode, string> = {
+const openGadgetErrors = codedErrorFamily<OpenGadgetErrorCode>({
   [OPEN_GADGET_ERROR_CODES.workspaceNotFound]: "Workspace not found.",
   [OPEN_GADGET_ERROR_CODES.workspaceAccessDenied]: "You don't have access to this workspace.",
-};
+});
 
 /** Creates an expected `openGadget()` error with a machine-readable code. */
-export function createOpenGadgetError(
-    code: OpenGadgetErrorCode): Error & { code: OpenGadgetErrorCode } {
-  return Object.assign(new Error(OPEN_GADGET_ERROR_MESSAGES[code]), { code });
-}
+export const createOpenGadgetError = openGadgetErrors.create;
 
 /** Reads the machine-readable code from an expected `openGadget()` error. */
-export function getOpenGadgetErrorCode(error: unknown): OpenGadgetErrorCode | undefined {
-  if (typeof error !== "object" || error === null) return undefined;
+export const getOpenGadgetErrorCode = openGadgetErrors.getCode;
 
-  const candidate = "code" in error ? error.code : undefined;
-  return isOpenGadgetErrorCode(candidate) ? candidate : undefined;
-}
+/** Stable error codes attached to authentication failures. */
+export const AUTH_ERROR_CODES = {
+  invalidSessionToken: "INVALID_SESSION_TOKEN",
+  notAuthenticatedWithAccess: "NOT_AUTHENTICATED_WITH_ACCESS",
+} as const;
 
-function isOpenGadgetErrorCode(value: unknown): value is OpenGadgetErrorCode {
-  return value === OPEN_GADGET_ERROR_CODES.workspaceNotFound ||
-      value === OPEN_GADGET_ERROR_CODES.workspaceAccessDenied;
-}
+/** An expected authentication failure code. */
+export type AuthErrorCode = typeof AUTH_ERROR_CODES[keyof typeof AUTH_ERROR_CODES];
+
+/** Messages for auth failures thrown without a surviving code; clients match these only as a
+ * classification fallback. */
+export const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
+  [AUTH_ERROR_CODES.invalidSessionToken]: "invalid session token",
+  [AUTH_ERROR_CODES.notAuthenticatedWithAccess]: "Not authenticated with Access.",
+};
+
+const authErrors = codedErrorFamily(AUTH_ERROR_MESSAGES);
+
+/** Creates an authentication failure with a machine-readable code. */
+export const createAuthError = authErrors.create;
+
+/** Reads the machine-readable code from an authentication failure. */
+export const getAuthErrorCode = authErrors.getCode;
 
 // Top-level API exposed to the user after they have authenticated.
 export interface AuthenticatedApi extends RpcTarget {


### PR DESCRIPTION
## Overview

Foundation PR for the Durable Object reset-resilience work: the client learns to tell recoverable RPC failures (DO resets, socket drops) from terminal ones, and stops shouting about the ones the system cures on its own. Extracted as a standalone base so the two follow-ups — server-side user-DO absorption and the workspace reopen flow — can land independently.

## Why

Every call site was `catch(console.error)`, so failures the platform recovers from looked terminal in the console and sometimes toasted at the user mid-recovery.

## Commits

- **Stable machine-readable codes for authentication failures** — auth failures carry codes (`INVALID_SESSION_TOKEN`, `NOT_AUTHENTICATED_WITH_ACCESS`) so the classifier doesn't rest on message strings; the per-code messages double as a compatibility fallback for older deployments.
- **Classify RPC errors client-side and quiet recoverable failures** — `rpcErrors.ts` classifies as do-reset / connection / auth / other using structured workerd flags first, message matching only as a fallback (pinned by canary tests against the installed capnweb, so an upgrade fails in CI rather than silently in the UX). `logRpcFailure` sweeps the call sites: transient failures drop to `console.debug`, everything else stays loud, and do-resets on action paths report to telemetry. Failed chat sends get an inline check-the-thread hint instead of a toast. All seven connected-accounts consumers now share one replay-aware subscriber that self-heals after a reset.

Deliberately no client-side retry here: recovery ownership lives with the follow-up PRs (Worker-side absorb; workspace reopen). `Connections` and `ObserverConfigModal` keep their loud failure paths on purpose — they have no retry, so quieting would strand the user.

## Verification

135/135 frontend tests (including new `rpcErrors` canary and `accountsSubscriber` replay suites), `tsc` and lint clean. Manual fault-injection results in the reset-resilience test report cover this code as part of the composed stack.
