### PR TITLE
Don't submit chat input on Enter during IME composition

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -3175,7 +3175,8 @@ export const ChatInput = ({
                   slashCommandPicker.dismiss();
                   return;
                 }
-                if (slashCommandPicker.open && e.key === "Enter" && !e.shiftKey) {
+                if (slashCommandPicker.open && e.key === "Enter" && !e.shiftKey &&
+                    !e.nativeEvent.isComposing) {
                   e.preventDefault();
                   if (slashCommandPicker.selectable && slashCommandPicker.activeChoice) {
                     slashCommandPicker.select(slashCommandPicker.activeChoice);
@@ -3223,8 +3224,9 @@ export const ChatInput = ({
                     return;
                   }
                 }
-                // Enter sends message (unless Shift is held)
-                if (e.key === "Enter" && !e.shiftKey) {
+                // Enter sends message (unless Shift is held or an IME
+                // composition is in progress)
+                if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
                   e.preventDefault();
                   if (!isAgentActive && !isBlocked) submitMessage();
                   return;
@@ -6538,7 +6540,7 @@ function ChatInterface({
                             onChange={(e) => setRenamingInput(e.target.value)}
                             onClick={(e) => e.stopPropagation()}
                             onKeyDown={(e) => {
-                              if (e.key === "Enter") {
+                              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
                                 e.preventDefault();
                                 handleSaveListRename(chat.id);
                               } else if (e.key === "Escape") {


### PR DESCRIPTION
## Problem

When typing with an IME (Japanese, Chinese, Korean, etc.), pressing Enter to confirm a text conversion sends the chat message instead of just committing the composition. This makes the chat input nearly unusable for CJK users.

## Fix

Check `KeyboardEvent.isComposing` before treating Enter as submit, in three places in `ChatInterface.tsx`:

- chat message send
- slash-command picker selection
- chat rename input

6 insertions, 4 deletions. Verified locally with a Japanese IME: Enter during conversion now only commits the composition; Enter after conversion sends as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)