### PR TITLE
Strip the opener from every link a Gadget UI opens

### DIFF
--- a/packages/workshop-frontend/src/GadgetUI.tsx
+++ b/packages/workshop-frontend/src/GadgetUI.tsx
@@ -66,13 +66,19 @@ window.addEventListener('keydown', (event) => {
   }
 }, true);
 
+// Strip the opener from every link the user clicks. This deliberately does not try to work out
+// which links open a new context: a link with no target attribute of its own still opens one when
+// the document carries a <base target="_blank">, which the CSP's base-uri does not restrict, and an
+// SVG anchor's .target is an SVGAnimatedString rather than a string. Since the frame's popups
+// escape the sandbox, missing one matters; adding rel=noopener to a same-context navigation
+// does not, because it is inert there.
 window.addEventListener('click', (event) => {
   if (!(event.target instanceof Element)) {
     return;
   }
 
-  const anchor = event.target.closest('a[href][target]');
-  if (!anchor || anchor.target.toLowerCase() !== '_blank') {
+  const anchor = event.target.closest('a[href]');
+  if (!anchor) {
     return;
   }
 


### PR DESCRIPTION
The Gadget iframe is `sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"`, so a link it opens lands in a context that is no longer sandboxed. The capture-phase click handler in `INJECTED_CODE_PREFIX` is what makes sure that context has no `opener`.

It matched `a[href][target]` and then required `anchor.target.toLowerCase() === "_blank"`. Two shapes reach a new context without satisfying that:

- **A link with no `target` attribute, in a document carrying `<base target="_blank">`.** CSP's `base-uri` restricts a base element's *href*, not its *target*, so Gadget code can set the default target for every link on the page. The anchor's own `target` attribute stays absent, so it does not match the selector and `a.target` is `""`.
- **An SVG anchor.** `SVGAElement.target` is an `SVGAnimatedString`, so `.toLowerCase()` throws and the handler never reaches the `rel` write.

The fix stops trying to decide which links open a new context and matches any anchor. `rel=noopener` is inert on a same-context navigation, so over-applying it costs nothing, while under-applying it is the failure that matters here. Dropping the `.target` read removes the SVG hazard as a side effect.

### Verification

The handler ships as a string injected into the sandboxed frame, so it is not reachable from the jsdom suite — there is no unit test to add against the shipped code. I ran the two selectors against a jsdom document to confirm the behaviour rather than infer it:

```
<base target="_blank">
<a id="x" href="https://example.com/">go</a>

OLD  a.target                     = ""
OLD  matches a[href][target]      = false
OLD  rel after click              = null
NEW  rel after click              = "noopener"
NEW  rel after click, on
     <a target="_blank" rel="me"> = "me noopener"
```

`pnpm exec tsc --noEmit` clean, `workshop-frontend` suite 118/118, oxlint reports nothing new.