### PR TITLE
Reopen the workspace after a Durable Object reset

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -5237,7 +5237,7 @@ function ChatInterface({
           forceUpdate();
         }
       } catch (err) {
-        if (!logRpcFailure("Failed to subscribe to chats:", err)) {
+        if (!logRpcFailure("Failed to subscribe to chats:", err, { reportSite: 'chat.subscribe' })) {
           reportIssue('chat.subscription-load', err)
           toasts.add({ title: "Unable to load conversations", variant: "error" });
         }
@@ -5246,9 +5246,13 @@ function ChatInterface({
 
     subscribe();
 
-    // Set up reconnection handling
-    overseer.onRpcBroken?.((error) => {
-      console.warn("RPC connection broken:", error);
+    // Socket-level teardown only: onRpcBroken never fires for a DO reset behind a healthy
+    // session (workerd probe — see useWorkspaceOpen), so the subscribe catch above owns that
+    // recovery path via logRpcFailure's workspace recovery hook. No logging here: the
+    // connection manager already reports the outage once, and callbacks from every overseer
+    // generation fire together at teardown (capnweb has no unregister API), so a log line
+    // here multiplies per reopen.
+    overseer.onRpcBroken?.(() => {
       setIsSubscribed(false);
       // Cache persists, component will get new overseer prop and resubscribe
     });

--- a/packages/workshop-frontend/src/Connections.tsx
+++ b/packages/workshop-frontend/src/Connections.tsx
@@ -21,6 +21,7 @@ import {
   loadBindingCardData,
 } from './components/BlueprintBindingCard'
 import { reportIssue } from './errorReporting'
+import { logRpcFailure } from './rpcErrors'
 
 interface ConnectionsProps {
   overseer: RpcStub<Overseer>
@@ -70,11 +71,14 @@ export default function Connections({ overseer, gadget, chatId, authenticatedApi
       setHooks(hookList.filter((hook) => hook.gadgetId === id))
       onHasGatekeepersChange?.(bindingList.length > 0)
     } catch (err) {
-      // Loud on purpose: this panel has no retry path, so a quieted transient failure would
-      // silently render "no connected resources".
-      console.error('Failed to load gatekeepers:', err)
-      reportIssue('connections.load', err)
-      toasts.add({ title: 'Failed to load connections', variant: 'error' })
+      // Transient failures stay quiet: this panel reloads on every overseer stub replacement
+      // (effect below), so the workspace reopen / socket reconnect is its retry path — a
+      // do-reset here even schedules that reopen via logRpcFailure. The panel may sit empty
+      // until recovery lands, but the window is bounded by the retry, no longer indefinite.
+      if (!logRpcFailure('Failed to load gatekeepers:', err, { reportSite: 'connections.load' })) {
+        reportIssue('connections.load', err)
+        toasts.add({ title: 'Failed to load connections', variant: 'error' })
+      }
     } finally {
       setLoading(false)
     }
@@ -92,7 +96,9 @@ export default function Connections({ overseer, gadget, chatId, authenticatedApi
       }
       await loadGatekeepers()
     } catch (err) {
-      console.error('Failed to toggle hook:', err)
+      // A do-reset schedules the workspace reopen inside logRpcFailure. Keep the toast even
+      // then: the click genuinely did nothing, and the reopen won't replay it.
+      logRpcFailure('Failed to toggle hook:', err, { reportSite: 'hook.toggle' })
       toasts.add({ title: `Failed to ${enabled ? 'enable' : 'disable'} hook`, variant: 'error' })
       // Revert optimistic update.
       setHooks((prev) => prev.map((h) => (h.id === id ? { ...h, enabled: !enabled } : h)))
@@ -111,7 +117,7 @@ export default function Connections({ overseer, gadget, chatId, authenticatedApi
       await overseer.deleteHook(deleteHookTarget.id)
       await loadGatekeepers()
     } catch (err) {
-      console.error('Failed to delete hook:', err)
+      logRpcFailure('Failed to delete hook:', err, { reportSite: 'hook.delete' })
       toasts.add({ title: 'Failed to delete hook', variant: 'error' })
     } finally {
       setDeleteHookTarget(null)

--- a/packages/workshop-frontend/src/GadgetCodeInterface.tsx
+++ b/packages/workshop-frontend/src/GadgetCodeInterface.tsx
@@ -11,6 +11,7 @@ import CodeEditor from './CodeEditor'
 import CodeDiffEditor from './CodeDiffEditor'
 import type { StreamingProposedChanges } from './ChatInterface'
 import { saveTextToFile } from './fileTransfers'
+import { logRpcFailure } from './rpcErrors'
 
 // RpcTarget implementation for receiving code updates from the server
 class CodeSubscriberImpl extends RpcTarget implements CodeSubscriber {
@@ -656,10 +657,12 @@ export default function GadgetCodeInterface({ overseer, filesRoot, height = '100
           setIsReady(true)
         }
       } catch (error) {
-        console.error('Failed to subscribe to code updates:', error)
+        // Quiet for transient errors: the workspace reopen replaces the overseer stub, which
+        // re-runs this effect and resubscribes.
+        const transient = logRpcFailure('Failed to subscribe to code updates:', error)
         // Only show error if we've never successfully loaded (never reached ready state)
         if (!isReadyRef.current) {
-          toasts.add({ title: 'Failed to load code files', variant: 'error' })
+          if (!transient) toasts.add({ title: 'Failed to load code files', variant: 'error' })
           setLoading(false)
         }
         // For reconnection failures after we've loaded, don't show toast - user can keep editing

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -30,6 +30,7 @@ import {
   WorkpiecesSubscriber,
 } from '@gadgets/workshop-shared/api'
 import ObserverConfigModal from './ObserverConfigModal'
+import { logRpcFailure } from './rpcErrors'
 import GadgetCodeInterface from './GadgetCodeInterface'
 import GadgetUI from './GadgetUI'
 import GadgetUseView from './GadgetUseView'
@@ -450,7 +451,7 @@ export default function GadgetEditor() {
     overseer,
     metadata,
     error,
-    connectionLost,
+    workspaceLost,
     observerConfig,
     retry: retryOpen,
     cancelObserverConfig,
@@ -1112,7 +1113,13 @@ export default function GadgetEditor() {
         if (cancelled) { s[Symbol.dispose](); return }
         sub = s
       })
-      .catch(err => console.error('Failed to subscribe to workpieces:', err))
+      .catch(err => {
+        // A reset that rejects this (or the console-log subscribe below) schedules a workspace
+        // reopen via logRpcFailure's recovery hook. That only covers resets with the subscribe
+        // in flight: once established, a subscription whose DO resets goes silent with no
+        // client-side signal, and recovery waits for the next failing call in the workspace.
+        logRpcFailure('Failed to subscribe to workpieces:', err, { reportSite: 'workpieces.subscribe' })
+      })
     return () => {
       cancelled = true
       subscriber.cancel()
@@ -1197,7 +1204,9 @@ export default function GadgetEditor() {
         if (cancelled) { s[Symbol.dispose](); return }
         sub = s
       })
-      .catch(err => console.error('Failed to subscribe to console logs:', err))
+      .catch(err => {
+        logRpcFailure('Failed to subscribe to console logs:', err, { reportSite: 'console-logs.subscribe' })
+      })
     return () => { cancelled = true; sub?.[Symbol.dispose]() }
   }, [overseer])
 
@@ -1413,7 +1422,7 @@ export default function GadgetEditor() {
             onViewActivity={openActivity}
           />
 
-          {connectionLost && (
+          {workspaceLost && (
             <span className="text-xs text-kumo-warning px-2 py-0.5 rounded-full bg-kumo-warning-tint border border-kumo-warning/20">
               Reconnecting…
             </span>

--- a/packages/workshop-frontend/src/GadgetUI.integration.test.tsx
+++ b/packages/workshop-frontend/src/GadgetUI.integration.test.tsx
@@ -487,4 +487,40 @@ describe('GadgetUI RPC recovery', () => {
     const reloadedChild = connectIframe(container.querySelector('iframe')!)
     await expect(reloadedChild.read()).resolves.toBe('reloaded')
   })
+
+  it('retries through a replacement gadget client after a failed handshake', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const first = fakeGadget(
+        'first',
+        'document.body.textContent = "first"',
+        vi.fn<() => Promise<RpcStub<TestGadget>>>(async () => {
+          throw new Error('The execution context which hosts this callback is no longer running.')
+        }),
+      )
+      await act(async () => {
+        root.render(<GadgetUI gadget={first.stub} height="100px" />)
+      })
+      await vi.waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+      await act(async () => {
+        dispatchIframeHandshake(container.querySelector('iframe')!, new MessageChannel().port2)
+      })
+      // The failed handshake swaps the iframe for the error banner (Kumo's Banner renders no
+      // text under jsdom, so assert on the swap rather than the banner copy).
+      await vi.waitFor(() => expect(consoleError).toHaveBeenCalledWith(
+        'Failed to establish RPC connection:', expect.anything()))
+      expect(container.querySelector('iframe')).toBeNull()
+
+      // The workspace reopened and produced a fresh client: the error must clear and the
+      // bundle reload on its own, without the manual "Try again".
+      const replacement = fakeGadget('replacement', 'document.body.textContent = "replacement"')
+      await act(async () => {
+        root.render(<GadgetUI gadget={replacement.stub} height="100px" />)
+      })
+      await vi.waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+      expect(replacement.getUiBundle).toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
 })

--- a/packages/workshop-frontend/src/GadgetUI.tsx
+++ b/packages/workshop-frontend/src/GadgetUI.tsx
@@ -163,6 +163,8 @@ function GadgetUISession({ gadget, height, reloadTrigger, isVisible = true, chat
   const onConsoleLogRef = useRef(onConsoleLog)
   onIframeEscapeRef.current = onIframeEscape
   onConsoleLogRef.current = onConsoleLog
+  const errorRef = useRef(error)
+  errorRef.current = error
 
   const suspendGadgetCalls = () => {
     if (!pendingGadgetStubRef.current) {
@@ -205,6 +207,13 @@ function GadgetUISession({ gadget, height, reloadTrigger, isVisible = true, chat
     if (!rpcSessionRef.current) {
       if (handshakePendingRef.current !== null) {
         reloadIframe(new Error('Gadget changed during RPC handshake.'))
+      } else if (errorRef.current !== null) {
+        // A replacement client arrived while showing a failure — e.g. the workspace reopened
+        // after a DO reset, which never fires onRpcBroken. Retry through it like "Try again".
+        setError(null)
+        setHasLoaded(false)
+        setIsInvalidated(false)
+        setRetryNonce(n => n + 1)
       }
       return
     }

--- a/packages/workshop-frontend/src/connection.ts
+++ b/packages/workshop-frontend/src/connection.ts
@@ -2,7 +2,7 @@ import { newWebSocketRpcSession, RpcStub } from 'capnweb'
 import { PublicApi } from '@gadgets/workshop-shared/api'
 import { createConnectionManager } from './connectionManager'
 
-// The app's singleton connection.
+// The app's singleton connection: manager wiring plus browser wake signals.
 
 function getBackendHost(): string {
   const backendHost = import.meta.env.VITE_BACKEND_HOST?.trim()
@@ -22,3 +22,8 @@ const manager = createConnectionManager({ makeSession })
 
 export const subscribeConnection = manager.subscribe
 export const getConnectionSnapshot = manager.getSnapshot
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') void manager.onWakeSignal()
+})
+window.addEventListener('online', () => void manager.onWakeSignal())

--- a/packages/workshop-frontend/src/connection.ts
+++ b/packages/workshop-frontend/src/connection.ts
@@ -1,0 +1,24 @@
+import { newWebSocketRpcSession, RpcStub } from 'capnweb'
+import { PublicApi } from '@gadgets/workshop-shared/api'
+import { createConnectionManager } from './connectionManager'
+
+// The app's singleton connection.
+
+function getBackendHost(): string {
+  const backendHost = import.meta.env.VITE_BACKEND_HOST?.trim()
+  if (backendHost) return backendHost
+
+  // When opening the Vite dev server directly (localhost:3000), the backend is at localhost:8787.
+  // Otherwise, the API is on the same host as the frontend.
+  return window.location.hostname === 'localhost' ? 'localhost:8787' : window.location.host
+}
+
+function makeSession(): RpcStub<PublicApi> {
+  const wsUrl = (window.location.protocol === 'https:' ? 'wss:' : 'ws:') + '//' + getBackendHost() + '/api'
+  return newWebSocketRpcSession<PublicApi>(wsUrl)
+}
+
+const manager = createConnectionManager({ makeSession })
+
+export const subscribeConnection = manager.subscribe
+export const getConnectionSnapshot = manager.getSnapshot

--- a/packages/workshop-frontend/src/connection.ts
+++ b/packages/workshop-frontend/src/connection.ts
@@ -1,6 +1,7 @@
 import { newWebSocketRpcSession, RpcStub } from 'capnweb'
 import { PublicApi } from '@gadgets/workshop-shared/api'
 import { createConnectionManager } from './connectionManager'
+import { reportIssue } from './errorReporting'
 
 // The app's singleton connection: manager wiring plus browser wake signals.
 
@@ -18,7 +19,17 @@ function makeSession(): RpcStub<PublicApi> {
   return newWebSocketRpcSession<PublicApi>(wsUrl)
 }
 
-const manager = createConnectionManager({ makeSession })
+const manager = createConnectionManager({
+  makeSession,
+  // One aggregated report per outage, at recovery — rate-limited server-side and a no-op
+  // unless frontend error reporting is configured. The reporter's fingerprint dedup further
+  // caps this at ~1 report/min per client during flapping; accepted as intentional rate limiting.
+  onOutageEnd: (outage) => {
+    reportIssue('connection.outage', new Error(JSON.stringify(outage)), {
+      severity: 'warning', handled: true,
+    })
+  },
+})
 
 export const subscribeConnection = manager.subscribe
 export const getConnectionSnapshot = manager.getSnapshot

--- a/packages/workshop-frontend/src/connectionManager.test.ts
+++ b/packages/workshop-frontend/src/connectionManager.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RpcStub } from 'capnweb'
+import { PublicApi } from '@gadgets/workshop-shared/api'
+import { createConnectionManager } from './connectionManager'
+
+type FakeStub = {
+  brokenCbs: Array<(err: unknown) => void>
+  probes: Array<{ resolve: (value: unknown) => void; reject: (err: unknown) => void }>
+  disposed: boolean
+  onRpcBroken(cb: (err: unknown) => void): void
+  getServerConfig(): Promise<unknown>
+  [Symbol.dispose](): void
+}
+
+function makeFakeStub(): FakeStub {
+  const stub: FakeStub = {
+    brokenCbs: [],
+    probes: [],
+    disposed: false,
+    onRpcBroken(cb) { stub.brokenCbs.push(cb) },
+    getServerConfig() {
+      return new Promise((resolve, reject) => { stub.probes.push({ resolve, reject }) })
+    },
+    [Symbol.dispose]() { stub.disposed = true },
+  }
+  return stub
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+function makeHarness() {
+  const stubs: FakeStub[] = []
+  const pendingSleeps: Array<{ ms: number; resolve: () => void }> = []
+
+  const manager = createConnectionManager({
+    makeSession: () => {
+      const stub = makeFakeStub()
+      stubs.push(stub)
+      return stub as unknown as RpcStub<PublicApi>
+    },
+    sleep: (ms) => new Promise<void>((resolve) => { pendingSleeps.push({ ms, resolve }) }),
+    random: () => 0.5,  // jitter factor exactly 1.0
+  })
+
+  let notifications = 0
+  manager.subscribe(() => { notifications++ })
+
+  return {
+    manager, stubs, pendingSleeps,
+    get notifications() { return notifications },
+    // Resolves the newest pending sleep of the given duration. Backoff and probe-timeout
+    // sleeps coexist (settled races leave their timeout sleeps pending forever), and the
+    // current attempt's sleep is always the most recently created.
+    elapse: async (ms: number) => {
+      const i = pendingSleeps.findLastIndex((s) => s.ms === ms)
+      expect(i, `no pending sleep of ${ms}ms`).toBeGreaterThanOrEqual(0)
+      pendingSleeps.splice(i, 1)[0].resolve()
+      await tick()
+    },
+    breakCurrent: async (err: unknown) => {
+      const current = manager.getSnapshot().stub as unknown as FakeStub
+      for (const cb of current.brokenCbs) cb(err)
+      await tick()
+    },
+  }
+}
+
+describe('createConnectionManager', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('publishes exactly twice per outage and only swaps to a proven stub', async () => {
+    const h = makeHarness()
+    const [s0] = h.stubs
+
+    await h.breakCurrent(new Error('Peer closed WebSocket: 1006 '))
+    expect(h.manager.getSnapshot()).toMatchObject({ connectionLost: true })
+    expect(h.notifications).toBe(1)
+
+    await h.elapse(1000)  // first backoff
+    const s1 = h.stubs[1]
+    s1.probes[0].reject(new Error('WebSocket connection failed.'))
+    await tick()
+    expect(s1.disposed).toBe(true)
+    expect(h.notifications).toBe(1)  // failed attempts publish nothing
+
+    await h.elapse(2000)  // doubled backoff
+    const s2 = h.stubs[2]
+    s2.probes[0].resolve({})
+    await tick()
+
+    const snapshot = h.manager.getSnapshot()
+    expect(snapshot.connectionLost).toBe(false)
+    expect(snapshot.stub).toBe(s2 as unknown as RpcStub<PublicApi>)
+    expect(h.notifications).toBe(2)
+    expect(s0.disposed).toBe(false)  // the broken stub is capnweb's to clean up
+  })
+
+  it('doubles backoff up to the cap', async () => {
+    const h = makeHarness()
+    await h.breakCurrent(new Error('Peer closed WebSocket: 1006 '))
+
+    for (const backoff of [1000, 2000, 4000, 8000, 10000, 10000]) {
+      await h.elapse(backoff)
+      const candidate = h.stubs[h.stubs.length - 1]
+      candidate.probes[0].reject(new Error('WebSocket connection failed.'))
+      await tick()
+    }
+  })
+
+  it('ignores broken events from stale stubs', async () => {
+    const h = makeHarness()
+    const [s0] = h.stubs
+    await h.breakCurrent(new Error('Peer closed WebSocket: 1006 '))
+    await h.elapse(1000)
+    h.stubs[1].probes[0].resolve({})
+    await tick()
+    expect(h.notifications).toBe(2)
+
+    for (const cb of s0.brokenCbs) cb(new Error('Peer closed WebSocket: 1006 '))
+    await tick()
+    expect(h.manager.getSnapshot().connectionLost).toBe(false)
+    expect(h.notifications).toBe(2)
+  })
+})

--- a/packages/workshop-frontend/src/connectionManager.test.ts
+++ b/packages/workshop-frontend/src/connectionManager.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RpcStub } from 'capnweb'
 import { PublicApi } from '@gadgets/workshop-shared/api'
-import { createConnectionManager } from './connectionManager'
+import { createConnectionManager, OutageSummary, SleepPurpose } from './connectionManager'
 
 type FakeStub = {
   brokenCbs: Array<(err: unknown) => void>
@@ -30,17 +30,19 @@ const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 
 function makeHarness() {
   const stubs: FakeStub[] = []
-  const pendingSleeps: Array<{ ms: number; resolve: () => void }> = []
+  const pendingSleeps: Array<{ ms: number; purpose: SleepPurpose; resolve: () => void }> = []
+  const outages: OutageSummary[] = []
   let clock = 0
 
   const manager = createConnectionManager({
+    onOutageEnd: (outage) => { outages.push(outage) },
     makeSession: () => {
       const stub = makeFakeStub()
       stubs.push(stub)
       return stub as unknown as RpcStub<PublicApi>
     },
     now: () => clock,
-    sleep: (ms) => new Promise<void>((resolve) => { pendingSleeps.push({ ms, resolve }) }),
+    sleep: (ms, purpose) => new Promise<void>((resolve) => { pendingSleeps.push({ ms, purpose, resolve }) }),
     random: () => 0.5,  // jitter factor exactly 1.0
   })
 
@@ -48,15 +50,15 @@ function makeHarness() {
   manager.subscribe(() => { notifications++ })
 
   return {
-    manager, stubs, pendingSleeps,
+    manager, stubs, pendingSleeps, outages,
     get notifications() { return notifications },
     advanceClock: (ms: number) => { clock += ms },
-    // Resolves the newest pending sleep of the given duration. Backoff and probe-timeout
-    // sleeps coexist (settled races leave their timeout sleeps pending forever), and the
-    // current attempt's sleep is always the most recently created.
+    // Resolves the newest pending backoff sleep of the given duration. Probe-timeout sleeps
+    // also queue here but are never resolved (settled races leave them pending forever); the
+    // purpose tag keeps them from ever shadowing a backoff of the same duration.
     elapse: async (ms: number) => {
-      const i = pendingSleeps.findLastIndex((s) => s.ms === ms)
-      expect(i, `no pending sleep of ${ms}ms`).toBeGreaterThanOrEqual(0)
+      const i = pendingSleeps.findLastIndex((s) => s.ms === ms && s.purpose === 'backoff')
+      expect(i, `no pending backoff sleep of ${ms}ms`).toBeGreaterThanOrEqual(0)
       pendingSleeps.splice(i, 1)[0].resolve()
       await tick()
     },
@@ -100,6 +102,10 @@ describe('createConnectionManager', () => {
     expect(snapshot.stub).toBe(s2 as unknown as RpcStub<PublicApi>)
     expect(h.notifications).toBe(2)
     expect(s0.disposed).toBe(false)  // the broken stub is capnweb's to clean up
+    expect(h.outages).toHaveLength(1)
+    expect(h.outages[0]).toMatchObject({
+      trigger: 'broken', attempts: 2, reason: 'Error: Peer closed WebSocket: 1006 ',
+    })
   })
 
   it('doubles backoff up to the cap', async () => {
@@ -107,7 +113,10 @@ describe('createConnectionManager', () => {
     await h.breakCurrent(new Error('Peer closed WebSocket: 1006 '))
 
     for (const backoff of [1000, 2000, 4000, 8000, 10000, 10000]) {
+      const stubsBefore = h.stubs.length
       await h.elapse(backoff)
+      // A new candidate appears only once this step's full backoff has elapsed.
+      expect(h.stubs.length).toBe(stubsBefore + 1)
       const candidate = h.stubs[h.stubs.length - 1]
       candidate.probes[0].reject(new Error('WebSocket connection failed.'))
       await tick()
@@ -146,7 +155,9 @@ describe('createConnectionManager', () => {
 
     const woke = h.manager.onWakeSignal()
     await tick()
-    s0.probes[0].reject(new Error('probe failed'))
+    s0.probes[0].reject(Object.assign(new Error('probe failed'), {
+      durableObjectReset: true, durableObjectId: 'abc123',
+    }))
     await woke
     await tick()
 
@@ -158,6 +169,9 @@ describe('createConnectionManager', () => {
 
     expect(h.manager.getSnapshot().connectionLost).toBe(false)
     expect(h.notifications).toBe(2)
+    expect(h.outages[0]).toMatchObject({
+      trigger: 'wake-zombie', doReset: true, durableObjectIds: ['abc123'],
+    })
   })
 
   it('ignores wake signals while the connection is fresh', async () => {

--- a/packages/workshop-frontend/src/connectionManager.test.ts
+++ b/packages/workshop-frontend/src/connectionManager.test.ts
@@ -31,6 +31,7 @@ const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 function makeHarness() {
   const stubs: FakeStub[] = []
   const pendingSleeps: Array<{ ms: number; resolve: () => void }> = []
+  let clock = 0
 
   const manager = createConnectionManager({
     makeSession: () => {
@@ -38,6 +39,7 @@ function makeHarness() {
       stubs.push(stub)
       return stub as unknown as RpcStub<PublicApi>
     },
+    now: () => clock,
     sleep: (ms) => new Promise<void>((resolve) => { pendingSleeps.push({ ms, resolve }) }),
     random: () => 0.5,  // jitter factor exactly 1.0
   })
@@ -48,6 +50,7 @@ function makeHarness() {
   return {
     manager, stubs, pendingSleeps,
     get notifications() { return notifications },
+    advanceClock: (ms: number) => { clock += ms },
     // Resolves the newest pending sleep of the given duration. Backoff and probe-timeout
     // sleeps coexist (settled races leave their timeout sleeps pending forever), and the
     // current attempt's sleep is always the most recently created.
@@ -124,5 +127,44 @@ describe('createConnectionManager', () => {
     await tick()
     expect(h.manager.getSnapshot().connectionLost).toBe(false)
     expect(h.notifications).toBe(2)
+  })
+
+  it('a wake signal short-circuits the backoff sleep', async () => {
+    const h = makeHarness()
+    await h.breakCurrent(new Error('Peer closed WebSocket: 1006 '))
+    expect(h.stubs).toHaveLength(1)  // still sleeping, no attempt yet
+
+    await h.manager.onWakeSignal()
+    await tick()
+    expect(h.stubs).toHaveLength(2)  // attempt started without waiting out the backoff
+  })
+
+  it('probes a stale connection on wake and reconnects without backoff', async () => {
+    const h = makeHarness()
+    const [s0] = h.stubs
+    h.advanceClock(20000)
+
+    const woke = h.manager.onWakeSignal()
+    await tick()
+    s0.probes[0].reject(new Error('probe failed'))
+    await woke
+    await tick()
+
+    expect(s0.disposed).toBe(true)
+    expect(h.notifications).toBe(1)
+    const s1 = h.stubs[1]  // created immediately: no backoff sleep before the first attempt
+    s1.probes[0].resolve({})
+    await tick()
+
+    expect(h.manager.getSnapshot().connectionLost).toBe(false)
+    expect(h.notifications).toBe(2)
+  })
+
+  it('ignores wake signals while the connection is fresh', async () => {
+    const h = makeHarness()
+    const [s0] = h.stubs
+    h.advanceClock(5000)  // under the idle threshold
+    await h.manager.onWakeSignal()
+    expect(s0.probes).toHaveLength(0)
   })
 })

--- a/packages/workshop-frontend/src/connectionManager.ts
+++ b/packages/workshop-frontend/src/connectionManager.ts
@@ -1,0 +1,91 @@
+import { RpcStub } from 'capnweb'
+import { PublicApi } from '@gadgets/workshop-shared/api'
+
+// WebSocket RPC connection management, as a plain state machine deliberately outside React
+// (StrictMode double-mounts effects, which would create fighting duplicate connections).
+//
+// A reconnect attempt only becomes the current connection after a probe RPC round-trips:
+// capnweb queues sends while the socket is still CONNECTING, so an unproven stub looks fine
+// until everything pipelined onto it fails at once. Proving first means subscribers hear
+// exactly twice per outage — lost, then restored — instead of once per failed attempt.
+
+export type ConnectionSnapshot = Readonly<{ stub: RpcStub<PublicApi>; connectionLost: boolean }>
+
+type Deps = Readonly<{
+  makeSession: () => RpcStub<PublicApi>
+  sleep?: (ms: number) => Promise<void>
+  random?: () => number
+}>
+
+const INITIAL_BACKOFF_MS = 1000
+const MAX_BACKOFF_MS = 10000
+// The probe is getServerConfig — a KV read plus a describe() fan-out to the auth vendors, the
+// same call the app needs to boot. Generous deadlines let a slow-but-alive backend settle
+// instead of connect/dispose looping (or, on wake, tearing down a healthy socket under load).
+const PROBE_TIMEOUT_MS = 20000
+
+export function createConnectionManager(deps: Deps) {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+  const random = deps.random ?? Math.random
+
+  const subscribers = new Set<() => void>()
+  let snapshot: ConnectionSnapshot = { stub: deps.makeSession(), connectionLost: false }
+  let reconnecting = false
+
+  const publish = (next: ConnectionSnapshot) => {
+    snapshot = next
+    for (const cb of [...subscribers]) cb()
+  }
+
+  const watch = (stub: RpcStub<PublicApi>) => stub.onRpcBroken((err: unknown) => onBroken(stub, err))
+
+  const dispose = (stub: RpcStub<PublicApi>) => {
+    try {
+      stub[Symbol.dispose]()
+    } catch {
+      // Already broken.
+    }
+  }
+
+  const onBroken = (stub: RpcStub<PublicApi>, err: unknown) => {
+    if (stub !== snapshot.stub || reconnecting) return  // stale stub, or recovery already underway
+    console.warn('RPC connection lost:', err)
+    publish({ stub: snapshot.stub, connectionLost: true })
+    void reconnectLoop()
+  }
+
+  const withTimeout = <T>(promise: Promise<T>, ms: number) =>
+    Promise.race([promise, sleep(ms).then((): never => { throw new Error('probe timed out') })])
+
+  async function reconnectLoop(): Promise<void> {
+    reconnecting = true
+    let backoff = INITIAL_BACKOFF_MS
+    while (true) {
+      await sleep(backoff * (0.85 + 0.3 * random()))  // jittered to avoid multi-tab stampedes
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+      const candidate = deps.makeSession()
+      try {
+        await withTimeout(candidate.getServerConfig(), PROBE_TIMEOUT_MS)
+      } catch (err) {
+        console.debug('Reconnect attempt failed:', err)
+        dispose(candidate)
+        continue
+      }
+      watch(candidate)
+      reconnecting = false
+      console.warn('RPC connection restored.')
+      publish({ stub: candidate, connectionLost: false })
+      return
+    }
+  }
+
+  watch(snapshot.stub)
+
+  return {
+    subscribe(cb: () => void) {
+      subscribers.add(cb)
+      return () => { subscribers.delete(cb) }
+    },
+    getSnapshot: () => snapshot,
+  }
+}

--- a/packages/workshop-frontend/src/connectionManager.ts
+++ b/packages/workshop-frontend/src/connectionManager.ts
@@ -1,5 +1,6 @@
 import { RpcStub } from 'capnweb'
 import { PublicApi } from '@gadgets/workshop-shared/api'
+import { getDurableObjectId, isDurableObjectResetError, isOverloadedError } from './rpcErrors'
 
 // WebSocket RPC connection management, as a plain state machine deliberately outside React
 // (StrictMode double-mounts effects, which would create fighting duplicate connections).
@@ -11,12 +12,29 @@ import { PublicApi } from '@gadgets/workshop-shared/api'
 
 export type ConnectionSnapshot = Readonly<{ stub: RpcStub<PublicApi>; connectionLost: boolean }>
 
+export type OutageTrigger = 'broken' | 'wake-zombie'
+
+/** One aggregated record per outage, delivered at recovery — never per attempt. */
+export type OutageSummary = Readonly<{
+  trigger: OutageTrigger
+  durationMs: number
+  attempts: number
+  reason: string
+  doReset: boolean
+  overloaded: boolean
+  durableObjectIds: readonly string[]
+}>
+
 type Deps = Readonly<{
   makeSession: () => RpcStub<PublicApi>
+  onOutageEnd?: (outage: OutageSummary) => void
   now?: () => number
-  sleep?: (ms: number) => Promise<void>
+  sleep?: (ms: number, purpose: SleepPurpose) => Promise<void>
   random?: () => number
 }>
+
+/** Why the manager is sleeping — lets the test harness resolve fake sleeps unambiguously. */
+export type SleepPurpose = 'backoff' | 'probe-timeout'
 
 const INITIAL_BACKOFF_MS = 1000
 const MAX_BACKOFF_MS = 10000
@@ -24,9 +42,7 @@ const MAX_BACKOFF_MS = 10000
 // same call the app needs to boot. Generous deadlines let a slow-but-alive backend settle
 // instead of connect/dispose looping (or, on wake, tearing down a healthy socket under load).
 const PROBE_TIMEOUT_MS = 20000
-// Not 10000: the test harness resolves fake sleeps by duration, and 10000 would collide with
-// MAX_BACKOFF_MS.
-const WAKE_PROBE_TIMEOUT_MS = 12000
+const WAKE_PROBE_TIMEOUT_MS = 10000
 const WAKE_PROBE_MIN_IDLE_MS = 15000
 
 export function createConnectionManager(deps: Deps) {
@@ -40,10 +56,19 @@ export function createConnectionManager(deps: Deps) {
   let probing = false
   let lastProvenAt = now()
   let wake: (() => void) | null = null
+  let outage: {
+    startedAt: number
+    trigger: OutageTrigger
+    reason: string
+    attempts: number
+    doReset: boolean
+    overloaded: boolean
+    durableObjectIds: Set<string>
+  } | null = null
 
   const publish = (next: ConnectionSnapshot) => {
     snapshot = next
-    for (const cb of [...subscribers]) cb()
+    for (const cb of subscribers) cb()
   }
 
   const watch = (stub: RpcStub<PublicApi>) => stub.onRpcBroken((err: unknown) => onBroken(stub, err))
@@ -56,19 +81,63 @@ export function createConnectionManager(deps: Deps) {
     }
   }
 
+  const noteError = (err: unknown) => {
+    if (!outage) return
+    if (isDurableObjectResetError(err)) outage.doReset = true
+    if (isOverloadedError(err)) outage.overloaded = true
+    const id = getDurableObjectId(err)
+    if (id && outage.durableObjectIds.size < 5) outage.durableObjectIds.add(id)
+  }
+
+  const beginOutage = (trigger: OutageTrigger, err: unknown) => {
+    outage = {
+      startedAt: now(),
+      trigger,
+      reason: String(err).slice(0, 300),
+      attempts: 0,
+      doReset: false,
+      overloaded: false,
+      durableObjectIds: new Set(),
+    }
+    noteError(err)
+  }
+
+  const endOutage = () => {
+    if (!outage) return
+    deps.onOutageEnd?.({
+      trigger: outage.trigger,
+      durationMs: now() - outage.startedAt,
+      attempts: outage.attempts,
+      reason: outage.reason,
+      doReset: outage.doReset,
+      overloaded: outage.overloaded,
+      durableObjectIds: [...outage.durableObjectIds],
+    })
+    outage = null
+  }
+
+  // Shared tail of both outage entry points: record it, tell subscribers, start reconnecting.
+  const startRecovery = (trigger: OutageTrigger, err: unknown, skipFirstBackoff: boolean) => {
+    beginOutage(trigger, err)
+    publish({ stub: snapshot.stub, connectionLost: true })
+    void reconnectLoop(skipFirstBackoff)
+  }
+
   const onBroken = (stub: RpcStub<PublicApi>, err: unknown) => {
     if (stub !== snapshot.stub || reconnecting) return  // stale stub, or recovery already underway
     console.warn('RPC connection lost:', err)
-    publish({ stub: snapshot.stub, connectionLost: true })
-    void reconnectLoop(false)
+    startRecovery('broken', err, false)
   }
 
   const interruptibleSleep = (ms: number) =>
-    Promise.race([sleep(ms), new Promise<void>((resolve) => { wake = resolve })])
+    Promise.race([sleep(ms, 'backoff'), new Promise<void>((resolve) => { wake = resolve })])
         .finally(() => { wake = null })
 
   const withTimeout = <T>(promise: Promise<T>, ms: number) =>
-    Promise.race([promise, sleep(ms).then((): never => { throw new Error('probe timed out') })])
+    Promise.race([
+      promise,
+      sleep(ms, 'probe-timeout').then((): never => { throw new Error('probe timed out') }),
+    ])
 
   async function reconnectLoop(skipFirstBackoff: boolean): Promise<void> {
     reconnecting = true
@@ -78,10 +147,12 @@ export function createConnectionManager(deps: Deps) {
         await interruptibleSleep(backoff * (0.85 + 0.3 * random()))  // jittered against stampedes
         backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
       }
+      if (outage) outage.attempts++
       const candidate = deps.makeSession()
       try {
         await withTimeout(candidate.getServerConfig(), PROBE_TIMEOUT_MS)
       } catch (err) {
+        noteError(err)
         console.debug('Reconnect attempt failed:', err)
         dispose(candidate)
         continue
@@ -89,6 +160,7 @@ export function createConnectionManager(deps: Deps) {
       watch(candidate)
       reconnecting = false
       lastProvenAt = now()
+      endOutage()
       console.warn('RPC connection restored.')
       publish({ stub: candidate, connectionLost: false })
       return
@@ -114,8 +186,7 @@ export function createConnectionManager(deps: Deps) {
       console.warn('Connection unresponsive after wake:', err)
       reconnecting = true  // claim recovery before disposing, so the broken event is ignored
       dispose(suspect)
-      publish({ stub: suspect, connectionLost: true })
-      void reconnectLoop(true)
+      startRecovery('wake-zombie', err, true)
     } finally {
       probing = false
     }

--- a/packages/workshop-frontend/src/connectionManager.ts
+++ b/packages/workshop-frontend/src/connectionManager.ts
@@ -13,6 +13,7 @@ export type ConnectionSnapshot = Readonly<{ stub: RpcStub<PublicApi>; connection
 
 type Deps = Readonly<{
   makeSession: () => RpcStub<PublicApi>
+  now?: () => number
   sleep?: (ms: number) => Promise<void>
   random?: () => number
 }>
@@ -23,14 +24,22 @@ const MAX_BACKOFF_MS = 10000
 // same call the app needs to boot. Generous deadlines let a slow-but-alive backend settle
 // instead of connect/dispose looping (or, on wake, tearing down a healthy socket under load).
 const PROBE_TIMEOUT_MS = 20000
+// Not 10000: the test harness resolves fake sleeps by duration, and 10000 would collide with
+// MAX_BACKOFF_MS.
+const WAKE_PROBE_TIMEOUT_MS = 12000
+const WAKE_PROBE_MIN_IDLE_MS = 15000
 
 export function createConnectionManager(deps: Deps) {
+  const now = deps.now ?? Date.now
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
   const random = deps.random ?? Math.random
 
   const subscribers = new Set<() => void>()
   let snapshot: ConnectionSnapshot = { stub: deps.makeSession(), connectionLost: false }
   let reconnecting = false
+  let probing = false
+  let lastProvenAt = now()
+  let wake: (() => void) | null = null
 
   const publish = (next: ConnectionSnapshot) => {
     snapshot = next
@@ -51,18 +60,24 @@ export function createConnectionManager(deps: Deps) {
     if (stub !== snapshot.stub || reconnecting) return  // stale stub, or recovery already underway
     console.warn('RPC connection lost:', err)
     publish({ stub: snapshot.stub, connectionLost: true })
-    void reconnectLoop()
+    void reconnectLoop(false)
   }
+
+  const interruptibleSleep = (ms: number) =>
+    Promise.race([sleep(ms), new Promise<void>((resolve) => { wake = resolve })])
+        .finally(() => { wake = null })
 
   const withTimeout = <T>(promise: Promise<T>, ms: number) =>
     Promise.race([promise, sleep(ms).then((): never => { throw new Error('probe timed out') })])
 
-  async function reconnectLoop(): Promise<void> {
+  async function reconnectLoop(skipFirstBackoff: boolean): Promise<void> {
     reconnecting = true
     let backoff = INITIAL_BACKOFF_MS
-    while (true) {
-      await sleep(backoff * (0.85 + 0.3 * random()))  // jittered to avoid multi-tab stampedes
-      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+    for (let attempt = 0; ; attempt++) {
+      if (attempt > 0 || !skipFirstBackoff) {
+        await interruptibleSleep(backoff * (0.85 + 0.3 * random()))  // jittered against stampedes
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+      }
       const candidate = deps.makeSession()
       try {
         await withTimeout(candidate.getServerConfig(), PROBE_TIMEOUT_MS)
@@ -73,9 +88,36 @@ export function createConnectionManager(deps: Deps) {
       }
       watch(candidate)
       reconnecting = false
+      lastProvenAt = now()
       console.warn('RPC connection restored.')
       publish({ stub: candidate, connectionLost: false })
       return
+    }
+  }
+
+  // Called on tab visibility / network-online signals. Passive close detection misses dead
+  // sockets after sleep or background throttling, so probe instead of waiting for a send to fail.
+  async function onWakeSignal(): Promise<void> {
+    if (reconnecting) {
+      wake?.()  // skip the rest of the backoff sleep — the network likely just came back
+      return
+    }
+    if (probing || now() - lastProvenAt < WAKE_PROBE_MIN_IDLE_MS) return
+    probing = true
+    const suspect = snapshot.stub
+    try {
+      await withTimeout(suspect.getServerConfig(), WAKE_PROBE_TIMEOUT_MS)
+      lastProvenAt = now()
+    } catch (err) {
+      // A real break may have won the race while the probe was in flight.
+      if (snapshot.stub !== suspect || reconnecting) return
+      console.warn('Connection unresponsive after wake:', err)
+      reconnecting = true  // claim recovery before disposing, so the broken event is ignored
+      dispose(suspect)
+      publish({ stub: suspect, connectionLost: true })
+      void reconnectLoop(true)
+    } finally {
+      probing = false
     }
   }
 
@@ -87,5 +129,6 @@ export function createConnectionManager(deps: Deps) {
       return () => { subscribers.delete(cb) }
     },
     getSnapshot: () => snapshot,
+    onWakeSignal,
   }
 }

--- a/packages/workshop-frontend/src/main.tsx
+++ b/packages/workshop-frontend/src/main.tsx
@@ -1,7 +1,7 @@
-import { StrictMode, useState, useEffect } from 'react'
+import { StrictMode, useState, useEffect, useSyncExternalStore } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from '@tanstack/react-router'
-import { RpcStub, newWebSocketRpcSession } from 'capnweb'
+import { RpcStub } from 'capnweb'
 import { PublicApi, ServerConfig } from '@gadgets/workshop-shared/api'
 import { RpcContext } from './RpcContext'
 import { ServerConfigContext, ServerConfigErrorContext } from './ServerConfigContext'
@@ -13,6 +13,7 @@ import './styles.css'
 import FrontendErrorBoundary from './FrontendErrorBoundary'
 import { installWorkshopErrorReporting, reportIssue } from './errorReporting'
 import { applySiteFavicon, cacheBustSiteLogoUrl } from './siteLogoUtils'
+import { getConnectionSnapshot, subscribeConnection } from './connection'
 
 // ---------------------------------------------------------------------------
 // Dev auto-login: if VITE_DEV_AUTO_LOGIN=true, automatically create/login
@@ -44,96 +45,15 @@ async function devAutoLogin(stub: RpcStub<PublicApi>): Promise<void> {
   }
 }
 
-// WebSocket RPC connection management.
-//
-// React's useEffect / useState machinery is kind of obnoxious in that, in dev mode, it runs
-// everything twice (runs once, immediately cleans up, then runs again). This isn't so good for
-// our WebSocket as it means we are creating redundant connections to the server and throwing
-// them away instantly. It gets even worse when we start trying to handle disconnects gracefully:
-// we can end up with two connections that are fighting to replace each other.
-//
-// Or maybe I (Kenton) was just holding it wrong, idk.
-//
-// Anyway, I pulled the connection management out into these globals instead.
-let lastConnectTime: number = 0;
-let backoff: number = 1000;
-
-function getBackendHost(): string {
-  const backendHost = import.meta.env.VITE_BACKEND_HOST?.trim();
-  if (backendHost) return backendHost;
-
-  // When opening the Vite dev server directly (localhost:3000), the backend is at localhost:8787.
-  // Otherwise, the API is on the same host as the frontend.
-  return window.location.hostname === 'localhost' ? 'localhost:8787' : window.location.host;
-}
-
-function startConnection(): RpcStub<PublicApi> {
-  lastConnectTime = Date.now();
-  const apiHost = getBackendHost();
-  const wsUrl = (window.location.protocol === 'https:' ? 'wss:' : 'ws:') + '//' + apiHost + '/api';
-  return newWebSocketRpcSession<PublicApi>(wsUrl);
-}
-
-async function handleBroken(error: any) {
-  console.warn('RPC connection lost:', error);
-
-  isConnectionLost = true;
-  for (let cb of notifyCurrentStubUpdated) { cb(); }
-
-  let timeSinceConnect = Date.now() - lastConnectTime;
-  if (timeSinceConnect < backoff) {
-    let waitTime = backoff - timeSinceConnect;
-    console.warn(`Will try again in ${Math.round(waitTime / 1000)} seconds...`)
-    await new Promise(resolve => setTimeout(resolve, waitTime));
-    console.warn(`Retrying connection...`);
-    backoff = Math.min(backoff * 2, 10000);
-  } else {
-    backoff = 1000;
-  }
-
-  currentStub = startConnection();
-  currentStub.onRpcBroken(handleBroken);
-
-  // Don't clear isConnectionLost here — the new connection hasn't proven
-  // it works yet. It gets cleared by markConnectionRestored() once the
-  // app successfully communicates with the backend.
-  for (let cb of notifyCurrentStubUpdated) {
-    cb();
-  }
-}
-
-// Callbacks to call whenever `currentStub` or connection state is updated.
-let notifyCurrentStubUpdated: Set<() => void> = new Set();
-let isConnectionLost = false;
-
-// Called externally (e.g., by auth) to indicate the connection is alive.
-export function markConnectionRestored() {
-  if (!isConnectionLost) return;
-  isConnectionLost = false;
-  for (let cb of notifyCurrentStubUpdated) { cb(); }
-}
-
-// Current stub. handleBroken() will replace this on disconnect.
 installWorkshopErrorReporting()
-let currentStub = startConnection();
-currentStub.onRpcBroken(handleBroken);
 
 const router = createRouter()
 applyStoredThemeMode()
 
 function AppWithConnection() {
-  const [rpcState, setRpcState] = useState<{stub: RpcStub<PublicApi>; connectionLost: boolean}>({
-    stub: currentStub,
-    connectionLost: isConnectionLost,
-  });
+  const rpcState = useSyncExternalStore(subscribeConnection, getConnectionSnapshot)
   const [serverConfig, setServerConfig] = useState<ServerConfig | null>(null);
   const [serverConfigError, setServerConfigError] = useState(false);
-
-  useEffect(() => {
-    let cb = () => setRpcState({ stub: currentStub, connectionLost: isConnectionLost });
-    notifyCurrentStubUpdated.add(cb);
-    return () => { notifyCurrentStubUpdated.delete(cb); };
-  }, []);
 
   // Fetch deployment config once the (re)connected stub is available. Re-fetch on reconnect so a
   // server restart with changed config is picked up.
@@ -186,7 +106,7 @@ const root = createRoot(document.getElementById('root')!, {
 // useAuth checks the token, the user skips the login page. If the backend
 // is unreachable, the app still renders immediately (showing a connection
 // banner or login page) instead of hanging on a blank screen.
-devAutoLogin(currentStub).catch(() => {})
+devAutoLogin(getConnectionSnapshot().stub).catch(() => {})
 
 root.render(
   <StrictMode>

--- a/packages/workshop-frontend/src/routes/__root.tsx
+++ b/packages/workshop-frontend/src/routes/__root.tsx
@@ -5,7 +5,6 @@ import { TooltipProvider, Toasty } from '@cloudflare/kumo'
 import { RpcStub } from 'capnweb'
 import { AuthenticatedApi } from '@gadgets/workshop-shared/api'
 import { useRpcStub, useConnectionLost } from '../RpcContext'
-import { markConnectionRestored } from '../main'
 import { useAuth, CF_ACCESS_MODE } from '../useAuth'
 import { AuthProvider } from '../AuthContext'
 import { FeatureFlagsProvider } from '../FeatureFlagsContext'
@@ -32,11 +31,6 @@ function RootComponent() {
   const connectionLost = useConnectionLost()
   const { isAuthenticated, authenticatedApi, isLoading, error, logout, login } = useAuth(rpcStub)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-
-  // When authenticatedApi becomes available, the connection is proven alive.
-  useEffect(() => {
-    if (authenticatedApi) markConnectionRestored()
-  }, [authenticatedApi])
 
   // Routes that don't require auth (public routes)
   const isSignup = pathname === '/signup'

--- a/packages/workshop-frontend/src/rpcErrors.ts
+++ b/packages/workshop-frontend/src/rpcErrors.ts
@@ -82,25 +82,39 @@ export function isTransientRpcError(err: unknown): boolean {
   return cls === 'do-reset' || cls === 'connection'
 }
 
+// Exactly one workspace is open per tab; its useWorkspaceOpen registers its recovery hook here,
+// making logRpcFailure the single do-reset recovery entry point: every call site that logs a
+// failure the standard way schedules a coalesced, backed-off reopen — quieting an error as
+// "transient" can then never orphan it, and new call sites need no per-site recovery wiring.
+// The hook also owns reset telemetry (tagged with the workspace id) for sites that name a
+// `reportSite`. Connection-class errors are owned by the connection manager's reconnect instead.
+let workspaceRecoveryHook: ((err: unknown, reportSite?: string) => void) | null = null
+
+/** Registers the open workspace's do-reset recovery hook; pass null on unmount. */
+export function setWorkspaceRecoveryHook(
+  hook: ((err: unknown, reportSite?: string) => void) | null,
+) {
+  workspaceRecoveryHook = hook
+}
+
 // Logs an RPC failure: quietly for transient errors (a retry or reconnect is expected to cure
 // them), loudly otherwise. Returns true when transient so call sites can skip their toasts.
-// Pass `reportSite` from action paths (sends, creates) to also report do-reset errors to the
-// client-errors endpoint, so resets that cost the user an action stay visible in telemetry.
+// A do-reset also schedules recovery of the open workspace (hook above). Pass `reportSite` from
+// action paths (sends, creates, approvals) to also report do-reset errors to the client-errors
+// endpoint, so resets that cost the user an action stay visible in telemetry.
 export function logRpcFailure(
   message: string, err: unknown, options?: { reportSite?: string },
 ): boolean {
   const cls = classifyRpcError(err)
-  if (cls === 'do-reset' && options?.reportSite) reportDoResetError(options.reportSite, err)
+  if (cls === 'do-reset') {
+    if (workspaceRecoveryHook) workspaceRecoveryHook(err, options?.reportSite)
+    else if (options?.reportSite) reportDoResetError(options.reportSite, err)
+  }
   const transient = cls === 'do-reset' || cls === 'connection'
   if (transient) console.debug(message, err)
   else console.error(message, err)
   return transient
 }
-
-// No client-side retry lives here on purpose: the Worker owns DO-reset recovery (fresh stubs,
-// one same-colo retry for idempotent reads — see workshop-backend's do-retry.ts), so a do-reset
-// error that reaches the browser already survived that and is worth surfacing. Connection-class
-// errors are owned by the connection manager's reconnect.
 
 /** Reports a DO-reset error to the client-errors endpoint (no-op unless reporting is enabled). */
 export function reportDoResetError(site: string, err: unknown, options?: { gadgetId?: string }) {

--- a/packages/workshop-frontend/src/useActions.ts
+++ b/packages/workshop-frontend/src/useActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { RpcStub, RpcTarget } from 'capnweb'
 import { ActionLogEntry, ActionsSubscriber, Overseer } from '@gadgets/workshop-shared/api'
+import { logRpcFailure } from './rpcErrors'
 
 // One ref-counted subscription per Overseer stub, shared across consumers.
 // `startAfter: epoch 0` asks the backend to replay full history through the
@@ -91,7 +92,9 @@ function openSubscription(overseer: RpcStub<Overseer>, store: Store) {
       if (store.generation === generation) {
         store.isReady = true
         notify(store)
-        console.error('Failed to subscribe to actions:', err)
+        // Quiet for transient errors: GadgetEditor's always-mounted subscriptions notify the
+        // workspace reopen, which replaces the overseer stub and resubscribes this store.
+        logRpcFailure('Failed to subscribe to actions:', err)
       }
     }
   })()

--- a/packages/workshop-frontend/src/useResolveAction.ts
+++ b/packages/workshop-frontend/src/useResolveAction.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, type Dispatch, type SetStateAction } from 'react'
 import { useKumoToastManager } from '@cloudflare/kumo'
 import type { RpcStub } from 'capnweb'
 import type { ActionState, Overseer } from '@gadgets/workshop-shared/api'
+import { logRpcFailure } from './rpcErrors'
 
 type ActionDecision = 'approve' | 'deny'
 
@@ -21,7 +22,9 @@ export function useResolveAction(
       else await overseer.rejectAction(actionId)
       onResolvedRef.current?.(actionId, decision === 'approve' ? 'approved' : 'rejected')
     } catch (error) {
-      console.error(`Failed to ${decision} action:`, error)
+      // A do-reset schedules a workspace reopen inside logRpcFailure. Keep the toast even then:
+      // the click genuinely did nothing, and the reopen won't replay it.
+      logRpcFailure(`Failed to ${decision} action:`, error, { reportSite: 'action.resolve' })
       toasts.add({ title: `Failed to ${decision} action`, variant: 'error' })
     } finally {
       setProcessing(previous => {

--- a/packages/workshop-frontend/src/useWorkspaceOpen.test.tsx
+++ b/packages/workshop-frontend/src/useWorkspaceOpen.test.tsx
@@ -13,6 +13,7 @@ import {
   type Overseer,
 } from '@gadgets/workshop-shared/api'
 import WorkspaceOpenErrorPage from './components/WorkspaceOpenErrorPage'
+import { logRpcFailure } from './rpcErrors'
 import { useWorkspaceOpen } from './useWorkspaceOpen'
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -37,6 +38,13 @@ function api(overseer: RpcStub<Overseer>): RpcStub<AuthenticatedApi> {
   return { openGadget: () => overseer } as unknown as RpcStub<AuthenticatedApi>
 }
 
+function resetError() {
+  return Object.assign(
+    new Error('Durable Object storage operation exceeded timeout which caused object to be reset.'),
+    { durableObjectReset: true },
+  )
+}
+
 const METADATA = {
   id: 'workspace-1',
   title: 'Quarterly planning',
@@ -51,6 +59,7 @@ function WorkspaceProbe({ authenticatedApi }: { authenticatedApi: RpcStub<Authen
     onMetadata: () => {},
     onShareKeyConsumed: () => {},
   })
+  if (state.workspaceLost) return <p>reconnecting</p>
   if (state.error?.kind === 'open') {
     return (
       <WorkspaceOpenErrorPage
@@ -140,5 +149,282 @@ describe('useWorkspaceOpen', () => {
     expect(document.title).toBe('Cloudflare OS')
     expect(firstSubscriptionDispose).toHaveBeenCalledOnce()
     expect(deniedOverseerDispose).toHaveBeenCalledOnce()
+  })
+
+  it('coalesces a burst of DO-reset errors into one reopen', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      const openGadget = vi.fn<() => RpcStub<Overseer>>(() => disposableStub({
+        subscribeToMetadata: async (callback: (metadata: GadgetMetadata) => void) => {
+          callback(METADATA)
+          return disposableStub({}) as RpcStub<{}>
+        },
+      }) as unknown as RpcStub<Overseer>)
+      const authenticatedApi = { openGadget } as unknown as RpcStub<AuthenticatedApi>
+
+      function Probe() {
+        useWorkspaceOpen({
+          id: 'workspace-1',
+          authenticatedApi,
+          onInvalidShareKey: () => {},
+          onMetadata: () => {},
+          onShareKeyConsumed: () => {},
+        })
+        return null
+      }
+
+      container = document.createElement('div')
+      document.body.append(container)
+      root = createRoot(container)
+      await act(async () => root!.render(<Probe />))
+      expect(openGadget).toHaveBeenCalledTimes(1)
+
+      // Any call site quieting a do-reset through logRpcFailure triggers the mounted
+      // workspace's registered recovery hook; a burst coalesces into one reopen.
+      act(() => {
+        for (let i = 0; i < 5; i++) expect(logRpcFailure('Failed op:', resetError())).toBe(true)
+      })
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(openGadget).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps backing off while each reopen succeeds but immediately fails again', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      const openGadget = vi.fn<() => RpcStub<Overseer>>(() => disposableStub({
+        subscribeToMetadata: async (callback: (metadata: GadgetMetadata) => void) => {
+          callback(METADATA)
+          return disposableStub({}) as RpcStub<{}>
+        },
+      }) as unknown as RpcStub<Overseer>)
+      const authenticatedApi = { openGadget } as unknown as RpcStub<AuthenticatedApi>
+
+      function Probe() {
+        useWorkspaceOpen({
+          id: 'workspace-1',
+          authenticatedApi,
+          onInvalidShareKey: () => {},
+          onMetadata: () => {},
+          onShareKeyConsumed: () => {},
+        })
+        return null
+      }
+
+      container = document.createElement('div')
+      document.body.append(container)
+      root = createRoot(container)
+      await act(async () => root!.render(<Probe />))
+      expect(openGadget).toHaveBeenCalledTimes(1)
+
+      act(() => { logRpcFailure('Failed op:', resetError()) })
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(openGadget).toHaveBeenCalledTimes(2)
+
+      // The flapping-DO shape: the reopen itself succeeded moments ago, then failed again. That
+      // quick success must NOT reset the gap back to the 500ms floor — the second reopen waits
+      // out the grown (jittered 5s) gap.
+      act(() => { logRpcFailure('Failed op:', resetError()) })
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(openGadget).toHaveBeenCalledTimes(2)
+      await act(async () => { vi.advanceTimersByTime(5400) })
+      expect(openGadget).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resets the backoff once the workspace has stayed healthy for a while', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      const openGadget = vi.fn<() => RpcStub<Overseer>>(() => disposableStub({
+        subscribeToMetadata: async (callback: (metadata: GadgetMetadata) => void) => {
+          callback(METADATA)
+          return disposableStub({}) as RpcStub<{}>
+        },
+      }) as unknown as RpcStub<Overseer>)
+      const authenticatedApi = { openGadget } as unknown as RpcStub<AuthenticatedApi>
+
+      function Probe() {
+        useWorkspaceOpen({
+          id: 'workspace-1',
+          authenticatedApi,
+          onInvalidShareKey: () => {},
+          onMetadata: () => {},
+          onShareKeyConsumed: () => {},
+        })
+        return null
+      }
+
+      container = document.createElement('div')
+      document.body.append(container)
+      root = createRoot(container)
+      await act(async () => root!.render(<Probe />))
+
+      // First outage grows the gap to 5s...
+      act(() => { logRpcFailure('Failed op:', resetError()) })
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(openGadget).toHaveBeenCalledTimes(2)
+
+      // ...but after a long healthy stretch, a fresh outage starts back at the 500ms floor.
+      await act(async () => { vi.advanceTimersByTime(31000) })
+      act(() => { logRpcFailure('Failed op:', resetError()) })
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(openGadget).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reopens for a flag-only retryable error (worker lost its connection to the DO)', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      const openGadget = vi.fn<() => RpcStub<Overseer>>(() => disposableStub({
+        subscribeToMetadata: async (callback: (metadata: GadgetMetadata) => void) => {
+          callback(METADATA)
+          return disposableStub({}) as RpcStub<{}>
+        },
+      }) as unknown as RpcStub<Overseer>)
+      const authenticatedApi = { openGadget } as unknown as RpcStub<AuthenticatedApi>
+
+      function Probe() {
+        useWorkspaceOpen({
+          id: 'workspace-1',
+          authenticatedApi,
+          onInvalidShareKey: () => {},
+          onMetadata: () => {},
+          onShareKeyConsumed: () => {},
+        })
+        return null
+      }
+
+      container = document.createElement('div')
+      document.body.append(container)
+      root = createRoot(container)
+      await act(async () => root!.render(<Probe />))
+      expect(openGadget).toHaveBeenCalledTimes(1)
+
+      // No durableObjectReset flag and no recognizable message — only `retryable`, which
+      // classifies as do-reset (arrived over a healthy socket, so no reconnect will cure it).
+      const retryableError = Object.assign(new Error('internal error'), { retryable: true })
+      act(() => {
+        expect(logRpcFailure('Failed op:', retryableError)).toBe(true)
+      })
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(openGadget).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not reopen for connection-class errors', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      const openGadget = vi.fn<() => RpcStub<Overseer>>(() => disposableStub({
+        subscribeToMetadata: async () => disposableStub({}) as RpcStub<{}>,
+      }) as unknown as RpcStub<Overseer>)
+      const authenticatedApi = { openGadget } as unknown as RpcStub<AuthenticatedApi>
+
+      function Probe() {
+        useWorkspaceOpen({
+          id: 'workspace-1',
+          authenticatedApi,
+          onInvalidShareKey: () => {},
+          onMetadata: () => {},
+          onShareKeyConsumed: () => {},
+        })
+        return null
+      }
+
+      container = document.createElement('div')
+      document.body.append(container)
+      root = createRoot(container)
+      await act(async () => root!.render(<Probe />))
+
+      // Still quieted (transient), but recovery belongs to the connection manager's reconnect,
+      // not a workspace reopen.
+      act(() => {
+        expect(logRpcFailure('Failed op:', new Error('Peer closed WebSocket: 1006 '))).toBe(true)
+      })
+      await act(async () => { vi.advanceTimersByTime(6000) })
+      expect(openGadget).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows reconnecting instead of a terminal error when the initial open fails transiently', async () => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const overseer = disposableStub({
+      subscribeToMetadata: vi.fn<() => Promise<RpcStub<{}>>>(async () => { throw resetError() }),
+    }) as unknown as RpcStub<Overseer>
+
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => root!.render(<WorkspaceProbe authenticatedApi={api(overseer)} />))
+
+    expect(container.textContent).toContain('reconnecting')
+    expect(container.textContent).not.toContain('access')
+  })
+
+  it('reschedules the reopen when an attempt never settles', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      let captured!: ReturnType<typeof useWorkspaceOpen>
+      let hang = false
+      const openGadget = vi.fn<() => RpcStub<Overseer>>(() => disposableStub({
+        subscribeToMetadata: async (callback: (metadata: GadgetMetadata) => void) => {
+          if (hang) return new Promise<RpcStub<{}>>(() => {})
+          callback(METADATA)
+          return disposableStub({}) as RpcStub<{}>
+        },
+      }) as unknown as RpcStub<Overseer>)
+      const authenticatedApi = { openGadget } as unknown as RpcStub<AuthenticatedApi>
+
+      function Probe() {
+        captured = useWorkspaceOpen({
+          id: 'workspace-1',
+          authenticatedApi,
+          onInvalidShareKey: () => {},
+          onMetadata: () => {},
+          onShareKeyConsumed: () => {},
+        })
+        return null
+      }
+
+      container = document.createElement('div')
+      document.body.append(container)
+      root = createRoot(container)
+      await act(async () => root!.render(<Probe />))
+      expect(openGadget).toHaveBeenCalledTimes(1)
+
+      hang = true
+      act(() => {
+        expect(logRpcFailure('Failed op:', resetError())).toBe(true)
+      })
+      await act(async () => { vi.advanceTimersByTime(600) })
+      expect(openGadget).toHaveBeenCalledTimes(2)
+
+      // The stranded attempt neither resolves nor rejects. The settlement deadline must turn it
+      // back into a scheduled retry with the pill showing, not a silent stall.
+      await act(async () => { vi.advanceTimersByTime(15100) })
+      expect(captured.workspaceLost).toBe(true)
+
+      hang = false
+      await act(async () => { vi.advanceTimersByTime(6000) })  // 5s gap, jittered up to 5.75s
+      expect(openGadget).toHaveBeenCalledTimes(3)
+      expect(captured.workspaceLost).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/workshop-frontend/src/useWorkspaceOpen.ts
+++ b/packages/workshop-frontend/src/useWorkspaceOpen.ts
@@ -9,6 +9,9 @@ import type {
   Overseer,
 } from '@gadgets/workshop-shared/api'
 import { reportIssue } from './errorReporting'
+import {
+  isTransientRpcError, logRpcFailure, reportDoResetError, setWorkspaceRecoveryHook,
+} from './rpcErrors'
 import { useDocumentTitle } from './useDocumentTitle'
 import {
   classifyWorkspaceOpenFailure,
@@ -16,6 +19,57 @@ import {
 } from './components/WorkspaceOpenErrorPage'
 
 const OBSERVER_CANCELLED = 'OBSERVER_CONFIG_CANCELLED'
+
+// A reset can strand the pipelined open/subscribe pair without ever settling it, which would
+// stall the recovery chain silently. This deadline turns a stalled attempt into a scheduled
+// retry (resolving null). While `isPaused` returns true the deadline re-arms instead of firing —
+// the observer-config modal legitimately blocks the open on user input.
+const OPEN_SETTLEMENT_TIMEOUT_MS = 15000
+
+// A successful open only resets the reopen backoff after the workspace has stayed healthy this
+// long. Resetting eagerly would defeat the backoff under a flapping DO: each cycle opens fine
+// (metadata subscribes), then a secondary subscription fails a beat later — with an eager reset
+// that loops at the 500ms floor forever, which is exactly the hammering the backoff exists to
+// prevent.
+const REOPEN_GAP_RESET_AFTER_MS = 30000
+
+function raceOpenSettlement<T extends { [Symbol.dispose](): void }>(
+  promise: Promise<T>,
+  isPaused: () => boolean,
+): Promise<T | null> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let timer: ReturnType<typeof setTimeout>
+    const arm = () => {
+      timer = setTimeout(() => {
+        if (isPaused()) arm()
+        else {
+          settled = true
+          resolve(null)
+        }
+      }, OPEN_SETTLEMENT_TIMEOUT_MS)
+    }
+    arm()
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        // A subscription arriving after we gave up belongs to a written-off attempt.
+        if (settled) value[Symbol.dispose]()
+        else {
+          settled = true
+          resolve(value)
+        }
+      },
+      (err: unknown) => {
+        clearTimeout(timer)
+        if (!settled) {
+          settled = true
+          reject(err as Error)
+        }
+      },
+    )
+  })
+}
 
 export type WorkspaceLoadError =
   | { kind: 'open'; failure: WorkspaceOpenFailureKind }
@@ -45,15 +99,55 @@ export function useWorkspaceOpen({
   const [overseer, setOverseer] = useState<{ stub: RpcStub<Overseer> } | null>(null)
   const [metadata, setMetadata] = useState<GadgetMetadata | null>(null)
   const [error, setError] = useState<WorkspaceLoadError | null>(null)
-  const [connectionLost, setConnectionLost] = useState(false)
+  // True while a transient open failure is showing "Reconnecting…" — the workspace-level
+  // recovery state, distinct from RpcContext's socket-level connectionLost.
+  const [workspaceLost, setWorkspaceLost] = useState(false)
   const [observerConfig, setObserverConfig] = useState<ObserverConfigState | null>(null)
   const [reloadNonce, setReloadNonce] = useState(0)
   const openWorkspaceIdRef = useRef<string | undefined>(undefined)
   const pendingObserverRejectRef = useRef<((error: unknown) => void) | null>(null)
+  const reopenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const reopenGapMsRef = useRef(0)
+  const lastOpenSuccessAtRef = useRef<number | null>(null)
   const callbacksRef = useRef({ onMetadata, onShareKeyConsumed, onInvalidShareKey })
   callbacksRef.current = { onMetadata, onShareKeyConsumed, onInvalidShareKey }
 
   useDocumentTitle(error ? '' : metadata?.title)
+
+  // Coalesces error bursts (every subscribed component fails at once) into one reopen, with
+  // growing gaps so a wedged DO isn't hammered from every open tab: first reopen after a short
+  // coalescing delay, then 5s doubling to a 60s cap. The gap starts over once the workspace has
+  // stayed healthy for a while (see REOPEN_GAP_RESET_AFTER_MS). Delays are jittered so tabs
+  // that saw the same reset don't stampede the recovering DO in lockstep.
+  const scheduleReopen = () => {
+    if (reopenTimerRef.current !== null) return
+    const lastSuccess = lastOpenSuccessAtRef.current
+    if (lastSuccess !== null && Date.now() - lastSuccess > REOPEN_GAP_RESET_AFTER_MS) {
+      reopenGapMsRef.current = 0
+    }
+    const delayMs = Math.max(500, reopenGapMsRef.current) * (0.85 + 0.3 * Math.random())
+    reopenTimerRef.current = setTimeout(() => {
+      reopenTimerRef.current = null
+      setReloadNonce(value => value + 1)
+    }, delayMs)
+    reopenGapMsRef.current = Math.min(Math.max(reopenGapMsRef.current * 2, 5000), 60000)
+  }
+
+  // The workspace's single recovery entry point. A DO reset — or the worker losing its
+  // connection to the DO (`retryable`) — rejects in-flight RPCs while the browser socket stays
+  // healthy, so nothing re-runs the open effect on its own; instead, every do-reset that any
+  // call site quiets through logRpcFailure lands here, is reported tagged with this workspace
+  // when the site named itself, and schedules a coalesced reopen. The ref indirection keeps the
+  // registration effect dependency-free while always running the current render's closure.
+  const recoverRef = useRef<(err: unknown, reportSite?: string) => void>(() => {})
+  recoverRef.current = (err, reportSite) => {
+    if (reportSite) reportDoResetError(reportSite, err, { gadgetId: id })
+    scheduleReopen()
+  }
+  useEffect(() => {
+    setWorkspaceRecoveryHook((err, reportSite) => recoverRef.current(err, reportSite))
+    return () => setWorkspaceRecoveryHook(null)
+  }, [])
 
   useEffect(() => {
     let overseerStub: RpcStub<Overseer> | null = null
@@ -76,7 +170,7 @@ export function useWorkspaceOpen({
       openWorkspaceIdRef.current = undefined
       setOverseer(null)
       setMetadata(null)
-      setConnectionLost(false)
+      setWorkspaceLost(false)
       setError(nextError)
     }
 
@@ -116,25 +210,45 @@ export function useWorkspaceOpen({
         configureObservers = new RpcStub(configureObserversTarget)
 
         overseerStub = authenticatedApi.openGadget(id, shareKey, configureObservers)
+        // No onRpcBroken here: a workerd probe showed it never fires for a DO-backed capability
+        // while the session lives (session-teardown only), so recovery rides on the logRpcFailure
+        // recovery hook instead. The hook can't see a reset that rejects nothing: a workspace
+        // idle at reset time recovers on its next failing call.
         setOverseer({ stub: overseerStub })
 
-        const resolvedSubscription = await overseerStub.subscribeToMetadata((nextMetadata) => {
+        const settledSubscription = await raceOpenSettlement(
+          overseerStub.subscribeToMetadata((nextMetadata) => {
+            if (cancelled) return
+            setMetadata(nextMetadata)
+            callbacksRef.current.onMetadata(nextMetadata)
+          }),
+          () => pendingObserverRejectRef.current !== null,
+        )
+        if (settledSubscription === null) {
           if (cancelled) return
-          setMetadata(nextMetadata)
-          callbacksRef.current.onMetadata(nextMetadata)
-        })
-        if (cancelled) {
-          resolvedSubscription[Symbol.dispose]()
+          console.debug('Workspace open attempt never settled; retrying.')
+          reportIssue('workspace.open-stalled', new Error('workspace open attempt never settled'), {
+            severity: 'warning', handled: true, gadgetId: id,
+          })
+          scheduleReopen()
+          if (!workspaceLost) setWorkspaceLost(true)
           return
         }
-        metadataSubscription = resolvedSubscription
+        if (cancelled) {
+          settledSubscription[Symbol.dispose]()
+          return
+        }
+        metadataSubscription = settledSubscription
 
         openWorkspaceIdRef.current = id
+        lastOpenSuccessAtRef.current = Date.now()
         setError(null)
-        if (connectionLost) setConnectionLost(false)
+        if (workspaceLost) setWorkspaceLost(false)
       } catch (caught) {
         if (cancelled) return
-        console.error('Failed to load gadget:', caught)
+        // For a do-reset this also reports (tagged with this workspace) and schedules the reopen
+        // via the recovery hook; the transient branch below only adds the "Reconnecting…" state.
+        logRpcFailure('Failed to load gadget:', caught, { reportSite: 'workspace.open' })
 
         // TODO: Give share-link and observer failures stable codes so this remaining legacy
         // message classification can be removed.
@@ -155,11 +269,16 @@ export function useWorkspaceOpen({
           const failure = classifyWorkspaceOpenFailure(caught)
           if (failure !== 'unexpected') {
             showTerminalError({ kind: 'open', failure })
+          } else if (isTransientRpcError(caught)) {
+            // Reset or dropped connection: keep the workspace mounted, show "Reconnecting…", and
+            // retry on the growing schedule — a failure on a healthy socket gets no other retry.
+            scheduleReopen()
+            if (!workspaceLost) setWorkspaceLost(true)
           } else if (!hadOpenWorkspace) {
             reportIssue('gadget.load', caught, { gadgetId: id })
             showTerminalError({ kind: 'open', failure })
-          } else if (!connectionLost) {
-            setConnectionLost(true)
+          } else if (!workspaceLost) {
+            setWorkspaceLost(true)
           }
         }
       }
@@ -168,6 +287,10 @@ export function useWorkspaceOpen({
     void load()
     return () => {
       cancelled = true
+      if (reopenTimerRef.current !== null) {
+        clearTimeout(reopenTimerRef.current)
+        reopenTimerRef.current = null
+      }
       if (pendingObserverRejectRef.current) {
         pendingObserverRejectRef.current(new Error('Cancelled'))
         pendingObserverRejectRef.current = null
@@ -181,7 +304,7 @@ export function useWorkspaceOpen({
     overseer,
     metadata,
     error,
-    connectionLost,
+    workspaceLost,
     observerConfig,
     retry() {
       setError(null)


### PR DESCRIPTION
Sibling of #104 (the user-DO half) building on #110. This PR is the workspace half, plus a rework of the socket-reconnect path it leans on.

**The problem.** When a workspace's Overseer DO resets (storage timeouts, overload, ... clusters #56 measured), the long-lived `open()` call dies along with every capability pipelined on it, but the WebSocket underneath stays perfectly healthy. Our only break signal, `onRpcBroken`, is session-level (no way to signal "one capability died") so the client hears nothing. The workspace looks fine, but every chat send fails with "Failed to start conversation" until a full page reload. Reproduced on a pre-PR baseline. (The server already tries to convert DO-loss into a socket close (the `notifyClosed` hack in `server.ts`) but it demonstrably doesn't fire for these resets, and its own TODO asks for exactly this client-side fix.)

## Solve

```mermaid
flowchart TD
    X([something breaks]) --> D{what died?}

    D -- "the WebSocket —<br/>onRpcBroken fires" --> C["connection manager:<br/>jittered backoff, probe round-trip,<br/>proven before publish"]
    C --> N["new session: app rebuilds everything,<br/>one aggregated lost/restored report"]

    D -- "the workspace DO —<br/>socket healthy, no signal at all" --> Q{was a call in flight?}
    Q -- "yes: it rejects with a<br/>reset-classified error" --> L["logRpcFailure — quieting the error<br/>and scheduling recovery are<br/>the same code path"]
    Q -. "no (idle): silent until the next<br/>failing call — the accepted gap" .-> L
    L --> H["coalesced, jittered reopen:<br/>500ms → 5s → … 60s cap"]
    H --> O["fresh openGadget()<br/>over the same socket"]
    O -- "new overseer stub" --> Z["chat / workpieces / console logs /<br/>actions / gadget pane all resubscribe"]
    O -. "open hangs >15s: settlement guard →<br/>'Reconnecting…' pill, retry" .-> H
```

**Workspace reopen.** `logRpcFailure` now doubles as the recovery entry point: any error it classifies as a DO reset schedules a reopen of the open workspace over the still-healthy socket.ke automatically when the stub is replaced, so it heals with the workspace instead of sticking on an error banner.

**Connection manager.** The socket-reconnect logic moved out of `main.tsx` globals into a tested `connectionManager.ts`. Reconnects are proven via a real round-trip (`getServerConfig`, which touches no DO) before the new stub is published, so the app never sees a half-alive connection. A tab-wake probe catches sockets that died while the tab slept, and each outage logs one aggregated lost/restored summary instead of a line per retry.

## Accepted gap (deliberate)

**No noise when a worspace is idle** -  Because there's no ping/health, recovery waits until the next call. Because recovery rides `logRpcFailure`, any failing call in the workspace is now enough (send, approve, hook toggle, subscribe…), but the wait is real: in fault injection, a workspace stayed dormant for minutes after a sustained abort loop until the next user action, which then healed it. A liveness heartbeat would close this; we left it out on purpose to keep the moving parts down.
