### PR TITLE
Add server-managed model providers (SERVER_MODELS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ While you can code a Gadget by hand if you want, the expectation is that AI writ
 
 You can choose your LLM. Cloudflare OS works with many major AI model providers and self-hosted models, with more providers being added all the time.
 
+By default each user supplies their own model credentials. A deployment can instead offer models to
+everyone with credentials held server-side — see [server-managed models](docs/server-managed-models.md).
+
 Because of the tightly-integrated and simplified nature of the platform, even when using the same underlying AI models, the Cloudflare OS coding agent often performs better and faster with fewer tokens than a general-purpose coding agent would.
 
 ### Collaborate with AI

--- a/docs/server-managed-models.md
+++ b/docs/server-managed-models.md
@@ -1,0 +1,85 @@
+# Server-managed models
+
+By default every user brings their own model credentials: each person adds a provider and API key
+in **Settings → Providers** before they can chat. That is the right default for a deployment whose
+users have their own accounts, but not for one where the operator wants to fund inference centrally
+— an internal LLM proxy, a corporate gateway, or a self-hosted model server.
+
+`SERVER_MODELS` lets a deployment offer models to everyone, with credentials that stay in the
+environment. Users select them from the picker like any other model, never see the token, and
+cannot edit or delete them.
+
+## Relationship to AI Gateway mode
+
+[AI Gateway mode](ai-gateway-billing.md) solves the same problem for Cloudflare-hosted
+inference: `CF_AI_GATEWAY` routes a curated set of `SUGGESTED_MODELS` through a Cloudflare AI
+Gateway, with the platform paying.
+
+`SERVER_MODELS` is the self-hosted counterpart. It points at any endpoint the existing providers
+can speak to, including models that have no `SUGGESTED_MODELS` entry.
+
+|  | AI Gateway mode | `SERVER_MODELS` |
+| --- | --- | --- |
+| Endpoint | Cloudflare AI Gateway | any URL you supply |
+| Models | `SUGGESTED_MODELS` for enabled providers | anything the provider's API accepts |
+| Credentials | `CF_AI_GATEWAY_API_TOKEN` | per-model `apiToken` |
+| Cost logging | via Gateway logs | none |
+
+The two are independent and can be used together; server models are never re-routed through a
+Gateway, since that would discard the endpoint and credentials they were configured with.
+
+## Configuration
+
+`SERVER_MODELS` is a JSON array. It holds credentials, so set it as a secret
+(`wrangler secret put SERVER_MODELS`), not as a plaintext var.
+
+```json
+[
+  {
+    "id": "house-sonnet",
+    "name": "Sonnet (internal)",
+    "provider": "anthropic",
+    "model": "claude-sonnet-5",
+    "apiUrl": "https://llm.internal.example.com",
+    "apiToken": "sk-...",
+    "contextWindow": 1000000
+  },
+  {
+    "provider": "ollama",
+    "model": "qwen3-coder",
+    "apiUrl": "http://ollama.internal:11434"
+  }
+]
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `provider` | yes | `openai`, `anthropic`, `google`, `cloudflare` or `ollama` — which API dialect the endpoint speaks |
+| `model` | yes | Model name as the endpoint expects it |
+| `id` | no | Stable id used in stored preferences and chat records. Defaults to `model` |
+| `name` | no | Display name in the picker. Defaults to `id` |
+| `apiUrl` | no | Endpoint. Defaults to the provider's public API |
+| `apiToken` | no | Sent as the provider's credential. Omit for an endpoint that needs none |
+| `accountId` | no | Required by `cloudflare`, whose REST endpoint is account-scoped |
+| `contextWindow` | no | Total token window. Defaults to 128,000 |
+| `outputLimit` | no | Response reservation, withheld from the prompt budget |
+
+Set `contextWindow` for any large-context model: without it a 1M-token model is treated as 128k and
+conversations are compacted far earlier than necessary.
+
+Choosing `provider` is about the **API dialect, not the vendor**. Any OpenAI-compatible
+chat-completions endpoint works with `ollama`, which is the provider that speaks that dialect (the
+`openai` provider uses the newer Responses API, which many compatible endpoints do not implement).
+
+Malformed configuration throws at startup rather than silently offering no models, and the error
+names the offending entry — `SERVER_MODELS[1]: "model" is required.`
+
+## Behaviour
+
+- Server models appear in every user's picker, in configured order, before their own models.
+- A user cannot add a model whose id collides with a server model, or delete one.
+- A server model can be chosen as the quick model used for lightweight tasks like title generation.
+- Removing an entry from `SERVER_MODELS` removes it from every picker. Users who had it selected
+  fall back to their next available model.
+- Changing an entry's `id` is equivalent to removing one model and adding another, so prefer
+  setting `id` explicitly if you may later change the underlying `model` name.

--- a/packages/workshop-backend/__tests__/server-models.test.ts
+++ b/packages/workshop-backend/__tests__/server-models.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { getServerModelsConfig, ServerModelsConfig } from "../src/server-models.js";
+import { getModelTokenLimits } from "../src/agent-compaction.js";
+
+function env(serverModels?: string): Cloudflare.Env {
+  return { SERVER_MODELS: serverModels } as unknown as Cloudflare.Env;
+}
+
+const ONE = JSON.stringify([{
+  id: "house-sonnet",
+  name: "Sonnet (internal)",
+  provider: "anthropic",
+  model: "claude-sonnet-5",
+  apiUrl: "https://llm.example.com",
+  apiToken: "secret-token",
+}]);
+
+describe("getServerModelsConfig", () => {
+  it("returns null when unset or empty", () => {
+    expect(getServerModelsConfig(env())).toBeNull();
+    expect(getServerModelsConfig(env(""))).toBeNull();
+    expect(getServerModelsConfig(env("   "))).toBeNull();
+    expect(getServerModelsConfig(env("[]"))).toBeNull();
+  });
+
+  it("parses a configured model", () => {
+    const config = getServerModelsConfig(env(ONE))!;
+    expect(config.has("house-sonnet")).toBe(true);
+    expect(config.getModelList()).toEqual([
+      { type: "agent", id: "house-sonnet", name: "Sonnet (internal)" },
+    ]);
+  });
+
+  it("resolves to a record carrying the deployment's own endpoint and token", () => {
+    const resolved = getServerModelsConfig(env(ONE))!.resolveModel("house-sonnet")!;
+    expect(resolved.config.apiUrl).toBe("https://llm.example.com");
+    expect(resolved.config.apiToken).toBe("secret-token");
+    // This flag is what keeps inference off an AI Gateway, which would discard both.
+    expect(resolved.config.serverManaged).toBe(true);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getServerModelsConfig(env(ONE))!.resolveModel("nope")).toBeUndefined();
+  });
+
+  it("defaults id and name to the model name", () => {
+    const config = new ServerModelsConfig(
+        JSON.stringify([{ provider: "ollama", model: "qwen3" }]));
+    expect(config.getModelList()).toEqual([{ type: "agent", id: "qwen3", name: "qwen3" }]);
+  });
+
+  it("allows an empty token, for endpoints that want no Authorization header", () => {
+    const config = new ServerModelsConfig(
+        JSON.stringify([{ provider: "ollama", model: "qwen3", apiUrl: "http://ollama:11434" }]));
+    expect(config.resolveModel("qwen3")!.config.apiToken).toBe("");
+  });
+
+  it("preserves configured order", () => {
+    const config = new ServerModelsConfig(JSON.stringify([
+      { provider: "ollama", model: "b" },
+      { provider: "ollama", model: "a" },
+    ]));
+    expect(config.getModelList().map(m => m.id)).toEqual(["b", "a"]);
+  });
+
+  // A deployment that meant to supply models should fail loudly rather than quietly offer none.
+  describe("rejects malformed configuration", () => {
+    const cases: Array<[string, string, RegExp]> = [
+      ["invalid JSON", "{not json", /not valid JSON/],
+      ["a non-array", JSON.stringify({ provider: "ollama" }), /must be a JSON array/],
+      ["a non-object entry", JSON.stringify(["x"]), /must be an object/],
+      ["an unknown provider",
+       JSON.stringify([{ provider: "hal9000", model: "m" }]), /"provider" must be one of/],
+      ["a missing model", JSON.stringify([{ provider: "ollama" }]), /"model" is required/],
+      ["a non-string apiUrl",
+       JSON.stringify([{ provider: "ollama", model: "m", apiUrl: 7 }]), /"apiUrl" must be a string/],
+      ["a non-numeric contextWindow",
+       JSON.stringify([{ provider: "ollama", model: "m", contextWindow: "big" }]),
+       /"contextWindow" must be a number/],
+      ["duplicate ids",
+       JSON.stringify([{ provider: "ollama", model: "m" }, { provider: "ollama", model: "m" }]),
+       /duplicate id/],
+    ];
+    for (const [label, json, message] of cases) {
+      it(`throws on ${label}`, () => {
+        expect(() => new ServerModelsConfig(json)).toThrow(message);
+      });
+    }
+  });
+
+  it("reports which entry was bad", () => {
+    expect(() => new ServerModelsConfig(JSON.stringify([
+      { provider: "ollama", model: "ok" },
+      { provider: "ollama" },
+    ]))).toThrow(/SERVER_MODELS\[1\]/);
+  });
+});
+
+describe("getModelTokenLimits with a server model", () => {
+  it("uses the configured window instead of the default", () => {
+    const config = new ServerModelsConfig(JSON.stringify([{
+      provider: "ollama", model: "big-context", contextWindow: 1_000_000, outputLimit: 64_000,
+    }])).resolveModel("big-context")!.config;
+
+    expect(getModelTokenLimits(config)).toEqual({
+      inputBudget: 1_000_000 - 64_000,
+      maxOutputTokens: 64_000,
+    });
+  });
+
+  it("falls back to the default window when none is configured", () => {
+    const config = new ServerModelsConfig(
+        JSON.stringify([{ provider: "ollama", model: "unknown-model" }]))
+        .resolveModel("unknown-model")!.config;
+
+    expect(getModelTokenLimits(config).inputBudget).toBe(128_000);
+  });
+});

--- a/packages/workshop-backend/src/agent-compaction.ts
+++ b/packages/workshop-backend/src/agent-compaction.ts
@@ -26,10 +26,14 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 export function getModelTokenLimits(config: AiModelConfig):
     {inputBudget: number, maxOutputTokens?: number} {
   let model = SUGGESTED_MODELS[config.provider][config.model];
-  let maxOutputTokens = model?.outputLimit ??
+  // An explicitly configured window wins: a server model or a hand-configured endpoint has no
+  // catalog entry, and defaulting a large-context model to DEFAULT_CONTEXT_WINDOW would compact
+  // it far earlier than necessary.
+  let maxOutputTokens = config.outputLimit ?? model?.outputLimit ??
       (config.provider === "cloudflare" ? WORKERS_AI_OUTPUT_LIMIT : undefined);
+  let contextWindow = config.contextWindow ?? model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
   return {
-    inputBudget: (model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW) - (maxOutputTokens ?? 0),
+    inputBudget: contextWindow - (maxOutputTokens ?? 0),
     maxOutputTokens,
   };
 }

--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -351,6 +351,13 @@ export function getModel(env: Cloudflare.Env, config: AiModelConfig,
         options.sessionAffinity);
   }
 
+  // Models supplied by the deployment always talk to their own endpoint with their own
+  // credentials. Re-routing them through a Gateway would discard both, and the endpoint is
+  // frequently one no Gateway can reach (an internal proxy, a self-hosted router).
+  if (config.serverManaged) {
+    return getModelDirect(config, options.sessionAffinity);
+  }
+
   // Otherwise: when a platform AI Gateway is configured, route through it (platform-funded free
   // tier). The config's apiToken/apiUrl are ignored in that mode.
   let gwConfig = getAiGatewayConfig(env);

--- a/packages/workshop-backend/src/env.d.ts
+++ b/packages/workshop-backend/src/env.d.ts
@@ -26,6 +26,17 @@ declare global {
       // Note: outside gateway mode, Workers AI (provider "cloudflare") is BYOK like every other
       // provider -- the account ID and API token live in the user's model config, not in env.
 
+      // Models the deployment supplies to every user, as a JSON array. Each entry needs at
+      // least `provider` and `model`, plus whatever the endpoint requires:
+      //
+      //   [{"id": "house-sonnet", "name": "Sonnet (internal)", "provider": "anthropic",
+      //     "model": "claude-sonnet-5", "apiUrl": "https://llm.example.com",
+      //     "apiToken": "...", "contextWindow": 1000000}]
+      //
+      // Users can select these but cannot edit or delete them, and never see the token. Holds
+      // credentials, so it should be set as a secret. See server-models.ts.
+      SERVER_MODELS?: string;
+
       // Blueprint storage bindings.
       BLUEPRINTS: KVNamespace;             // Workers KV for blueprint metadata lookup
       BLUEPRINT_CONTENT: R2Bucket;         // R2 bucket for blueprint code snapshots

--- a/packages/workshop-backend/src/server-models.ts
+++ b/packages/workshop-backend/src/server-models.ts
@@ -1,0 +1,158 @@
+// Server-managed models: models the deployment supplies to every user, with credentials that live
+// in the deployment's environment rather than in each user's settings.
+//
+// This is the self-hosted counterpart to AI Gateway mode (see ai-gateway.ts). Both let an operator
+// fund inference centrally, but a Gateway is Cloudflare-hosted and limited to the providers and
+// models it knows about, whereas this points at any OpenAI-compatible endpoint -- an internal
+// gateway, a corporate LLM proxy, a self-hosted router, or a vLLM/Ollama box. The two are
+// independent and may be used together; server models are never re-routed through a Gateway.
+//
+// Users see these models in the picker alongside their own, but cannot edit or delete them and
+// never handle the API token.
+
+import { AiChatAuthorInfo, AiModelConfig, AiModelProvider } from "@gadgets/workshop-shared/api";
+import { UserAiModelRecord } from "./user.js";
+
+const PROVIDERS: ReadonlySet<string> =
+    new Set<AiModelProvider>(["openai", "anthropic", "google", "cloudflare", "ollama"]);
+
+/** One entry of the SERVER_MODELS array, after validation. */
+export type ServerModel = {
+  id: string;
+  name: string;
+  config: AiModelConfig;
+};
+
+function fail(index: number, message: string): never {
+  throw new Error(`SERVER_MODELS[${index}]: ${message}`);
+}
+
+function parseEntry(raw: unknown, index: number): ServerModel {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    fail(index, "must be an object.");
+  }
+  const e = raw as Record<string, unknown>;
+
+  const provider = e.provider;
+  if (typeof provider !== "string" || !PROVIDERS.has(provider)) {
+    fail(index, `"provider" must be one of ${[...PROVIDERS].join(", ")}.`);
+  }
+
+  const model = e.model;
+  if (typeof model !== "string" || model === "") {
+    fail(index, `"model" is required.`);
+  }
+
+  // `id` is what the user's stored preference and every chat record refer to, so it must be
+  // stable. It defaults to the model name, which is stable for the common single-endpoint case.
+  const id = e.id === undefined ? model : e.id;
+  if (typeof id !== "string" || id === "") {
+    fail(index, `"id" must be a non-empty string.`);
+  }
+
+  const name = e.name === undefined ? id : e.name;
+  if (typeof name !== "string" || name === "") {
+    fail(index, `"name" must be a non-empty string.`);
+  }
+
+  if (e.apiUrl !== undefined && typeof e.apiUrl !== "string") {
+    fail(index, `"apiUrl" must be a string.`);
+  }
+  if (e.apiToken !== undefined && typeof e.apiToken !== "string") {
+    fail(index, `"apiToken" must be a string.`);
+  }
+  for (const key of ["contextWindow", "outputLimit"] as const) {
+    if (e[key] !== undefined && (typeof e[key] !== "number" || !Number.isFinite(e[key]))) {
+      fail(index, `"${key}" must be a number.`);
+    }
+  }
+
+  return {
+    id,
+    name,
+    config: {
+      provider: provider as AiModelProvider,
+      model,
+      // Some endpoints (a trusted proxy on a private network, a local Ollama) want no
+      // Authorization header at all; the providers already treat "" as "send nothing".
+      apiToken: (e.apiToken as string | undefined) ?? "",
+      ...(e.apiUrl !== undefined ? { apiUrl: e.apiUrl as string } : {}),
+      ...(e.accountId !== undefined ? { accountId: String(e.accountId) } : {}),
+      ...(e.contextWindow !== undefined ? { contextWindow: e.contextWindow as number } : {}),
+      ...(e.outputLimit !== undefined ? { outputLimit: e.outputLimit as number } : {}),
+      serverManaged: true,
+    },
+  };
+}
+
+export class ServerModelsConfig {
+  /** Models by id, in configured order (which is the order the picker shows them in). */
+  readonly models: ReadonlyMap<string, ServerModel>;
+
+  constructor(json: string) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch (err) {
+      throw new Error(
+          `SERVER_MODELS is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err });
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error("SERVER_MODELS must be a JSON array of model objects.");
+    }
+
+    const models = new Map<string, ServerModel>();
+    parsed.forEach((raw, i) => {
+      const entry = parseEntry(raw, i);
+      if (models.has(entry.id)) {
+        fail(i, `duplicate id "${entry.id}".`);
+      }
+      models.set(entry.id, entry);
+    });
+    this.models = models;
+  }
+
+  /** The models offered to every user, as picker entries. */
+  getModelList(): AiChatAuthorInfo[] {
+    return [...this.models.values()].map(m => ({ type: "agent", id: m.id, name: m.name }));
+  }
+
+  /** Look up a server model by id, in the same shape a user-configured model resolves to. */
+  resolveModel(modelId: string): UserAiModelRecord | undefined {
+    const entry = this.models.get(modelId);
+    if (!entry) return undefined;
+    return {
+      profile: { type: "agent", id: entry.id, name: entry.name },
+      config: entry.config,
+    };
+  }
+
+  has(modelId: string): boolean {
+    return this.models.has(modelId);
+  }
+}
+
+// Parsing is cheap but happens on hot paths (every listModels, every chat context), so memoize
+// per env object.
+const cache = new WeakMap<object, ServerModelsConfig | null>();
+
+/**
+ * Parse server-managed model configuration from the environment. Returns null when SERVER_MODELS
+ * is unset or empty.
+ *
+ * Throws if SERVER_MODELS is present but malformed: a deployment that meant to supply models
+ * should fail loudly rather than silently offer none.
+ */
+export function getServerModelsConfig(env: Cloudflare.Env): ServerModelsConfig | null {
+  const raw = env.SERVER_MODELS;
+  if (!raw || raw.trim() === "") return null;
+
+  const cached = cache.get(env as unknown as object);
+  if (cached !== undefined) return cached;
+
+  const config = new ServerModelsConfig(raw);
+  const result = config.models.size > 0 ? config : null;
+  cache.set(env as unknown as object, result);
+  return result;
+}

--- a/packages/workshop-backend/src/server.ts
+++ b/packages/workshop-backend/src/server.ts
@@ -16,6 +16,7 @@ export { PendingLogin, LoginConnectCallbackImpl };
 import { GatekeeperUiFrame } from "@gadgets/workshop-shared/gatekeeper";
 import { LanguageModelGatekeeper } from "./ai-models";
 import { getAiGatewayConfig } from "./ai-gateway.js";
+import { getServerModelsConfig } from "./server-models.js";
 import { AdminSettings, AdminApiImpl } from "./admin-settings.js";
 import { BlueprintKvRecord, buildBlueprintArchiveStream, sanitizeBlueprintOutput, listFeaturedBlueprintsFromKv, parseBlueprintArchive, randomBlueprintId, readBlueprintContent, readBlueprintKvRecord } from "./blueprint-archive.js";
 import { GatekeeperConnectCallbackImpl, normalizeUsername, UserDurableObject, CLOUDFLARE_VENDOR_ID } from "./user";
@@ -187,14 +188,18 @@ class AuthenticatedApiImpl extends RpcTarget implements AuthenticatedApi {
   }
 
   getAiConfig(): Promise<AiGatewayInfo> {
+    let serverConfig = getServerModelsConfig(this.env);
+    let serverModelIds = serverConfig ? [...serverConfig.models.keys()] : undefined;
+
     let gwConfig = getAiGatewayConfig(this.env);
     if (gwConfig) {
       return Promise.resolve({
         enabled: true,
         enabledProviders: [...gwConfig.providers] as AiModelProvider[],
+        serverModelIds,
       });
     } else {
-      return Promise.resolve({ enabled: false });
+      return Promise.resolve({ enabled: false, serverModelIds });
     }
   }
 

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -7,6 +7,7 @@ import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
 import { createTypedStorage, collection } from "@gadgets/typed-storage";
 import { createWorkshopLogger } from "./observability";
 import { getAiGatewayConfig } from "./ai-gateway.js";
+import { getServerModelsConfig } from "./server-models.js";
 import { utcDayKey, nextUtcMidnightIso, DailyQuotaResult } from "./ai-gateway-billing/limits/config.js";
 import type { AdminSettings } from "./admin-settings.js";
 import { isReservedBlueprintKey, readBlueprintKvRecord } from "./blueprint-archive.js";
@@ -515,7 +516,18 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
       }
     }
 
-    // Also include user-configured models, skipping any that duplicate a gateway model.
+    // Models supplied by the deployment are offered to everyone.
+    let serverConfig = getServerModelsConfig(this.env);
+    if (serverConfig) {
+      for (let entry of serverConfig.getModelList()) {
+        if (!gwModelIds.has(entry.id)) {
+          result.push(entry);
+          gwModelIds.add(entry.id);
+        }
+      }
+    }
+
+    // Also include user-configured models, skipping any that duplicate a gateway or server model.
     for (let model of this.storage.aiModels.list()) {
       if (!gwModelIds.has(model.profile.id)) {
         result.push(model.profile);
@@ -528,6 +540,15 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     let gwConfig = getAiGatewayConfig(this.env);
     if (gwConfig && !gwConfig.providers.has(config.provider)) {
       throw new Error(`Provider "${config.provider}" is not available in AI Gateway mode.`);
+    }
+    // A user model with a server model's id would be shadowed by it in listModels() and
+    // getChatContext(), so reject it rather than silently store something unreachable.
+    if (getServerModelsConfig(this.env)?.has(profile.id)) {
+      throw new Error(`"${profile.id}" is provided by this deployment and cannot be replaced.`);
+    }
+    // serverManaged is what exempts a model from Gateway routing; it must never be user-settable.
+    if (config.serverManaged) {
+      throw new Error("Cannot mark a user-configured model as server-managed.");
     }
 
     profile.type = "agent";
@@ -545,6 +566,10 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
       }
     }
 
+    if (getServerModelsConfig(this.env)?.has(id)) {
+      throw new Error("Cannot delete a model provided by this deployment.");
+    }
+
     this.storage.aiModels.delete(id);
   }
 
@@ -554,7 +579,8 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
 
   async getQuickModel(): Promise<null | string> {
     let result = this.storage.quickModel.get();
-    if (result && this.storage.aiModels.get(result)) {
+    if (result && (this.storage.aiModels.get(result) ||
+                   getServerModelsConfig(this.env)?.has(result))) {
       return result;
     } else {
       return null;
@@ -569,7 +595,8 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     if (id !== null) {
       // Validate that the model exists in the user's configured models or as a gateway model.
       let gwConfig = getAiGatewayConfig(this.env);
-      let exists = !!this.storage.aiModels.get(id) || !!gwConfig?.resolveModel(id);
+      let exists = !!this.storage.aiModels.get(id) || !!gwConfig?.resolveModel(id) ||
+          !!getServerModelsConfig(this.env)?.has(id);
       if (!exists) {
         throw new Error(`No such model: ${id}`);
       }
@@ -675,6 +702,9 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
         result.aiModel = gwConfig.resolveModel(modelId);
       }
       if (!result.aiModel) {
+        result.aiModel = getServerModelsConfig(this.env)?.resolveModel(modelId);
+      }
+      if (!result.aiModel) {
         result.aiModel = this.storage.aiModels.get(modelId);
       }
       if (!result.aiModel) throw new Error(`No such model: ${modelId}`);
@@ -687,7 +717,8 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     } else {
       let quickModelId = this.storage.quickModel.get();
       if (quickModelId) {
-        let quickModel = this.storage.aiModels.get(quickModelId);
+        let quickModel = this.storage.aiModels.get(quickModelId) ??
+            getServerModelsConfig(this.env)?.resolveModel(quickModelId);
         if (quickModel) {
           result.quickModel = quickModel.config;
         }

--- a/packages/workshop-frontend/src/routes/providers.tsx
+++ b/packages/workshop-frontend/src/routes/providers.tsx
@@ -168,6 +168,8 @@ function ProvidersPage() {
   const gatewayMode = aiConfig?.enabled === true
 
   const isBuiltIn = (modelId: string): boolean => {
+    // Models the deployment supplies are built-in whether or not a Gateway is configured.
+    if (aiConfig?.serverModelIds?.includes(modelId)) return true
     if (!aiConfig?.enabled) return false
     const enabled = new Set((aiConfig as Extract<AiGatewayInfo, { enabled: true }>).enabledProviders)
     return PROVIDER_ORDER.some((p) => enabled.has(p) && modelId in SUGGESTED_MODELS[p])

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -947,11 +947,16 @@ export type CloudflareAccountOption = {
 export type AiModelProvider = "openai" | "anthropic" | "google" | "cloudflare" | "ollama";
 
 // Information about the AI gateway configuration. Returned by `AuthenticatedApi.getAiConfig()`.
-export type AiGatewayInfo = {
+export type AiGatewayInfo = ({
   enabled: true;
   enabledProviders: AiModelProvider[];
 } | {
   enabled: false;
+}) & {
+  // Ids of models the deployment supplies for every user (see the SERVER_MODELS environment
+  // variable). Users may select these but cannot edit or delete them. Independent of AI Gateway
+  // mode: a deployment may offer server models with or without a Gateway configured.
+  serverModelIds?: string[];
 };
 
 // Configuration specifying how to connect to an AI model provider.
@@ -973,6 +978,17 @@ export type AiModelConfig = {
   // useful in order to use AI proxy products like Cloudflare's AI gateway, or even to use an
   // alternative provider that provides a compatible API.
   apiUrl?: string;
+
+  // Set on models supplied by the deployment (see SERVER_MODELS). Such a model always talks to
+  // its own `apiUrl` with its own `apiToken`, and is never re-routed through an AI Gateway --
+  // the deployment, not the user, is paying, and the endpoint may not be one a Gateway can serve.
+  serverManaged?: boolean;
+
+  // Token limits for models that have no SUGGESTED_MODELS entry. Without these a custom model
+  // falls back to a conservative default window, so a large-context model would be compacted
+  // far earlier than necessary.
+  contextWindow?: number;
+  outputLimit?: number;
 };
 
 // Workers AI adds the response cap to the prompt and rejects a request whose total exceeds the


### PR DESCRIPTION
## Problem

Every user has to supply their own model credentials before they can use the OS. That fits a deployment whose users each have provider accounts, but not one where the operator wants to fund inference centrally — an internal LLM proxy, a corporate gateway, or a self-hosted model server. Today the operator's only options are to have everyone paste the same key, or to patch the source.

AI Gateway mode already solves this for Cloudflare-hosted inference, but it's limited to `SUGGESTED_MODELS` reached through `gateway.ai.cloudflare.com`.

## What this adds

`SERVER_MODELS`: a JSON array of models the deployment offers to every user, pointing at any endpoint the existing providers can speak to, with credentials that stay in the environment. Users select them like any other model, never see the token, and can't edit or delete them.

```json
[{"id": "house-sonnet", "name": "Sonnet (internal)", "provider": "anthropic",
  "model": "claude-sonnet-5", "apiUrl": "https://llm.internal.example.com",
  "apiToken": "sk-...", "contextWindow": 1000000}]
```

Docs: `docs/server-managed-models.md`.

## Design notes

- **No new inference path.** Server models resolve to the same `UserAiModelRecord` that user-configured models produce, so `getModel()` and everything downstream is unchanged.
- **Exempt from Gateway routing.** Routing a server model through an AI Gateway would discard the `apiUrl`/`apiToken` it was configured with, and the endpoint often isn't one a Gateway can reach. A `serverManaged` flag on `AiModelConfig` carries that exemption; `addModel()` rejects it from user input so it can't be used to bypass Gateway mode.
- **Independent of AI Gateway mode.** Both can be enabled; server models simply aren't routed through the Gateway.
- **`contextWindow` / `outputLimit`** are optional additions to `AiModelConfig`. A model with no `SUGGESTED_MODELS` entry otherwise falls back to `DEFAULT_CONTEXT_WINDOW`, so a large-context model would be compacted far earlier than necessary.
- **Fails loudly.** Malformed config throws, naming the offending entry (`SERVER_MODELS[1]: "model" is required.`), rather than silently offering no models.

## Testing

18 unit tests in `packages/workshop-backend/__tests__/server-models.test.ts` covering parsing, defaults, resolution, ordering, token limits and every validation failure. `pnpm run lint` and `pnpm run types:check` are clean.

Also exercised on a self-hosted deployment running the whole stack on Miniflare/workerd behind Cloudflare Access, with models served through a GitHub Copilot proxy.

## Open questions

- Should `SERVER_MODELS` entries be able to *override* a `SUGGESTED_MODELS` id (currently the Gateway entry wins)?
- Would you prefer this validated eagerly at worker startup rather than on first use? There didn't seem to be an obvious hook.

Happy to adjust naming or shape.
