### PR TITLE
Bump capnweb to 0.11.1

### DIFF
--- a/packages/gatekeeper-cloudflare/package.json
+++ b/packages/gatekeeper-cloudflare/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-cloudflare/package.json
+++ b/packages/gatekeeper-cloudflare/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-confluence/package.json
+++ b/packages/gatekeeper-confluence/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1",
     "node-html-parser": "^7.1.0"
   },

--- a/packages/gatekeeper-confluence/package.json
+++ b/packages/gatekeeper-confluence/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1",
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:",
     "node-html-parser": "^7.1.0"
   },
   "devDependencies": {

--- a/packages/gatekeeper-context/package.json
+++ b/packages/gatekeeper-context/package.json
@@ -18,8 +18,8 @@
     "@gadgets/error-reporting": "workspace:*",
     "@gadgets/typed-storage": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1",
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:",
     "isomorphic-git": "^1.40.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/packages/gatekeeper-context/package.json
+++ b/packages/gatekeeper-context/package.json
@@ -18,7 +18,7 @@
     "@gadgets/error-reporting": "workspace:*",
     "@gadgets/typed-storage": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1",
     "isomorphic-git": "^1.40.0",
     "yaml": "^2.9.0",

--- a/packages/gatekeeper-email/package.json
+++ b/packages/gatekeeper-email/package.json
@@ -14,7 +14,7 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1",
     "postal-mime": "^2.7.5"
   },

--- a/packages/gatekeeper-email/package.json
+++ b/packages/gatekeeper-email/package.json
@@ -14,8 +14,8 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1",
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:",
     "postal-mime": "^2.7.5"
   },
   "devDependencies": {

--- a/packages/gatekeeper-github/package.json
+++ b/packages/gatekeeper-github/package.json
@@ -15,7 +15,7 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-github/package.json
+++ b/packages/gatekeeper-github/package.json
@@ -15,8 +15,8 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-google/package.json
+++ b/packages/gatekeeper-google/package.json
@@ -14,8 +14,8 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1",
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:",
     "mimetext": "^3.0.28",
     "postal-mime": "^2.7.5"
   },

--- a/packages/gatekeeper-google/package.json
+++ b/packages/gatekeeper-google/package.json
@@ -14,7 +14,7 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1",
     "mimetext": "^3.0.28",
     "postal-mime": "^2.7.5"

--- a/packages/gatekeeper-homeassistant/package.json
+++ b/packages/gatekeeper-homeassistant/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-homeassistant/package.json
+++ b/packages/gatekeeper-homeassistant/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-linear/package.json
+++ b/packages/gatekeeper-linear/package.json
@@ -14,7 +14,7 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-linear/package.json
+++ b/packages/gatekeeper-linear/package.json
@@ -14,8 +14,8 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-mcp-portal/package.json
+++ b/packages/gatekeeper-mcp-portal/package.json
@@ -16,7 +16,7 @@
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/mcp-shared": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-mcp-portal/package.json
+++ b/packages/gatekeeper-mcp-portal/package.json
@@ -16,8 +16,8 @@
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/mcp-shared": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-mcp/package.json
+++ b/packages/gatekeeper-mcp/package.json
@@ -16,7 +16,7 @@
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/mcp-shared": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-mcp/package.json
+++ b/packages/gatekeeper-mcp/package.json
@@ -16,8 +16,8 @@
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/mcp-shared": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-notion/package.json
+++ b/packages/gatekeeper-notion/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-notion/package.json
+++ b/packages/gatekeeper-notion/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-scheduler/package.json
+++ b/packages/gatekeeper-scheduler/package.json
@@ -17,7 +17,7 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/error-reporting": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1",
     "temporal-polyfill": "1.0.2"
   },

--- a/packages/gatekeeper-scheduler/package.json
+++ b/packages/gatekeeper-scheduler/package.json
@@ -17,8 +17,8 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/error-reporting": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1",
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:",
     "temporal-polyfill": "1.0.2"
   },
   "devDependencies": {

--- a/packages/gatekeeper-slack/package.json
+++ b/packages/gatekeeper-slack/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-slack/package.json
+++ b/packages/gatekeeper-slack/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-spotify/package.json
+++ b/packages/gatekeeper-spotify/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-spotify/package.json
+++ b/packages/gatekeeper-spotify/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-supabase/package.json
+++ b/packages/gatekeeper-supabase/package.json
@@ -14,7 +14,7 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/gatekeeper-supabase/package.json
+++ b/packages/gatekeeper-supabase/package.json
@@ -14,8 +14,8 @@
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-zoominfo/package.json
+++ b/packages/gatekeeper-zoominfo/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1"
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/gatekeeper-zoominfo/package.json
+++ b/packages/gatekeeper-zoominfo/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1"
   },
   "devDependencies": {

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
+    "capnweb": "catalog:",
     "jsonc-parser": "^3.3.1",
     "zod": "^4.4.3"
   },

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "jsonc-parser": "^3.3.1",
     "zod": "^4.4.3"
   },

--- a/packages/workshop-backend/package.json
+++ b/packages/workshop-backend/package.json
@@ -23,7 +23,7 @@
     "@gadgets/error-reporting": "workspace:*",
     "@gadgets/typed-storage": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "capnweb-validate": "0.2.1",
     "diff": "^8.0.4",
     "jose": "^6.2.5",

--- a/packages/workshop-backend/package.json
+++ b/packages/workshop-backend/package.json
@@ -23,8 +23,8 @@
     "@gadgets/error-reporting": "workspace:*",
     "@gadgets/typed-storage": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
-    "capnweb": "^0.11.1",
-    "capnweb-validate": "0.2.1",
+    "capnweb": "catalog:",
+    "capnweb-validate": "catalog:",
     "diff": "^8.0.4",
     "jose": "^6.2.5",
     "yjs": "^13.6.31"

--- a/packages/workshop-frontend/package.json
+++ b/packages/workshop-frontend/package.json
@@ -17,7 +17,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/react-router": "^1.170.18",
-    "capnweb": "^0.11.1",
+    "capnweb": "catalog:",
     "hash-wasm": "^4.12.0",
     "monaco-editor": "^0.52.2",
     "react": "^19.2.8",

--- a/packages/workshop-frontend/package.json
+++ b/packages/workshop-frontend/package.json
@@ -17,7 +17,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/react-router": "^1.170.18",
-    "capnweb": "^0.8.0",
+    "capnweb": "^0.11.1",
     "hash-wasm": "^4.12.0",
     "monaco-editor": "^0.52.2",
     "react": "^19.2.8",

--- a/packages/workshop-frontend/src/GadgetUI.tsx
+++ b/packages/workshop-frontend/src/GadgetUI.tsx
@@ -9,6 +9,8 @@ import { GadgetClient, ConsoleLogEvent } from '@gadgets/workshop-shared/api'
 // content.
 import CAPNWEB_BUNDLE from 'capnweb?raw'
 
+// btoa() below requires this to stay ASCII; capnweb's build enforces ASCII-only dist bundles
+// since 0.11.1.
 let CAPNWEB_BUNDLE_ANNOTATED = `//# sourceURL=jsrpc.js\n${CAPNWEB_BUNDLE}`
 
 // Unfortunately, we will have to embed the code as a data: URL, because our iframe is totally

--- a/packages/workshop-shared/package.json
+++ b/packages/workshop-shared/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "^5.20260722.1",
-    "capnweb": "^0.8.0"
+    "capnweb": "^0.11.1"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/workshop-shared/package.json
+++ b/packages/workshop-shared/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "^5.20260722.1",
-    "capnweb": "^0.11.1"
+    "capnweb": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,11 +93,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -115,11 +115,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       node-html-parser:
         specifier: ^7.1.0
         version: 7.1.0
@@ -149,11 +149,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       isomorphic-git:
         specifier: ^1.40.0
         version: 1.40.0
@@ -267,11 +267,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       postal-mime:
         specifier: ^2.7.5
         version: 2.7.5
@@ -295,11 +295,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -323,11 +323,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -351,11 +351,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -376,11 +376,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -404,11 +404,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -435,11 +435,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -460,11 +460,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -488,11 +488,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       temporal-polyfill:
         specifier: 1.0.2
         version: 1.0.2
@@ -567,11 +567,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -589,11 +589,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -614,11 +614,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -636,11 +636,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -655,8 +655,8 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
@@ -756,11 +756,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       capnweb-validate:
         specifier: 0.2.1
-        version: 0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       diff:
         specifier: ^8.0.4
         version: 8.0.4
@@ -811,8 +811,8 @@ importers:
         specifier: ^1.170.18
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
       hash-wasm:
         specifier: ^4.12.0
         version: 4.12.0
@@ -878,8 +878,8 @@ importers:
         specifier: ^5.20260722.1
         version: 5.20260804.1
       capnweb:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.11.1
+        version: 0.11.1
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -2984,8 +2984,8 @@ packages:
       capnweb:
         optional: true
 
-  capnweb@0.8.0:
-    resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
+  capnweb@0.11.1:
+    resolution: {integrity: sha512-7LyJhH96Ak7qyM3nUShVP5noXRMav2TvnhZ+hDxANrNqkFaPcu9MkbMIKTvBGV8+HN44kKTDlNMHzjPDRr36KQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -6756,12 +6756,12 @@ snapshots:
 
   caniuse-lite@1.0.30001806: {}
 
-  capnweb-validate@0.2.1(capnweb@0.8.0)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)):
+  capnweb-validate@0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       typescript: 5.9.3
       unplugin: 3.3.0(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
-      capnweb: 0.8.0
+      capnweb: 0.11.1
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -6773,7 +6773,7 @@ snapshots:
       - vite
       - webpack
 
-  capnweb@0.8.0: {}
+  capnweb@0.11.1: {}
 
   ccount@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,12 @@ catalogs:
     '@cloudflare/vitest-pool-workers':
       specifier: ^0.18.8
       version: 0.18.8
+    capnweb:
+      specifier: ^0.11.1
+      version: 0.11.1
+    capnweb-validate:
+      specifier: 0.2.4
+      version: 0.2.4
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -93,11 +99,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -115,11 +121,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       node-html-parser:
         specifier: ^7.1.0
         version: 7.1.0
@@ -149,11 +155,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       isomorphic-git:
         specifier: ^1.40.0
         version: 1.40.0
@@ -267,11 +273,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       postal-mime:
         specifier: ^2.7.5
         version: 2.7.5
@@ -295,11 +301,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -323,11 +329,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -351,11 +357,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -376,11 +382,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -404,11 +410,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -435,11 +441,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -460,11 +466,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -488,11 +494,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       temporal-polyfill:
         specifier: 1.0.2
         version: 1.0.2
@@ -567,11 +573,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -589,11 +595,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -614,11 +620,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -636,11 +642,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -655,7 +661,7 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       jsonc-parser:
         specifier: ^3.3.1
@@ -756,11 +762,11 @@ importers:
         specifier: workspace:*
         version: link:../workshop-shared
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       capnweb-validate:
-        specifier: 0.2.1
-        version: 0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))
       diff:
         specifier: ^8.0.4
         version: 8.0.4
@@ -811,7 +817,7 @@ importers:
         specifier: ^1.170.18
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
       hash-wasm:
         specifier: ^4.12.0
@@ -878,7 +884,7 @@ importers:
         specifier: ^5.20260722.1
         version: 5.20260804.1
       capnweb:
-        specifier: ^0.11.1
+        specifier: 'catalog:'
         version: 0.11.1
     devDependencies:
       typescript:
@@ -2974,12 +2980,11 @@ packages:
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
-  capnweb-validate@0.2.1:
-    resolution: {integrity: sha512-u9IG7JPYFemnyC5NwOwHi428wIlY3Pqbb0nrjjTNfdWRlZOKuQrmZJ9cel11O73b+MPdYWN6+FWR5IWzO7uEjw==}
+  capnweb-validate@0.2.4:
+    resolution: {integrity: sha512-1E1OqJZ96P/YE1WbhnPHGs8hvZ1g2Da7f/DJSgxGQ6aKy17bjkJa9sEhTixQKJ0VsNRIdmeEjFE3brBlXcF/Uw==}
     hasBin: true
     peerDependencies:
       capnweb: '>=0.7.0'
-      typescript: '>=5.7.0'
     peerDependenciesMeta:
       capnweb:
         optional: true
@@ -6756,7 +6761,7 @@ snapshots:
 
   caniuse-lite@1.0.30001806: {}
 
-  capnweb-validate@0.2.1(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(typescript@5.9.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)):
+  capnweb-validate@0.2.4(capnweb@0.11.1)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:
       typescript: 5.9.3
       unplugin: 3.3.0(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ packages:
 # needing to hand edit a bunch of different package.json files.
 catalog:
   '@cloudflare/vitest-pool-workers': ^0.18.8
+  capnweb: ^0.11.1
+  # Exact: pinned in lockstep with capnweb (declared as a >=0.7.0 peer)
+  capnweb-validate: 0.2.4
   typescript: ^5.9.3
   # Exact, not ranged: the transform has to stay on esbuild. Oxc does not lower the Stage-3
   # decorators capnweb-validate's `@validateRpc()` relies on (cloudflare/workers-sdk#12626).


### PR DESCRIPTION
Bumps capnweb `^0.10.0` → `^0.11.1` across the workspace. 0.11.0's shared `RpcPromise` alias (cloudflare/capnweb#237) is what unblocks TypeScript 7 type-checking

Second commit moves capnweb and capnweb-validate into the pnpm catalog (one edit per bump instead of 20 manifests), which also takes capnweb-validate `0.2.1` → `0.2.4` (cloudflare/capnweb#240: it ships its own capped typescript dependency for the `@validateRpc` transform)