### PR TITLE
Fix contribution policy exemptions

### DIFF
--- a/.github/workflows/contribution-policy.yml
+++ b/.github/workflows/contribution-policy.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   enforce:
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
+    if: github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/scripts/contribution-policy.js
+++ b/scripts/contribution-policy.js
@@ -31,7 +31,6 @@ const REQUIRED_CONFIRMATIONS = [
 export function getContributionPolicyViolations(pullRequest) {
   if (
     pullRequest.state !== "open" ||
-    pullRequest.draft ||
     TRUSTED_ASSOCIATIONS.has(pullRequest.author_association) ||
     pullRequest.user?.login === "dependabot[bot]" ||
     pullRequest.labels?.some((label) => label.name === OVERRIDE_LABEL)

--- a/scripts/contribution-policy.js
+++ b/scripts/contribution-policy.js
@@ -4,6 +4,7 @@ const MAX_COMMENT_PAGES = 5;
 const OVERRIDE_LABEL = "policy/override";
 
 const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const TRUSTED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 const REQUIRED_CONFIRMATIONS = [
   {
     marker: "contribution-policy:concrete-change",
@@ -74,6 +75,16 @@ export async function enforceContributionPolicy({ github, context, core }) {
   let violations = getContributionPolicyViolations(pullRequest);
 
   if (violations.length === 0) return;
+
+  const username = pullRequest.user?.login;
+  if (username) {
+    const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+      owner,
+      repo,
+      username,
+    });
+    if (TRUSTED_PERMISSIONS.has(permission.permission)) return;
+  }
 
   const existingComment = await findAutomationComment(github, {
     owner,

--- a/scripts/contribution-policy.test.js
+++ b/scripts/contribution-policy.test.js
@@ -11,6 +11,10 @@ const pullRequestTemplate = readFileSync(
   new URL("../.github/pull_request_template.md", import.meta.url),
   "utf8",
 );
+const contributionPolicyWorkflow = readFileSync(
+  new URL("../.github/workflows/contribution-policy.yml", import.meta.url),
+  "utf8",
+);
 const compliantBody = pullRequestTemplate.replaceAll("- [ ]", "- [x]");
 
 function makePullRequest(overrides = {}) {
@@ -111,12 +115,14 @@ describe("getContributionPolicyViolations", () => {
     });
   }
 
-  it("exempts drafts", () => {
+  it("checks draft pull requests", () => {
     const violations = getContributionPolicyViolations(
-      makePullRequest({ additions: 100, body: "", draft: true }),
+      makePullRequest({ additions: 31, deletions: 0, draft: true }),
     );
 
-    assert.deepEqual(violations, []);
+    assert.deepEqual(violations, [
+      "The patch changes 31 lines; the automatic limit is 30.",
+    ]);
   });
 
   for (const [description, pullRequest] of [
@@ -154,6 +160,12 @@ describe("getContributionPolicyViolations", () => {
     );
 
     assert.deepEqual(violations, []);
+  });
+});
+
+describe("contribution policy workflow", () => {
+  it("runs the enforcement job for draft pull requests", () => {
+    assert.doesNotMatch(contributionPolicyWorkflow, /github\.event\.pull_request\.draft/);
   });
 });
 

--- a/scripts/contribution-policy.test.js
+++ b/scripts/contribution-policy.test.js
@@ -215,6 +215,36 @@ describe("enforceContributionPolicy", () => {
     assert.deepEqual(calls, []);
   });
 
+  it("does not close a pull request whose contributor-associated author can push", async () => {
+    const calls = [];
+    const github = makeGitHub(
+      makePullRequest({ additions: 100, author_association: "CONTRIBUTOR", body: "" }),
+      [],
+      calls,
+      { authorPermission: "write" },
+    );
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("still closes a pull request whose contributor-associated author cannot push", async () => {
+    const calls = [];
+    const github = makeGitHub(
+      makePullRequest({ additions: 100, author_association: "CONTRIBUTOR", body: "" }),
+      [],
+      calls,
+    );
+
+    await enforceContributionPolicy({ github, context, core });
+
+    assert.deepEqual(calls.map(({ operation }) => operation), [
+      "createComment",
+      "closePullRequest",
+    ]);
+  });
+
   it("does not close a pull request corrected during evaluation", async () => {
     const calls = [];
     const github = makeGitHub(
@@ -252,7 +282,7 @@ const context = {
 
 const core = { notice() {} };
 
-function makeGitHub(pullRequest, comments, calls) {
+function makeGitHub(pullRequest, comments, calls, { authorPermission = "read" } = {}) {
   const pullRequests = Array.isArray(pullRequest) ? pullRequest : [pullRequest];
   let pullRequestIndex = 0;
   const paginate = async () => comments;
@@ -273,6 +303,11 @@ function makeGitHub(pullRequest, comments, calls) {
           data: pullRequests[Math.min(pullRequestIndex++, pullRequests.length - 1)],
         }),
         update: async (args) => calls.push({ operation: "closePullRequest", ...args }),
+      },
+      repos: {
+        getCollaboratorPermissionLevel: async () => ({
+          data: { permission: authorPermission },
+        }),
       },
     },
   };


### PR DESCRIPTION
GitHub’s `author_association` depends on the viewer: the Actions token classified a maintainer as `CONTRIBUTOR` and auto-closed #167. This uses the author’s effective repository permission instead, which is the authority the exemption is meant to represent.

Drafts are no longer a blanket exemption. External draft PRs are subject to the same checks as ready PRs; maintainers, Dependabot, and `policy/override` remain exempt.