### PR TITLE
Frontend reconnect hardening: tab wake & reconnect probe

### DIFF
--- a/packages/workshop-backend/src/server.ts
+++ b/packages/workshop-backend/src/server.ts
@@ -643,6 +643,8 @@ class PublicApiImpl extends RpcTarget implements PublicApi {
     this.users = this.ctx.exports.UserDurableObject;
   }
 
+  async ping(): Promise<void> {}
+
   async getServerConfig(): Promise<ServerConfig> {
     return getServerConfig(this.env);
   }

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from '@phosphor-icons/react'
 import { RpcStub, RpcTarget } from 'capnweb'
 import { useAuthenticatedApi } from './AuthContext'
+import { useConnectionLost } from './RpcContext'
 import UserMenu from './components/UserMenu'
 import SiteLogo from './components/SiteLogo'
 
@@ -449,6 +450,7 @@ export default function GadgetEditor() {
   isEditingTitleRef.current = isEditingTitle
   const [titleInput, setTitleInput] = useState('')
 
+  const rpcConnectionLost = useConnectionLost()
   const {
     overseer,
     metadata,
@@ -472,6 +474,10 @@ export default function GadgetEditor() {
     },
   })
   const [userInfo, setUserInfo] = useState<AiChatAuthorInfo | null>(null)
+
+  // The workspace-level flag covers reopen failures; the socket-level flag covers the outage
+  // window itself, during which the dead stub stays published and no reopen is attempted yet.
+  const showReconnecting = connectionLost || rpcConnectionLost
 
   // ── role gating ────────────────────────────────────────────────────────────────
   // "use"-role collaborators receive a restricted overseer that only permits rendering and
@@ -1434,7 +1440,7 @@ export default function GadgetEditor() {
             onViewActivity={openActivity}
           />
 
-          {connectionLost && <ReconnectingChip />}
+          {showReconnecting && <ReconnectingChip />}
 
           <WorkshopIconButton
             onClick={() => setShareModalOpen(true)}
@@ -1466,7 +1472,7 @@ export default function GadgetEditor() {
 
         </div>
         <div className="ml-1 flex shrink-0 items-center gap-2">
-          <span className="md:hidden">{connectionLost && <ReconnectingChip />}</span>
+          <span className="md:hidden">{showReconnecting && <ReconnectingChip />}</span>
           {/* Desktop reaches Export from the gadget pane's tab bar, which is hidden on phones. */}
           <span className="md:hidden">
             <GadgetExportMenu

--- a/packages/workshop-frontend/src/main.tsx
+++ b/packages/workshop-frontend/src/main.tsx
@@ -59,15 +59,20 @@ let lastConnectTime: number = 0;
 
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 10000;
-// The probe is getServerConfig — the same call the app needs to boot anyway. A generous
-// deadline lets a slow-but-alive backend settle instead of connect/dispose looping.
+// The probe is getServerConfig — the same call the app needs to boot anyway. Generous deadlines
+// let a slow-but-alive backend settle instead of connect/dispose looping (or, on wake, tearing
+// down a healthy socket under load).
 const RECONNECT_PROBE_TIMEOUT_MS = 20000;
+const WAKE_PROBE_TIMEOUT_MS = 10000;
+const WAKE_PROBE_MIN_IDLE_MS = 15000;
 
 // Callbacks to call whenever `currentStub` or connection state is updated.
 const subscribers = new Set<() => void>();
 const notifySubscribers = () => subscribers.forEach(cb => cb());
 let isConnectionLost = false;
 let reconnecting = false;
+let probing = false;
+let lastProvenAt = Date.now();
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -127,6 +132,7 @@ async function handleBroken(error: unknown) {
 
     candidate.onRpcBroken(handleBroken);
     currentStub = candidate;
+    lastProvenAt = Date.now();
     reconnecting = false;
     isConnectionLost = false;
     console.warn('RPC connection restored.');
@@ -134,6 +140,32 @@ async function handleBroken(error: unknown) {
     return;
   }
 }
+
+// Passive close detection misses sockets killed during laptop sleep or tab throttling, so on
+// tab-visible / network-online signals probe the connection instead of letting the user's next
+// action hang on a zombie socket.
+async function probeOnWake() {
+  if (reconnecting || probing || Date.now() - lastProvenAt < WAKE_PROBE_MIN_IDLE_MS) return;
+  probing = true;
+  const suspect = currentStub;
+  try {
+    await withTimeout(suspect.getServerConfig(), WAKE_PROBE_TIMEOUT_MS);
+    lastProvenAt = Date.now();
+  } catch (error) {
+    if (currentStub !== suspect || reconnecting) return;  // a real broken event won the race
+    console.warn('Connection unresponsive after wake:', error);
+    // Disposal fires onRpcBroken → handleBroken recovers. Its skip-first-backoff path retries
+    // immediately — right for "the network just came back".
+    disposeQuietly(suspect);
+  } finally {
+    probing = false;
+  }
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') void probeOnWake();
+});
+window.addEventListener('online', () => void probeOnWake());
 
 // Current stub. handleBroken() will replace this on disconnect.
 installWorkshopErrorReporting()

--- a/packages/workshop-frontend/src/main.tsx
+++ b/packages/workshop-frontend/src/main.tsx
@@ -56,7 +56,23 @@ async function devAutoLogin(stub: RpcStub<PublicApi>): Promise<void> {
 //
 // Anyway, I pulled the connection management out into these globals instead.
 let lastConnectTime: number = 0;
-let backoff: number = 1000;
+
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 10000;
+// The probe is getServerConfig — the same call the app needs to boot anyway. A generous
+// deadline lets a slow-but-alive backend settle instead of connect/dispose looping.
+const RECONNECT_PROBE_TIMEOUT_MS = 20000;
+
+// Callbacks to call whenever `currentStub` or connection state is updated.
+const subscribers = new Set<() => void>();
+const notifySubscribers = () => subscribers.forEach(cb => cb());
+let isConnectionLost = false;
+let reconnecting = false;
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T> =>
+  Promise.race([promise, sleep(ms).then((): never => { throw new Error(`timed out after ${ms}ms`); })]);
 
 function getBackendHost(): string {
   // Only the Vite dev server is hosted separately from the backend. Built assets are served from
@@ -74,43 +90,49 @@ function startConnection(): RpcStub<PublicApi> {
   return newWebSocketRpcSession<PublicApi>(wsUrl);
 }
 
-async function handleBroken(error: any) {
+const disposeQuietly = (stub: RpcStub<PublicApi>) => {
+  try { stub[Symbol.dispose](); } catch { /* already broken */ }
+};
+
+// A reconnect attempt only becomes `currentStub` after a probe RPC round-trips: capnweb queues
+// sends while the socket is still CONNECTING, so an unproven stub looks fine until everything
+// pipelined onto it fails at once. Proving first means subscribers hear exactly twice per
+// outage — lost, then restored — instead of once per failed attempt.
+async function handleBroken(error: unknown) {
+  if (reconnecting) return;  // stale/disposed stub, or recovery already underway
+  reconnecting = true;
+
   console.warn('RPC connection lost:', error);
-
   isConnectionLost = true;
-  for (let cb of notifyCurrentStubUpdated) { cb(); }
+  notifySubscribers();  // `currentStub` stays the dead one, so stub-keyed effects don't re-fire
 
-  let timeSinceConnect = Date.now() - lastConnectTime;
-  if (timeSinceConnect < backoff) {
-    let waitTime = backoff - timeSinceConnect;
-    console.warn(`Will try again in ${Math.round(waitTime / 1000)} seconds...`)
-    await new Promise(resolve => setTimeout(resolve, waitTime));
-    console.warn(`Retrying connection...`);
-    backoff = Math.min(backoff * 2, 10000);
-  } else {
-    backoff = 1000;
+  // Fast recovery from one-off blips: skip the first backoff if the dying connection was up a while.
+  let skipSleep = Date.now() - lastConnectTime >= INITIAL_BACKOFF_MS;
+  let backoff = INITIAL_BACKOFF_MS;
+  for (;;) {
+    if (!skipSleep) {
+      await sleep(backoff * (0.85 + 0.3 * Math.random()));  // jittered against stampedes
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+    }
+    skipSleep = false;
+
+    const candidate = startConnection();
+    try {
+      await withTimeout(candidate.getServerConfig(), RECONNECT_PROBE_TIMEOUT_MS);
+    } catch (probeError) {
+      console.debug('Reconnect attempt failed:', probeError);
+      disposeQuietly(candidate);
+      continue;
+    }
+
+    candidate.onRpcBroken(handleBroken);
+    currentStub = candidate;
+    reconnecting = false;
+    isConnectionLost = false;
+    console.warn('RPC connection restored.');
+    notifySubscribers();
+    return;
   }
-
-  currentStub = startConnection();
-  currentStub.onRpcBroken(handleBroken);
-
-  // Don't clear isConnectionLost here — the new connection hasn't proven
-  // it works yet. It gets cleared by markConnectionRestored() once the
-  // app successfully communicates with the backend.
-  for (let cb of notifyCurrentStubUpdated) {
-    cb();
-  }
-}
-
-// Callbacks to call whenever `currentStub` or connection state is updated.
-let notifyCurrentStubUpdated: Set<() => void> = new Set();
-let isConnectionLost = false;
-
-/** Called externally (e.g., by auth) to indicate the connection is alive. */
-export function markConnectionRestored() {
-  if (!isConnectionLost) return;
-  isConnectionLost = false;
-  for (let cb of notifyCurrentStubUpdated) { cb(); }
 }
 
 // Current stub. handleBroken() will replace this on disconnect.
@@ -153,9 +175,9 @@ function AppWithConnection() {
   }, []);
 
   useEffect(() => {
-    let cb = () => setRpcState({ stub: currentStub, connectionLost: isConnectionLost });
-    notifyCurrentStubUpdated.add(cb);
-    return () => { notifyCurrentStubUpdated.delete(cb); };
+    const cb = () => setRpcState({ stub: currentStub, connectionLost: isConnectionLost });
+    subscribers.add(cb);
+    return () => { subscribers.delete(cb); };
   }, []);
 
   // Fetch deployment config once the (re)connected stub is available. Re-fetch on reconnect so a

--- a/packages/workshop-frontend/src/main.tsx
+++ b/packages/workshop-frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode, useState, useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from '@tanstack/react-router'
-import { RpcStub, newWebSocketRpcSession } from 'capnweb'
+import { RpcPromise, RpcStub, newWebSocketRpcSession } from 'capnweb'
 import { PublicApi, ServerConfig } from '@gadgets/workshop-shared/api'
 import { RpcContext } from './RpcContext'
 import { ServerConfigContext, ServerConfigErrorContext } from './ServerConfigContext'
@@ -98,18 +98,10 @@ const disposeQuietly = (stub: RpcStub<PublicApi>) => {
   try { stub[Symbol.dispose](); } catch { /* already broken */ }
 };
 
-// A reconnect attempt only becomes `currentStub` after a probe RPC round-trips: capnweb queues
-// sends while the socket is still CONNECTING, so an unproven stub looks fine until everything
-// pipelined onto it fails at once. Proving first means subscribers hear exactly twice per
-// outage — lost, then restored — instead of once per failed attempt.
-async function handleBroken(error: unknown) {
-  if (reconnecting) return;  // stale/disposed stub, or recovery already underway
-  reconnecting = true;
-
-  console.warn('RPC connection lost:', error);
-  isConnectionLost = true;
-  notifySubscribers();  // `currentStub` stays the dead one, so stub-keyed effects don't re-fire
-
+// Connects with jittered backoff until a candidate answers a probe, and resolves only to that
+// proven connection: capnweb queues sends while a socket is still CONNECTING, so an unproven stub
+// looks fine right up until everything pipelined onto it fails at once.
+async function reconnect(): Promise<RpcStub<PublicApi>> {
   // Fast recovery from one-off blips: skip the first backoff if the dying connection was up a while.
   let skipSleep = Date.now() - lastConnectTime >= INITIAL_BACKOFF_MS;
   let backoff = INITIAL_BACKOFF_MS;
@@ -130,14 +122,31 @@ async function handleBroken(error: unknown) {
     }
 
     candidate.onRpcBroken(handleBroken);
-    currentStub = candidate;
     lastProvenAt = Date.now();
     reconnecting = false;
     isConnectionLost = false;
     console.warn('RPC connection restored.');
     notifySubscribers();
-    return;
+    return candidate;
   }
+}
+
+// Subscribers hear exactly twice per outage — lost here, restored in `reconnect` — because
+// `currentStub` is replaced once, by a promise, rather than once per attempt.
+function handleBroken(error: unknown) {
+  if (reconnecting) return;  // stale/disposed stub, or recovery already underway
+  reconnecting = true;
+
+  console.warn('RPC connection lost:', error);
+  isConnectionLost = true;
+
+  // Publish a stub for the connection we have not made yet, so the dead one stops being reachable
+  // immediately. capnweb queues calls pipelined onto an unresolved `RpcPromise` and delivers them,
+  // in order, once it resolves — so work issued during the outage waits for the replacement
+  // instead of failing against a socket known to be gone. The `RpcPromise` takes ownership of its
+  // resolution, keeping the proven stub on a single disposal path.
+  currentStub = new RpcPromise<PublicApi>(reconnect());
+  notifySubscribers();
 }
 
 // Passive close detection misses sockets killed during laptop sleep or tab throttling, so on

--- a/packages/workshop-frontend/src/main.tsx
+++ b/packages/workshop-frontend/src/main.tsx
@@ -59,9 +59,8 @@ let lastConnectTime: number = 0;
 
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 10000;
-// The probe is getServerConfig — the same call the app needs to boot anyway. Generous deadlines
-// let a slow-but-alive backend settle instead of connect/dispose looping (or, on wake, tearing
-// down a healthy socket under load).
+// Generous probe deadlines let a slow-but-alive backend settle instead of connect/dispose looping
+// (or, on wake, tearing down a healthy socket under load).
 const RECONNECT_PROBE_TIMEOUT_MS = 20000;
 const WAKE_PROBE_TIMEOUT_MS = 10000;
 const WAKE_PROBE_MIN_IDLE_MS = 15000;
@@ -123,7 +122,7 @@ async function handleBroken(error: unknown) {
 
     const candidate = startConnection();
     try {
-      await withTimeout(candidate.getServerConfig(), RECONNECT_PROBE_TIMEOUT_MS);
+      await withTimeout(candidate.ping(), RECONNECT_PROBE_TIMEOUT_MS);
     } catch (probeError) {
       console.debug('Reconnect attempt failed:', probeError);
       disposeQuietly(candidate);
@@ -149,7 +148,7 @@ async function probeOnWake() {
   probing = true;
   const suspect = currentStub;
   try {
-    await withTimeout(suspect.getServerConfig(), WAKE_PROBE_TIMEOUT_MS);
+    await withTimeout(suspect.ping(), WAKE_PROBE_TIMEOUT_MS);
     lastProvenAt = Date.now();
   } catch (error) {
     if (currentStub !== suspect || reconnecting) return;  // a real broken event won the race

--- a/packages/workshop-frontend/src/main.tsx
+++ b/packages/workshop-frontend/src/main.tsx
@@ -69,14 +69,18 @@ const WAKE_PROBE_MIN_IDLE_MS = 15000;
 const subscribers = new Set<() => void>();
 const notifySubscribers = () => subscribers.forEach(cb => cb());
 let isConnectionLost = false;
-let reconnecting = false;
 let probing = false;
 let lastProvenAt = Date.now();
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T> =>
-  Promise.race([promise, sleep(ms).then((): never => { throw new Error(`timed out after ${ms}ms`); })]);
+const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+};
 
 function getBackendHost(): string {
   // Only the Vite dev server is hosted separately from the backend. Built assets are served from
@@ -91,7 +95,9 @@ function startConnection(): RpcStub<PublicApi> {
   lastConnectTime = Date.now();
   const apiHost = getBackendHost();
   const wsUrl = (window.location.protocol === 'https:' ? 'wss:' : 'ws:') + '//' + apiHost + '/api';
-  return newWebSocketRpcSession<PublicApi>(wsUrl);
+  const stub = newWebSocketRpcSession<PublicApi>(wsUrl);
+  stub.onRpcBroken(handleBroken);
+  return stub;
 }
 
 const disposeQuietly = (stub: RpcStub<PublicApi>) => {
@@ -121,9 +127,7 @@ async function reconnect(): Promise<RpcStub<PublicApi>> {
       continue;
     }
 
-    candidate.onRpcBroken(handleBroken);
     lastProvenAt = Date.now();
-    reconnecting = false;
     isConnectionLost = false;
     console.warn('RPC connection restored.');
     notifySubscribers();
@@ -134,11 +138,10 @@ async function reconnect(): Promise<RpcStub<PublicApi>> {
 // Subscribers hear exactly twice per outage — lost here, restored in `reconnect` — because
 // `currentStub` is replaced once, by a promise, rather than once per attempt.
 function handleBroken(error: unknown) {
-  if (reconnecting) return;  // stale/disposed stub, or recovery already underway
-  reconnecting = true;
+  if (isConnectionLost) return;  // stale/disposed stub, or recovery already underway
+  isConnectionLost = true;
 
   console.warn('RPC connection lost:', error);
-  isConnectionLost = true;
 
   // Publish a stub for the connection we have not made yet, so the dead one stops being reachable
   // immediately. capnweb queues calls pipelined onto an unresolved `RpcPromise` and delivers them,
@@ -153,14 +156,14 @@ function handleBroken(error: unknown) {
 // tab-visible / network-online signals probe the connection instead of letting the user's next
 // action hang on a zombie socket.
 async function probeOnWake() {
-  if (reconnecting || probing || Date.now() - lastProvenAt < WAKE_PROBE_MIN_IDLE_MS) return;
+  if (isConnectionLost || probing || Date.now() - lastProvenAt < WAKE_PROBE_MIN_IDLE_MS) return;
   probing = true;
   const suspect = currentStub;
   try {
     await withTimeout(suspect.ping(), WAKE_PROBE_TIMEOUT_MS);
     lastProvenAt = Date.now();
   } catch (error) {
-    if (currentStub !== suspect || reconnecting) return;  // a real broken event won the race
+    if (currentStub !== suspect || isConnectionLost) return;  // a real broken event won the race
     console.warn('Connection unresponsive after wake:', error);
     // Disposal fires onRpcBroken → handleBroken recovers. Its skip-first-backoff path retries
     // immediately — right for "the network just came back".
@@ -178,7 +181,6 @@ window.addEventListener('online', () => void probeOnWake());
 // Current stub. handleBroken() will replace this on disconnect.
 installWorkshopErrorReporting()
 let currentStub = startConnection();
-currentStub.onRpcBroken(handleBroken);
 
 const router = createRouter()
 applyStoredThemeMode()

--- a/packages/workshop-frontend/src/routes/__root.tsx
+++ b/packages/workshop-frontend/src/routes/__root.tsx
@@ -5,7 +5,6 @@ import { TooltipProvider, Toasty } from '@cloudflare/kumo'
 import { RpcStub } from 'capnweb'
 import { AuthenticatedApi } from '@gadgets/workshop-shared/api'
 import { useRpcStub, useConnectionLost } from '../RpcContext'
-import { markConnectionRestored } from '../main'
 import { useAuth, CF_ACCESS_MODE } from '../useAuth'
 import { AuthProvider } from '../AuthContext'
 import { FeatureFlagsProvider } from '../FeatureFlagsContext'
@@ -24,11 +23,6 @@ function RootComponent() {
   const connectionLost = useConnectionLost()
   const { isAuthenticated, authenticatedApi, isLoading, error, logout, login } = useAuth(rpcStub)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-
-  // When authenticatedApi becomes available, the connection is proven alive.
-  useEffect(() => {
-    if (authenticatedApi) markConnectionRestored()
-  }, [authenticatedApi])
 
   // Routes that don't require auth (public routes)
   const isSignup = pathname === '/signup'

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -46,6 +46,9 @@ export interface LoginAttempt extends RpcTarget {
 
 /** Public API exposed to the internet. */
 export interface PublicApi extends RpcTarget {
+  /** Confirms that the RPC connection can round-trip without performing application work. */
+  ping(): Promise<void>;
+
   /**
    * Returns deployment-level configuration the client needs at boot (auth mode, available sign-in
    * vendors, whether the Cloudflare limits flow is enabled). Contains no secrets.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,11 @@ catalogs:
       specifier: ^0.20.2
       version: 0.20.3
     capnweb:
-      specifier: ^0.11.1
-      version: 0.11.1
+      specifier: ^0.12.0
+      version: 0.12.0
     capnweb-validate:
-      specifier: 0.2.4
-      version: 0.2.4
+      specifier: 0.3.0
+      version: 0.3.0
     typescript:
       specifier: 7.0.2
       version: 7.0.2
@@ -109,10 +109,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
@@ -140,10 +140,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       node-html-parser:
         specifier: ^7.1.0
         version: 7.1.0
@@ -174,10 +174,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       isomorphic-git:
         specifier: ^1.40.5
         version: 1.40.5
@@ -295,10 +295,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       postal-mime:
         specifier: ^2.7.6
         version: 2.7.6
@@ -323,10 +323,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -351,10 +351,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -379,10 +379,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -404,10 +404,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -432,10 +432,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -463,10 +463,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -488,10 +488,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -516,10 +516,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       temporal-polyfill:
         specifier: 1.0.2
         version: 1.0.2
@@ -598,10 +598,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -620,10 +620,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -645,10 +645,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -667,10 +667,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -686,7 +686,7 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
@@ -790,10 +790,10 @@ importers:
         version: link:../workshop-shared
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       capnweb-validate:
         specifier: 'catalog:'
-        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       diff:
         specifier: ^8.0.4
         version: 8.0.4
@@ -851,7 +851,7 @@ importers:
         version: 1.170.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
       hash-wasm:
         specifier: ^4.12.0
         version: 4.12.0
@@ -918,7 +918,7 @@ importers:
         version: 5.20260808.1
       capnweb:
         specifier: 'catalog:'
-        version: 0.11.1
+        version: 0.12.0
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -3115,8 +3115,8 @@ packages:
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
-  capnweb-validate@0.2.4:
-    resolution: {integrity: sha512-1E1OqJZ96P/YE1WbhnPHGs8hvZ1g2Da7f/DJSgxGQ6aKy17bjkJa9sEhTixQKJ0VsNRIdmeEjFE3brBlXcF/Uw==}
+  capnweb-validate@0.3.0:
+    resolution: {integrity: sha512-YjYu37+WE/cQWNM39Hv9sjov9fDgHIT/142ZD5pdt4iXk0YQqXg3FGgn5I3bg2ytQMJMsQQsnfooEKwnqc2E3A==}
     hasBin: true
     peerDependencies:
       capnweb: '>=0.7.0'
@@ -3124,8 +3124,8 @@ packages:
       capnweb:
         optional: true
 
-  capnweb@0.11.1:
-    resolution: {integrity: sha512-7LyJhH96Ak7qyM3nUShVP5noXRMav2TvnhZ+hDxANrNqkFaPcu9MkbMIKTvBGV8+HN44kKTDlNMHzjPDRr36KQ==}
+  capnweb@0.12.0:
+    resolution: {integrity: sha512-jgZ/LMtMVTi+RVlooIslH78Gg23XbDTdvcLghWx3oz17D6u5GuJARt+uhZk/wcTo+f81eeabfnow4d3zLBj+JQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -6951,12 +6951,12 @@ snapshots:
 
   caniuse-lite@1.0.30001806: {}
 
-  capnweb-validate@0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0)):
+  capnweb-validate@0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:
       typescript: 6.0.3
       unplugin: 3.3.0(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
     optionalDependencies:
-      capnweb: 0.11.1
+      capnweb: 0.12.0
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -6968,7 +6968,7 @@ snapshots:
       - vite
       - webpack
 
-  capnweb@0.11.1: {}
+  capnweb@0.12.0: {}
 
   ccount@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,9 +5,9 @@ packages:
 # needing to hand edit a bunch of different package.json files.
 catalog:
   '@cloudflare/vitest-pool-workers': ^0.20.2
-  capnweb: ^0.11.1
+  capnweb: ^0.12.0
   # Exact: pinned in lockstep with capnweb (declared as a >=0.7.0 peer)
-  capnweb-validate: 0.2.4
+  capnweb-validate: 0.3.0
   # Exact: TypeScript 7 (tsgo). Type-checking runs on the native compiler. Build-time
   # transpilers that need the JS compiler API (scripts/build-gatekeeper-configurator.ts)
   # use the root "typescript6" npm alias instead; capnweb-validate ships its own


### PR DESCRIPTION
Handles 2 cases the server cannot automagically help with recovery on:
- Reconnecting flicker: probe each candidate with `ping()` and only publish a stub that has round-tripped. This stops false reporting a reconnected state just to go back to disconnected 
- Probe the connection on tab wake. `visibilitychange`/`online` triggers a probe of the current stub 

<img width="2430" height="1748" alt="Screenshot from 2026-08-12 11-48-33" src="https://github.com/user-attachments/assets/faa0a8b1-26d6-4a97-8656-425ac2057d1b" />
_note reconnecting chip_

###  Testing

Types, unit tests, lint. Manually against the local dev stack:

- Outage (backend down ~3 min with a workspace open): chip appears once, no flicker; exactly one RPC connection lost / one RPC connection restored; measured attempts at +0.2s, +1.3s, +3.2s, +6.8s, +14s, then ~10s apart (correct jittered doubling backoff); chat works after recovery.
- Zombie (kill -STOP on workerd, then a wake event): probe times out at ~10s, disposes the stub, and the app recovers on its own once the process thaws (no user action needed).
- Tab-switch noise (counted probe frames by hooking WebSocket.send): a burst of 8 wake/online events yields exactly 1 probe past the 15s idle window, 0 within it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-os/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->