### PR TITLE
Absorb user-DO resets in the Overseer's session capabilities

### DIFF
--- a/packages/workshop-backend/__integration__/open-gadget-rpc.test.ts
+++ b/packages/workshop-backend/__integration__/open-gadget-rpc.test.ts
@@ -1,4 +1,4 @@
-import { abortAllDurableObjects } from "cloudflare:test";
+import { abortAllDurableObjects, runInDurableObject } from "cloudflare:test";
 import { exports } from "cloudflare:workers";
 import { newWebSocketRpcSession, type RpcStub } from "capnweb";
 import {
@@ -14,6 +14,9 @@ import { describe, expect, it } from "vitest";
 type CodedError = Error & { code?: unknown };
 
 const PASSWORD_HASH = new Uint8Array([1, 2, 3]);
+// Also whitelisted in vitest.integration.config.ts onUnhandledError: capabilities held across
+// the injected abort reject on their own schedule.
+const USER_DO_ABORT_REASON = "user-DO reset injected by test";
 const EXPECTED_MESSAGES: Record<OpenGadgetErrorCode, string> = {
   [OPEN_GADGET_ERROR_CODES.workspaceNotFound]: "Workspace not found.",
   [OPEN_GADGET_ERROR_CODES.workspaceAccessDenied]: "You don't have access to this workspace.",
@@ -178,5 +181,42 @@ describe("user-DO reset flags", () => {
     // Permanently broken, not fail-once: the fresh-stub-per-call design rests on this.
     const nativeErr2 = await rejection(userStub.listModels());
     expect(nativeErr2.message).toBe("Application called abortAllDurableObjects().");
+  });
+});
+
+// The asymmetric reset a retained-stub design can't absorb: the USER DO resets while the
+// workspace (Overseer) DO keeps running. The Overseer used to mint its owner/clientUser stubs
+// once at open(); after the user DO's incarnation died, every user-DO-carrying call on the
+// still-open session — newChat, listModels, createGadget, setPinned — failed against the
+// poisoned stub until the WebSocket reconnected. The session capabilities now mint a fresh stub
+// per call, so the first post-reset call simply restarts the object — no reset flags needed,
+// which is also why this is testable despite local aborts rejecting flagless (see above).
+// abortAllDurableObjects() can't produce the asymmetry (it kills the Overseer too), so the
+// reset is injected into the one object via runInDurableObject + state.abort().
+describe("workspace session across a user-DO-only reset", () => {
+  it("chat, models, and gadget capabilities survive the user DO resetting", async () => {
+    using publicApi = await connect();
+    const account = await createAccount(publicApi, "chatreset");
+    using authenticated = await publicApi.authenticate(account.token);
+    using workspace = await authenticated.newGadget();
+
+    // Model id null: commits the message without starting an agent — the pure chat-start path.
+    expect(await workspace.newChat("before the reset", null)).toEqual(expect.any(Number));
+
+    const userStub = exports.UserDurableObject.get(
+      exports.UserDurableObject.idFromName(account.username));
+    // The abort kills the very call delivering it, so the rejection is the success signal.
+    await rejection(runInDurableObject(userStub, (_instance, state) => {
+      state.abort(USER_DO_ABORT_REASON);
+    }));
+
+    // Every operation below crosses into the user DO through the SAME retained workspace
+    // capability. Each minting a fresh stub is what restarts the object and recovers.
+    expect(await workspace.newChat("after the reset", null)).toEqual(expect.any(Number));
+    expect(await workspace.listModels()).toBeInstanceOf(Array);
+    // createGadget resolves the binding name via getChatContext, and hands back a nested
+    // GadgetClient capability that must also be born with the fresh-stub design.
+    using gadget = await workspace.createGadget("post-reset gadget");
+    expect(await gadget.getTitle()).toBe("post-reset gadget");
   });
 });

--- a/packages/workshop-backend/src/do-telemetry.ts
+++ b/packages/workshop-backend/src/do-telemetry.ts
@@ -23,8 +23,10 @@ export function isDoResetError(e: unknown): boolean {
 
 /** Wraps a DO stub so every method call observes DO-reset rejections for telemetry
  * (`user_do.reset.surfaced`, with the method name as the operation) and rethrows them
- * unchanged. Otherwise transparent. */
-export function wrapDoStubForTelemetry<T extends { id: DurableObjectId }>(stub: T): T {
+ * unchanged. Otherwise transparent. Pass the caller's logger so the log attributes the reset
+ * to the component (and context, e.g. gadgetId) that observed it; defaults to the Worker's. */
+export function wrapDoStubForTelemetry<T extends { id: DurableObjectId }>(
+    stub: T, log: ReturnType<typeof createWorkshopLogger> = logger): T {
   return new Proxy(stub, {
     get(target, prop) {
       const value = Reflect.get(target, prop) as unknown;
@@ -42,7 +44,7 @@ export function wrapDoStubForTelemetry<T extends { id: DurableObjectId }>(stub: 
             return await (result as PromiseLike<unknown>);
           } catch (e) {
             if (isDoResetError(e)) {
-              logger.warn("user DO reset observed", {
+              log.warn("user DO reset observed", {
                 event: "user_do.reset.surfaced",
                 operation: prop,
                 durableObjectId: target.id.toString(),

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -38,6 +38,7 @@ import { SharingManager, SharingCaller, CollaboratorRecord, ShareKeyRecord } fro
 import { AutoApprovalDrainer } from "./auto-approval";
 import { collectSlashCommands, invokeSlashCommand } from "./slash-commands";
 import { createWorkshopLogger, obsContext, traced } from "./observability";
+import { wrapDoStubForTelemetry } from "./do-telemetry";
 import type { ChatGatewayRpcTarget, SubmitExternalMessageResult } from "@gadgets/workshop-shared/external-message-gateway";
 import {
   assertChatAttachmentSupportedByProvider,
@@ -6479,11 +6480,11 @@ export class OverseerDurableObject extends DurableObject<Cloudflare.Env> {
     if (role === "use") {
       // "use" collaborators get a restricted capability exposing only the gadget UI.
       return new UseOverseerInterface(
-          this.impl, owner, clientUser, profileId, userId, notifyClosed.dup());
+          this.impl, profileId, userId, notifyClosed.dup());
     }
 
     return new OverseerClientInterface(
-        this.impl, owner, clientUser, profileId, userId, isOwner, notifyClosed.dup(),
+        this.impl, profileId, userId, isOwner, notifyClosed.dup(),
         ensureCapsules);
   }
 
@@ -7120,10 +7121,8 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   #clientProfilePromise: Promise<AiChatAuthorInfo> | undefined;
 
   constructor(private impl: OverseerImpl,
-              private owner: DurableObjectStub<UserDurableObject>,
-              private clientUser: DurableObjectStub<UserDurableObject>,
               private clientProfileId: string,
-              clientUserId: string,
+              private clientUserId: string,
               private isOwner: boolean,
               private notifyClosed: NativeRpcStub<() => void>,
               // Ambient capsule reconciliation started during open(); listSlashCommands() waits for
@@ -7132,7 +7131,21 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     super();
     this.#leavePresence = joinSessionPresence(
         this.impl, this.clientProfileId, "build", () => this.#getClientProfile());
-    this.#leaveOutputsFanout = this.impl.joinOutputsFanout(clientUserId);
+    this.#leaveOutputsFanout = this.impl.joinOutputsFanout(this.clientUserId);
+  }
+
+  // We create a new stub for every call so that we don't have to worry about detecting when a
+  // stub has become broken (see AuthenticatedApiImpl.#user in server.ts).
+  get #owner(): DurableObjectStub<UserDurableObject> {
+    return wrapDoStubForTelemetry(
+        this.impl.users.get(this.impl.users.idFromString(this.impl.ownerId!)),
+        this.impl.logger);
+  }
+
+  get #clientUser(): DurableObjectStub<UserDurableObject> {
+    return wrapDoStubForTelemetry(
+        this.impl.users.get(this.impl.users.idFromString(this.clientUserId)),
+        this.impl.logger);
   }
 
   #leavePresence: () => void;
@@ -7152,7 +7165,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
 
   async #getClientProfile(): Promise<AiChatAuthorInfo> {
     if (!this.#clientProfilePromise) {
-      this.#clientProfilePromise = this.clientUser.whoami().catch((err: unknown) => {
+      this.#clientProfilePromise = this.#clientUser.whoami().catch((err: unknown) => {
         this.#clientProfilePromise = undefined;
         throw err;
       });
@@ -7172,7 +7185,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
       defaultGadgetId: this.impl.defaultGadgetId,
     };
     if (!this.isOwner) {
-      result.owner = await this.owner.whoami();
+      result.owner = await this.#owner.whoami();
     }
     return result;
   }
@@ -7193,7 +7206,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
 
     // For collaborators, include owner info.
     if (!this.isOwner) {
-      metadata.owner = await this.owner.whoami();
+      metadata.owner = await this.#owner.whoami();
     }
 
     let titleSubscriber = {
@@ -7243,11 +7256,11 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
 
   async setTitle(title: string): Promise<void> {
     this.impl.storage.title.put(title);
-    await this.owner.updateTitle(this.impl.ctx.id.toString(), title);
+    await this.#owner.updateTitle(this.impl.ctx.id.toString(), title);
   }
 
   async setPinned(pinned: boolean): Promise<void> {
-    await this.clientUser.updatePinned(this.impl.ctx.id.toString(), pinned);
+    await this.#clientUser.updatePinned(this.impl.ctx.id.toString(), pinned);
   }
 
   async subscribeToWorkpieces(subscriber: RpcStub<WorkpiecesSubscriber>): Promise<RpcStub<{}>> {
@@ -7274,7 +7287,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
       let taken = new Set(
           [...this.impl.storage.gadgets.list()].map(gadget => gadget.bindingName));
       for (let name of chatNames ?? []) taken.add(name);
-      let userMeta = await this.clientUser.getChatContext(null);
+      let userMeta = await this.#clientUser.getChatContext(null);
       if (userMeta.quickModel) {
         bindingName = await this.impl.generateBindingName(
             title, taken, {config: userMeta.quickModel, initiator: userMeta.profile});
@@ -7308,14 +7321,14 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     }
     // @ts-expect-error An RpcTarget implementing the interface works in place of a stub, but the
     //     type system doesn't know this.
-    return new GadgetClientImpl(this.impl, record.id, this.clientUser);
+    return new GadgetClientImpl(this.impl, record.id, this.clientUserId);
   }
 
   async getGadget(id: WorkpieceId): Promise<RpcStub<GadgetClient>> {
     this.impl.getGadgetRecord(id);  // validate it exists
     // @ts-expect-error An RpcTarget implementing the interface works in place of a stub, but the
     //     type system doesn't know this.
-    return new GadgetClientImpl(this.impl, id, this.clientUser);
+    return new GadgetClientImpl(this.impl, id, this.clientUserId);
   }
 
   async deleteSelf(): Promise<void> {
@@ -7326,7 +7339,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
 
     this.impl.recordGadgetAnalytics({
       event_name: "gadget_deleted",
-      user_id: this.clientUser.id.toString(),
+      user_id: this.#clientUser.id.toString(),
     });
 
     this.impl.destroyAllLiveChats();
@@ -7344,7 +7357,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     }
 
     await this.impl.ctx.blockConcurrencyWhile(async () => {
-      await this.owner.deleteGadget(this.impl.ctx.id.toString());
+      await this.#owner.deleteGadget(this.impl.ctx.id.toString());
       await this.impl.ctx.storage.deleteAll();
       this.impl.scheduleRevocationRestart();
       this.impl.ownerId = undefined;
@@ -7453,7 +7466,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     let gatekeeperId = await result.getId();
     this.impl.recordGadgetAnalytics({
       event_name: "connection_created",
-      user_id: this.clientUser.id.toString(),
+      user_id: this.#clientUser.id.toString(),
       gatekeeper_id: gatekeeperId,
       connection_type: connectionType,
       vendor_id: vendorId,
@@ -7463,7 +7476,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   async newGatekeeper(accountId: number, resourceUrl: string)
       : Promise<GatekeeperClient<any> | null> {
     let {class: cls, vendorId, typeUrlPattern} =
-        await this.clientUser.getGatekeeperClassFor(accountId, resourceUrl);
+        await this.#clientUser.getGatekeeperClassFor(accountId, resourceUrl);
     let creationSpec: GatekeeperCreationSpec = {
       type: "gatekeeper",
       vendorId,
@@ -7476,7 +7489,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   }
 
   async newAiModelGatekeeper(modelId: string): Promise<GatekeeperClient<any>> {
-    let chatMeta = await this.clientUser.getChatContext(modelId);
+    let chatMeta = await this.#clientUser.getChatContext(modelId);
     let props: LanguageModelGatekeeperProps = {
       displayName: chatMeta.aiModel!.profile.name,
       config: chatMeta.aiModel!.config,
@@ -7523,7 +7536,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     let props: AgentSpawnerBindingProps = {
       overseerId: this.impl.ctx.id.toString(),
       config,
-      creatorUserId: this.clientUser.id.toString(),
+      creatorUserId: this.#clientUser.id.toString(),
     };
 
     // Resolve model provider/name for blueprint metadata.
@@ -7532,7 +7545,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
       config,
     };
     if (config.modelId) {
-      let chatMeta = await this.clientUser.getChatContext(config.modelId);
+      let chatMeta = await this.#clientUser.getChatContext(config.modelId);
       if (chatMeta.aiModel) {
         creationSpec.modelProvider = chatMeta.aiModel.config.provider;
         creationSpec.modelName = chatMeta.aiModel.config.model;
@@ -7840,7 +7853,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
       }
     }
 
-    let userMeta = await this.clientUser.getChatContext(modelId);
+    let userMeta = await this.#clientUser.getChatContext(modelId);
     if (!userMeta.aiModel) return;  // No model resolved; nothing to resume.
 
     let preparation = this.impl.waitForChatMessagePreparation(chatId);
@@ -7859,7 +7872,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     this.impl.storage.chatMeta.put(fresh);
 
     this.impl.startAgent(chatId, userMeta.aiModel, userMeta.profile,
-                         this.clientUser.id.toString());
+                         this.#clientUser.id.toString());
   }
 
   async acceptConnectionRequest(
@@ -7957,7 +7970,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   }
 
   async listModels(): Promise<AiChatAuthorInfo[]> {
-    return this.clientUser.listModels();
+    return this.#clientUser.listModels();
   }
 
   async listSlashCommands(): Promise<SlashCommandChoice[]> {
@@ -7971,7 +7984,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   ): Promise<ChatAttachmentHandle> {
     let provider: AiModelConfig["provider"] | undefined;
     if (modelId !== null) {
-      provider = (await this.clientUser.getChatContext(modelId)).aiModel?.config.provider;
+      provider = (await this.#clientUser.getChatContext(modelId)).aiModel?.config.provider;
     }
     attachment = validateChatAttachmentUpload(
       attachment,
@@ -8195,8 +8208,8 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   async newChat(initialMessage: string | SlashCommandRequest, chosenModelId: string | null,
                 capsules?: CapsuleSpecifier[], attachments?: ChatAttachmentHandle[],
                 formats?: MessageFormatRef[]): Promise<number> {
-    let userMeta = await this.clientUser.getChatContext(chosenModelId);
-    return this.impl.newChat(this.clientUser, userMeta, initialMessage, capsules, attachments,
+    let userMeta = await this.#clientUser.getChatContext(chosenModelId);
+    return this.impl.newChat(this.#clientUser, userMeta, initialMessage, capsules, attachments,
                              undefined, undefined, formats);
   }
 
@@ -8204,9 +8217,9 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
       chatId: number, message: string | SlashCommandRequest, chosenModelId: string | null,
       capsules?: CapsuleSpecifier[], attachments?: ChatAttachmentHandle[],
       formats?: MessageFormatRef[]): Promise<void> {
-    let userMeta = await this.clientUser.getChatContext(chosenModelId);
+    let userMeta = await this.#clientUser.getChatContext(chosenModelId);
     return this.impl.sendChatMessage(
-        this.clientUser, userMeta, chatId, message, capsules, attachments, undefined, formats);
+        this.#clientUser, userMeta, chatId, message, capsules, attachments, undefined, formats);
   }
 
   async setChatTitle(chatId: number, title: string): Promise<void> {
@@ -8221,7 +8234,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
 
   async mergeChanges(chatId: number, mergeThrough: number | null,
                      options?: { includeDraft?: boolean }): Promise<void> {
-    let userMeta = await this.clientUser.getChatContext(null);
+    let userMeta = await this.#clientUser.getChatContext(null);
 
     let meta = this.impl.assertChatNotActive(chatId);
     if (options?.includeDraft) {
@@ -8320,7 +8333,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     }
     this.impl.recordGadgetAnalytics({
       event_name: "gadget_interaction",
-      user_id: this.clientUser.id.toString(),
+      user_id: this.#clientUser.id.toString(),
       chat_id: chatId,
       interaction_type: "code_merged",
     });
@@ -8487,7 +8500,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   }
 
   async retryAgent(chatId: number, modelId: string): Promise<void> {
-    let userMeta = await this.clientUser.getChatContext(modelId);
+    let userMeta = await this.#clientUser.getChatContext(modelId);
 
     let meta = this.impl.assertChatNotActive(chatId);
     if (!userMeta.aiModel) {
@@ -8502,7 +8515,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     this.impl.storage.chatMeta.put(meta);
 
     this.impl.startAgent(chatId, userMeta.aiModel, userMeta.profile,
-                         this.clientUser.id.toString());
+                         this.#clientUser.id.toString());
   }
 
   async finalizeChatDraft(chatId: number): Promise<void> {
@@ -8740,7 +8753,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
         // Check if the creator is the owner (requires an RPC to the owner's DO).
         let ownerProfileId = await this.impl.getOwnerProfileId();
         if (ownerProfileId === record.createdBy) {
-          createdBy = await this.owner.whoami();
+          createdBy = await this.#owner.whoami();
         }
         // Check if the creator is a collaborator (resolved locally).
         if (!createdBy) {
@@ -8787,15 +8800,26 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
 @validateRpc()
 class UseOverseerInterface extends RpcTarget implements Overseer {
   constructor(private impl: OverseerImpl,
-              private owner: DurableObjectStub<UserDurableObject>,
-              private clientUser: DurableObjectStub<UserDurableObject>,
               private clientProfileId: string,
-              clientUserId: string,
+              private clientUserId: string,
               private notifyClosed: NativeRpcStub<() => void>) {
     super();
     this.#leavePresence = joinSessionPresence(
-        this.impl, this.clientProfileId, "use", () => this.clientUser.whoami());
-    this.#leaveOutputsFanout = this.impl.joinOutputsFanout(clientUserId);
+        this.impl, this.clientProfileId, "use", () => this.#clientUser.whoami());
+    this.#leaveOutputsFanout = this.impl.joinOutputsFanout(this.clientUserId);
+  }
+
+  // Fresh stub per call; see OverseerClientInterface.#clientUser.
+  get #owner(): DurableObjectStub<UserDurableObject> {
+    return wrapDoStubForTelemetry(
+        this.impl.users.get(this.impl.users.idFromString(this.impl.ownerId!)),
+        this.impl.logger);
+  }
+
+  get #clientUser(): DurableObjectStub<UserDurableObject> {
+    return wrapDoStubForTelemetry(
+        this.impl.users.get(this.impl.users.idFromString(this.clientUserId)),
+        this.impl.logger);
   }
 
   #leavePresence: () => void;
@@ -8819,7 +8843,7 @@ class UseOverseerInterface extends RpcTarget implements Overseer {
     return {
       id: this.impl.ctx.id.toString(),
       title: this.impl.storage.title.get(),
-      owner: await this.owner.whoami(),
+      owner: await this.#owner.whoami(),
       role: "use",
       defaultGadgetId: this.impl.defaultGadgetId,
     };
@@ -8833,7 +8857,7 @@ class UseOverseerInterface extends RpcTarget implements Overseer {
     let metadata: GadgetMetadata = {
       id: this.impl.ctx.id.toString(),
       title: this.impl.storage.title.get(),
-      owner: await this.owner.whoami(),
+      owner: await this.#owner.whoami(),
       role: "use",
       defaultGadgetId: this.impl.defaultGadgetId,
     };
@@ -8881,7 +8905,7 @@ class UseOverseerInterface extends RpcTarget implements Overseer {
     }
     // @ts-expect-error An RpcTarget implementing the interface works in place of a stub, but the
     //     type system doesn't know this.
-    return new UseGadgetClientInterface(this.impl, id, this.clientUser);
+    return new UseGadgetClientInterface(this.impl, id, this.clientUserId);
   }
 
   // --- Denied methods (build-only) ---
@@ -9013,8 +9037,15 @@ class UseOverseerInterface extends RpcTarget implements Overseer {
 @validateRpc()
 class GadgetClientImpl extends RpcTarget implements GadgetClient {
   constructor(private impl: OverseerImpl, private id: WorkpieceId,
-      private clientUser: DurableObjectStub<UserDurableObject>) {
+      private clientUserId: string) {
     super();
+  }
+
+  // Fresh stub per call; see OverseerClientInterface.#clientUser.
+  get #clientUser(): DurableObjectStub<UserDurableObject> {
+    return wrapDoStubForTelemetry(
+        this.impl.users.get(this.impl.users.idFromString(this.clientUserId)),
+        this.impl.logger);
   }
 
   async getId(): Promise<WorkpieceId> {
@@ -9065,7 +9096,7 @@ class GadgetClientImpl extends RpcTarget implements GadgetClient {
   async connectToGadget(chatId?: number): Promise<RpcStub<any>> {
     this.impl.recordGadgetAnalytics({
       event_name: "gadget_interaction",
-      user_id: this.clientUser.id.toString(),
+      user_id: this.#clientUser.id.toString(),
       chat_id: chatId,
       interaction_type: "gadget_ui_connected",
     });
@@ -9119,7 +9150,7 @@ class GadgetClientImpl extends RpcTarget implements GadgetClient {
     if (!this.impl.storage.chatMeta.get(chatId)) {
       throw new Error(`No such chat: ${chatId}`);
     }
-    let author = await this.clientUser.whoami();
+    let author = await this.#clientUser.whoami();
     this.impl.bindWorkpiece(this.id, name, target, chatId);
     this.impl.addChatMessages(chatId, author, [{
       type: "changes",
@@ -9252,7 +9283,7 @@ class GadgetClientImpl extends RpcTarget implements GadgetClient {
 
     this.impl.recordGadgetAnalytics({
       event_name: "blueprint_created",
-      user_id: this.clientUser.id.toString(),
+      user_id: this.#clientUser.id.toString(),
       blueprint_id: id,
     });
 
@@ -9278,8 +9309,15 @@ class GadgetClientImpl extends RpcTarget implements GadgetClient {
 @validateRpc()
 class UseGadgetClientInterface extends RpcTarget implements GadgetClient {
   constructor(private impl: OverseerImpl, private id: WorkpieceId,
-      private clientUser: DurableObjectStub<UserDurableObject>) {
+      private clientUserId: string) {
     super();
+  }
+
+  // Fresh stub per call; see OverseerClientInterface.#clientUser.
+  get #clientUser(): DurableObjectStub<UserDurableObject> {
+    return wrapDoStubForTelemetry(
+        this.impl.users.get(this.impl.users.idFromString(this.clientUserId)),
+        this.impl.logger);
   }
 
   #deny(): never {
@@ -9313,7 +9351,7 @@ class UseGadgetClientInterface extends RpcTarget implements GadgetClient {
 
     this.impl.recordGadgetAnalytics({
       event_name: "gadget_interaction",
-      user_id: this.clientUser.id.toString(),
+      user_id: this.#clientUser.id.toString(),
       interaction_type: "gadget_ui_connected",
     });
     return this.impl.getGadgetFacet(this.id, undefined);

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -7137,8 +7137,9 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
   // We create a new stub for every call so that we don't have to worry about detecting when a
   // stub has become broken (see AuthenticatedApiImpl.#user in server.ts).
   get #owner(): DurableObjectStub<UserDurableObject> {
+    if (!this.impl.ownerId) throw new Error("Workspace has been deleted.");
     return wrapDoStubForTelemetry(
-        this.impl.users.get(this.impl.users.idFromString(this.impl.ownerId!)),
+        this.impl.users.get(this.impl.users.idFromString(this.impl.ownerId)),
         this.impl.logger);
   }
 
@@ -8811,8 +8812,9 @@ class UseOverseerInterface extends RpcTarget implements Overseer {
 
   // Fresh stub per call; see OverseerClientInterface.#clientUser.
   get #owner(): DurableObjectStub<UserDurableObject> {
+    if (!this.impl.ownerId) throw new Error("Workspace has been deleted.");
     return wrapDoStubForTelemetry(
-        this.impl.users.get(this.impl.users.idFromString(this.impl.ownerId!)),
+        this.impl.users.get(this.impl.users.idFromString(this.impl.ownerId)),
         this.impl.logger);
   }
 

--- a/packages/workshop-backend/vitest.integration.config.ts
+++ b/packages/workshop-backend/vitest.integration.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
       // held across the abort (e.g. the fire-and-forget AdminSettings install kicked off by the
       // fetch handler) reject on their own schedule, independent of any awaited call.
       if (error.message?.includes("abortAllDurableObjects")) return false;
+      // Same, for the test that aborts only the user DO (state.abort with this reason).
+      if (error.message?.includes("user-DO reset injected by test")) return false;
     },
   },
 });

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -1211,13 +1211,17 @@ export default function GadgetEditor() {
   }, [authenticatedApi])
 
   // ── title save/cancel ─────────────────────────────────────────────────────────
+  const titleSaveInFlight = useRef(false)
   const handleSaveTitle = async () => {
     if (!overseer || !titleInput.trim()) return
+    if (titleSaveInFlight.current) return
+    titleSaveInFlight.current = true
     try {
       await overseer.stub.setTitle(titleInput.trim())
       updateTitle(titleInput.trim())
       setIsEditingTitle(false)
     } catch { toasts.add({ title: 'Failed to update title', variant: 'error' }) }
+    finally { titleSaveInFlight.current = false }
   }
   const handleCancelEdit = () => {
     setTitleInput(metadata?.title || '')


### PR DESCRIPTION
When a user DO resets under an open workspace, the session stays broken until the browser reconnects. Chat sends fail, the model picker and gatekeeper setup wedge until a reload, and pin/title updates stop propagating. The cause is the same one #133 fixed at the Worker layer: the Overseer minted its user-DO stubs once at `open()` and reused them for the whole session, and a stub is permanently broken once its incarnation dies.

### Changes

The session capability classes now store the user ID and create a fresh stub for each call, through the same telemetry wrapper the Worker uses.

### Deliberately out of scope

No retries, matching #133. No call deadline either: a user DO wedged behind a stuck input gate hangs `newChat` silently for an unbounded-but-usually-finite window (i.e. the 30s DO timeout), then rejects (and now recovers). Will add as a followup if we think its necessary