### PR TITLE
Add OpenRouter model provider support

### DIFF
--- a/docs/ai-gateway-billing.md
+++ b/docs/ai-gateway-billing.md
@@ -52,7 +52,7 @@ CLOUDFLARE_OAUTH_CLIENT_SECRET=...
 
 # Platform AI Gateway used for the free tier (see existing AI Gateway docs):
 CF_AI_GATEWAY=your-gateway
-CF_AI_GATEWAY_PROVIDERS=anthropic,openai,google
+CF_AI_GATEWAY_PROVIDERS=anthropic,openai,google,openrouter
 
 # Required whenever CF_AI_GATEWAY is set (all inference goes over HTTPS with tokens):
 CF_AI_GATEWAY_ACCOUNT_ID=...

--- a/docs/public-server.md
+++ b/docs/public-server.md
@@ -38,7 +38,7 @@ CLOUDFLARE_OAUTH_CLIENT_SECRET=...
 
 # Platform AI Gateway used for the free tier:
 CF_AI_GATEWAY=your-gateway
-CF_AI_GATEWAY_PROVIDERS=anthropic,openai,google
+CF_AI_GATEWAY_PROVIDERS=anthropic,openai,google,openrouter
 
 # Required whenever CF_AI_GATEWAY is set (all inference goes over HTTPS with tokens):
 CF_AI_GATEWAY_ACCOUNT_ID=...

--- a/packages/workshop-backend/__tests__/ai-models.test.ts
+++ b/packages/workshop-backend/__tests__/ai-models.test.ts
@@ -32,6 +32,12 @@ const WORKERS_AI_CONFIG: AiModelConfig = {
   apiToken: "ignored-in-gateway-mode",
 };
 
+const OPENROUTER_CONFIG: AiModelConfig = {
+  provider: "openrouter",
+  model: "openai/gpt-5.2",
+  apiToken: "ignored-in-gateway-mode",
+};
+
 function env(overrides: Partial<Cloudflare.Env> = {}): Cloudflare.Env {
   return {
     CF_AI_GATEWAY: "platform-gateway",
@@ -122,6 +128,37 @@ describe("getModel AI Gateway routing", () => {
       accountId: "gateway-account-id",
       apiToken: "gateway-token",
     });
+  });
+
+  it("routes OpenRouter through its provider-native gateway endpoint", async () => {
+    const handle = getModel(env({
+      CF_AI_GATEWAY_PROVIDERS: "anthropic,openrouter",
+    }), OPENROUTER_CONFIG, INITIATOR);
+
+    expect(handle.model.api).toBe("openai-completions");
+    expect(handle.model.baseUrl).toBe(
+        "https://gateway.ai.cloudflare.com/v1/gateway-account-id/platform-gateway/openrouter");
+    expect(handle.model.contextWindow).toBe(400000);
+    expect(handle.model.maxTokens).toBe(128000);
+    expect(handle.model.compat?.thinkingFormat).toBe("openrouter");
+
+    const request = await captureRequest(handle);
+    expect(request.url).toBe(
+        "https://gateway.ai.cloudflare.com/v1/gateway-account-id/platform-gateway/openrouter/" +
+        "chat/completions");
+    expect(request.headers.get("cf-aig-authorization")).toBe("Bearer gateway-token");
+    expect(request.headers.get("authorization")).toBeNull();
+  }, 15000);
+
+  it("keeps OpenRouter on the deployment gateway when user billing is connected", () => {
+    const handle = getModel(env({
+      CF_AI_GATEWAY_PROVIDERS: "openrouter",
+    }), OPENROUTER_CONFIG, INITIATOR, {
+      userGateway: { accountId: "user-account-id", apiKey: "user-token" },
+    });
+
+    expect(handle.model.baseUrl).toBe(
+        "https://gateway.ai.cloudflare.com/v1/gateway-account-id/platform-gateway/openrouter");
   });
 
   it("preserves gadget automation metadata", async () => {
@@ -265,6 +302,33 @@ describe("getModel direct routing (no gateway)", () => {
   beforeEach(() => {
     capturedRequests.length = 0;
   });
+
+  it("uses OpenRouter's OpenAI-compatible endpoint with direct credentials", async () => {
+    const handle = getModel({} as Cloudflare.Env, {
+      ...OPENROUTER_CONFIG,
+      apiToken: "openrouter-token",
+    }, INITIATOR);
+
+    expect(handle.model.baseUrl).toBe("https://openrouter.ai/api/v1");
+    const request = await captureRequest(handle);
+    expect(request.url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(request.headers.get("authorization")).toBe("Bearer openrouter-token");
+  }, 15000);
+
+  it("uses OpenRouter direct credentials instead of a connected user gateway", async () => {
+    const handle = getModel({} as Cloudflare.Env, {
+      ...OPENROUTER_CONFIG,
+      apiToken: "openrouter-token",
+    }, INITIATOR, {
+      userGateway: { accountId: "user-account-id", apiKey: "user-token" },
+    });
+
+    expect(handle.model.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(handle.aiGatewayLogRoute).toBeUndefined();
+    const request = await captureRequest(handle);
+    expect(request.headers.get("authorization")).toBe("Bearer openrouter-token");
+    expect(request.headers.get("cf-aig-authorization")).toBeNull();
+  }, 15000);
 
   it("uses the provider defaults and the config's own credentials", async () => {
     const handle = getModel(env({ CF_AI_GATEWAY: undefined }), {

--- a/packages/workshop-backend/__tests__/chat-attachment-validation.test.ts
+++ b/packages/workshop-backend/__tests__/chat-attachment-validation.test.ts
@@ -31,6 +31,10 @@ describe("assertChatAttachmentSupportedByProvider", () => {
       .toThrow("Unsupported file type");
     expect(() => assertChatAttachmentSupportedByProvider("cloudflare", "application/pdf", 1))
       .toThrow("Unsupported file type");
+    expect(() => assertChatAttachmentSupportedByProvider("openrouter", "image/png", 1))
+      .not.toThrow();
+    expect(() => assertChatAttachmentSupportedByProvider("openrouter", "application/pdf", 1))
+      .toThrow("Unsupported file type");
     expect(() => assertChatAttachmentSupportedByProvider("ollama", "application/zip", 1))
       .toThrow("Unsupported file type");
   });

--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -12,6 +12,7 @@ import { ANTHROPIC_MODELS } from "@earendil-works/pi-ai/providers/anthropic.mode
 import { CLOUDFLARE_WORKERS_AI_MODELS } from "@earendil-works/pi-ai/providers/cloudflare-workers-ai.models";
 import { GOOGLE_MODELS } from "@earendil-works/pi-ai/providers/google.models";
 import { OPENAI_MODELS } from "@earendil-works/pi-ai/providers/openai.models";
+import { OPENROUTER_MODELS } from "@earendil-works/pi-ai/providers/openrouter.models";
 import { ApprovalQueue, Gatekeeper, ResourceDescription, stripTrailingSlashes } from '@gadgets/workshop-shared/gatekeeper';
 import { LanguageModelBinding } from "./ai-model-binding";
 import AI_MODEL_BINDING_TYPES from "./ai-model-binding.txt";
@@ -133,6 +134,7 @@ function catalogModel(provider: AiModelConfig["provider"], modelId: string): Mod
     case "openai": return (OPENAI_MODELS as Record<string, Model<Api>>)[modelId];
     case "google": return (GOOGLE_MODELS as Record<string, Model<Api>>)[modelId];
     case "cloudflare": return (CLOUDFLARE_WORKERS_AI_MODELS as Record<string, Model<Api>>)[modelId];
+    case "openrouter": return (OPENROUTER_MODELS as Record<string, Model<Api>>)[modelId];
     case "ollama": return undefined;
     default: return undefined;
   }
@@ -240,6 +242,19 @@ function gatewayNativeModel(config: AiModelConfig, gatewayUrl: string): Model<Ap
         cost: catalog?.cost ?? ZERO_COST,
         ...window,
         compat: workersAiCompat(catalog),
+      };
+    case "openrouter":
+      return {
+        id: config.model,
+        name: catalog?.name ?? config.model,
+        api: "openai-completions",
+        provider: "openrouter",
+        baseUrl: `${gatewayUrl}/openrouter`,
+        reasoning: catalog?.reasoning ?? true,
+        input: catalog?.input ?? ["text", "image"],
+        cost: catalog?.cost ?? ZERO_COST,
+        ...window,
+        compat: catalog?.compat,
       };
     default:
       return undefined;
@@ -352,10 +367,13 @@ function makeHandle(args: HandleArgs): ModelHandle {
 export function getModel(env: Cloudflare.Env, config: AiModelConfig,
                          initiator: AiChatAuthorInfo,
                          options: ModelRoutingOptions = {}): ModelHandle {
-  // BYOK: a connected user's own Cloudflare account pays for everything (all providers, including
-  // Workers AI), routed through the user's own AI Gateway with unified billing. Honored regardless
-  // of whether a platform AI Gateway is configured, so connected users are always billed correctly.
-  if (options.userGateway) {
+  // BYOK: a connected user's own Cloudflare account pays for unified-billing providers (including
+  // Workers AI), routed through the user's own AI Gateway. Honored regardless of whether a
+  // platform AI Gateway is configured, so connected users are billed correctly where supported.
+  // OpenRouter is a provider aggregator rather than a Cloudflare Unified Billing provider. It
+  // must use the deployment gateway's stored OpenRouter key (or direct credentials), not a
+  // connected user's otherwise-preferred Cloudflare billing gateway.
+  if (options.userGateway && config.provider !== "openrouter") {
     return getModelViaUserGateway(
         config, buildMetadata(initiator, options.metadata), options.userGateway,
         options.sessionAffinity);
@@ -615,6 +633,23 @@ function getModelDirect(config: AiModelConfig, sessionAffinity?: string): ModelH
           cost: catalog?.cost ?? ZERO_COST,
           ...window,
           thinkingLevelMap: catalog?.thinkingLevelMap,
+          compat: catalog?.compat,
+        },
+        apiKey: config.apiToken,
+        sessionAffinity,
+      });
+    case "openrouter":
+      return makeHandle({
+        model: {
+          id: config.model,
+          name: catalog?.name ?? config.model,
+          api: "openai-completions",
+          provider: "openrouter",
+          baseUrl: config.apiUrl ?? "https://openrouter.ai/api/v1",
+          reasoning: catalog?.reasoning ?? true,
+          input: catalog?.input ?? ["text", "image"],
+          cost: catalog?.cost ?? ZERO_COST,
+          ...window,
           compat: catalog?.compat,
         },
         apiKey: config.apiToken,

--- a/packages/workshop-backend/src/chat-attachment-validation.ts
+++ b/packages/workshop-backend/src/chat-attachment-validation.ts
@@ -31,12 +31,14 @@ const isTextImageOrPdfMime = (mimeType: string) =>
 // pi-ai encodes only text and image content parts, so text + images are universal. PDFs ride an
 // image part and are bridged to a provider's native document input where one exists: Gemini takes
 // application/pdf inline data as-is, and Anthropic/OpenAI payloads are rewritten in flight (see
-// chat-attachment-pdf.ts). Workers AI and Ollama chat endpoints have no document input at all.
+// chat-attachment-pdf.ts). OpenRouter, Workers AI, and Ollama chat endpoints have no document
+// bridge here, so they accept only text and images.
 const ATTACHMENT_SUPPORT_BY_PROVIDER = {
   anthropic: isTextImageOrPdfMime,
   openai: isTextImageOrPdfMime,
   google: isTextImageOrPdfMime,
   cloudflare: isTextOrImageMime,
+  openrouter: isTextOrImageMime,
   ollama: isTextOrImageMime,
 } satisfies Record<AiModelProvider, (mimeType: string) => boolean>;
 

--- a/packages/workshop-backend/src/env.d.ts
+++ b/packages/workshop-backend/src/env.d.ts
@@ -17,7 +17,7 @@ declare global {
       // Inference goes over HTTPS with tokens (there is no Workers-binding transport), so the
       // ACCOUNT_ID/API_TOKEN pair is REQUIRED whenever CF_AI_GATEWAY is set.
       CF_AI_GATEWAY?: string;            // Gateway name (enables gateway mode)
-      CF_AI_GATEWAY_PROVIDERS?: string;   // Comma-separated list: "anthropic,openai,google,cloudflare"
+      CF_AI_GATEWAY_PROVIDERS?: string;   // Comma-separated: "anthropic,openai,google,cloudflare,openrouter"
       CF_AI_GATEWAY_ACCOUNT_ID?: string;  // Gateway owner account ID (required with CF_AI_GATEWAY)
       CF_AI_GATEWAY_API_TOKEN?: string;   // Run + Read token for inference and cost-log reads
       CF_AI_GATEWAY_WAI?: string;         // Optional Workers AI gateway override

--- a/packages/workshop-frontend/src/AddModelModal.tsx
+++ b/packages/workshop-frontend/src/AddModelModal.tsx
@@ -21,6 +21,7 @@ const PROVIDER_LABELS: Record<AiModelProvider, string> = {
   openai: 'OpenAI',
   google: 'Google',
   cloudflare: 'Cloudflare Workers AI',
+  openrouter: 'OpenRouter',
   ollama: 'Ollama',
 }
 
@@ -30,17 +31,25 @@ const API_TOKEN_PLACEHOLDERS: Record<AiModelProvider, string> = {
   openai: 'sk-...',
   google: 'AIza...',
   cloudflare: 'Cloudflare API token',
+  openrouter: 'sk-or-v1-...',
   ollama: '(optional)',
 }
 
-// Example used in the custom-model placeholders for providers that have no suggested models
-// (currently Ollama, which serves whatever the user has pulled locally).
-const FALLBACK_EXAMPLE_MODEL = { modelId: 'gemma4:31b', name: 'Gemma 4 31B' }
+// Examples used in custom-model placeholders for providers without suggested models.
+const FALLBACK_EXAMPLE_MODELS: Partial<Record<AiModelProvider, {
+  modelId: string,
+  name: string,
+}>> = {
+  openrouter: { modelId: 'openai/gpt-5.2', name: 'GPT-5.2 via OpenRouter' },
+  ollama: { modelId: 'gemma4:31b', name: 'Gemma 4 31B' },
+}
 
 // Pick an example model to show in the custom-model placeholders for the given provider.
 function exampleModel(provider: AiModelProvider): { modelId: string, name: string } {
   const first = Object.entries(SUGGESTED_MODELS[provider])[0]
-  return first ? { modelId: first[0], name: first[1].name } : FALLBACK_EXAMPLE_MODEL
+  return first
+    ? { modelId: first[0], name: first[1].name }
+    : FALLBACK_EXAMPLE_MODELS[provider] ?? { modelId: 'provider/model', name: 'Custom model' }
 }
 
 // Encode a selection into a string value for the Select component.

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -1130,7 +1130,13 @@ export type CloudflareAccountOption = {
 };
 
 /** Supported AI providers. */
-export type AiModelProvider = "openai" | "anthropic" | "google" | "cloudflare" | "ollama";
+export type AiModelProvider =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "cloudflare"
+  | "openrouter"
+  | "ollama";
 
 /** Information about the AI gateway configuration. Returned by `AuthenticatedApi.getAiConfig()`. */
 export type AiGatewayInfo = {
@@ -1203,6 +1209,10 @@ export const SUGGESTED_MODELS: Record<
   },
   "google": {
     "gemini-3.6-flash": {name: "Gemini 3.6 Flash", contextWindow: 1048576},
+  },
+  // OpenRouter's catalog changes independently and uses provider-prefixed model IDs. Keep it
+  // custom-entry-only rather than pinning a second, quickly stale suggested-model catalog here.
+  "openrouter": {
   },
   "ollama": {
   },


### PR DESCRIPTION
> [!IMPORTANT]
> This is a draft because the current contribution policy directs external feature proposals to Discussions and automatically closes non-draft external patches over 30 changed lines. I am leaving the policy attestations unchecked rather than inaccurately claiming this is not a feature.

## What does this change?

Adds OpenRouter as a first-class model provider:

- Routes OpenRouter through the Cloudflare AI Gateway native /openrouter endpoint, using the gateway stored provider key.
- Supports direct OpenRouter credentials through its OpenAI-compatible API.
- Keeps OpenRouter off the connected-account Unified Billing path, which does not support OpenRouter provider billing.
- Adds the provider to the model UI, attachment validation, shared API types, environment docs, and public-server docs.
- Uses provider-prefixed custom model IDs while retaining metadata from the pinned pi-ai OpenRouter catalog when available.

## Why is this obviously correct and trivially verifiable?

This is a feature and exceeds the repository automatic external-contribution size limit, so I am not asserting that it meets this criterion. The routing behavior is isolated to the existing provider switches and is covered by request-level tests for gateway auth, direct auth, connected-account precedence, catalog metadata, and attachment policy.

## Validation

- mise exec node@24 -- pnpm build
- mise exec node@24 -- pnpm lint:check
- mise exec node@24 -- pnpm test
- Focused backend tests: 39 passed

## Checklist

- [ ] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.