### PR TITLE
Trace gatekeeper session resolution and stamp identity on loopback invocations

### DIFF
--- a/packages/backend-utils/__tests__/tracing.test.ts
+++ b/packages/backend-utils/__tests__/tracing.test.ts
@@ -127,6 +127,9 @@ describe("tracedPipelined", () => {
 // the stamp becomes redundant.
 describe("unended span visibility in tail events", () => {
   it("streams the open event but not the attributes of a span that never ends", { timeout: 15_000 }, async () => {
+    // Start fresh so marker strings can be reused by future tests without flaking.
+    await probeEnv.SPAN_RECORDER.clear();
+
     // Control: an ended span reaches the recorder with its attributes.
     tracedPipelined("pin-ended-span", (span) => {
       span.setAttribute("pinMarkerEnded", "yes");

--- a/packages/backend-utils/__tests__/tracing.test.ts
+++ b/packages/backend-utils/__tests__/tracing.test.ts
@@ -11,11 +11,32 @@
 //   guards the signal itself: if invocations stop being traced, isTraced starts false and the
 //   test fails rather than silently passing.
 
+import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
-import { createTracer } from "../src/tracing";
+import { createPipelinedTracer, createTracer } from "../src/tracing";
+import type { TraceSpan } from "../src/tracing";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const traced = createTracer(() => ({}));
+const tracedPipelined = createPipelinedTracer(() => ({}));
+
+type SpanRecorder = {
+  getEvents(): Promise<string[]>;
+  clear(): Promise<void>;
+};
+const probeEnv = env as unknown as { SPAN_RECORDER: SpanRecorder };
+
+// Tail delivery is asynchronous; poll until the recorder's stream mentions `needle`.
+async function recordedEventsMentioning(needle: string): Promise<string[]> {
+  let events: string[] = [];
+  for (let attempt = 0; attempt < 100; attempt++) {
+    events = await probeEnv.SPAN_RECORDER.getEvents();
+    if (events.some((event) => event.includes(needle))) return events;
+    await sleep(50);
+  }
+  throw new Error(`span recorder never streamed an event mentioning ${needle}; saw: ${
+      JSON.stringify(events)}`);
+}
 
 describe("traced span lifetime", () => {
   it("keeps the span open across awaits in an async callback", async () => {
@@ -45,5 +66,87 @@ describe("traced span lifetime", () => {
       }),
     ).rejects.toThrow("boom");
     expect(openWhenErrorSet).toBe(true);
+  });
+});
+
+describe("tracedPipelined", () => {
+  it("returns the callback result by reference, never wrapped", async () => {
+    const original = Promise.resolve(42);
+    const result = tracedPipelined("probe-identity", () => original);
+    expect(result).toBe(original);
+    await result;
+  });
+
+  it("ends the span only when the promise settles", async () => {
+    let captured: TraceSpan | undefined;
+    let resolve!: (value: number) => void;
+    const pending = new Promise<number>((r) => { resolve = r; });
+    const result = tracedPipelined("probe-settle", (span) => {
+      captured = span;
+      return pending;
+    });
+    expect(result).toBe(pending);
+    expect(captured!.isTraced).toBe(true); // still open after the sync return
+    resolve(1);
+    await pending;
+    await sleep(0); // let the side observer run
+    expect(captured!.isTraced).toBe(false); // ended once settled
+  });
+
+  it("records the error attribute before ending on rejection", async () => {
+    let openWhenErrorSet: boolean | undefined;
+    let captured: TraceSpan | undefined;
+    const rejected = tracedPipelined("probe-pipelined-reject", (span) => {
+      captured = span;
+      const original = span.setAttribute.bind(span);
+      span.setAttribute = (key, value) => {
+        if (key === "error") openWhenErrorSet = span.isTraced;
+        original(key, value);
+      };
+      return sleep(20).then(() => { throw new Error("boom"); });
+    });
+    await expect(rejected).rejects.toThrow("boom");
+    await sleep(0);
+    expect(openWhenErrorSet).toBe(true);
+    expect(captured!.isTraced).toBe(false);
+  });
+
+  it("ends the span and rethrows when the callback throws synchronously", () => {
+    let captured: TraceSpan | undefined;
+    expect(() => tracedPipelined("probe-sync-throw", (span) => {
+      captured = span;
+      throw new Error("sync");
+    })).toThrow("sync");
+    expect(captured!.isTraced).toBe(false);
+  });
+});
+
+// Pins that an unended span (a hung pipelined RPC) streams its spanOpen but loses its
+// attributes, which flush only at spanClose. workshop-backend's loopback emits a
+// separately-closed identity stamp because of this; if attributes start streaming eagerly,
+// the stamp becomes redundant.
+describe("unended span visibility in tail events", () => {
+  it("streams the open event but not the attributes of a span that never ends", { timeout: 15_000 }, async () => {
+    // Control: an ended span reaches the recorder with its attributes.
+    tracedPipelined("pin-ended-span", (span) => {
+      span.setAttribute("pinMarkerEnded", "yes");
+      return Promise.resolve();
+    });
+    const controlEvents = await recordedEventsMentioning("pinMarkerEnded");
+    expect(controlEvents.join("\n")).toContain("pin-ended-span");
+
+    // Under test: attribute set at open, promise never settles, end() never runs.
+    const never = new Promise(() => {});
+    tracedPipelined("pin-unended-span", (span) => {
+      span.setAttribute("pinMarkerUnended", "yes");
+      return never;
+    });
+
+    // The open event (name) streams while the span is still open...
+    await recordedEventsMentioning("pin-unended-span");
+    // ...but its attribute never arrives (allow ample delivery time before asserting absence).
+    await sleep(500);
+    const events = await probeEnv.SPAN_RECORDER.getEvents();
+    expect(events.join("\n")).not.toContain("pinMarkerUnended");
   });
 });

--- a/packages/backend-utils/src/tracing.ts
+++ b/packages/backend-utils/src/tracing.ts
@@ -2,10 +2,19 @@ import { tracing } from "cloudflare:workers";
 
 type Attribute = boolean | number | string;
 
-// The span surface exposed to callbacks. Lifetime is managed by `traced`, so no `end()`.
+// The span surface exposed to callbacks. Lifetime is managed by the tracer helpers, so no `end()`.
 export interface TraceSpan {
   readonly isTraced: boolean;
   setAttribute(key: string, value?: Attribute): void;
+}
+
+function stampContext(span: Pick<TraceSpan, "setAttribute">,
+    context: Readonly<Record<string, unknown>>) {
+  for (const [key, value] of Object.entries(context)) {
+    if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+      span.setAttribute(key, value);
+    }
+  }
 }
 
 /**
@@ -18,13 +27,7 @@ export interface TraceSpan {
 export function createTracer(getContext: () => Readonly<Record<string, unknown>>) {
   return function traced<Result>(name: string, callback: (span: TraceSpan) => Result): Result {
     return tracing.enterSpan(name, (span) => {
-      if (span.isTraced) {
-        for (const [key, value] of Object.entries(getContext())) {
-          if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
-            span.setAttribute(key, value);
-          }
-        }
-      }
+      if (span.isTraced) stampContext(span, getContext());
       // Boolean marker only: error text is unbounded and possibly sensitive, so it belongs to
       // logs/reporting, not trace attributes.
       const fail = () => span.setAttribute("error", true);
@@ -39,6 +42,43 @@ export function createTracer(getContext: () => Readonly<Record<string, unknown>>
             : result;
       } catch (err) {
         fail();
+        throw err;
+      }
+    });
+  };
+}
+
+/**
+ * Like `createTracer`, but the helper returns the callback result unchanged, preserving RPC
+ * promise/stub identity where `traced`'s `.catch` wrapper would collapse pipelining. A side
+ * observer ends the span on settle (`error: true` on rejection).
+ *
+ * A promise that never settles streams only its spanOpen — attributes flush at close and are
+ * lost (pinned by __tests__/tracing.test.ts) — so identity that must survive hangs needs a
+ * separately-ended span alongside.
+ */
+export function createPipelinedTracer(getContext: () => Readonly<Record<string, unknown>>) {
+  return function tracedPipelined<Result extends PromiseLike<unknown>>(
+      name: string, callback: (span: TraceSpan) => Result): Result {
+    return tracing.startActiveSpan(name, (span) => {
+      if (span.isTraced) stampContext(span, getContext());
+      try {
+        const result = callback(span);
+        if (!span.isTraced) {
+          span.end();
+          return result;
+        }
+        // Side observer only: `result` is returned as-is, never wrapped.
+        void result.then(
+            () => span.end(),
+            () => {
+              span.setAttribute("error", true);
+              span.end();
+            });
+        return result;
+      } catch (err) {
+        span.setAttribute("error", true);
+        span.end();
         throw err;
       }
     });

--- a/packages/backend-utils/src/tracing.ts
+++ b/packages/backend-utils/src/tracing.ts
@@ -68,8 +68,8 @@ export function createPipelinedTracer(getContext: () => Readonly<Record<string, 
           span.end();
           return result;
         }
-        // Side observer only: `result` is returned as-is, never wrapped. Note observing does
-        // force resolution delivery, which pipeline-only callers would otherwise skip.
+        // Side observer only: `result` is returned as-is, never wrapped. The RPC return message
+        // flows regardless; observing only materializes the result locally, off the critical path.
         void result.then(
             () => span.end(),
             () => {

--- a/packages/backend-utils/src/tracing.ts
+++ b/packages/backend-utils/src/tracing.ts
@@ -68,7 +68,8 @@ export function createPipelinedTracer(getContext: () => Readonly<Record<string, 
           span.end();
           return result;
         }
-        // Side observer only: `result` is returned as-is, never wrapped.
+        // Side observer only: `result` is returned as-is, never wrapped. Note observing does
+        // force resolution delivery, which pipeline-only callers would otherwise skip.
         void result.then(
             () => span.end(),
             () => {

--- a/packages/backend-utils/vitest.config.ts
+++ b/packages/backend-utils/vitest.config.ts
@@ -11,10 +11,14 @@ export default defineConfig({
         compatibilityFlags: ["experimental", "nodejs_als", "streaming_tail_worker"],
         serviceBindings: {
           ERROR_REPORTER: { name: "reporter", entrypoint: "ErrorReporter" },
+          SPAN_RECORDER: { name: "span-recorder", entrypoint: "SpanRecorder" },
         },
         // Invocations are only traced (span.isTraced === true) when a tail consumer is attached;
         // the no-op "span-sink" below exists solely so tracing.test.ts can observe span lifetime.
         tails: ["span-sink"],
+        // Span events flow only to streamingTails consumers (`tails` is the legacy path); the
+        // recorder captures them for tracing.test.ts.
+        streamingTails: ["span-recorder"],
         workers: [{
           name: "span-sink",
           modules: true,
@@ -23,6 +27,36 @@ export default defineConfig({
           // The no-op tail() silences workerd's legacy tail delivery, which it attempts alongside
           // the streaming path.
           script: `export default { tail: () => {}, tailStream: () => () => {} }`,
+        }, {
+          // Records every tail-stream event as JSON strings queryable over RPC. Streaming
+          // delivery is incremental, so tests can observe their own invocation's spans mid-flight.
+          name: "span-recorder",
+          modules: true,
+          compatibilityDate: "2026-02-02",
+          compatibilityFlags: ["experimental", "streaming_tail_worker"],
+          script: `
+            import { WorkerEntrypoint } from "cloudflare:workers";
+            let events = [];
+            const record = (ev) => {
+              try {
+                events.push(JSON.stringify(ev));
+              } catch (err) {
+                events.push("unserializable: " + String(err));
+              }
+            };
+            export default {
+              // The no-op tail() silences workerd's legacy tail delivery (see span-sink above).
+              tail: () => {},
+              tailStream(event) {
+                record(event);
+                return record;
+              },
+            };
+            export class SpanRecorder extends WorkerEntrypoint {
+              async getEvents() { return events; }
+              async clear() { events = []; }
+            }
+          `,
         }, {
           name: "reporter",
           modules: true,

--- a/packages/workshop-backend/src/observability.ts
+++ b/packages/workshop-backend/src/observability.ts
@@ -1,5 +1,5 @@
 import { createObservabilityContext } from "@gadgets/backend-utils/observability-context";
-import { createTracer } from "@gadgets/backend-utils/tracing";
+import { createPipelinedTracer, createTracer } from "@gadgets/backend-utils/tracing";
 
 /** Observability fields emitted by the Workshop backend. */
 export type WorkshopObservabilityFields = {
@@ -8,6 +8,10 @@ export type WorkshopObservabilityFields = {
   autoProvisioned: boolean;
   blueprintId: string;
   callbackInitiated: boolean;
+  // Who initiated a binding call (`operation` names what is being done).
+  callerFrom: "agent" | "gadget" | "user" | "hook";
+  // The calling gadget's workpiece id (`gadgetId` is the overseer DO id).
+  callerGadgetId: number;
   chatId: number;
   durationMs: number;
   eventName: string;
@@ -42,3 +46,6 @@ export function createWorkshopLogger(component: string) {
 
 /** Runs `callback` in a trace span carrying the ambient observability fields as attributes. */
 export const traced = createTracer(obsContext.get);
+
+/** Like `traced`, but returns the callback's promise unchanged — safe around pipelined RPC. */
+export const tracedPipelined = createPipelinedTracer(obsContext.get);

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -6864,8 +6864,10 @@ export class GatekeeperLoopback extends WorkerEntrypoint<Cloudflare.Env, Gatekee
     let {target: bindingTarget, caller, vendorId} = ctx.props;
     let stampIdentity = (span: TraceSpan) => {
       span.setAttribute("bindingTargetType", bindingTarget.type);
+      // For gatekeeper targets this is the same workpiece id logged as `gatekeeperId` on the
+      // gatekeeper.session.open span.
       span.setAttribute("bindingTargetId", bindingTarget.id);
-      span.setAttribute("vendorId", vendorId);
+      span.setAttribute("vendorId", vendorId); // undefined is a no-op
       span.setAttribute("callerFrom", caller.from);
       if ("chatId" in caller) span.setAttribute("chatId", caller.chatId);
       if (caller.from === "gadget") span.setAttribute("callerGadgetId", caller.gadgetId);

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -37,7 +37,8 @@ import { refreshCachedBalance } from "./ai-gateway-billing/cloudflare/connection
 import { SharingManager, SharingCaller, CollaboratorRecord, ShareKeyRecord } from "./sharing";
 import { AutoApprovalDrainer } from "./auto-approval";
 import { collectSlashCommands, invokeSlashCommand } from "./slash-commands";
-import { createWorkshopLogger, obsContext, traced } from "./observability";
+import { createWorkshopLogger, obsContext, traced, tracedPipelined } from "./observability";
+import type { TraceSpan } from "@gadgets/backend-utils/tracing";
 import type { ChatGatewayRpcTarget, SubmitExternalMessageResult } from "@gadgets/workshop-shared/external-message-gateway";
 import {
   assertChatAttachmentSupportedByProvider,
@@ -2037,6 +2038,9 @@ class OverseerImpl implements AgentHooks {
       overseerId: this.ctx.id.toString(),
       target,
       caller,
+      vendorId: target.type === "gatekeeper"
+          ? gatekeeperVendorId(this.storage.gatekeepers.get(target.id))
+          : undefined,
     };
     return this.ctx.exports.GatekeeperLoopback({props});
   }
@@ -6830,6 +6834,10 @@ type GatekeeperLoopbackProps = {
   target: BindingLoopbackTarget;
 
   caller: GatekeeperCaller;
+
+  // Target gatekeeper's vendor id (immutable, so safe to denormalize), stamped on the
+  // loopback's trace. Absent for gadget targets.
+  vendorId?: string;
 };
 
 type BindingLoopbackTarget = {
@@ -6853,9 +6861,26 @@ export class GatekeeperLoopback extends WorkerEntrypoint<Cloudflare.Env, Gatekee
     let stub: DurableObjectStub<OverseerDurableObject> =
         ns.get(ns.idFromString(ctx.props.overseerId));
 
-    // @ts-ignore: LSP-only RPC types bug, "type instantiation is excessively deep"
-    let session = stub.startGatekeeperSession(
-        this.ctx.props.target, this.ctx.props.caller);
+    let {target: bindingTarget, caller, vendorId} = ctx.props;
+    let stampIdentity = (span: TraceSpan) => {
+      span.setAttribute("bindingTargetType", bindingTarget.type);
+      span.setAttribute("bindingTargetId", bindingTarget.id);
+      span.setAttribute("vendorId", vendorId);
+      span.setAttribute("callerFrom", caller.from);
+      if ("chatId" in caller) span.setAttribute("chatId", caller.chatId);
+      if (caller.from === "gadget") span.setAttribute("callerGadgetId", caller.gadgetId);
+    };
+    // Immediately-closed stamp: an unended span's attributes are never streamed (pinned in
+    // backend-utils tracing.test.ts), so this is what identifies a hung invocation.
+    traced("gatekeeper.loopback.identity", stampIdentity);
+
+    // Measures session resolution; on a hang, its never-closed spanOpen marks the stage.
+    // tracedPipelined returns the RpcPromise unchanged, so the Proxy still pipelines.
+    let session = tracedPipelined("gatekeeper.loopback.resolve", (span) => {
+      stampIdentity(span);
+      // @ts-ignore: LSP-only RPC types bug, "type instantiation is excessively deep"
+      return stub.startGatekeeperSession(bindingTarget, caller);
+    });
 
     return new Proxy(session, {
       get(target, prop, receiver) {
@@ -9398,8 +9423,33 @@ class GatekeeperClientImpl<Session extends RpcCompatible<Session>>
   }
 
   async openSession(): Promise<RpcStub<Session>> {
+    let caller = this.caller;
+    let vendorId = gatekeeperVendorId(this.impl.storage.gatekeepers.get(this.id));
+    let fields = {
+      operation: "gatekeeper.session.open",
+      gatekeeperId: this.id,
+      callerFrom: caller.from,
+      ...(vendorId !== undefined && {vendorId}),
+      ...("chatId" in caller && caller.chatId !== undefined && {chatId: caller.chatId}),
+      ...(caller.from === "gadget" && caller.gadgetId !== undefined
+          && {callerGadgetId: caller.gadgetId}),
+    };
+    // Span covers the common path; only failures log. Awaiting is safe here: this async
+    // function already adopted the promise, so caller-side pipelining is unaffected.
     // @ts-expect-error TODO: Remove annotation when Cap'n Web fixes cyclic type issues
-    return this.facet.startSession(new ApprovalQueueImpl(this.impl, this.id, this.caller));
+    return obsContext.with(fields, () => traced("gatekeeper.session.open", async () => {
+      let startedAt = Date.now();
+      try {
+        return await this.facet.startSession(
+            new ApprovalQueueImpl(this.impl, this.id, this.caller));
+      } catch (error) {
+        logger.warn("gatekeeper session open failed", {
+          event: "gatekeeper.session.open.failed",
+          durationMs: Date.now() - startedAt, outcome: "error", error,
+        });
+        throw error;
+      }
+    }));
   }
 
   async getCreationSpec(): Promise<GatekeeperCreationSpec> {


### PR DESCRIPTION
Looking at production trace data, nearly every retained `GatekeeperLoopback.jsrpc` record was a "code had hung" cancellation, arriving in bursts tied to agent-initiated gatekeeper calls. The canceled invocations carry no vendor or caller identity, and the traces don't show which stage stalled, so the investigation had to infer both from sibling spans.

This adds three small instruments to workshop-backend so the next investigation can read the answer straight off the trace:

- Every loopback invocation stamps a `gatekeeper.loopback.identity` span with vendorId, target, callerFrom, and chatId. Canceled invocations become directly groupable by vendor.
- A `gatekeeper.loopback.resolve` span times session resolution. It uses a new `createPipelinedTracer` helper that returns the RpcPromise unchanged, since the existing `traced` helper would break capnweb pipelining here.
- A `gatekeeper.session.open` span (plus a failure-only log event) wraps `openSession` in the overseer DO. Comparing it against the loopback spans localizes a hang to overseer dispatch, connector session open, or the downstream connector call.

Connector-side instrumentation of the tool call itself is deferred to a follow-up.