### PR TITLE
chore: enable Bonk reviews for fork PRs

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot'
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -34,7 +34,7 @@ jobs:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           variant: "high"
           mentions: "/bonk,@ask-bonk"
-          forks: "false"
+          forks: "true"
           permissions: write
           token_permissions: NO_PUSH
           agent: bonk


### PR DESCRIPTION
Allows us to manually trigger (via `/bonk` or `@ask-bonk`) bonk on fork PRs via comment. This only runs for people with repo write access, so we are okay if someone else tries to run this