### PR TITLE
store composer drafts in session storage until sent

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -81,6 +81,7 @@ import {
   WorkpieceId,
   BlueprintOutput,
   MessageFormatRef,
+  OutputIcon,
   OutputFormatOffer,
 } from "@gadgets/workshop-shared/api";
 import { ActionKind, ResourceDescription } from "@gadgets/workshop-shared/gatekeeper";
@@ -122,6 +123,13 @@ import OutOfCreditsModal from "./components/billing/OutOfCreditsModal";
 import { useSlashCommandPicker } from "./components/chat/SlashCommandPicker";
 import { formatFullTimestamp } from "./utils/formatTimestamp";
 import { copyToClipboard } from "./clipboard";
+import {
+  composerDraftStorageKey,
+  readComposerDraft,
+  serializeComposerDraft,
+  writeComposerDraft,
+  type StoredComposerDraft,
+} from "./composerDraft";
 
 export interface StreamingProposedChanges {
   updates: Uint8Array[];
@@ -313,11 +321,21 @@ const CAPSULE_LOGO_SLOT = "\u2003\u2060\u00a0";
 
 // The format a new workspace will be made from, as a token in the composer's text.
 type FormatToken = ComposerRange & {
-  format: OutputFormatOffer;
+  noun: string;
+  icon: OutputIcon;
   // Data URL for the format's icon, painted into the token's logo slot. Absent if it couldn't be
   // rendered, in which case the token carries no slot either.
   logo?: string;
 };
+
+function formatTokensFromDraft(draft: StoredComposerDraft | undefined): FormatToken[] {
+  return draft?.formats.map(({position, length, noun, icon}) => ({
+    start: position,
+    length,
+    noun,
+    icon,
+  })) ?? [];
+}
 
 const cssLogoUrls = new Map<string, string>();
 
@@ -1778,6 +1796,7 @@ export const ChatInput = ({
   minRows = 2,
   seedText,
   seedNonce,
+  draftStorageKey,
   attachLabel,
   draftUpdateBanner,
   blockedReason,
@@ -1821,6 +1840,8 @@ export const ChatInput = ({
    * whenever `seedNonce` changes, so the same text can be re-seeded by bumping the nonce. */
   seedText?: string;
   seedNonce?: number;
+  /** Session-storage key used to recover this composer's draft prompt after a page refresh. */
+  draftStorageKey?: string;
   /** Optional label for the attach menu item. */
   attachLabel?: string;
   draftUpdateBanner?: ReactNode;
@@ -1838,8 +1859,11 @@ export const ChatInput = ({
    * pre-approval catalog and proactively offer to pre-approve its actions. */
 }) => {
   const toasts = useKumoToastManager();
-  const [inputValue, setInputValue] = useState("");
+  const [initialDraft] = useState(() => readComposerDraft(draftStorageKey));
+  const [inputValue, setInputValue] = useState(() => initialDraft?.text ?? "");
   const [capsules, setCapsules] = useState<InputCapsule[]>([]);
+  const [formatTokens, setFormatTokens] = useState<FormatToken[]>(() =>
+    formatTokensFromDraft(initialDraft));
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [isSending, setIsSending] = useState(false);
   // The chat the "may not have been sent" hint belongs to; the render condition scopes it, and
@@ -1900,6 +1924,55 @@ export const ChatInput = ({
   // Keep inputValue in a ref so handleCursorChange can read it without re-binding.
   const inputValueRef = useRef(inputValue);
   inputValueRef.current = inputValue;
+  const draftEditedRef = useRef(false);
+
+  const loadedDraftKeyRef = useRef(draftStorageKey);
+  const skipDraftWriteRef = useRef(false);
+  useEffect(() => {
+    if (loadedDraftKeyRef.current === draftStorageKey) return;
+    const previousKey = loadedDraftKeyRef.current;
+    loadedDraftKeyRef.current = draftStorageKey;
+    skipDraftWriteRef.current = true;
+    const storedDraft = readComposerDraft(draftStorageKey);
+    const preserveLocalDraft = previousKey === undefined &&
+      (draftEditedRef.current || inputValueRef.current.length > 0);
+    if (preserveLocalDraft) {
+      writeComposerDraft(draftStorageKey, serializeComposerDraft(
+        inputValueRef.current,
+        capsulesRef.current.map(({start, length, description}) => ({
+          start,
+          length,
+          url: description.url,
+        })),
+        formatTokensRef.current,
+      ));
+      skipDraftWriteRef.current = false;
+      return;
+    }
+    setInputValue(storedDraft?.text ?? "");
+    if (previousKey !== undefined) {
+      draftEditedRef.current = false;
+      setCapsules([]);
+      setSelectedSlashCommand(null);
+    }
+    setFormatTokens(formatTokensFromDraft(storedDraft));
+  }, [draftStorageKey]);
+
+  useEffect(() => {
+    if (skipDraftWriteRef.current) {
+      skipDraftWriteRef.current = false;
+      return;
+    }
+    writeComposerDraft(draftStorageKey, serializeComposerDraft(
+      inputValue,
+      capsules.map(({start, length, description}) => ({
+        start,
+        length,
+        url: description.url,
+      })),
+      formatTokens,
+    ));
+  }, [capsules, draftStorageKey, formatTokens, inputValue]);
 
   // Seed the composer from an external suggestion (Home task cards). Re-runs whenever the nonce
   // changes so picking the same suggestion twice still works. Focus + move the cursor to the end.
@@ -1907,6 +1980,8 @@ export const ChatInput = ({
     if (seedNonce === undefined) return;
     const text = seedText ?? "";
     setSelectedSlashCommand(null);
+    setCapsules([]);
+    setFormatTokens([]);
     setInputValue(text);
     requestAnimationFrame(() => {
       const ta = composerTextareaRef.current;
@@ -2255,6 +2330,9 @@ export const ChatInput = ({
       capsule.start >= tokenEnd
         ? {...capsule, start: capsule.start + splice.delta}
         : capsule));
+    setFormatTokens(previous => previous.map(token => token.start >= tokenEnd
+      ? {...token, start: token.start + splice.delta}
+      : token));
     setSelectedSlashCommand({choice, start: splice.start, length: splice.length});
     requestAnimationFrame(() => {
       composerTextareaRef.current?.focus();
@@ -2269,6 +2347,13 @@ export const ChatInput = ({
     setSelectedSlashCommand(previous => previous && previous.start >= position
       ? {...previous, start: previous.start + delta}
       : previous);
+  };
+
+  const shiftFormatTokens = (position: number, delta: number) => {
+    if (delta === 0) return;
+    setFormatTokens(previous => previous.map(token => token.start >= position
+      ? {...token, start: token.start + delta}
+      : token));
   };
 
   const slashCommandPicker = useSlashCommandPicker({
@@ -2304,6 +2389,7 @@ export const ChatInput = ({
 
     sendInFlightRef.current = true;
     setIsSending(true);
+    const sendingDraftKey = draftStorageKey;
     try {
       let messageInput = inputValue;
       let inputCapsules = capsules;
@@ -2315,7 +2401,7 @@ export const ChatInput = ({
         let delta = 0;
         for (const token of formatTokens) {
           if (token.start + token.length <= position) {
-            delta += token.format.output.noun.length - token.length;
+            delta += token.noun.length - token.length;
           }
         }
         return delta;
@@ -2328,7 +2414,7 @@ export const ChatInput = ({
         // back-to-front so earlier offsets stay valid while the text is rewritten.
         let text = messageInput;
         for (const token of [...formatTokens].toSorted((a, b) => b.start - a.start)) {
-          text = text.slice(0, token.start) + token.format.output.noun +
+          text = text.slice(0, token.start) + token.noun +
               text.slice(token.start + token.length);
         }
         inputCapsules = capsules.map(capsule => {
@@ -2441,12 +2527,15 @@ export const ChatInput = ({
       // arguments: the part the transcript renders as the user's words.
       const formatRefs = locateMessageFormatRefs(
           typeof message === "string" ? message : message.args,
-          [...formatTokens].toSorted((a, b) => a.start - b.start).map(token => token.format));
+          [...formatTokens].toSorted((a, b) => a.start - b.start));
 
       await onSend(message, selectedModel,
           capsuleSpecifiers?.length ? capsuleSpecifiers : undefined,
           readyAttachments.length ? readyAttachments : undefined,
           formatRefs);
+      writeComposerDraft(sendingDraftKey, undefined);
+      if (loadedDraftKeyRef.current !== sendingDraftKey) return;
+      draftEditedRef.current = false;
       for (const attachment of attachmentsSnapshot) {
         if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
       }
@@ -2511,6 +2600,7 @@ export const ChatInput = ({
 
         // Adjust positions of existing capsules and add the new one.
         shiftSelectedSlashCommand(urlEnd, splice.delta);
+        shiftFormatTokens(urlEnd, splice.delta);
         setCapsules((prev) => [
           ...prev.map((c) => c.start >= urlEnd ? { ...c, start: c.start + splice.delta } : c),
           {
@@ -2557,6 +2647,7 @@ export const ChatInput = ({
 
     // Adjust positions of any capsules that come after the URL.
     shiftSelectedSlashCommand(urlEnd, lengthDiff);
+    shiftFormatTokens(urlEnd, lengthDiff);
     if (lengthDiff !== 0) {
       setCapsules((prev) => {
         const adjusted = prev.map((c) =>
@@ -2622,6 +2713,7 @@ export const ChatInput = ({
 
     // Shift any existing capsules after the insertion point.
     shiftSelectedSlashCommand(insertPos, splice.delta);
+    shiftFormatTokens(insertPos, splice.delta);
     setCapsules((prev) => [
       ...prev.map((c) =>
         c.start >= insertPos ? { ...c, start: c.start + splice.delta } : c),
@@ -2897,7 +2989,6 @@ export const ChatInput = ({
   // Formats named in the message are inline tokens like capsules, addressed by the caret as one
   // unit. There can be several, and where each sits says which part of the request it belongs to,
   // so they stay in the text rather than becoming a separate field.
-  const [formatTokens, setFormatTokens] = useState<FormatToken[]>([]);
   const formatTokensRef = useRef(formatTokens);
   formatTokensRef.current = formatTokens;
 
@@ -2924,7 +3015,13 @@ export const ChatInput = ({
       ...previous.map(token => token.start >= at
         ? {...token, start: token.start + splice.delta}
         : token),
-      {format, logo, start: splice.start, length: splice.length},
+      {
+        noun: format.output.noun,
+        icon: format.output.icon,
+        logo,
+        start: splice.start,
+        length: splice.length,
+      },
     ]);
     requestAnimationFrame(() => {
       composerTextareaRef.current?.focus();
@@ -3113,6 +3210,7 @@ export const ChatInput = ({
               aria-controls={slashCommandPicker.open ? slashCommandPicker.listboxId : undefined}
               aria-activedescendant={slashCommandPicker.activeDescendant}
               onChange={(e) => {
+                draftEditedRef.current = true;
                 handleInputChange(e.target.value, e.target.selectionStart ?? 0);
                 syncPickerCaret(e.target.selectionStart ?? 0);
                 requestAnimationFrame(handleCursorChange);
@@ -4044,6 +4142,7 @@ function fallbackToStoredModelSelection(
 }
 
 interface ChatInterfaceProps {
+  workspaceId: string | undefined;
   overseer: RpcStub<Overseer>;
   selectedChatId: number | null;
   onNavigateToChat: (
@@ -4237,6 +4336,7 @@ function getOrCreateProvisionalToolCall(
 }
 
 function ChatInterface({
+  workspaceId,
   overseer,
   selectedChatId,
   onNavigateToChat,
@@ -6660,6 +6760,9 @@ function ChatInterface({
             onToggleThinkingTraces={toggleShowThinkingTraces}
             minRows={2}
             newChat
+            draftStorageKey={currentUser && workspaceId
+              ? composerDraftStorageKey(currentUser.id, `workspace:${workspaceId}:new`)
+              : undefined}
           />
           {/* Reserve the same height as the token/cost row to avoid layout shift. */}
           <div aria-hidden className="min-h-[1rem]" />
@@ -7621,6 +7724,12 @@ function ChatInterface({
                     onStop={handleStop}
                     showThinkingTraces={showThinkingTraces}
                     onToggleThinkingTraces={toggleShowThinkingTraces}
+                    draftStorageKey={currentUser && workspaceId && selectedChatId !== null
+                      ? composerDraftStorageKey(
+                          currentUser.id,
+                          `workspace:${workspaceId}:chat:${selectedChatId}`,
+                        )
+                      : undefined}
                     blockedReason={
                       hasPendingConnectionRequest
                         ? "Set up or deny the connection request above to continue."

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -1984,6 +1984,8 @@ export const ChatInput = ({
   };
 
   useEffect(() => {
+    // On a cold load the user-scoped key usually arrives after authentication; the key-change
+    // effect below restores that draft, while this path handles drafts available at mount.
     if (!initialDraft) return;
     const generation = ++draftRestoreGenerationRef.current;
     restoreDraftPresentation(initialDraft, draftStorageKey, generation);

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -92,7 +92,7 @@ import {
   ComposerMirror, composerTextareaClass, type ComposerMirrorHandle, type MirrorToken,
 } from "./components/chat/ComposerMirror";
 import {
-  useSlashCommandChoice, type OverseerSource,
+  slashCommandKey, useSlashCommandChoice, type OverseerSource,
 } from "./components/chat/slash-command-catalog";
 import {
   removeComposerToken, snapCaretOutOfRanges, spliceComposerToken, type ComposerRange,
@@ -336,6 +336,13 @@ function formatTokensFromDraft(draft: StoredComposerDraft | undefined): FormatTo
     noun,
     icon,
   })) ?? [];
+}
+
+function slashCommandFromDraft(draft: StoredComposerDraft | undefined): SelectedSlashCommand | null {
+  const command = draft?.command;
+  return command
+    ? { start: command.position, length: command.length, choice: command.choice }
+    : null;
 }
 
 const cssLogoUrls = new Map<string, string>();
@@ -1872,7 +1879,9 @@ export const ChatInput = ({
   const [sendHiccup, setSendHiccup] = useState<{ chatKey?: number | null } | null>(null);
   useEffect(() => setSendHiccup(null), [chatKey]);
   const [isAttachmentDragActive, setIsAttachmentDragActive] = useState(false);
-  const [selectedSlashCommand, setSelectedSlashCommand] = useState<SelectedSlashCommand | null>(null);
+  const [selectedSlashCommand, setSelectedSlashCommand] = useState<SelectedSlashCommand | null>(
+    () => slashCommandFromDraft(initialDraft),
+  );
   // The caret the slash command picker parses at. Deliberately updated only when it moves to a
   // different command token (see `syncPickerCaret`): the mirror owns the caret the user sees,
   // so ordinary caret movement doesn't have to re-render the composer.
@@ -1950,8 +1959,14 @@ export const ChatInput = ({
   };
 
   const composerMatchesStoredDraft = (draft: StoredComposerDraft) => {
+    const currentCommand = selectedSlashCommandRef.current;
+    const storedCommand = draft.command;
     if (inputValueRef.current !== draft.text || capsulesRef.current.length > 0 ||
-        selectedSlashCommandRef.current) {
+        !!currentCommand !== !!storedCommand || currentCommand && storedCommand &&
+        (currentCommand.start !== storedCommand.position ||
+          currentCommand.length !== storedCommand.length ||
+          slashCommandKey(currentCommand.choice.selection) !==
+            slashCommandKey(storedCommand.choice.selection))) {
       return false;
     }
     const currentFormats = formatTokensRef.current;
@@ -1978,6 +1993,7 @@ export const ChatInput = ({
         const restored = decorateComposerDraft(draft, logos, CAPSULE_LOGO_SLOT);
         setInputValue(restored.text);
         setFormatTokens(restored.formats);
+        setSelectedSlashCommand(restored.command ?? null);
         placeRestoredCaretAtEnd(restored.text, key, generation);
       });
     });
@@ -2016,6 +2032,7 @@ export const ChatInput = ({
           url: description.url,
         })),
         formatTokensRef.current,
+        selectedSlashCommandRef.current ?? undefined,
       ));
       skipDraftWriteRef.current = false;
       return;
@@ -2024,9 +2041,9 @@ export const ChatInput = ({
     if (previousKey !== undefined) {
       draftEditedRef.current = false;
       setCapsules([]);
-      setSelectedSlashCommand(null);
     }
     setFormatTokens(formatTokensFromDraft(storedDraft));
+    setSelectedSlashCommand(slashCommandFromDraft(storedDraft));
     if (storedDraft) restoreDraftPresentation(storedDraft, draftStorageKey, generation);
   }, [draftStorageKey]);
 
@@ -2043,8 +2060,9 @@ export const ChatInput = ({
         url: description.url,
       })),
       formatTokens,
+      selectedSlashCommand ?? undefined,
     ));
-  }, [capsules, draftStorageKey, formatTokens, inputValue]);
+  }, [capsules, draftStorageKey, formatTokens, inputValue, selectedSlashCommand]);
 
   // Seed the composer from an external suggestion (Home task cards). Re-runs whenever the nonce
   // changes so picking the same suggestion twice still works. Focus + move the cursor to the end.
@@ -6820,7 +6838,9 @@ function ChatInterface({
           extra p-4 (which would shrink the input vs. the in-chat composer). */}
       <div className="flex-shrink-0 border-t border-kumo-line">
         <div className={useConstrainedChatWidth ? "mx-auto w-full max-w-[920px]" : ""}>
+          {/* Attachments and pending resource operations belong to this workspace's composer. */}
           <ChatInput
+            key={workspaceId}
             createCapsuleGatekeeper={(accountId, url) =>
               overseer.newGatekeeper(accountId, url)
             }
@@ -7779,7 +7799,9 @@ function ChatInterface({
               {/* ── Bottom: input, update state, and cost ──────────────── */}
               <div className={`flex-shrink-0 bg-kumo-base ${sidebarMode ? "" : "border-t border-kumo-line"}`}>
                 <div className={useConstrainedChatWidth ? "mx-auto w-full max-w-[920px]" : ""}>
+                  {/* Remount all transient composer state when the conversation changes. */}
                   <ChatInput
+                    key={`${workspaceId}:${selectedChatId}`}
                     chatKey={selectedChatId}
                     createCapsuleGatekeeper={(accountId, url) =>
                       overseer.newGatekeeper(accountId, url)

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -125,6 +125,7 @@ import { formatFullTimestamp } from "./utils/formatTimestamp";
 import { copyToClipboard } from "./clipboard";
 import {
   composerDraftStorageKey,
+  decorateComposerDraft,
   readComposerDraft,
   serializeComposerDraft,
   writeComposerDraft,
@@ -1928,8 +1929,76 @@ export const ChatInput = ({
 
   const loadedDraftKeyRef = useRef(draftStorageKey);
   const skipDraftWriteRef = useRef(false);
+  const draftRestoreGenerationRef = useRef(0);
+
+  const placeRestoredCaretAtEnd = (
+    text: string,
+    key: string | undefined,
+    generation: number,
+  ) => {
+    requestAnimationFrame(() => {
+      if (draftRestoreGenerationRef.current !== generation ||
+          loadedDraftKeyRef.current !== key || inputValueRef.current !== text) {
+        return;
+      }
+      const textarea = composerTextareaRef.current;
+      if (!textarea) return;
+      if (autoFocus) textarea.focus();
+      textarea.setSelectionRange(text.length, text.length);
+      autoResizeTextarea(textarea, minRows, newChat ? 10 : 4);
+    });
+  };
+
+  const composerMatchesStoredDraft = (draft: StoredComposerDraft) => {
+    if (inputValueRef.current !== draft.text || capsulesRef.current.length > 0 ||
+        selectedSlashCommandRef.current) {
+      return false;
+    }
+    const currentFormats = formatTokensRef.current;
+    return currentFormats.length === draft.formats.length && currentFormats.every((format, index) => {
+      const stored = draft.formats[index];
+      return !format.logo && format.start === stored.position && format.length === stored.length &&
+        format.noun === stored.noun && format.icon === stored.icon;
+    });
+  };
+
+  const restoreDraftPresentation = (
+    draft: StoredComposerDraft,
+    key: string | undefined,
+    generation: number,
+  ) => {
+    placeRestoredCaretAtEnd(draft.text, key, generation);
+    if (draft.formats.length === 0) return;
+    void Promise.all(draft.formats.map(({icon}) => formatIconDataUrl(icon))).then((logos) => {
+      requestAnimationFrame(() => {
+        if (draftRestoreGenerationRef.current !== generation ||
+            loadedDraftKeyRef.current !== key || !composerMatchesStoredDraft(draft)) {
+          return;
+        }
+        const restored = decorateComposerDraft(draft, logos, CAPSULE_LOGO_SLOT);
+        setInputValue(restored.text);
+        setFormatTokens(restored.formats);
+        placeRestoredCaretAtEnd(restored.text, key, generation);
+      });
+    });
+  };
+
+  useEffect(() => {
+    if (!initialDraft) return;
+    const generation = ++draftRestoreGenerationRef.current;
+    restoreDraftPresentation(initialDraft, draftStorageKey, generation);
+    return () => {
+      if (draftRestoreGenerationRef.current === generation) {
+        draftRestoreGenerationRef.current++;
+      }
+    };
+    // Restoration belongs to the draft captured during initialization, not later prop values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     if (loadedDraftKeyRef.current === draftStorageKey) return;
+    const generation = ++draftRestoreGenerationRef.current;
     const previousKey = loadedDraftKeyRef.current;
     loadedDraftKeyRef.current = draftStorageKey;
     skipDraftWriteRef.current = true;
@@ -1956,6 +2025,7 @@ export const ChatInput = ({
       setSelectedSlashCommand(null);
     }
     setFormatTokens(formatTokensFromDraft(storedDraft));
+    if (storedDraft) restoreDraftPresentation(storedDraft, draftStorageKey, generation);
   }, [draftStorageKey]);
 
   useEffect(() => {
@@ -1978,6 +2048,7 @@ export const ChatInput = ({
   // changes so picking the same suggestion twice still works. Focus + move the cursor to the end.
   useEffect(() => {
     if (seedNonce === undefined) return;
+    draftRestoreGenerationRef.current++;
     const text = seedText ?? "";
     setSelectedSlashCommand(null);
     setCapsules([]);
@@ -3211,6 +3282,7 @@ export const ChatInput = ({
               aria-activedescendant={slashCommandPicker.activeDescendant}
               onChange={(e) => {
                 draftEditedRef.current = true;
+                draftRestoreGenerationRef.current++;
                 handleInputChange(e.target.value, e.target.selectionStart ?? 0);
                 syncPickerCaret(e.target.selectionStart ?? 0);
                 requestAnimationFrame(handleCursorChange);

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -1479,6 +1479,7 @@ export default function GadgetEditor() {
               <div className={layoutModeReady ? 'h-full' : 'h-full invisible'}>
                 <ChatInterface
                   key={id}
+                  workspaceId={id}
                   overseer={overseer.stub}
                   selectedChatId={effectiveSelectedChatId}
                   onNavigateToChat={navigateToChat}

--- a/packages/workshop-frontend/src/components/format/__tests__/messageFormatRefs.test.ts
+++ b/packages/workshop-frontend/src/components/format/__tests__/messageFormatRefs.test.ts
@@ -1,18 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import type { OutputFormatOffer } from '@gadgets/workshop-shared/api'
+import type { MessageFormatRef } from '@gadgets/workshop-shared/api'
 import { locateMessageFormatRefs } from '../messageFormatRefs'
 
-function offer(blueprintId: string, noun: string): OutputFormatOffer {
-  return {
-    blueprintId,
-    output: { id: noun.toLowerCase(), noun, plural: `${noun}s`, icon: 'fileText' },
-    description: '',
-    requiresSetup: false,
-  }
+function format(noun: string): Pick<MessageFormatRef, 'noun' | 'icon'> {
+  return { noun, icon: 'fileText' }
 }
 
-const doc = offer('format.document', 'Doc')
-const slides = offer('format.slides', 'Slides')
+const doc = format('Doc')
+const slides = format('Slides')
 
 describe('locateMessageFormatRefs', () => {
   it('finds each noun where it ended up in the sent text', () => {

--- a/packages/workshop-frontend/src/components/format/messageFormatRefs.ts
+++ b/packages/workshop-frontend/src/components/format/messageFormatRefs.ts
@@ -10,18 +10,18 @@
 // first. A hand-typed noun can still take a chip's place, which is cosmetic -- it names the same
 // format.
 
-import type { MessageFormatRef, OutputFormatOffer } from '@gadgets/workshop-shared/api'
+import type { MessageFormatRef } from '@gadgets/workshop-shared/api'
 
 export function locateMessageFormatRefs(
   text: string,
-  formats: readonly OutputFormatOffer[],
+  formats: readonly Pick<MessageFormatRef, 'noun' | 'icon'>[],
 ): MessageFormatRef[] | undefined {
   if (formats.length === 0) return undefined
 
   const refs: MessageFormatRef[] = []
   let cursor = 0
   for (const format of formats) {
-    const noun = format.output.noun
+    const noun = format.noun
     const position = text.indexOf(noun, cursor)
     // A noun can genuinely go missing: a slash command's arguments may not include the part of the
     // line the format was in. Dropping the ref leaves the message correct, just unadorned.
@@ -30,7 +30,7 @@ export function locateMessageFormatRefs(
       position,
       length: noun.length,
       noun,
-      icon: format.output.icon,
+      icon: format.icon,
     })
     cursor = position + noun.length
   }

--- a/packages/workshop-frontend/src/composerDraft.test.ts
+++ b/packages/workshop-frontend/src/composerDraft.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   composerDraftStorageKey,
+  decorateComposerDraft,
   readComposerDraft,
   serializeComposerDraft,
   writeComposerDraft,
@@ -57,6 +58,47 @@ describe("composer drafts", () => {
       noun: "Document",
       icon: "fileText",
     }]);
+  });
+
+  it("decorates restored formats and adjusts later token positions", () => {
+    const stored: StoredComposerDraft = {
+      version: 1,
+      text: "Create a Document and a Sheet",
+      formats: [
+        { position: 9, length: 8, noun: "Document", icon: "fileText" },
+        { position: 24, length: 5, noun: "Sheet", icon: "table" },
+      ],
+    };
+    const logoSlot = "\u2003\u2060\u00a0";
+
+    const restored = decorateComposerDraft(stored, ["data:doc", "data:sheet"], logoSlot);
+
+    expect(restored.text).toBe(`Create a ${logoSlot}Document and a ${logoSlot}Sheet`);
+    expect(restored.formats).toEqual([
+      {
+        start: 9,
+        length: logoSlot.length + 8,
+        noun: "Document",
+        icon: "fileText",
+        logo: "data:doc",
+      },
+      {
+        start: 24 + logoSlot.length,
+        length: logoSlot.length + 5,
+        noun: "Sheet",
+        icon: "table",
+        logo: "data:sheet",
+      },
+    ]);
+  });
+
+  it("leaves a restored format undecorated when its icon cannot be rendered", () => {
+    const restored = decorateComposerDraft(draft, [undefined], "\u2003\u2060\u00a0");
+
+    expect(restored).toEqual({
+      text: draft.text,
+      formats: [{ start: 9, length: 8, noun: "Document", icon: "fileText" }],
+    });
   });
 
   it("rejects stored format ranges that do not match the text", () => {

--- a/packages/workshop-frontend/src/composerDraft.test.ts
+++ b/packages/workshop-frontend/src/composerDraft.test.ts
@@ -9,11 +9,20 @@ import {
   writeComposerDraft,
   type StoredComposerDraft,
 } from "./composerDraft";
+import type { SlashCommandChoice } from "@gadgets/workshop-shared/api";
 
 const draft: StoredComposerDraft = {
   version: 1,
   text: "Create a Document",
   formats: [{ position: 9, length: 8, noun: "Document", icon: "fileText" }],
+};
+
+const deployCommand: SlashCommandChoice = {
+  selection: { gatekeeperId: 42, commandId: "deploy" },
+  name: "deploy",
+  description: "Deploy the current project",
+  providerLabel: "GitHub",
+  resourceLabel: "octo/repo",
 };
 
 describe("composer drafts", () => {
@@ -92,6 +101,53 @@ describe("composer drafts", () => {
     ]);
   });
 
+  it("preserves an inline slash command through token normalization and decoration", () => {
+    const logoSlot = "\u2003\u2060\u00a0";
+    const text = `Use Q3 Plan as a ${logoSlot}Document, then /deploy it`;
+    const formatStart = text.indexOf(logoSlot);
+    const commandStart = text.indexOf("/deploy");
+
+    const stored = serializeComposerDraft(
+      text,
+      [{ start: 4, length: "Q3 Plan".length, url: "https://example.com/q3" }],
+      [{
+        start: formatStart,
+        length: logoSlot.length + "Document".length,
+        noun: "Document",
+        icon: "fileText",
+      }],
+      { start: commandStart, length: "/deploy".length, choice: deployCommand },
+    );
+
+    expect(stored.text).toBe("Use https://example.com/q3 as a Document, then /deploy it");
+    expect(stored.command).toEqual({
+      position: stored.text.indexOf("/deploy"),
+      length: "/deploy".length,
+      choice: deployCommand,
+    });
+
+    const restored = decorateComposerDraft(stored, ["data:doc"], logoSlot);
+    expect(restored.command).toEqual({
+      start: restored.text.indexOf("/deploy"),
+      length: "/deploy".length,
+      choice: deployCommand,
+    });
+  });
+
+  it("round-trips the exact slash command provider selection", () => {
+    const key = composerDraftStorageKey("user-a", "workspace:one:chat:2");
+    const stored = serializeComposerDraft(
+      "Please /deploy this",
+      [],
+      [],
+      { start: 7, length: 7, choice: deployCommand },
+    );
+
+    writeComposerDraft(key, stored);
+
+    expect(readComposerDraft(key)?.command?.choice).toEqual(deployCommand);
+  });
+
   it("leaves a restored format undecorated when its icon cannot be rendered", () => {
     const restored = decorateComposerDraft(draft, [undefined], "\u2003\u2060\u00a0");
 
@@ -106,6 +162,39 @@ describe("composer drafts", () => {
     sessionStorage.setItem(key, JSON.stringify({
       ...draft,
       formats: [{ position: 0, length: 8, noun: "Document", icon: "fileText" }],
+    }));
+
+    expect(readComposerDraft(key)).toBeUndefined();
+  });
+
+  it("rejects stored slash command metadata that does not match the text", () => {
+    const key = composerDraftStorageKey("user-a", "home");
+    sessionStorage.setItem(key, JSON.stringify({
+      version: 1,
+      text: "Please /deploy this",
+      formats: [],
+      command: { position: 0, length: 7, choice: deployCommand },
+    }));
+
+    expect(readComposerDraft(key)).toBeUndefined();
+  });
+
+  it("rejects a built-in command stored under a different name", () => {
+    const key = composerDraftStorageKey("user-a", "home");
+    sessionStorage.setItem(key, JSON.stringify({
+      version: 1,
+      text: "/delete this",
+      formats: [],
+      command: {
+        position: 0,
+        length: 7,
+        choice: {
+          selection: { builtin: true, commandId: "compact" },
+          name: "delete",
+          description: "Misleading command",
+          providerLabel: "Workshop",
+        },
+      },
     }));
 
     expect(readComposerDraft(key)).toBeUndefined();

--- a/packages/workshop-frontend/src/composerDraft.test.ts
+++ b/packages/workshop-frontend/src/composerDraft.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  composerDraftStorageKey,
+  readComposerDraft,
+  serializeComposerDraft,
+  writeComposerDraft,
+  type StoredComposerDraft,
+} from "./composerDraft";
+
+const draft: StoredComposerDraft = {
+  version: 1,
+  text: "Create a Document",
+  formats: [{ position: 9, length: 8, noun: "Document", icon: "fileText" }],
+};
+
+describe("composer drafts", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    sessionStorage.clear();
+  });
+
+  it("isolates structured drafts by user and destination", () => {
+    const home = composerDraftStorageKey("user-a", "home");
+    const chat = composerDraftStorageKey("user-a", "workspace:one:chat:2");
+    const otherUser = composerDraftStorageKey("user-b", "home");
+
+    writeComposerDraft(home, draft);
+    writeComposerDraft(chat, { version: 1, text: "chat draft", formats: [] });
+
+    expect(readComposerDraft(home)).toEqual(draft);
+    expect(readComposerDraft(chat)?.text).toBe("chat draft");
+    expect(readComposerDraft(otherUser)).toBeUndefined();
+  });
+
+  it("downgrades capsules to URLs and records formats against normalized text", () => {
+    const logoSlot = "\u2003\u2060\u00a0";
+    const text = `Use Q3 Plan to create a ${logoSlot}Document`;
+    const formatStart = text.indexOf(logoSlot);
+
+    const stored = serializeComposerDraft(
+      text,
+      [{ start: 4, length: "Q3 Plan".length, url: "https://example.com/q3" }],
+      [{
+        start: formatStart,
+        length: logoSlot.length + "Document".length,
+        noun: "Document",
+        icon: "fileText",
+      }],
+    );
+
+    expect(stored.text).toBe("Use https://example.com/q3 to create a Document");
+    expect(stored.formats).toEqual([{
+      position: stored.text.indexOf("Document"),
+      length: "Document".length,
+      noun: "Document",
+      icon: "fileText",
+    }]);
+  });
+
+  it("rejects stored format ranges that do not match the text", () => {
+    const key = composerDraftStorageKey("user-a", "home");
+    sessionStorage.setItem(key, JSON.stringify({
+      ...draft,
+      formats: [{ position: 0, length: 8, noun: "Document", icon: "fileText" }],
+    }));
+
+    expect(readComposerDraft(key)).toBeUndefined();
+  });
+
+  it("removes a draft when the composer is cleared", () => {
+    const key = composerDraftStorageKey("user-a", "home");
+    writeComposerDraft(key, draft);
+
+    writeComposerDraft(key, undefined);
+
+    expect(readComposerDraft(key)).toBeUndefined();
+    expect(sessionStorage.getItem(key)).toBeNull();
+  });
+
+  it("tolerates unavailable browser storage", () => {
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => { throw new Error("blocked"); },
+      setItem: () => { throw new Error("blocked"); },
+      removeItem: () => { throw new Error("blocked"); },
+    });
+
+    expect(readComposerDraft("key")).toBeUndefined();
+    expect(() => writeComposerDraft("key", draft)).not.toThrow();
+  });
+});

--- a/packages/workshop-frontend/src/composerDraft.ts
+++ b/packages/workshop-frontend/src/composerDraft.ts
@@ -49,6 +49,7 @@ export function serializeComposerDraft(
       continue;
     }
     normalized += text.slice(cursor, token.start);
+    // Capsule capability URLs restore as plain links, not chips.
     const replacement = token.kind === "capsule" ? token.url : token.noun;
     if (token.kind === "format") {
       storedFormats.push({

--- a/packages/workshop-frontend/src/composerDraft.ts
+++ b/packages/workshop-frontend/src/composerDraft.ts
@@ -21,6 +21,11 @@ export type StoredComposerDraft = {
   formats: MessageFormatRef[];
 };
 
+export type RestoredComposerDraft = {
+  text: string;
+  formats: Array<ComposerDraftFormat & { logo?: string }>;
+};
+
 export function composerDraftStorageKey(userId: string, scope: string): string {
   return `${COMPOSER_DRAFT_PREFIX}:${userId}:${scope}`;
 }
@@ -59,6 +64,33 @@ export function serializeComposerDraft(
   normalized += text.slice(cursor);
 
   return { version: 1, text: normalized, formats: storedFormats };
+}
+
+export function decorateComposerDraft(
+  draft: StoredComposerDraft,
+  logos: readonly (string | undefined)[],
+  logoSlot: string,
+): RestoredComposerDraft {
+  let text = "";
+  let cursor = 0;
+  const formats: RestoredComposerDraft["formats"] = [];
+  for (const [index, format] of draft.formats.entries()) {
+    text += draft.text.slice(cursor, format.position);
+    const logo = logos[index];
+    const prefix = logo ? logoSlot : "";
+    const start = text.length;
+    text += prefix + format.noun;
+    formats.push({
+      start,
+      length: prefix.length + format.length,
+      noun: format.noun,
+      icon: format.icon,
+      ...(logo ? { logo } : {}),
+    });
+    cursor = format.position + format.length;
+  }
+  text += draft.text.slice(cursor);
+  return { text, formats };
 }
 
 export function readComposerDraft(key: string | undefined): StoredComposerDraft | undefined {

--- a/packages/workshop-frontend/src/composerDraft.ts
+++ b/packages/workshop-frontend/src/composerDraft.ts
@@ -1,0 +1,113 @@
+import { isOutputIcon, type MessageFormatRef, type OutputIcon } from "@gadgets/workshop-shared/api";
+
+const COMPOSER_DRAFT_PREFIX = "gadgets:composer-draft:v1";
+
+export type ComposerDraftCapsule = {
+  start: number;
+  length: number;
+  url: string;
+};
+
+export type ComposerDraftFormat = {
+  start: number;
+  length: number;
+  noun: string;
+  icon: OutputIcon;
+};
+
+export type StoredComposerDraft = {
+  version: 1;
+  text: string;
+  formats: MessageFormatRef[];
+};
+
+export function composerDraftStorageKey(userId: string, scope: string): string {
+  return `${COMPOSER_DRAFT_PREFIX}:${userId}:${scope}`;
+}
+
+export function serializeComposerDraft(
+  text: string,
+  capsules: readonly ComposerDraftCapsule[],
+  formats: readonly ComposerDraftFormat[],
+): StoredComposerDraft {
+  const tokens = [
+    ...capsules.map((capsule) => ({ ...capsule, kind: "capsule" as const })),
+    ...formats.map((format) => ({ ...format, kind: "format" as const })),
+  ].toSorted((a, b) => a.start - b.start);
+
+  let normalized = "";
+  let cursor = 0;
+  const storedFormats: MessageFormatRef[] = [];
+  for (const token of tokens) {
+    if (token.start < cursor || token.start < 0 || token.length < 0 ||
+        token.start + token.length > text.length) {
+      continue;
+    }
+    normalized += text.slice(cursor, token.start);
+    const replacement = token.kind === "capsule" ? token.url : token.noun;
+    if (token.kind === "format") {
+      storedFormats.push({
+        position: normalized.length,
+        length: replacement.length,
+        noun: token.noun,
+        icon: token.icon,
+      });
+    }
+    normalized += replacement;
+    cursor = token.start + token.length;
+  }
+  normalized += text.slice(cursor);
+
+  return { version: 1, text: normalized, formats: storedFormats };
+}
+
+export function readComposerDraft(key: string | undefined): StoredComposerDraft | undefined {
+  if (!key) return undefined;
+  try {
+    const value: unknown = JSON.parse(window.sessionStorage.getItem(key) ?? "null");
+    if (!value || typeof value !== "object") return undefined;
+    const record = value as Record<string, unknown>;
+    if (record.version !== 1 || typeof record.text !== "string" ||
+        !Array.isArray(record.formats)) {
+      return undefined;
+    }
+
+    const formats: MessageFormatRef[] = [];
+    let previousEnd = 0;
+    for (const candidate of record.formats) {
+      if (!candidate || typeof candidate !== "object") return undefined;
+      const format = candidate as Record<string, unknown>;
+      if (!Number.isInteger(format.position) || !Number.isInteger(format.length) ||
+          typeof format.noun !== "string" || !isOutputIcon(format.icon)) {
+        return undefined;
+      }
+      const position = format.position as number;
+      const length = format.length as number;
+      if (position < previousEnd || format.noun.length === 0 || length !== format.noun.length ||
+          record.text.slice(position, position + length) !== format.noun) {
+        return undefined;
+      }
+      formats.push({ position, length, noun: format.noun, icon: format.icon });
+      previousEnd = position + length;
+    }
+    return { version: 1, text: record.text, formats };
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeComposerDraft(
+  key: string | undefined,
+  draft: StoredComposerDraft | undefined,
+): void {
+  if (!key) return;
+  try {
+    if (draft?.text) {
+      window.sessionStorage.setItem(key, JSON.stringify(draft));
+    } else {
+      window.sessionStorage.removeItem(key);
+    }
+  } catch {
+    // Storage can be unavailable in restricted browser contexts. Draft recovery is best-effort.
+  }
+}

--- a/packages/workshop-frontend/src/composerDraft.ts
+++ b/packages/workshop-frontend/src/composerDraft.ts
@@ -1,4 +1,10 @@
-import { isOutputIcon, type MessageFormatRef, type OutputIcon } from "@gadgets/workshop-shared/api";
+import {
+  isOutputIcon,
+  type MessageFormatRef,
+  type OutputIcon,
+  type SlashCommandChoice,
+  type SlashCommandId,
+} from "@gadgets/workshop-shared/api";
 
 const COMPOSER_DRAFT_PREFIX = "gadgets:composer-draft:v1";
 
@@ -15,15 +21,29 @@ export type ComposerDraftFormat = {
   icon: OutputIcon;
 };
 
+export type ComposerDraftSlashCommand = {
+  start: number;
+  length: number;
+  choice: SlashCommandChoice;
+};
+
+type StoredComposerDraftSlashCommand = {
+  position: number;
+  length: number;
+  choice: SlashCommandChoice;
+};
+
 export type StoredComposerDraft = {
   version: 1;
   text: string;
   formats: MessageFormatRef[];
+  command?: StoredComposerDraftSlashCommand;
 };
 
 export type RestoredComposerDraft = {
   text: string;
   formats: Array<ComposerDraftFormat & { logo?: string }>;
+  command?: ComposerDraftSlashCommand;
 };
 
 export function composerDraftStorageKey(userId: string, scope: string): string {
@@ -34,15 +54,22 @@ export function serializeComposerDraft(
   text: string,
   capsules: readonly ComposerDraftCapsule[],
   formats: readonly ComposerDraftFormat[],
+  command?: ComposerDraftSlashCommand,
 ): StoredComposerDraft {
-  const tokens = [
+  const tokens: Array<
+    | (ComposerDraftCapsule & { kind: "capsule" })
+    | (ComposerDraftFormat & { kind: "format" })
+    | (ComposerDraftSlashCommand & { kind: "command" })
+  > = [
     ...capsules.map((capsule) => ({ ...capsule, kind: "capsule" as const })),
     ...formats.map((format) => ({ ...format, kind: "format" as const })),
+    ...(command ? [{ ...command, kind: "command" as const }] : []),
   ].toSorted((a, b) => a.start - b.start);
 
   let normalized = "";
   let cursor = 0;
   const storedFormats: MessageFormatRef[] = [];
+  let storedCommand: StoredComposerDraftSlashCommand | undefined;
   for (const token of tokens) {
     if (token.start < cursor || token.start < 0 || token.length < 0 ||
         token.start + token.length > text.length) {
@@ -50,7 +77,11 @@ export function serializeComposerDraft(
     }
     normalized += text.slice(cursor, token.start);
     // Capsule capability URLs restore as plain links, not chips.
-    const replacement = token.kind === "capsule" ? token.url : token.noun;
+    const replacement = token.kind === "capsule"
+      ? token.url
+      : token.kind === "format"
+        ? token.noun
+        : text.slice(token.start, token.start + token.length);
     if (token.kind === "format") {
       storedFormats.push({
         position: normalized.length,
@@ -58,13 +89,24 @@ export function serializeComposerDraft(
         noun: token.noun,
         icon: token.icon,
       });
+    } else if (token.kind === "command") {
+      storedCommand = {
+        position: normalized.length,
+        length: replacement.length,
+        choice: token.choice,
+      };
     }
     normalized += replacement;
     cursor = token.start + token.length;
   }
   normalized += text.slice(cursor);
 
-  return { version: 1, text: normalized, formats: storedFormats };
+  return {
+    version: 1,
+    text: normalized,
+    formats: storedFormats,
+    ...(storedCommand && { command: storedCommand }),
+  };
 }
 
 export function decorateComposerDraft(
@@ -75,6 +117,11 @@ export function decorateComposerDraft(
   let text = "";
   let cursor = 0;
   const formats: RestoredComposerDraft["formats"] = [];
+  const command = draft.command && {
+    start: draft.command.position,
+    length: draft.command.length,
+    choice: draft.command.choice,
+  };
   for (const [index, format] of draft.formats.entries()) {
     text += draft.text.slice(cursor, format.position);
     const logo = logos[index];
@@ -88,10 +135,45 @@ export function decorateComposerDraft(
       icon: format.icon,
       ...(logo ? { logo } : {}),
     });
+    if (command && format.position + format.length <= draft.command!.position) {
+      command.start += prefix.length;
+    }
     cursor = format.position + format.length;
   }
   text += draft.text.slice(cursor);
-  return { text, formats };
+  return { text, formats, ...(command && { command }) };
+}
+
+function readSlashCommandId(value: unknown): SlashCommandId | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (record.builtin === true) {
+    return record.commandId === "compact" ? { builtin: true, commandId: "compact" } : undefined;
+  }
+  if (record.builtin !== undefined || !Number.isInteger(record.gatekeeperId) ||
+      typeof record.commandId !== "string" || !record.commandId) {
+    return undefined;
+  }
+  return { gatekeeperId: record.gatekeeperId as number, commandId: record.commandId };
+}
+
+function readSlashCommandChoice(value: unknown): SlashCommandChoice | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const selection = readSlashCommandId(record.selection);
+  if (!selection || typeof record.name !== "string" || !record.name ||
+      "builtin" in selection && record.name !== selection.commandId ||
+      typeof record.description !== "string" || typeof record.providerLabel !== "string" ||
+      record.resourceLabel !== undefined && typeof record.resourceLabel !== "string") {
+    return undefined;
+  }
+  return {
+    selection,
+    name: record.name,
+    description: record.description,
+    providerLabel: record.providerLabel,
+    ...(record.resourceLabel !== undefined && { resourceLabel: record.resourceLabel as string }),
+  };
 }
 
 export function readComposerDraft(key: string | undefined): StoredComposerDraft | undefined {
@@ -123,7 +205,26 @@ export function readComposerDraft(key: string | undefined): StoredComposerDraft 
       formats.push({ position, length, noun: format.noun, icon: format.icon });
       previousEnd = position + length;
     }
-    return { version: 1, text: record.text, formats };
+
+    let command: StoredComposerDraftSlashCommand | undefined;
+    if (record.command !== undefined) {
+      if (!record.command || typeof record.command !== "object") return undefined;
+      const candidate = record.command as Record<string, unknown>;
+      const choice = readSlashCommandChoice(candidate.choice);
+      if (!Number.isInteger(candidate.position) || !Number.isInteger(candidate.length) || !choice) {
+        return undefined;
+      }
+      const position = candidate.position as number;
+      const length = candidate.length as number;
+      if (position < 0 || length !== choice.name.length + 1 ||
+          record.text.slice(position, position + length) !== `/${choice.name}` ||
+          formats.some(format => position < format.position + format.length &&
+            format.position < position + length)) {
+        return undefined;
+      }
+      command = { position, length, choice };
+    }
+    return { version: 1, text: record.text, formats, ...(command && { command }) };
   } catch {
     return undefined;
   }

--- a/packages/workshop-frontend/src/homePromptFlow.test.tsx
+++ b/packages/workshop-frontend/src/homePromptFlow.test.tsx
@@ -11,10 +11,12 @@ const testState = vi.hoisted(() => {
   return {
     addToast: vi.fn<(toast: unknown) => void>(),
     authenticatedApi: { listModels, newGadget },
+    currentUser: { id: "user-a", name: "User A" },
     listModels,
     navigate: vi.fn<(options: unknown) => void>(),
     newGadget,
     seeds: [] as Array<{ text?: string; nonce?: number }>,
+    draftStorageKeys: [] as Array<string | undefined>,
   };
 });
 
@@ -30,12 +32,18 @@ vi.mock("@cloudflare/kumo", () => ({
 vi.mock("./AuthContext", () => ({
   useAuthenticatedApi: () => ({
     authenticatedApi: testState.authenticatedApi,
+    currentUser: testState.currentUser,
   }),
 }));
 
 vi.mock("./ChatInterface", () => ({
-  ChatInput: ({ seedText, seedNonce }: { seedText?: string; seedNonce?: number }) => {
+  ChatInput: ({ seedText, seedNonce, draftStorageKey }: {
+    seedText?: string;
+    seedNonce?: number;
+    draftStorageKey?: string;
+  }) => {
     testState.seeds.push({ text: seedText, nonce: seedNonce });
+    testState.draftStorageKeys.push(draftStorageKey);
     return <textarea aria-label="Prompt" readOnly value={seedText ?? ""} />;
   },
 }));
@@ -57,6 +65,7 @@ describe("Home prompt route flow", () => {
     container?.remove();
     localStorage.clear();
     testState.seeds.length = 0;
+    testState.draftStorageKeys.length = 0;
     vi.clearAllMocks();
   });
 
@@ -72,5 +81,6 @@ describe("Home prompt route flow", () => {
     expect(Math.max(...testState.seeds.map(({ nonce }) => nonce ?? 0))).toBe(1);
     expect(testState.navigate).toHaveBeenCalledWith({ to: "/", search: {}, replace: true });
     expect(testState.newGadget).not.toHaveBeenCalled();
+    expect(testState.draftStorageKeys).toContain("gadgets:composer-draft:v1:user-a:home");
   });
 });

--- a/packages/workshop-frontend/src/routes/index.tsx
+++ b/packages/workshop-frontend/src/routes/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "../modelSelection";
 import { useDocumentTitle } from "../useDocumentTitle";
 import { homePromptFromSearch } from "../homePrompt";
+import { composerDraftStorageKey } from "../composerDraft";
 
 type HomeSearch = { prompt?: string };
 
@@ -41,18 +42,18 @@ function HomePage() {
 export function HomePageContent({ prompt }: HomeSearch) {
   useDocumentTitle("Home");
 
-  const { authenticatedApi } = useAuthenticatedApi();
+  const { authenticatedApi, currentUser } = useAuthenticatedApi();
   const navigate = useNavigate();
   const toasts = useKumoToastManager();
 
   const [models, setModels] = useState<AiChatAuthorInfo[]>([]);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   // Bumped each time a task suggestion is picked; the composer re-seeds its text off the nonce.
-  const [seed, setSeed] = useState<{ text: string; nonce: number }>({ text: "", nonce: 0 });
+  const [seed, setSeed] = useState<{ text: string; nonce: number } | null>(null);
 
   useEffect(() => {
     if (!prompt) return;
-    setSeed((previous) => ({ text: prompt, nonce: previous.nonce + 1 }));
+    setSeed((previous) => ({ text: prompt, nonce: (previous?.nonce ?? 0) + 1 }));
     navigate({ to: "/", search: {}, replace: true });
   }, [navigate, prompt]);
 
@@ -192,14 +193,17 @@ export function HomePageContent({ prompt }: HomeSearch) {
           offerFormats
           autoFocus
           minRows={3}
-          seedText={seed.text}
-          seedNonce={seed.nonce}
+          seedText={seed?.text}
+          seedNonce={seed?.nonce}
+          draftStorageKey={currentUser
+            ? composerDraftStorageKey(currentUser.id, "home")
+            : undefined}
         />
 
         {/* A few example work tasks to spark ideas. Picking one seeds the composer above. */}
         <HomeTaskSuggestions
           onPick={(suggestion) =>
-            setSeed((prev) => ({ text: suggestion, nonce: prev.nonce + 1 }))
+            setSeed((prev) => ({ text: suggestion, nonce: (prev?.nonce ?? 0) + 1 }))
           }
         />
       </div>


### PR DESCRIPTION
This PR stores prompt drafts in session storage until they are sent to the agent. This means page refreshes don't wipe composer state, which helps mitigate workspace and conversation creation failures. Prompts typed into the new workspace, new conversation, and existing conversation composers are all covered. Capsules are serialized to their corresponding resource URL for storage, and format specifiers (docs, slides, etc.) are fully preserved.