### PR TITLE
Fix observer verification for legacy account grants

### DIFF
--- a/packages/workshop-frontend/src/ObserverConfigModal.test.tsx
+++ b/packages/workshop-frontend/src/ObserverConfigModal.test.tsx
@@ -211,6 +211,53 @@ describe('ObserverConfigModal account selection', () => {
     expect(window.open).toHaveBeenCalledWith(
       'https://accounts.google.test/oauth', '_blank', 'noopener,noreferrer',
     )
+    expect(rendered.textContent).not.toContain('Ready')
+    expect(verify?.disabled).toBe(true)
+  })
+
+  it('checks the resource grant when legacy account metadata omits it', async () => {
+    const ensureAccountResources = vi.fn<
+      (accountId: number, resourceUrlPatterns: string[]) => Promise<{ url?: string }>
+    >().mockResolvedValue({ url: 'https://accounts.google.test/oauth' })
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+    const legacy = account(1, 'dan@cloudflare.com')
+    const rendered = await render([legacy], {
+      api: fakeApi([legacy], { ensureAccountResources }),
+    })
+
+    const verify = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Verify and open')
+    const grant = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Grant the access needed to verify this resource')
+    expect(verify?.disabled).toBe(true)
+    expect(grant).toBeDefined()
+
+    await act(async () => grant!.click())
+
+    expect(ensureAccountResources).toHaveBeenCalledWith(1, [DOC_RESOURCE.urlPattern])
+    expect(window.open).toHaveBeenCalledWith(
+      'https://accounts.google.test/oauth', '_blank', 'noopener,noreferrer',
+    )
+  })
+
+  it('allows verification when the gatekeeper confirms an unknown grant needs no OAuth', async () => {
+    const ensureAccountResources = vi.fn<
+      (accountId: number, resourceUrlPatterns: string[]) => Promise<{ url?: string }>
+    >().mockResolvedValue({})
+    const legacy = account(1, 'dan@cloudflare.com')
+    const rendered = await render([legacy], {
+      api: fakeApi([legacy], { ensureAccountResources }),
+    })
+
+    const grant = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Grant the access needed to verify this resource')
+    await act(async () => grant!.click())
+
+    const verify = [...rendered.querySelectorAll('button')]
+      .find(button => button.textContent === 'Verify and open')
+    expect(ensureAccountResources).toHaveBeenCalledWith(1, [DOC_RESOURCE.urlPattern])
+    expect(rendered.textContent).toContain('Ready')
+    expect(verify?.disabled).toBe(false)
   })
 
   it('allows verification when the account already has the required grant', async () => {

--- a/packages/workshop-frontend/src/ObserverConfigModal.tsx
+++ b/packages/workshop-frontend/src/ObserverConfigModal.tsx
@@ -60,12 +60,11 @@ function requiredResourceUrlPatterns(
   return resolved.ok && resolved.resource.grantable ? [resolved.resource.urlPattern] : []
 }
 
-// Filter required resource types down to those the account has not granted yet. An omitted
-// granted-resource list denotes a legacy or full-scope account and therefore satisfies every
-// requirement.
+// Older account records may not list which resources were granted. Ask the gatekeeper to check
+// instead of assuming the account has access.
 function missingResourceUrlPatterns(account: AccountInfo, required: string[]): string[] {
   const granted = account.description.grantedResourceUrlPatterns
-  return granted === undefined ? [] : required.filter(pattern => !granted.includes(pattern))
+  return granted === undefined ? required : required.filter(pattern => !granted.includes(pattern))
 }
 
 interface ObserverConfigModalProps {
@@ -252,7 +251,29 @@ export default function ObserverConfigModal({
     try {
       const { url } = await authenticatedApi.ensureAccountResources(account.id, missing)
       if (url) window.open(url, '_blank', 'noopener,noreferrer')
-      else setGranting(null)
+      else {
+        // The gatekeeper confirmed this account already has access. Update the modal so the user can
+        // continue without an OAuth flow.
+        setAccounts(prev => {
+          const current = prev.get(account.id)
+          if (!current) return prev
+          const next = new Map(prev)
+          next.set(account.id, {
+            ...current,
+            description: {
+              ...current.description,
+              grantedResourceUrlPatterns: [
+                ...new Set([
+                  ...(current.description.grantedResourceUrlPatterns ?? []),
+                  ...missing,
+                ]),
+              ],
+            },
+          })
+          return next
+        })
+        setGranting(null)
+      }
     } catch (err) {
       console.error('Failed to request additional access:', err)
       toasts.add({ title: 'Failed to request additional access', variant: 'error' })


### PR DESCRIPTION
Fix an issue where users with legacy Google grants were unable to view a Gadget connected to a shared spreadsheet that they had access to. Previously, legacy grants that did not store granted resource URLs were assumed to cover all resources, but that was an unsafe assumption. Instead, we should validate the legacy grant against the required resources, and prompt the user to reauthenticate if the legacy grant doesn't cover these resources.