### PR TITLE
fix: dispose ResourcePicker subscription that resolves after unmount

### DIFF
--- a/packages/workshop-frontend/src/ResourcePicker.test.tsx
+++ b/packages/workshop-frontend/src/ResourcePicker.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+/* eslint-disable react/react-in-jsx-scope */
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcStub } from 'capnweb'
+import type { AuthenticatedApi } from '@gadgets/workshop-shared/api'
+import ResourcePicker from './ResourcePicker'
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@cloudflare/kumo', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  useKumoToastManager: () => ({ add: vi.fn<(toast: unknown) => void>() }),
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(next => { resolve = next })
+  return { promise, resolve }
+}
+
+describe('ResourcePicker', () => {
+  let root: Root | undefined
+  let container: HTMLDivElement | undefined
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    container?.remove()
+    vi.restoreAllMocks()
+  })
+
+  it('disposes a connected-account subscription that resolves after unmount', async () => {
+    const pendingSubscription = deferred<{ [Symbol.dispose](): void }>()
+    const dispose = vi.fn<() => void>()
+    const authenticatedApi = {
+      subscribeConnectedAccounts: () => pendingSubscription.promise,
+      listGatekeeperVendors: async () => [],
+    } as unknown as RpcStub<AuthenticatedApi>
+
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => root!.render(
+      <ResourcePicker
+        authenticatedApi={authenticatedApi}
+        searchText="https://example.com"
+        onSelectAccount={() => {}}
+      />,
+    ))
+
+    act(() => root!.unmount())
+    root = undefined
+    await act(async () => {
+      pendingSubscription.resolve({ [Symbol.dispose]: dispose })
+      await Promise.resolve()
+    })
+
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/workshop-frontend/src/ResourcePicker.test.tsx
+++ b/packages/workshop-frontend/src/ResourcePicker.test.tsx
@@ -17,8 +17,11 @@ vi.mock('@cloudflare/kumo', () => ({
 
 function deferred<T>() {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>(next => { resolve = next })
-  return { promise, resolve }
+  const dispose = vi.fn<() => void>()
+  const promise = Object.assign(new Promise<T>(next => { resolve = next }), {
+    [Symbol.dispose]: dispose,
+  })
+  return { promise, resolve, dispose }
 }
 
 describe('ResourcePicker', () => {
@@ -31,9 +34,8 @@ describe('ResourcePicker', () => {
     vi.restoreAllMocks()
   })
 
-  it('disposes a connected-account subscription that resolves after unmount', async () => {
+  it('disposes a pending connected-account subscription on unmount', async () => {
     const pendingSubscription = deferred<{ [Symbol.dispose](): void }>()
-    const dispose = vi.fn<() => void>()
     const authenticatedApi = {
       subscribeConnectedAccounts: () => pendingSubscription.promise,
       listGatekeeperVendors: async () => [],
@@ -52,11 +54,7 @@ describe('ResourcePicker', () => {
 
     act(() => root!.unmount())
     root = undefined
-    await act(async () => {
-      pendingSubscription.resolve({ [Symbol.dispose]: dispose })
-      await Promise.resolve()
-    })
 
-    expect(dispose).toHaveBeenCalledOnce()
+    expect(pendingSubscription.dispose).toHaveBeenCalledOnce()
   })
 })

--- a/packages/workshop-frontend/src/ResourcePicker.tsx
+++ b/packages/workshop-frontend/src/ResourcePicker.tsx
@@ -1,14 +1,16 @@
+import { logRpcFailure } from './rpcErrors'
 import { useState, useEffect, useRef, useMemo, useCallback, type MutableRefObject } from 'react'
 import { Tooltip, useKumoToastManager } from '@cloudflare/kumo'
 import { Plus, CaretRight, Warning } from '@phosphor-icons/react'
-import { RpcStub, RpcTarget } from 'capnweb'
-import { AuthenticatedApi, ConnectedAccountsSubscriber } from '@gadgets/workshop-shared/api'
+import { RpcStub } from 'capnweb'
+import { AuthenticatedApi } from '@gadgets/workshop-shared/api'
 import { AccountDescription, SupportedResource, VendorDescription } from '@gadgets/workshop-shared/gatekeeper'
 import { extractHostname, extractBaseUrl, matchesResource, matchesResourceText, classifyMatch, getPlaceholderRanges } from './resourceMatching'
 import { GatekeeperIcon } from './components/GatekeeperIcon'
 import {
   PICKER_CAPTION, PICKER_EMPTY, PICKER_ROW, PICKER_ROW_ACTIVE, TabHint,
 } from './components/pickerRows'
+import { AccountsSubscriberAdapter } from './accountsSubscriber'
 
 export interface VendorOption {
   id: string
@@ -107,15 +109,12 @@ export default function ResourcePicker({
   const [grantingAccount, setGrantingAccount] = useState<number | null>(null)
 
   const subscriptionRef = useRef<{ stub: { [Symbol.dispose](): void } } | null>(null)
-  const seenAccountIdsRef = useRef(new Set<number>())
-
   // Subscribe to connected accounts on mount.
   useEffect(() => {
-    seenAccountIdsRef.current = new Set()
+    let cancelled = false
 
-    class AccountsSubscriber extends RpcTarget implements ConnectedAccountsSubscriber {
-      add(id: number, description: AccountDescription, vendor: VendorDescription, supportedResources: SupportedResource[] = [], credentialsValid: boolean = true, _vendorId: string = '') {
-        seenAccountIdsRef.current.add(id)
+    const subscriber = new AccountsSubscriberAdapter({
+      add({ id, description, vendor, supportedResources, credentialsValid }) {
         setAllAccounts(prev => {
           const next = new Map(prev)
           next.set(id, { description, vendor, supportedResources, credentialsValid })
@@ -125,49 +124,33 @@ export default function ResourcePicker({
         if (credentialsValid) {
           setReconnectingAccount(prev => prev === id ? null : prev)
         }
-      }
-
-      remove(id: number) {
-        seenAccountIdsRef.current.delete(id)
+      },
+      remove(id) {
         setAllAccounts(prev => {
           const next = new Map(prev)
           next.delete(id)
           return next
         })
-      }
-
+      },
       ready() {
         setAccountsLoaded(true)
-        const seen = seenAccountIdsRef.current
-        seenAccountIdsRef.current = new Set()
-        setAllAccounts(prev => {
-          let changed = false
-          const next = new Map(prev)
-          for (const id of next.keys()) {
-            if (!seen.has(id)) {
-              next.delete(id)
-              changed = true
-            }
-          }
-          return changed ? next : prev
-        })
-      }
-    }
-
-    const subscriber = new AccountsSubscriber()
+      },
+    })
     const subscribe = async () => {
       try {
         const stub = await authenticatedApi.subscribeConnectedAccounts(subscriber)
-        subscriptionRef.current = { stub }
+        if (cancelled) stub[Symbol.dispose]()
+        else subscriptionRef.current = { stub }
       } catch (error) {
-        console.error('Failed to subscribe to connected accounts:', error)
+        logRpcFailure('Failed to subscribe to connected accounts:', error)
         // Nothing more is coming, so show what we have rather than hiding forever.
-        setAccountsLoaded(true)
+        if (!cancelled) setAccountsLoaded(true)
       }
     }
     subscribe()
 
     return () => {
+      cancelled = true
       if (subscriptionRef.current) {
         subscriptionRef.current.stub[Symbol.dispose]()
         subscriptionRef.current = null

--- a/packages/workshop-frontend/src/ResourcePicker.tsx
+++ b/packages/workshop-frontend/src/ResourcePicker.tsx
@@ -1,5 +1,5 @@
 import { logRpcFailure } from './rpcErrors'
-import { useState, useEffect, useRef, useMemo, useCallback, type MutableRefObject } from 'react'
+import { useState, useEffect, useMemo, useCallback, type MutableRefObject } from 'react'
 import { Tooltip, useKumoToastManager } from '@cloudflare/kumo'
 import { Plus, CaretRight, Warning } from '@phosphor-icons/react'
 import { RpcStub } from 'capnweb'
@@ -108,7 +108,6 @@ export default function ResourcePicker({
   const [reconnectingAccount, setReconnectingAccount] = useState<number | null>(null)
   const [grantingAccount, setGrantingAccount] = useState<number | null>(null)
 
-  const subscriptionRef = useRef<{ stub: { [Symbol.dispose](): void } } | null>(null)
   // Subscribe to connected accounts on mount.
   useEffect(() => {
     let cancelled = false
@@ -136,25 +135,17 @@ export default function ResourcePicker({
         setAccountsLoaded(true)
       },
     })
-    const subscribe = async () => {
-      try {
-        const stub = await authenticatedApi.subscribeConnectedAccounts(subscriber)
-        if (cancelled) stub[Symbol.dispose]()
-        else subscriptionRef.current = { stub }
-      } catch (error) {
-        logRpcFailure('Failed to subscribe to connected accounts:', error)
-        // Nothing more is coming, so show what we have rather than hiding forever.
-        if (!cancelled) setAccountsLoaded(true)
-      }
-    }
-    subscribe()
+    const subscription = authenticatedApi.subscribeConnectedAccounts(subscriber)
+    subscription.catch(error => {
+      if (cancelled) return
+      logRpcFailure('Failed to subscribe to connected accounts:', error)
+      // Nothing more is coming, so show what we have rather than hiding forever.
+      setAccountsLoaded(true)
+    })
 
     return () => {
       cancelled = true
-      if (subscriptionRef.current) {
-        subscriptionRef.current.stub[Symbol.dispose]()
-        subscriptionRef.current = null
-      }
+      subscription[Symbol.dispose]()
     }
   }, [authenticatedApi])
 


### PR DESCRIPTION
Extracted from #104 as a standalone fix.

`ResourcePicker` could unmount while `subscribeConnectedAccounts()` was still pending. The resolved subscription would then have no owner, leaking the Durable Object registration for the rest of the RPC session.

Keep the Cap’n Web `RpcPromise` as the subscription owner and dispose it in the effect cleanup. Disposing the promise also disposes its eventual result and may cancel the pending call. Cancellation-induced rejections are ignored after cleanup; real subscription failures still go through `logRpcFailure`.

This also replaces ResourcePicker’s local subscriber class with the shared `AccountsSubscriberAdapter` used by the other connected-account consumers.

## Testing

`ResourcePicker.test.tsx` uses a disposable pending subscription and verifies that unmounting disposes the RPC promise before it resolves. The full frontend suite passes (136 tests).