### PR TITLE
Propagate deployment accents to gatekeeper apps

### DIFF
--- a/packages/gatekeeper-context/app/main.tsx
+++ b/packages/gatekeeper-context/app/main.tsx
@@ -6,19 +6,23 @@ import { TooltipProvider, Toasty } from '@cloudflare/kumo'
 import { RpcTarget, newMessagePortRpcSession } from 'capnweb'
 import type { RpcStub } from 'capnweb'
 import type { ContextApi } from '../src/context-types'
+import type {
+  GatekeeperAppTheme,
+  GatekeeperAppThemeReceiver,
+} from '@gadgets/workshop-shared/theme'
 import ContextLibraryPage from './ContextLibraryPage'
 import { ContextApiProvider, PresentationProvider, type PresentAck } from './bridge'
-import { applyThemeMode, type ResolvedThemeMode } from './theme'
+import { applyAppTheme } from './theme'
 import './styles.css'
 import ErrorBoundary from './ErrorBoundary'
 import { installErrorReporting, reportIssue } from './error-reporting'
 
 installErrorReporting()
 
-// The only capability the iframe exposes back to the host: a receiver for theme-mode pushes.
-class AppIframe extends RpcTarget {
-  setThemeMode(mode: ResolvedThemeMode): void {
-    applyThemeMode(mode)
+// The only capability the iframe exposes back to the host: a receiver for theme pushes.
+class AppIframe extends RpcTarget implements GatekeeperAppThemeReceiver {
+  setTheme(theme: GatekeeperAppTheme): void {
+    applyAppTheme(theme)
   }
 }
 
@@ -26,8 +30,8 @@ interface HostCapability extends RpcTarget {
   readonly ui: RpcStub<ContextApi>
   // Grow the iframe to a full-viewport overlay for app-level modals (`true`) or restore it (`false`).
   setPresenting(active: boolean): Promise<PresentAck>
-  // Returns the current resolved theme mode and calls back on `receiver` whenever it changes.
-  subscribeTheme(receiver: AppIframe): Promise<ResolvedThemeMode>
+  // Returns the current theme and calls back on `receiver` whenever it changes.
+  subscribeTheme(receiver: GatekeeperAppThemeReceiver): Promise<GatekeeperAppTheme>
 }
 
 function main() {
@@ -40,8 +44,8 @@ function main() {
   window.parent.postMessage({ type: 'handshake' }, '*', [port2])
   const iframe = new AppIframe()
   const host = newMessagePortRpcSession<HostCapability>(port1, iframe)
-  // The initial mode comes back from the call; later changes arrive via iframe.setThemeMode().
-  host.subscribeTheme(iframe).then(applyThemeMode).catch(() => {})
+  // The initial theme comes back from the call; later changes arrive via iframe.setTheme().
+  host.subscribeTheme(iframe).then(applyAppTheme).catch(() => {})
 
   createRoot(root, {
     onUncaughtError: (error) => reportIssue('context.react-root', error, {

--- a/packages/gatekeeper-context/app/theme.ts
+++ b/packages/gatekeeper-context/app/theme.ts
@@ -9,6 +9,11 @@
 // A subscription is exposed so imperative widgets that can't rely on CSS variables — the CodeMirror
 // editor and the emoji picker — can react when the mode changes at runtime.
 
+import {
+  applyAccentColor,
+  type GatekeeperAppTheme,
+} from "@gadgets/workshop-shared/theme";
+
 // The two concrete modes the host resolves `light`/`dark`/`system` down to before pushing it here.
 export type ResolvedThemeMode = "light" | "dark";
 
@@ -30,6 +35,11 @@ export function applyThemeMode(mode: ResolvedThemeMode): void {
   if (mode === current) return;
   current = mode;
   for (const listener of listeners) listener(mode);
+}
+
+export function applyAppTheme(theme: GatekeeperAppTheme): void {
+  applyThemeMode(theme.mode);
+  applyAccentColor(document.documentElement.style, theme.accentColor);
 }
 
 // Subscribe to mode changes. Returns an unsubscribe function.

--- a/packages/gatekeeper-scheduler/app/main.tsx
+++ b/packages/gatekeeper-scheduler/app/main.tsx
@@ -1,22 +1,26 @@
 import { createRoot } from "react-dom/client";
 import { RpcTarget, newMessagePortRpcSession, type RpcStub } from "capnweb";
+import type {
+  GatekeeperAppTheme,
+  GatekeeperAppThemeReceiver,
+} from "@gadgets/workshop-shared/theme";
 import SchedulerPage, { type ScheduleManagementClient } from "./SchedulerPage";
 import ErrorBoundary from "./ErrorBoundary";
 import { installErrorReporting, reportIssue } from "./error-reporting";
-import { applyThemeMode, type ResolvedThemeMode } from "./theme";
+import { applyAppTheme } from "./theme";
 import "./styles.css";
 
 installErrorReporting();
 
-class AppIframe extends RpcTarget {
-  setThemeMode(mode: ResolvedThemeMode): void {
-    applyThemeMode(mode);
+class AppIframe extends RpcTarget implements GatekeeperAppThemeReceiver {
+  setTheme(theme: GatekeeperAppTheme): void {
+    applyAppTheme(theme);
   }
 }
 
 interface HostCapability extends RpcTarget {
   readonly ui: RpcStub<ScheduleManagementClient>;
-  subscribeTheme(receiver: AppIframe): Promise<ResolvedThemeMode>;
+  subscribeTheme(receiver: GatekeeperAppThemeReceiver): Promise<GatekeeperAppTheme>;
   openWorkspace(workspaceId: string, gadgetId?: number): Promise<void>;
   resolveWorkspaceTitles(ids: string[]): Promise<(string | null)[]>;
   openPrompt(prompt: string): Promise<void>;
@@ -32,7 +36,7 @@ function main() {
   const host = newMessagePortRpcSession<HostCapability>(port1, iframe);
   host
     .subscribeTheme(iframe)
-    .then(applyThemeMode)
+    .then(applyAppTheme)
     .catch(() => {});
 
   createRoot(element, {

--- a/packages/gatekeeper-scheduler/app/theme.test.ts
+++ b/packages/gatekeeper-scheduler/app/theme.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { applyAppTheme } from "./theme";
+
+describe("applyAppTheme", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("data-mode");
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("applies the host mode and accent and can restore the base accent", () => {
+    applyAppTheme({ mode: "dark", accentColor: "#3b82f6" });
+
+    expect(document.documentElement.dataset.mode).toBe("dark");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(document.documentElement.style.getPropertyValue("--color-kumo-brand"))
+      .toContain("#3b82f6");
+
+    applyAppTheme({ mode: "light", accentColor: null });
+
+    expect(document.documentElement.dataset.mode).toBe("light");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(document.documentElement.style.getPropertyValue("--color-kumo-brand")).toBe("");
+  });
+});

--- a/packages/gatekeeper-scheduler/app/theme.ts
+++ b/packages/gatekeeper-scheduler/app/theme.ts
@@ -1,6 +1,16 @@
+import {
+  applyAccentColor,
+  type GatekeeperAppTheme,
+} from "@gadgets/workshop-shared/theme";
+
 export type ResolvedThemeMode = "light" | "dark";
 
 export function applyThemeMode(mode: ResolvedThemeMode): void {
   document.documentElement.dataset.mode = mode;
   document.documentElement.style.colorScheme = mode;
+}
+
+export function applyAppTheme(theme: GatekeeperAppTheme): void {
+  applyThemeMode(theme.mode);
+  applyAccentColor(document.documentElement.style, theme.accentColor);
 }

--- a/packages/workshop-frontend/src/SandboxedGatekeeperApp.test.tsx
+++ b/packages/workshop-frontend/src/SandboxedGatekeeperApp.test.tsx
@@ -13,10 +13,18 @@ import {
 import { newMessagePortRpcSession, RpcStub, RpcTarget } from "capnweb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatekeeperUiFrame } from "@gadgets/workshop-shared/gatekeeper";
+import type {
+  GatekeeperAppTheme,
+  GatekeeperAppThemeReceiver,
+} from "@gadgets/workshop-shared/theme";
 import SandboxedGatekeeperApp from "./SandboxedGatekeeperApp";
 
 vi.mock("./ThemeContext", () => ({
   useTheme: () => ({ resolvedThemeMode: "light" }),
+}));
+
+vi.mock("./ServerConfigContext", () => ({
+  useServerConfig: () => ({ accentColor: "#7c3aed" }),
 }));
 
 vi.mock("./errorReporting", () => ({
@@ -28,20 +36,26 @@ const WORKSPACE_ID = "a".repeat(64);
 const listGadgets = vi.fn<() => Promise<{ id: string; title: string }[]>>(async () => [
   { id: WORKSPACE_ID, title: "Daily Brief" },
 ]);
+const authenticatedApi = { listGadgets };
 
 vi.mock("./AuthContext", () => ({
-  useAuthenticatedApi: () => ({ authenticatedApi: { listGadgets } }),
+  useAuthenticatedApi: () => ({ authenticatedApi }),
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 interface TestHost extends RpcTarget {
+  subscribeTheme(receiver: GatekeeperAppThemeReceiver): Promise<GatekeeperAppTheme>;
   openWorkspace(workspaceId: string, gadgetId?: number): Promise<void>;
   resolveWorkspaceTitles(ids: string[]): Promise<(string | null)[]>;
   openPrompt(prompt: string): Promise<void>;
 }
 
 class EmptyUi extends RpcTarget {}
+
+class TestThemeReceiver extends RpcTarget implements GatekeeperAppThemeReceiver {
+  setTheme(_theme: GatekeeperAppTheme): void {}
+}
 
 describe("SandboxedGatekeeperApp navigation", () => {
   let container: HTMLDivElement | undefined;
@@ -59,7 +73,7 @@ describe("SandboxedGatekeeperApp navigation", () => {
     vi.restoreAllMocks();
   });
 
-  it("routes validated targets and bounded prompts from the iframe host", async () => {
+  it("provides the deployment theme and routes bounded iframe requests", async () => {
     const frame = {
       iframeHtml: "<!doctype html><title>Scheduler</title>",
       ui: new RpcStub(new EmptyUi()),
@@ -95,6 +109,12 @@ describe("SandboxedGatekeeperApp navigation", () => {
         ports: [port2],
       }),
     );
+
+    const themeReceiver = new TestThemeReceiver();
+    await expect(host.subscribeTheme(themeReceiver)).resolves.toEqual({
+      mode: "light",
+      accentColor: "#7c3aed",
+    });
 
     await act(async () => {
       await host!.openWorkspace(WORKSPACE_ID, 2);

--- a/packages/workshop-frontend/src/SandboxedGatekeeperApp.tsx
+++ b/packages/workshop-frontend/src/SandboxedGatekeeperApp.tsx
@@ -3,9 +3,14 @@ import { flushSync } from 'react-dom'
 import { RpcStub, RpcTarget, newMessagePortRpcSession } from 'capnweb'
 import { useNavigate } from '@tanstack/react-router'
 import type { GatekeeperUiFrame } from '@gadgets/workshop-shared/gatekeeper'
+import type {
+  GatekeeperAppTheme,
+  GatekeeperAppThemeReceiver,
+} from '@gadgets/workshop-shared/theme'
+import { isHexColor } from '@gadgets/workshop-shared/api'
 import { createRateLimitedCapability } from './rateLimitedCapability'
 import { useTheme } from './ThemeContext'
-import type { ResolvedThemeMode } from './theme'
+import { useServerConfig } from './ServerConfigContext'
 import { forwardTrustedFrameError } from './errorReporting'
 import { useAuthenticatedApi } from './AuthContext'
 import {
@@ -13,11 +18,6 @@ import {
   parseGatekeeperAppWorkspaceTarget,
   type GatekeeperAppWorkspaceTarget,
 } from './gatekeeperAppNavigation'
-
-// A receiver, defined by the sandboxed app, that the host calls to push theme changes into the frame.
-interface ThemeReceiver extends RpcTarget {
-  setThemeMode(mode: ResolvedThemeMode): void
-}
 
 // The content-pane rect, in viewport coordinates, that the app pins its page to while the iframe
 // is full-viewport.
@@ -83,8 +83,8 @@ class GatekeeperAppHostImpl extends RpcTarget {
   readonly #openPrompt: OpenPrompt
   readonly #resolveWorkspaceTitles: ResolveWorkspaceTitles
   #presenting = false
-  #themeMode: ResolvedThemeMode
-  #themeReceiver: RpcStub<ThemeReceiver> | null = null
+  #theme: GatekeeperAppTheme
+  #themeReceiver: RpcStub<GatekeeperAppThemeReceiver> | null = null
   // Presentation changes are coalesced to a single apply per animation frame (see #applyPending).
   #pendingActive: boolean | null = null
   #pendingResolvers: ((ack: PresentAck) => void)[] = []
@@ -93,13 +93,13 @@ class GatekeeperAppHostImpl extends RpcTarget {
   constructor(
     capability: any,
     present: PresentController,
-    themeMode: ResolvedThemeMode,
+    theme: GatekeeperAppTheme,
     openTarget: OpenTarget,
     openPrompt: OpenPrompt,
     resolveWorkspaceTitles: ResolveWorkspaceTitles,
   ) {
     super()
-    this.#themeMode = themeMode
+    this.#theme = theme
     const { capability: ui, dispose } = createRateLimitedCapability(capability, {
       maxConcurrency: 8,
       maxCallsPerMinute: 600,
@@ -138,29 +138,29 @@ class GatekeeperAppHostImpl extends RpcTarget {
     this.#openPrompt(normalizeGatekeeperAppPrompt(prompt))
   }
 
-  // The app calls this once to learn the current mode and register a receiver for later changes.
+  // The app calls this once to learn the current theme and register a receiver for later changes.
   // Apps that don't theme themselves never call it.
-  subscribeTheme(receiver: RpcStub<ThemeReceiver>): ResolvedThemeMode {
+  subscribeTheme(receiver: RpcStub<GatekeeperAppThemeReceiver>): GatekeeperAppTheme {
     this.#themeReceiver?.[Symbol.dispose]?.()
     // The argument stub is disposed when this call returns, so keep our own dup (released in dispose).
     this.#themeReceiver = receiver.dup()
-    return this.#themeMode
+    return this.#theme
   }
 
-  #dropThemeReceiver(receiver: RpcStub<ThemeReceiver>) {
+  #dropThemeReceiver(receiver: RpcStub<GatekeeperAppThemeReceiver>) {
     if (this.#themeReceiver !== receiver) return
     receiver[Symbol.dispose]?.()
     this.#themeReceiver = null
   }
 
-  // Push a new mode to a subscribed app; a no-op until (and unless) the app subscribes.
-  updateTheme(mode: ResolvedThemeMode) {
-    this.#themeMode = mode
+  // Push a new theme to a subscribed app; a no-op until (and unless) the app subscribes.
+  updateTheme(theme: GatekeeperAppTheme) {
+    this.#theme = theme
     const receiver = this.#themeReceiver
     if (!receiver) return
 
     try {
-      Promise.resolve(receiver.setThemeMode(mode)).catch(() => this.#dropThemeReceiver(receiver))
+      Promise.resolve(receiver.setTheme(theme)).catch(() => this.#dropThemeReceiver(receiver))
     } catch {
       this.#dropThemeReceiver(receiver)
     }
@@ -224,13 +224,17 @@ export default function SandboxedGatekeeperApp({ frame, gatekeeperVendorId }: {
   const invalidatedRef = useRef(false)
   const [overlay, setOverlay] = useState<OverlayState>(null)
   const overlayRef = useRef<OverlayState>(null)
-  // Push the Workshop's resolved light/dark mode to the app whenever it changes.
+  // Push the Workshop's resolved light/dark mode and deployment accent whenever either changes.
   const { resolvedThemeMode } = useTheme()
-  const themeModeRef = useRef(resolvedThemeMode)
-  themeModeRef.current = resolvedThemeMode
+  const configuredAccentColor = useServerConfig()?.accentColor
+  const accentColor = configuredAccentColor && isHexColor(configuredAccentColor)
+    ? configuredAccentColor
+    : null
+  const themeRef = useRef<GatekeeperAppTheme>({ mode: resolvedThemeMode, accentColor })
+  themeRef.current = { mode: resolvedThemeMode, accentColor }
   useEffect(() => {
-    hostRef.current?.updateTheme(resolvedThemeMode)
-  }, [resolvedThemeMode])
+    hostRef.current?.updateTheme({ mode: resolvedThemeMode, accentColor })
+  }, [resolvedThemeMode, accentColor])
 
   const setOverlayPhase = useCallback((next: OverlayState) => {
     if (overlayRef.current === next) return
@@ -312,7 +316,7 @@ export default function SandboxedGatekeeperApp({ frame, gatekeeperVendorId }: {
       const host = new GatekeeperAppHostImpl(
         capabilityRef.current,
         present,
-        themeModeRef.current,
+        themeRef.current,
         openTarget,
         openPrompt,
         resolveWorkspaceTitles,

--- a/packages/workshop-frontend/src/theme.ts
+++ b/packages/workshop-frontend/src/theme.ts
@@ -8,10 +8,10 @@
 // (`oklch(from <seed> ...)`), so the admin only picks one color.
 //
 // Only the accent-related variables are overridden at runtime; backgrounds, lines, and neutral text
-// follow the light/dark palettes selected by `data-mode` in styles.css. The seed is always a
-// validated hex string (see isHexColor), so interpolating it into the CSS strings below is safe.
+// follow the light/dark palettes selected by `data-mode` in styles.css. The shared applicator
+// validates the seed before interpolating it into CSS values.
 
-import { isHexColor } from '@gadgets/workshop-shared/api'
+import { applyAccentColor as applyAccentColorToStyle } from '@gadgets/workshop-shared/theme'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 export type ResolvedThemeMode = 'light' | 'dark'
@@ -61,36 +61,9 @@ export function applyStoredThemeMode(): ResolvedThemeMode {
   return applyThemeMode(readThemeMode())
 }
 
-// Variables derived from the seed, as (name -> value-template) pairs. `light-dark()` keeps custom
-// deployment accents mode-aware without needing to reapply them when the user toggles themes.
-function accentVars(seed: string): Record<string, string> {
-  return {
-    '--color-kumo-brand': `light-dark(${seed}, oklch(from ${seed} 0.45 c h))`,
-    // Slightly darker for hover/pressed states.
-    '--color-kumo-brand-hover': `light-dark(oklch(from ${seed} calc(l - 0.06) c h), oklch(from ${seed} 0.38 c h))`,
-    '--color-accent-100': `light-dark(${seed}, oklch(from ${seed} 0.45 c h))`,
-    // Lighter/brighter secondary accent.
-    '--color-accent-200': `light-dark(oklch(from ${seed} calc(l + 0.08) c h), oklch(from ${seed} 0.76 c h))`,
-    '--text-color-kumo-brand': `light-dark(${seed}, oklch(from ${seed} 0.76 c h))`,
-    '--text-color-kumo-link': `light-dark(${seed}, oklch(from ${seed} 0.76 c h))`,
-    // Soft tinted selection background + readable selection text.
-    '--color-selection-bg': `light-dark(oklch(from ${seed} 0.94 calc(c * 0.35) h), oklch(from ${seed} 0.28 calc(c * 0.45) h))`,
-    '--color-selection-text': `light-dark(oklch(from ${seed} calc(l - 0.06) c h), oklch(0.97 0.006 285))`,
-  }
-}
-
-const ALL_VARS = Object.keys(accentVars('#000'))
-
 // Apply the accent color to the document root. Pass "" / invalid to clear back to the base theme.
 export function applyAccentColor(color: string | null | undefined): void {
-  const root = document.documentElement
-  if (!color || !isHexColor(color)) {
-    for (const v of ALL_VARS) root.style.removeProperty(v)
-    return
-  }
-  for (const [v, value] of Object.entries(accentVars(color))) {
-    root.style.setProperty(v, value)
-  }
+  applyAccentColorToStyle(document.documentElement.style, color)
 }
 
 // The base/default accent, shown in the admin picker when no custom color is set.

--- a/packages/workshop-shared/package.json
+++ b/packages/workshop-shared/package.json
@@ -28,6 +28,10 @@
     "./external-message-gateway": {
       "types": "./src/external-message-gateway.ts",
       "import": "./src/external-message-gateway.ts"
+    },
+    "./theme": {
+      "types": "./src/theme.ts",
+      "import": "./src/theme.ts"
     }
   },
   "scripts": {

--- a/packages/workshop-shared/src/theme.ts
+++ b/packages/workshop-shared/src/theme.ts
@@ -1,0 +1,54 @@
+import type { RpcTarget } from "capnweb";
+
+/** The complete appearance state sent from Workshop to a sandboxed gatekeeper app. */
+export interface GatekeeperAppTheme {
+  /** The concrete light or dark mode resolved by Workshop. */
+  mode: "light" | "dark";
+  /** The deployment accent seed, or null to use the app's base palette. */
+  accentColor: string | null;
+}
+
+/** A sandboxed gatekeeper app capability that receives complete appearance updates. */
+export interface GatekeeperAppThemeReceiver extends RpcTarget {
+  /** Applies the latest Workshop appearance state. */
+  setTheme(theme: GatekeeperAppTheme): void;
+}
+
+interface StylePropertyTarget {
+  removeProperty(name: string): unknown;
+  setProperty(name: string, value: string): unknown;
+}
+
+function accentVariables(seed: string): Record<string, string> {
+  return {
+    "--color-kumo-brand": `light-dark(${seed}, oklch(from ${seed} 0.45 c h))`,
+    "--color-kumo-brand-hover": `light-dark(oklch(from ${seed} calc(l - 0.06) c h), oklch(from ${seed} 0.38 c h))`,
+    "--color-accent-100": `light-dark(${seed}, oklch(from ${seed} 0.45 c h))`,
+    "--color-accent-200": `light-dark(oklch(from ${seed} calc(l + 0.08) c h), oklch(from ${seed} 0.76 c h))`,
+    "--text-color-kumo-brand": `light-dark(${seed}, oklch(from ${seed} 0.76 c h))`,
+    "--text-color-kumo-link": `light-dark(${seed}, oklch(from ${seed} 0.76 c h))`,
+    "--color-selection-bg": `light-dark(oklch(from ${seed} 0.94 calc(c * 0.35) h), oklch(from ${seed} 0.28 calc(c * 0.45) h))`,
+    "--color-selection-text": `light-dark(oklch(from ${seed} calc(l - 0.06) c h), oklch(0.97 0.006 285))`,
+  };
+}
+
+const accentVariableNames = Object.keys(accentVariables("#000"));
+
+function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value);
+}
+
+/** Applies an accent seed, or clears the overrides when the seed is invalid or empty. */
+export function applyAccentColor(
+  target: StylePropertyTarget,
+  color: string | null | undefined,
+): void {
+  if (!color || !isHexColor(color)) {
+    for (const name of accentVariableNames) target.removeProperty(name);
+    return;
+  }
+
+  for (const [name, value] of Object.entries(accentVariables(color))) {
+    target.setProperty(name, value);
+  }
+}


### PR DESCRIPTION
Built-in Context and Scheduled apps now use the deployment accent color instead of the default orange.

Mode and accent share the existing theme rpc and update  when either changes. Accent derivation is shared so Workshop and embedded apps use the same palette.

<img width="2064" height="1004" alt="Screenshot from 2026-08-11 12-50-24" src="https://github.com/user-attachments/assets/d3162f42-1cdb-4dad-993e-25ce6e96913b" />