### PR TITLE
Automatically reject clear contribution-policy violations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,25 @@
 > [!IMPORTANT]
-> We are not generally accepting outside contributions. We only accept small,
-> trivially verified pull requests that fix a concrete problem. Please read our
-> [contribution guidelines](https://github.com/cloudflare/cloudflare-os/blob/main/CONTRIBUTING.md)
-> before submitting. For larger changes, please start a
-> [discussion](https://github.com/cloudflare/cloudflare-os/discussions) instead.
+> We are not generally accepting outside contributions. We may accept a small
+> change only when, in the maintainers' assessment, it is obviously correct and
+> trivially verifiable by reading the patch.
+>
+> If you found a bug, please [file an issue](https://github.com/cloudflare/cloudflare-os/issues/new)
+> first. For feature requests and other proposals, please
+> [open a discussion](https://github.com/cloudflare/cloudflare-os/discussions).
 
-## What does this fix?
+## What does this change?
 
-<!-- Describe the concrete problem and how this patch fixes it. -->
+<!-- Describe the concrete problem and how this patch addresses it. -->
 
-## Why is this trivially verifiable?
+## Why is this obviously correct and trivially verifiable?
 
-<!-- Explain how a reviewer can establish correctness by reading the patch. -->
+<!-- Explain how the complete effects can be established by reading the patch. -->
 
 ## Checklist
 
-If you cannot check every item, please close this pull request and start a
-discussion instead. Pull requests that do not meet these criteria will be closed.
+Checking every item does not guarantee acceptance. Maintainers determine whether
+a pull request meets the contribution policy.
 
-- [ ] <!-- contribution-policy:concrete-fix --> This fixes a concrete problem; it is not a feature, refactor, or low-value cleanup such as a typo fix.
-- [ ] <!-- contribution-policy:small-patch --> This patch is about a dozen changed lines and can be fully verified by reading it.
+- [ ] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
+- [ ] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
 - [ ] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+> [!IMPORTANT]
+> We are not generally accepting outside contributions. We only accept small,
+> trivially verified pull requests that fix a concrete problem. Please read our
+> [contribution guidelines](https://github.com/cloudflare/cloudflare-os/blob/main/CONTRIBUTING.md)
+> before submitting. For larger changes, please start a
+> [discussion](https://github.com/cloudflare/cloudflare-os/discussions) instead.
+
+## What does this fix?
+
+<!-- Describe the concrete problem and how this patch fixes it. -->
+
+## Why is this trivially verifiable?
+
+<!-- Explain how a reviewer can establish correctness by reading the patch. -->
+
+## Checklist
+
+If you cannot check every item, please close this pull request and start a
+discussion instead. Pull requests that do not meet these criteria will be closed.
+
+- [ ] <!-- contribution-policy:concrete-fix --> This fixes a concrete problem; it is not a feature, refactor, or low-value cleanup such as a typo fix.
+- [ ] <!-- contribution-policy:small-patch --> This patch is about a dozen changed lines and can be fully verified by reading it.
+- [ ] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

--- a/.github/workflows/contribution-policy.yml
+++ b/.github/workflows/contribution-policy.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   enforce:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/contribution-policy.yml
+++ b/.github/workflows/contribution-policy.yml
@@ -1,0 +1,37 @@
+name: Contribution policy
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, ready_for_review, converted_to_draft, labeled, unlabeled]
+
+permissions: {}
+
+concurrency:
+  group: contribution-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enforce:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out trusted workflow revision
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Enforce contribution policy
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { pathToFileURL } = await import("node:url");
+            const policyUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/scripts/contribution-policy.js`,
+            );
+            const { enforceContributionPolicy } = await import(policyUrl.href);
+            await enforceContributionPolicy({ github, context, core });

--- a/scripts/contribution-policy.js
+++ b/scripts/contribution-policy.js
@@ -29,6 +29,7 @@ const REQUIRED_CONFIRMATIONS = [
  */
 export function getContributionPolicyViolations(pullRequest) {
   if (
+    pullRequest.state !== "open" ||
     pullRequest.draft ||
     TRUSTED_ASSOCIATIONS.has(pullRequest.author_association) ||
     pullRequest.user?.login === "dependabot[bot]" ||

--- a/scripts/contribution-policy.js
+++ b/scripts/contribution-policy.js
@@ -1,0 +1,153 @@
+const AUTOMATION_COMMENT_MARKER = "<!-- contribution-policy-automation -->";
+const MAX_CHANGED_LINES = 30;
+const MAX_COMMENT_PAGES = 5;
+const OVERRIDE_LABEL = "policy/override";
+
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const REQUIRED_CONFIRMATIONS = [
+  {
+    marker: "contribution-policy:concrete-change",
+    violation: 'The "small, concrete change" confirmation is not checked.',
+  },
+  {
+    marker: "contribution-policy:maintainer-assessment",
+    violation: 'The "maintainer assessment" confirmation is not checked.',
+  },
+  {
+    marker: "contribution-policy:guidelines",
+    violation: 'The "contribution guidelines" confirmation is not checked.',
+  },
+];
+
+/**
+ * Returns the deterministic policy violations that require closing a pull request.
+ * An empty result means the automation should take no action, not that maintainers
+ * have accepted the change.
+ *
+ * @param {object} pullRequest GitHub pull request API response.
+ * @returns {string[]} Human-readable policy violations.
+ */
+export function getContributionPolicyViolations(pullRequest) {
+  if (
+    pullRequest.draft ||
+    TRUSTED_ASSOCIATIONS.has(pullRequest.author_association) ||
+    pullRequest.user?.login === "dependabot[bot]" ||
+    pullRequest.labels?.some((label) => label.name === OVERRIDE_LABEL)
+  ) {
+    return [];
+  }
+
+  const body = pullRequest.body ?? "";
+  const violations = REQUIRED_CONFIRMATIONS
+    .filter(({ marker }) => !hasCheckedConfirmation(body, marker))
+    .map(({ violation }) => violation);
+  const changedLines = pullRequest.additions + pullRequest.deletions;
+
+  if (changedLines > MAX_CHANGED_LINES) {
+    violations.push(
+      `The patch changes ${changedLines} lines; the automatic limit is ${MAX_CHANGED_LINES}.`,
+    );
+  }
+
+  return violations;
+}
+
+/**
+ * Enforces the contribution policy using the GitHub API client provided by
+ * actions/github-script.
+ *
+ * @param {object} options GitHub Actions runtime dependencies.
+ * @param {object} options.github Authenticated GitHub API client.
+ * @param {object} options.context GitHub Actions event context.
+ * @param {object} options.core GitHub Actions logging helper.
+ */
+export async function enforceContributionPolicy({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  const pullNumber = context.issue.number;
+  const pullRequestArgs = {
+    owner,
+    repo,
+    pull_number: pullNumber,
+  };
+  const { data: pullRequest } = await github.rest.pulls.get(pullRequestArgs);
+  let violations = getContributionPolicyViolations(pullRequest);
+
+  if (violations.length === 0) return;
+
+  const existingComment = await findAutomationComment(github, {
+    owner,
+    repo,
+    issue_number: pullNumber,
+    per_page: 100,
+  });
+  const { data: latestPullRequest } = await github.rest.pulls.get(pullRequestArgs);
+  violations = getContributionPolicyViolations(latestPullRequest);
+
+  if (violations.length === 0) return;
+
+  const body = formatAutomationComment(violations);
+
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existingComment.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pullNumber,
+      body,
+    });
+  }
+
+  await github.rest.pulls.update({
+    owner,
+    repo,
+    pull_number: pullNumber,
+    state: "closed",
+  });
+  core.notice(`Closed pull request #${pullNumber} for contribution policy violations.`);
+}
+
+function hasCheckedConfirmation(body, marker) {
+  const escapedMarker = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `^[ \\t]*-[ \\t]*\\[[xX]\\][ \\t]*<!--[ \\t]*${escapedMarker}[ \\t]*-->`,
+    "m",
+  ).test(body);
+}
+
+async function findAutomationComment(github, args) {
+  let pageCount = 0;
+
+  for await (const { data: comments } of github.paginate.iterator(
+    github.rest.issues.listComments,
+    args,
+  )) {
+    const comment = comments.find(
+      (candidate) =>
+        candidate.user?.login === "github-actions[bot]" &&
+        candidate.body?.includes(AUTOMATION_COMMENT_MARKER),
+    );
+    if (comment) return comment;
+    if (++pageCount >= MAX_COMMENT_PAGES) break;
+  }
+
+  return undefined;
+}
+
+function formatAutomationComment(violations) {
+  const details = violations.map((violation) => `- ${violation}`).join("\n");
+
+  return `${AUTOMATION_COMMENT_MARKER}
+Thank you for taking the time to contribute. This pull request was automatically closed because:
+
+${details}
+
+Please update the pull request to meet these automatic checks, then reopen it. Passing these checks does not guarantee acceptance; maintainers still determine whether a change is obviously correct and trivially verifiable.
+
+If an exception is appropriate, a maintainer can apply the \`${OVERRIDE_LABEL}\` label before reopening the pull request. See the [contribution guidelines](https://github.com/cloudflare/cloudflare-os/blob/main/CONTRIBUTING.md) for details.`;
+}

--- a/scripts/contribution-policy.test.js
+++ b/scripts/contribution-policy.test.js
@@ -21,6 +21,7 @@ function makePullRequest(overrides = {}) {
     deletions: 5,
     draft: false,
     labels: [],
+    state: "open",
     user: { login: "external-contributor" },
     ...overrides,
   };
@@ -118,6 +119,19 @@ describe("getContributionPolicyViolations", () => {
     assert.deepEqual(violations, []);
   });
 
+  for (const [description, pullRequest] of [
+    ["closed", { state: "closed" }],
+    ["merged", { merged: true, state: "closed" }],
+  ]) {
+    it(`exempts ${description} pull requests`, () => {
+      const violations = getContributionPolicyViolations(
+        makePullRequest({ additions: 100, body: "", ...pullRequest }),
+      );
+
+      assert.deepEqual(violations, []);
+    });
+  }
+
   it("exempts Dependabot", () => {
     const violations = getContributionPolicyViolations(
       makePullRequest({
@@ -205,6 +219,22 @@ describe("enforceContributionPolicy", () => {
     const calls = [];
     const github = makeGitHub(
       [makePullRequest({ body: "" }), makePullRequest()],
+      [],
+      calls,
+    );
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("does not comment on a pull request closed during evaluation", async () => {
+    const calls = [];
+    const github = makeGitHub(
+      [
+        makePullRequest({ body: "" }),
+        makePullRequest({ body: "", state: "closed" }),
+      ],
       [],
       calls,
     );

--- a/scripts/contribution-policy.test.js
+++ b/scripts/contribution-policy.test.js
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+import {
+  enforceContributionPolicy,
+  getContributionPolicyViolations,
+} from "./contribution-policy.js";
+
+const pullRequestTemplate = readFileSync(
+  new URL("../.github/pull_request_template.md", import.meta.url),
+  "utf8",
+);
+const compliantBody = pullRequestTemplate.replaceAll("- [ ]", "- [x]");
+
+function makePullRequest(overrides = {}) {
+  return {
+    additions: 10,
+    author_association: "NONE",
+    body: compliantBody,
+    deletions: 5,
+    draft: false,
+    labels: [],
+    user: { login: "external-contributor" },
+    ...overrides,
+  };
+}
+
+describe("getContributionPolicyViolations", () => {
+  it("allows an external pull request that meets the automatic checks", () => {
+    assert.deepEqual(getContributionPolicyViolations(makePullRequest()), []);
+  });
+
+  it("reports every unchecked confirmation", () => {
+    const violations = getContributionPolicyViolations(
+      makePullRequest({ body: "The marker names alone do not count." }),
+    );
+
+    assert.deepEqual(violations, [
+      'The "small, concrete change" confirmation is not checked.',
+      'The "maintainer assessment" confirmation is not checked.',
+      'The "contribution guidelines" confirmation is not checked.',
+    ]);
+  });
+
+  it("recognizes every confirmation in the pull request template", () => {
+    for (const marker of [
+      "contribution-policy:concrete-change",
+      "contribution-policy:maintainer-assessment",
+      "contribution-policy:guidelines",
+    ]) {
+      assert.equal(pullRequestTemplate.split(marker).length - 1, 1);
+    }
+    assert.deepEqual(
+      getContributionPolicyViolations(
+        makePullRequest({ body: pullRequestTemplate }),
+      ),
+      [
+        'The "small, concrete change" confirmation is not checked.',
+        'The "maintainer assessment" confirmation is not checked.',
+        'The "contribution guidelines" confirmation is not checked.',
+      ],
+    );
+    assert.deepEqual(
+      getContributionPolicyViolations(makePullRequest({ body: compliantBody })),
+      [],
+    );
+  });
+
+  it("does not accept a confirmation marker on another line", () => {
+    const body = compliantBody.replace(
+      "- [x] <!-- contribution-policy:concrete-change -->",
+      "- [x]\n<!-- contribution-policy:concrete-change -->",
+    );
+
+    assert.deepEqual(getContributionPolicyViolations(makePullRequest({ body })), [
+      'The "small, concrete change" confirmation is not checked.',
+    ]);
+  });
+
+  it("allows exactly 30 changed lines", () => {
+    const violations = getContributionPolicyViolations(
+      makePullRequest({ additions: 20, deletions: 10 }),
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  it("reports more than 30 changed lines", () => {
+    const violations = getContributionPolicyViolations(
+      makePullRequest({ additions: 20, deletions: 11 }),
+    );
+
+    assert.deepEqual(violations, [
+      "The patch changes 31 lines; the automatic limit is 30.",
+    ]);
+  });
+
+  for (const authorAssociation of ["OWNER", "MEMBER", "COLLABORATOR"]) {
+    it(`exempts ${authorAssociation.toLowerCase()} pull requests`, () => {
+      const violations = getContributionPolicyViolations(
+        makePullRequest({
+          additions: 100,
+          author_association: authorAssociation,
+          body: "",
+        }),
+      );
+
+      assert.deepEqual(violations, []);
+    });
+  }
+
+  it("exempts drafts", () => {
+    const violations = getContributionPolicyViolations(
+      makePullRequest({ additions: 100, body: "", draft: true }),
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  it("exempts Dependabot", () => {
+    const violations = getContributionPolicyViolations(
+      makePullRequest({
+        additions: 100,
+        body: "",
+        user: { login: "dependabot[bot]" },
+      }),
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  it("exempts pull requests with the policy override label", () => {
+    const violations = getContributionPolicyViolations(
+      makePullRequest({
+        additions: 100,
+        body: "",
+        labels: [{ name: "policy/override" }],
+      }),
+    );
+
+    assert.deepEqual(violations, []);
+  });
+});
+
+describe("enforceContributionPolicy", () => {
+  it("comments and closes a pull request with policy violations", async () => {
+    const calls = [];
+    const github = makeGitHub(makePullRequest({ additions: 31 }), [], calls);
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls.map(({ operation }) => operation), [
+      "createComment",
+      "closePullRequest",
+    ]);
+    assert.match(calls[0].body, /patch changes 36 lines/);
+  });
+
+  it("updates its existing comment before closing again", async () => {
+    const calls = [];
+    const comments = [{
+      body: "<!-- contribution-policy-automation -->\nOld explanation",
+      id: 456,
+      user: { login: "github-actions[bot]" },
+    }];
+    const github = makeGitHub(makePullRequest({ body: "" }), comments, calls);
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls.map(({ operation }) => operation), [
+      "updateComment",
+      "closePullRequest",
+    ]);
+    assert.equal(calls[0].comment_id, 456);
+  });
+
+  it("does not trust another author's automation marker", async () => {
+    const calls = [];
+    const comments = [{
+      body: "<!-- contribution-policy-automation -->\nSpoofed explanation",
+      id: 789,
+      user: { login: "external-contributor" },
+    }];
+    const github = makeGitHub(makePullRequest({ body: "" }), comments, calls);
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls.map(({ operation }) => operation), [
+      "createComment",
+      "closePullRequest",
+    ]);
+  });
+
+  it("does nothing when the automatic checks pass", async () => {
+    const calls = [];
+    const github = makeGitHub(makePullRequest(), [], calls);
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("does not close a pull request corrected during evaluation", async () => {
+    const calls = [];
+    const github = makeGitHub(
+      [makePullRequest({ body: "" }), makePullRequest()],
+      [],
+      calls,
+    );
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls, []);
+  });
+});
+
+const context = {
+  issue: { number: 123 },
+  repo: { owner: "cloudflare", repo: "cloudflare-os" },
+};
+
+const core = { notice() {} };
+
+function makeGitHub(pullRequest, comments, calls) {
+  const pullRequests = Array.isArray(pullRequest) ? pullRequest : [pullRequest];
+  let pullRequestIndex = 0;
+  const paginate = async () => comments;
+  paginate.iterator = async function* () {
+    yield { data: comments };
+  };
+
+  return {
+    paginate,
+    rest: {
+      issues: {
+        createComment: async (args) => calls.push({ operation: "createComment", ...args }),
+        listComments() {},
+        updateComment: async (args) => calls.push({ operation: "updateComment", ...args }),
+      },
+      pulls: {
+        get: async () => ({
+          data: pullRequests[Math.min(pullRequestIndex++, pullRequests.length - 1)],
+        }),
+        update: async (args) => calls.push({ operation: "closePullRequest", ...args }),
+      },
+    },
+  };
+}


### PR DESCRIPTION
The contribution policy has both objective requirements and a subjective final judgment. This automates only the objective rejection cases: incomplete author confirmations and patches over 30 changed lines. It deliberately does not decide whether a remaining PR is obviously correct or trivially verifiable; that stays with maintainers.

Because closing fork PRs requires a write-capable workflow, it executes only repository-owned code and never checks out the contributor’s branch.

Depends on #144.