### PR TITLE
Harden MCP connection lifecycle

### DIFF
--- a/packages/mcp-shared/__tests__/account-endpoint.test.ts
+++ b/packages/mcp-shared/__tests__/account-endpoint.test.ts
@@ -190,11 +190,30 @@ describe("connect initiation nonce", () => {
     const repoint = account.beginConnect(nonce, {
       ...server("https://new.example/mcp"), provenance: "deployment",
     });
-    await account.setMcpSessionId(old.endpoint, connection.generation, "old-session");
+    await account.setMcpSessionId(
+      old.endpoint, connection.generation, connection.sessionId, "old-session");
     expect(context.storage.kv.get("mcpSessionId")).toBeUndefined();
 
     account.failProbe();
     await expect(repoint).rejects.toThrow("stop test probe");
+  });
+
+  it("does not let concurrent initialization overwrite the first stored session", async () => {
+    const context = fakeContext();
+    const connected = { ...server("https://mcp.example/mcp"), auth: "none" as const };
+    context.storage.kv.put("server", connected);
+    const account = new InterleavingAccount(context as never, {});
+    const first = await account.getConnection(connected.endpoint);
+    const second = await account.getConnection(connected.endpoint);
+
+    await expect(account.setMcpSessionId(
+      connected.endpoint, first.generation, null, "first-session")).resolves.toBe(true);
+    await expect(account.setMcpSessionId(
+      connected.endpoint, second.generation, null, "first-session")).resolves.toBe(true);
+    await expect(account.setMcpSessionId(
+      connected.endpoint, second.generation, null, "second-session")).resolves.toBe(false);
+
+    expect(context.storage.kv.get("mcpSessionId")).toBe("first-session");
   });
 
   it("does not let an old in-flight refresh restore tokens after repoint", async () => {

--- a/packages/mcp-shared/__tests__/connection.test.ts
+++ b/packages/mcp-shared/__tests__/connection.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+import {
+  callMayHaveTakenEffect,
+  McpCallNotDispatchedError,
+  McpClient,
+} from "../src/client.js";
+import { withClient, type ConnectionAccount } from "../src/connection.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+it("keeps a direct credential rejection classified as not dispatched", async () => {
+  vi.stubGlobal("fetch", async () => new Response(null, { status: 401 }));
+  let expired = 0;
+  const account: ConnectionAccount = {
+    async getConnection() {
+      return { authorization: "token", sessionId: "session", generation: 1 };
+    },
+    async assertConnectionCurrent() {},
+    async setMcpSessionId() { return true; },
+    async noteCredentialsExpired() { expired++; },
+  };
+
+  const error = await withClient({}, account, "https://mcp.example.com",
+    client => client.callTool("send", {}), { retryOnExpiry: false }).catch(err => err);
+
+  expect(error).toBeInstanceOf(McpCallNotDispatchedError);
+  expect(callMayHaveTakenEffect(error)).toBe(false);
+  expect(expired).toBe(1);
+});
+
+it("keeps credential rejection classified when expiry notification fails", async () => {
+  vi.stubGlobal("fetch", async () => new Response(null, { status: 401 }));
+  const account: ConnectionAccount = {
+    async getConnection() {
+      return { authorization: "token", sessionId: "session", generation: 1 };
+    },
+    async assertConnectionCurrent() {},
+    async setMcpSessionId() { return true; },
+    async noteCredentialsExpired() { throw new Error("callback unavailable"); },
+  };
+
+  const error = await withClient({}, account, "https://mcp.example.com",
+    client => client.callTool("send", {}), { retryOnExpiry: false }).catch(err => err);
+
+  expect(error).toBeInstanceOf(McpCallNotDispatchedError);
+  expect(callMayHaveTakenEffect(error)).toBe(false);
+});
+
+it("classifies credential lookup failure as not dispatched", async () => {
+  const account: ConnectionAccount = {
+    async getConnection() { throw new Error("credential store unavailable"); },
+    async assertConnectionCurrent() {},
+    async setMcpSessionId() { return true; },
+    async noteCredentialsExpired() {},
+  };
+
+  const error = await withClient({}, account, "https://mcp.example.com",
+    client => client.callTool("send", {}), { retryOnExpiry: false }).catch(err => err);
+
+  expect(error).toBeInstanceOf(McpCallNotDispatchedError);
+  expect(callMayHaveTakenEffect(error)).toBe(false);
+});
+
+it("classifies initialization failure as not dispatched", async () => {
+  vi.stubGlobal("fetch", async () => new Response(null, { status: 500 }));
+  const account: ConnectionAccount = {
+    async getConnection() {
+      return { authorization: "token", sessionId: null, generation: 1 };
+    },
+    async assertConnectionCurrent() {},
+    async setMcpSessionId() { return true; },
+    async noteCredentialsExpired() {},
+  };
+
+  const error = await withClient({}, account, "https://mcp.example.com",
+    client => client.callTool("send", {}), { retryOnExpiry: false }).catch(err => err);
+
+  expect(error).toBeInstanceOf(McpCallNotDispatchedError);
+  expect(callMayHaveTakenEffect(error)).toBe(false);
+});
+
+it("classifies an expired pre-fetch deadline as not dispatched", async () => {
+  const client = new McpClient(
+    "https://mcp.example.com", async () => "token", null, { deadline: 0 });
+
+  const error = await client.callTool("send", {}).catch(err => err);
+
+  expect(error).toBeInstanceOf(McpCallNotDispatchedError);
+  expect(callMayHaveTakenEffect(error)).toBe(false);
+});
+
+it("rechecks account generation immediately before the tool request", async () => {
+  let current = true;
+  let requests = 0;
+  vi.stubGlobal("fetch", async () => {
+    requests++;
+    return new Response("{}");
+  });
+  const account: ConnectionAccount = {
+    async getConnection() {
+      return { authorization: "token", sessionId: "session", generation: 1 };
+    },
+    async assertConnectionCurrent() {
+      if (!current) throw new Error("connection replaced");
+    },
+    async setMcpSessionId() { return true; },
+    async noteCredentialsExpired() {},
+  };
+
+  const error = await withClient({}, account, "https://mcp.example.com", async client => {
+    current = false;
+    return client.callTool("send", {});
+  }, { retryOnExpiry: false }).catch(err => err);
+
+  expect(error).toBeInstanceOf(McpCallNotDispatchedError);
+  expect(requests).toBe(0);
+});
+
+it("persists a successful initialization before running the requested operation", async () => {
+  const writes: Array<string | null> = [];
+  vi.stubGlobal("fetch", async (_input: unknown, init?: RequestInit) => {
+    const request = JSON.parse(String(init?.body));
+    if (request.method === "initialize") {
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: request.id, result: {} }), {
+        headers: { "Content-Type": "application/json", "Mcp-Session-Id": "new-session" },
+      });
+    }
+    return new Response(null, { status: 202 });
+  });
+  const account: ConnectionAccount = {
+    async getConnection() {
+      return { authorization: "token", sessionId: null, generation: 1 };
+    },
+    async assertConnectionCurrent() {},
+    async setMcpSessionId(_endpoint, _generation, _previous, sessionId) {
+      writes.push(sessionId);
+      return true;
+    },
+    async noteCredentialsExpired() {},
+  };
+
+  await expect(withClient({}, account, "https://mcp.example.com", async () => {
+    throw new Error("operation failed");
+  })).rejects.toThrow(/operation failed/);
+
+  expect(writes).toEqual(["new-session"]);
+});
+
+it("does not persist a transport session changed after the requested operation", async () => {
+  const account: ConnectionAccount = {
+    async getConnection() {
+      return { authorization: "token", sessionId: "old-session", generation: 1 };
+    },
+    async assertConnectionCurrent() {},
+    async setMcpSessionId() { throw new Error("unexpected persistence"); },
+    async noteCredentialsExpired() {},
+  };
+
+  await expect(withClient({}, account, "https://mcp.example.com", async client => {
+    client.sessionId = "rotated-session";
+    return "completed";
+  }, { retryOnExpiry: false })).resolves.toBe("completed");
+});
+
+it("reports credentials expired when session recovery is rejected", async () => {
+  let requests = 0;
+  let expired = 0;
+  vi.stubGlobal("fetch", async () => {
+    requests++;
+    return new Response(null, { status: requests === 1 ? 404 : 401 });
+  });
+  const account: ConnectionAccount = {
+    async getConnection() {
+      return { authorization: "token", sessionId: "expired-session", generation: 1 };
+    },
+    async assertConnectionCurrent() {},
+    async setMcpSessionId() { return true; },
+    async noteCredentialsExpired() { expired++; },
+  };
+
+  const error = await withClient({}, account, "https://mcp.example.com",
+    client => client.listTools(1)).catch(err => err);
+
+  expect(error).toBeInstanceOf(McpCallNotDispatchedError);
+  expect(expired).toBe(1);
+});

--- a/packages/mcp-shared/__tests__/fetch.test.ts
+++ b/packages/mcp-shared/__tests__/fetch.test.ts
@@ -28,12 +28,40 @@ function stubChain(chain: Record<string, string>, status = 307): Hop[] {
   return hops;
 }
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe("guardedFetch", () => {
+  it("does not impose a deadline unless the caller requests one", async () => {
+    let signal: AbortSignal | null | undefined;
+    vi.stubGlobal("fetch", async (_input: string, init: RequestInit) => {
+      signal = init.signal;
+      return new Response("ok");
+    });
+
+    await guardedFetch("https://mcp.example.com/mcp", {});
+    expect(signal).toBeUndefined();
+  });
+
   it("refuses a blocked host outright", async () => {
     stubChain({});
     await expect(guardedFetch("http://169.254.169.254/", {})).rejects.toThrow(/Refusing to contact/);
+  });
+
+  it("aborts an outbound operation after its configured timeout", async () => {
+    vi.stubGlobal("fetch", (_input: string, init: RequestInit) =>
+      new Promise<Response>((resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        setTimeout(() => resolve(new Response("late")), 50);
+      }));
+
+    await expect(guardedFetch(
+      "https://mcp.example.com/mcp",
+      {},
+      { timeoutMs: 5 },
+    )).rejects.toThrow(/timed out|timeout/i);
   });
 
   it("does not follow a redirect into a blocked host", async () => {
@@ -155,6 +183,23 @@ describe("isAllowedUrl", () => {
 });
 
 describe("sdkFetch", () => {
+  it("shares one deadline across an OAuth SDK operation", async () => {
+    let now = 0;
+    let calls = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.stubGlobal("fetch", async () => {
+      calls++;
+      now += 20;
+      return new Response("{}");
+    });
+    const fetchFn = sdkFetch({ timeoutMs: 30 });
+
+    await fetchFn("https://auth.example.com/one");
+    await fetchFn("https://auth.example.com/two");
+    await expect(fetchFn("https://auth.example.com/three")).rejects.toThrow(/timed out/i);
+    expect(calls).toBe(2);
+  });
+
   it("refuses an OAuth response larger than the shared response limit", async () => {
     vi.stubGlobal("fetch", async () => new Response("x".repeat(2 * 1024 * 1024)));
     await expect(sdkFetch()("https://auth.example.com/metadata"))

--- a/packages/mcp-shared/__tests__/schema-to-ts.test.ts
+++ b/packages/mcp-shared/__tests__/schema-to-ts.test.ts
@@ -304,6 +304,9 @@ describe("generateSessionTypes", { timeout: 15_000 }, () => {
     ]);
     expect(output).toContain("recorded as an observation");
     expect(output).toContain("queued for approval");
+    expect(output).toContain("return from that executeCode call");
+    expect(output).toContain("Approval resumes the agent;");
+    expect(output).toContain("denial ends the turn");
     expect(output).toContain("supplied by the user, so no action is ever applied automatically");
   });
 

--- a/packages/mcp-shared/__tests__/session.test.ts
+++ b/packages/mcp-shared/__tests__/session.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 
 import { McpSessionBase, type McpSessionHost, type StoredAction } from "../src/session.js";
+import { classifyTool } from "../src/tools.js";
 
 it("reports an execution failure distinctly from a rejected approval", async () => {
   const failed: StoredAction = {
@@ -24,4 +25,32 @@ it("reports an execution failure distinctly from a rejected approval", async () 
     status: "failed",
     message: "The outcome is unknown.",
   });
+});
+
+it("tells an agent to return a pending action so its approval can appear in chat", async () => {
+  const entry = classifyTool({ name: "jira_create_issue" }, "byo");
+  const staged: StoredAction = {
+    id: 7,
+    toolName: entry.tool.name,
+    args: {},
+    state: "pending",
+    submittedAt: 0,
+  };
+  const host = {
+    serverName: "Jira",
+    endpoint: "https://mcp.example.com",
+    scope: { serverId: "jira" },
+    tools: async () => [entry],
+    stageAction: () => staged,
+    discardStagedAction() {},
+    actionKindFor: () => ({ tag: "jira:create", label: "Create issue" }),
+  } as unknown as McpSessionHost;
+  const session = new McpSessionBase(host, { submitAction() {} } as never);
+
+  const result = await session.callTool(entry.tool.name);
+
+  expect(result).toMatchObject({ status: "pending", actionId: staged.id });
+  if (result.status !== "pending") throw new Error("Expected a pending action.");
+  expect(result.message).toContain("return from this executeCode call");
+  expect(result.message).not.toMatch(/poll/i);
 });

--- a/packages/mcp-shared/src/account.ts
+++ b/packages/mcp-shared/src/account.ts
@@ -309,7 +309,8 @@ export abstract class McpAccountBase<E extends AccountEnv, P = unknown>
     // the new portal's token.
     const generation = this.advanceConnectionGeneration();
     if (existing) this.ctx.storage.kv.delete("mcpSessionId");
-    if (existing && existing.endpoint !== server.endpoint) {
+    const endpointChanged = existing !== undefined && existing.endpoint !== server.endpoint;
+    if (endpointChanged) {
       this.ctx.storage.kv.put("server", server);
       for (const key of [
         "tokens", "oauthClient", "oauthDiscovery", "oauthVerifier", "pendingAuth",
@@ -575,11 +576,11 @@ export abstract class McpAccountBase<E extends AccountEnv, P = unknown>
     }
     const pending = this.ctx.storage.kv.get<PendingAuthorization>("pendingAuth");
     if (!pending) return false;
+    const server = this.requireServer();
     // Single-use: consumed before the exchange, so a replayed callback cannot reach the token endpoint.
     this.ctx.storage.kv.delete("nonce");
     this.ctx.storage.kv.delete("pendingAuth");
 
-    const server = this.requireServer();
     if (!this.isCurrentConnection(server, pending.generation)) return false;
     let result: Awaited<ReturnType<typeof auth>>;
     try {
@@ -677,6 +678,15 @@ export abstract class McpAccountBase<E extends AccountEnv, P = unknown>
       sessionId: this.ctx.storage.kv.get<string>("mcpSessionId") ?? null,
       generation,
     };
+  }
+
+  /** Fails if credentials captured for `generation` are no longer current for this endpoint. */
+  async assertConnectionCurrent(endpoint: string, generation: number): Promise<void> {
+    const server = this.server();
+    if (!server || !sameEndpoint(endpoint, server.endpoint)
+        || generation !== this.connectionGeneration()) {
+      throw new Error("This MCP connection changed before the request was sent. Try again.");
+    }
   }
 
   // Returns the bearer token for one captured connection generation, refreshing it when close to
@@ -801,17 +811,25 @@ export abstract class McpAccountBase<E extends AccountEnv, P = unknown>
   }
 
   /**
-   * Records the transport session id, so repeat calls skip the `initialize` handshake. An MCP call
-   * can finish after reconnecting; endpoint plus generation keep its old session out of new state.
+   * Records the transport session id, so repeat calls skip the `initialize` handshake.
+   *
+   * An MCP call can finish after reconnecting or after another call replaced its session; endpoint,
+   * generation, and the previously read id keep either stale operation out of current state.
    */
   async setMcpSessionId(
-    endpoint: string, generation: number, sessionId: string | null,
-  ): Promise<void> {
+    endpoint: string,
+    generation: number,
+    previousSessionId: string | null,
+    sessionId: string | null,
+  ): Promise<boolean> {
     const server = this.server();
     if (!server || !sameEndpoint(endpoint, server.endpoint)
-        || generation !== this.connectionGeneration()) return;
+        || generation !== this.connectionGeneration()) return false;
+    const currentSessionId = this.ctx.storage.kv.get<string>("mcpSessionId") ?? null;
+    if (currentSessionId !== previousSessionId) return currentSessionId === sessionId;
     if (sessionId) this.ctx.storage.kv.put("mcpSessionId", sessionId);
     else this.ctx.storage.kv.delete("mcpSessionId");
+    return true;
   }
 
   /**

--- a/packages/mcp-shared/src/client.ts
+++ b/packages/mcp-shared/src/client.ts
@@ -14,6 +14,7 @@
 // 401/403/404 classification below are the SSRF and response-size boundary for this connector.
 
 import {
+  FetchNotStartedError,
   guardedFetch,
   MAX_RESPONSE_BYTES,
   readTextCapped,
@@ -129,6 +130,14 @@ export class McpSessionExpiredError extends Error {
   }
 }
 
+/** A connector-side failure that happened before the requested MCP tool was dispatched. */
+export class McpCallNotDispatchedError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "McpCallNotDispatchedError";
+  }
+}
+
 /**
  * What a failed call is known to have done to the server.
  *
@@ -164,6 +173,7 @@ export class McpProtocolError extends Error {
  * the other way is a duplicated write that MCP offers no way to undo.
  */
 export function callMayHaveTakenEffect(err: unknown): boolean {
+  if (err instanceof McpCallNotDispatchedError) return false;
   // The server demanded authorization, so it never reached the tool.
   if (err instanceof McpAuthRequiredError) return false;
   // A genuine MCP session-expiry response means the server rejected the request before dispatch,
@@ -294,8 +304,8 @@ function clampTool(tool: McpWireTool): McpTool {
   };
 }
 
-/** Bearer token supplier; returns null for servers that need no authorization. */
-export type AuthorizationProvider = () => Promise<string | null>;
+/** Supplies a bearer token for an MCP method, or null for a public server. */
+export type AuthorizationProvider = (method: string) => Promise<string | null>;
 
 /**
  * A stateless-per-instance MCP client. Construct one per operation; the only state worth keeping
@@ -326,13 +336,13 @@ export class McpClient {
   // `#quoteServerText`.
   #lastCredential: string | null = null;
 
-  async #headers(): Promise<Headers> {
+  async #headers(method: string): Promise<Headers> {
     const headers = new Headers({
       "Content-Type": "application/json",
       "Accept": "application/json, text/event-stream",
       "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
     });
-    const authorization = await this.#getAuthorization();
+    const authorization = await this.#getAuthorization(method);
     this.#lastCredential = authorization;
     if (authorization) headers.set("Authorization", `Bearer ${authorization}`);
     if (this.sessionId) headers.set("Mcp-Session-Id", this.sessionId);
@@ -340,26 +350,49 @@ export class McpClient {
   }
 
   async #post(body: unknown): Promise<Response> {
-    const response = await guardedFetch(this.#endpoint, {
-      method: "POST",
-      headers: await this.#headers(),
-      body: JSON.stringify(body),
-    }, this.#fetchOptions);
+    let headers: Headers;
+    try {
+      const method = typeof body === "object" && body !== null && "method" in body
+        ? String((body as { method: unknown }).method)
+        : "unknown";
+      headers = await this.#headers(method);
+    } catch (err) {
+      throw new McpCallNotDispatchedError(
+        err instanceof Error ? err.message : String(err), err);
+    }
+    let response: Response;
+    try {
+      response = await guardedFetch(this.#endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      }, this.#fetchOptions);
+    } catch (err) {
+      if (err instanceof FetchNotStartedError) {
+        throw new McpCallNotDispatchedError(err.message, err);
+      }
+      throw err;
+    }
 
     // Only 401 means the credentials are the problem. A 403 is an authenticated caller refused this
     // particular tool; treating it as an auth failure would mark the account expired and prompt a
     // reconnect that cannot help.
     if (response.status === 401) {
+      await response.body?.cancel().catch(() => undefined);
       throw new McpAuthRequiredError(
         "The MCP server requires authorization.",
         parseResourceMetadataUrl(response.headers.get("WWW-Authenticate")));
     }
     if (response.status === 403) {
+      await response.body?.cancel().catch(() => undefined);
       throw new McpProtocolError(
         "The MCP server refused this request. The connected account may not have access to it.",
         undefined, "declined");
     }
-    if (response.status === 404 && this.sessionId) throw new McpSessionExpiredError();
+    if (response.status === 404 && this.sessionId) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new McpSessionExpiredError();
+    }
     return response;
   }
 
@@ -368,6 +401,7 @@ export class McpClient {
     const response = await this.#post({ jsonrpc: "2.0", id, method, params });
 
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       throw new McpProtocolError(
         `MCP server returned HTTP ${response.status} for "${method}".`);
     }
@@ -432,6 +466,17 @@ export class McpClient {
     });
     await this.#notify("notifications/initialized");
     return info;
+  }
+
+  /** Best-effort termination for a transport session this client no longer owns. */
+  async closeSession(): Promise<void> {
+    if (!this.sessionId) return;
+    const response = await guardedFetch(this.#endpoint, {
+      method: "DELETE",
+      headers: await this.#headers("DELETE"),
+    }, this.#fetchOptions);
+    await response.body?.cancel();
+    this.sessionId = null;
   }
 
   /**

--- a/packages/mcp-shared/src/connection.ts
+++ b/packages/mcp-shared/src/connection.ts
@@ -7,7 +7,13 @@
 // landed. A write is left to fail as outcome-unknown; its approved action is closed, and a person
 // must deliberately stage a new one after checking whether the first took effect.
 
-import { McpAuthRequiredError, McpClient, McpSessionExpiredError, type ToolCatalog }
+import {
+  McpAuthRequiredError,
+  McpCallNotDispatchedError,
+  McpClient,
+  McpSessionExpiredError,
+  type ToolCatalog,
+}
   from "./client.js";
 import { fetchOptions, type InsecureEnv } from "./fetch.js";
 import { MAX_TOOLS_PER_SERVER } from "./tools.js";
@@ -51,13 +57,27 @@ export type ConnectionAccount = {
    * send the new server's bearer token to the old server.
    */
   getConnection(endpoint: string): Promise<McpConnection>;
-  setMcpSessionId(endpoint: string, generation: number, sessionId: string | null): Promise<void>;
+  assertConnectionCurrent(endpoint: string, generation: number): Promise<void>;
+  setMcpSessionId(
+    endpoint: string,
+    generation: number,
+    previousSessionId: string | null,
+    sessionId: string | null,
+  ): Promise<boolean>;
   noteCredentialsExpired(endpoint: string, generation: number): Promise<void>;
 };
 
 /** The name this deployment gives when introducing itself to an MCP server. */
 export function clientName(env: ConnectionEnv): string {
   return env.MCP_CLIENT_NAME ?? "Gadgets";
+}
+
+function notDispatched(err: unknown): McpCallNotDispatchedError {
+  if (err instanceof McpCallNotDispatchedError) return err;
+  return new McpCallNotDispatchedError(
+    err instanceof Error ? err.message : String(err),
+    err,
+  );
 }
 
 /** Runs `fn` against an initialized client for `endpoint`, using the account's credentials. */
@@ -70,39 +90,92 @@ export async function withClient<T>(
 ): Promise<T> {
   // Read once for the whole operation. The account refreshes a token a minute before expiry, so one
   // valid here stays valid for the handful of requests a single `withClient` makes.
-  const { authorization, sessionId, generation } = await account.getConnection(endpoint);
+  let connection: McpConnection;
+  try {
+    connection = await account.getConnection(endpoint);
+  } catch (err) {
+    throw notDispatched(err);
+  }
+  const { authorization, sessionId, generation } = connection;
   const client = new McpClient(
-    endpoint, async () => authorization, sessionId, fetchOptions(env));
+    endpoint, async method => {
+      if (method === "tools/call") {
+        await account.assertConnectionCurrent(endpoint, generation);
+      }
+      return authorization;
+    }, sessionId, fetchOptions(env));
+  let persistedSessionId = sessionId;
 
-  const run = async (): Promise<T> => {
-    const result = await fn(client);
-    if (client.sessionId !== sessionId) {
-      await account.setMcpSessionId(endpoint, generation, client.sessionId);
+  const persistSession = async (): Promise<void> => {
+    if (client.sessionId === persistedSessionId) return;
+    const accepted = await account.setMcpSessionId(
+      endpoint, generation, persistedSessionId, client.sessionId);
+    if (!accepted) {
+      await client.closeSession().catch(() => undefined);
+      throw new McpCallNotDispatchedError(
+        "Another request replaced this MCP transport session. Try again.");
     }
-    return result;
+    persistedSessionId = client.sessionId;
+  };
+
+  const initialize = async (): Promise<void> => {
+    await client.initialize(clientName(env));
+    await persistSession();
+  };
+
+  const rejectCredentials = async (err: McpAuthRequiredError): Promise<never> => {
+    const rejected = new Error(
+      "The MCP server rejected this connection's credentials. Please reconnect the account.",
+      { cause: err });
+    let cause: unknown = rejected;
+    try {
+      await account.noteCredentialsExpired(endpoint, generation);
+    } catch (notificationError) {
+      cause = new AggregateError(
+        [rejected, notificationError],
+        "The credentials were rejected and their expiry notification failed.",
+      );
+    }
+    throw new McpCallNotDispatchedError(rejected.message, cause);
   };
 
   try {
-    if (!sessionId) await client.initialize(clientName(env));
-    return await run();
-  } catch (err) {
-    if (err instanceof McpSessionExpiredError) {
+    if (!sessionId) {
+      try {
+        await initialize();
+      } catch (err) {
+        // Let the outer handler record credential rejection. Every other initialization failure is
+        // known to precede the requested tool call.
+        if (err instanceof McpAuthRequiredError) throw err;
+        throw notDispatched(err);
+      }
+    }
+    try {
+      return await fn(client);
+    } catch (err) {
+      if (!(err instanceof McpSessionExpiredError)) throw err;
       if (options.retryOnExpiry !== false) {
         client.sessionId = null;
-        await client.initialize(clientName(env));
-        return await run();
+        try {
+          await initialize();
+        } catch (initializeError) {
+          if (initializeError instanceof McpAuthRequiredError) throw initializeError;
+          throw notDispatched(initializeError);
+        }
+        return await fn(client);
       }
       // This call is not retried, since it may already have taken effect. The session is gone all
       // the same, so the cached id is dead: left in place it would fail every later call for a
       // reason already known, including the retry the Workshop offers the user. Clearing it makes
       // the next call re-initialize.
-      if (sessionId) await account.setMcpSessionId(endpoint, generation, null);
+      if (persistedSessionId) {
+        await account.setMcpSessionId(endpoint, generation, persistedSessionId, null);
+      }
+      throw err;
     }
+  } catch (err) {
     if (err instanceof McpAuthRequiredError) {
-      await account.noteCredentialsExpired(endpoint, generation);
-      throw new Error(
-        "The MCP server rejected this connection's credentials. Please reconnect the account.",
-        { cause: err });
+      return rejectCredentials(err);
     }
     throw err;
   }

--- a/packages/mcp-shared/src/fetch.ts
+++ b/packages/mcp-shared/src/fetch.ts
@@ -12,17 +12,34 @@ import type { FetchLike } from "@modelcontextprotocol/client";
 // Enough for the http->https and apex->www hops real deployments use. Discovery already tries
 // several candidate URLs, so a longer chain is more likely a loop than a working server.
 const MAX_REDIRECTS = 3;
+/** Default wall-clock budget for one outbound operation, including redirects and body streaming. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
-/** Set by local development against an MCP server on localhost, which is otherwise refused. */
-export type FetchOptions = { allowInsecure?: boolean };
+/** Policy and deadline options applied to one outbound operation. */
+export type FetchOptions = {
+  /** Permits plain HTTP and private hosts for local development. */
+  allowInsecure?: boolean;
+  /** Bounds the complete operation, including redirects and response-body streaming. */
+  timeoutMs?: number;
+  /** Absolute deadline shared by every request in a multi-page or retried operation. */
+  deadline?: number;
+};
 
 /** The one environment variable this package reads. Each Worker's own `Env` satisfies it structurally. */
 export type InsecureEnv = {
   /** When `"true"`, permits plain HTTP and private hosts. Local development only. */
   MCP_ALLOW_INSECURE?: string;
 };
+
+/** Outbound failure known to have happened before the platform `fetch()` call began. */
+export class FetchNotStartedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FetchNotStartedError";
+  }
+}
 
 /**
  * Reads the local-development escape hatch. One definition, since this switch turns off the SSRF
@@ -84,8 +101,13 @@ export async function readTextCapped(
 
 /** Gives SDK OAuth helpers the same redirect and response-size policy as the local MCP transport. */
 export function sdkFetch(options: FetchOptions = {}): FetchLike {
+  const operationOptions: FetchOptions = {
+    ...options,
+    deadline: options.deadline
+      ?? Date.now() + (options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS),
+  };
   return async (url, init) => {
-    const response = await guardedFetch(String(url), init ?? {}, options);
+    const response = await guardedFetch(String(url), init ?? {}, operationOptions);
     const body = await readTextCapped(response);
     return new Response(body || null, {
       status: response.status,
@@ -121,7 +143,7 @@ export async function guardedFetch(
   url: string, init: RequestInit, options: FetchOptions = {},
 ): Promise<Response> {
   if (!isAllowedUrl(url, options)) {
-    throw new Error(`Refusing to contact ${hostForMessage(url)}.`);
+    throw new FetchNotStartedError(`Refusing to contact ${hostForMessage(url)}.`);
   }
 
   let current = url;
@@ -129,9 +151,20 @@ export async function guardedFetch(
   let method = init.method ?? "GET";
   let body = init.body;
   const origin = new URL(url).origin;
+  let signal = init.signal ?? undefined;
+  if (options.deadline !== undefined || options.timeoutMs !== undefined) {
+    const remaining = options.deadline === undefined
+      ? options.timeoutMs!
+      : Math.max(0, options.deadline - Date.now());
+    if (remaining === 0) throw new FetchNotStartedError("The outbound operation timed out.");
+    const timeout = AbortSignal.timeout(remaining);
+    signal = signal ? AbortSignal.any([signal, timeout]) : timeout;
+  }
 
   for (let hop = 0; ; hop++) {
-    const response = await fetch(current, { ...init, method, body, headers, redirect: "manual" });
+    const response = await fetch(current, {
+      ...init, method, body, headers, redirect: "manual", signal,
+    });
     if (!REDIRECT_STATUSES.has(response.status)) return response;
 
     const location = response.headers.get("Location");
@@ -171,6 +204,7 @@ export async function guardedFetch(
       headers.delete("Content-Type");
       headers.delete("Content-Length");
     }
+    await response.body?.cancel().catch(() => undefined);
     current = next;
   }
 }

--- a/packages/mcp-shared/src/schema-to-ts.ts
+++ b/packages/mcp-shared/src/schema-to-ts.ts
@@ -343,6 +343,9 @@ export function generateSessionTypes(args: {
   lines.push(" * as observations. The remaining " + actionTools.length + " tool(s) are treated as actions:");
   lines.push(" * `callTool` queues them for approval and returns `{ status: \"pending\" }`; the result");
   lines.push(" * becomes available through `getActionResult` once a human approves.");
+  lines.push(" * When using this session from `executeCode`, return from that executeCode call as soon as");
+  lines.push(" * an action is pending so its approval can appear in chat. Approval resumes the agent;");
+  lines.push(" * denial ends the turn. Call `getActionResult` after approval.");
   if (args.trust === "byo") {
     lines.push(" *");
     lines.push(" * This server was supplied by the user, so no action is ever applied automatically.");

--- a/packages/mcp-shared/src/session.ts
+++ b/packages/mcp-shared/src/session.ts
@@ -156,8 +156,9 @@ export class McpSessionBase extends RpcTarget {
       status: "pending",
       actionId: staged.id,
       message:
-        `Calling "${name}" on ${host.serverName} needs approval. Poll getActionResult(` +
-        `${staged.id}) for the outcome.`,
+        `Calling "${name}" on ${host.serverName} needs approval. If this is running in an ` +
+        `agent's executeCode call, return from this executeCode call now so the approval can ` +
+        `appear in chat. After approval, call getActionResult(${staged.id}) for the outcome.`,
     };
   }
 


### PR DESCRIPTION
Every MCP request uses one snapshot of the endpoint, credentials, transport session, and connection generation. A reconnect cannot write stale state back into the account, initialization is persisted before the requested operation runs, reads may recover once from an expired session, and writes are never retried after they may have executed.

Pending actions also return control to the agent loop immediately, allowing the approval card to appear in chat. Approval resumes the agent; denial ends the turn.