### PR TITLE
Qualify Slack account identity with its workspace

### DIFF
--- a/packages/gatekeeper-slack/src/slack-api.ts
+++ b/packages/gatekeeper-slack/src/slack-api.ts
@@ -403,13 +403,20 @@ export class SlackApi {
     return user;
   }
 
-  async getAccountDescription(userId: string): Promise<AccountDescription> {
+  // `teamId` qualifies the account when the workspace host is unavailable; see uniqueName below.
+  async getAccountDescription(userId: string, teamId: string): Promise<AccountDescription> {
+    let hostPromise = this.#getWorkspaceHost();
     let data = await this.#call<SlackApiEnvelope & { user?: RawUser }>(
         "users.info", { user: userId });
     let profile = data.user?.profile;
+    let handle = data.user?.name;
+    // A Slack handle is unique only within a workspace, but the Workshop dedupes connected accounts
+    // by uniqueName — so an unqualified handle would collapse two workspaces the same person
+    // connected into one account. Qualify it with the workspace, which is globally unique.
+    let workspace = (await hostPromise) || teamId;
     return {
-      displayName: profile?.real_name || profile?.display_name || data.user?.name,
-      uniqueName: data.user?.name,
+      displayName: profile?.real_name || profile?.display_name || handle,
+      uniqueName: handle && workspace ? `${handle}@${workspace}` : handle,
       avatar: { url: profile?.image_192 || profile?.image_72 || profile?.image_48 || "" },
     };
   }

--- a/packages/gatekeeper-slack/src/slack.ts
+++ b/packages/gatekeeper-slack/src/slack.ts
@@ -538,8 +538,10 @@ export class SlackUserImpl extends WorkerEntrypoint<Env, SlackUserImplProps>
   async describe(): Promise<AccountDescription> {
     let account = this.#account();
     let userIdPromise = account.getUserId();
+    let teamIdPromise = account.getTeamId();
     let grantedPromise = account.getGrantedResourceUrlPatterns();
-    let description = await this.#api().getAccountDescription(await userIdPromise);
+    let description = await this.#api().getAccountDescription(
+        await userIdPromise, await teamIdPromise);
     description.grantedResourceUrlPatterns = await grantedPromise;
     return description;
   }


### PR DESCRIPTION
The Workshop dedupes connected accounts by `(vendorId, uniqueName)`, so `uniqueName` has to be globally unique per vendor. A Slack handle is only unique *within* a workspace, so the unqualified handle we were reporting collapsed two different workspaces the same person connected into a single account.

Qualify it with the workspace host from `auth.test` (`handle@workspace-host`), falling back to the team ID and then to the bare handle. `displayName` is unchanged, so the UI still shows the person's real name.

Follow-up to the Slack gatekeeper; no new OAuth scope is required. Existing connected accounts keep their legacy bare `uniqueName` until the user reconnects, which is cosmetic.