### PR TITLE
Prevent IME composition from submitting chat

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -61,6 +61,7 @@ import {
   getStoredSelectedModel,
   persistSelectedModel,
 } from "./modelSelection";
+import { isImeComposing } from "./components/chat/composer-keyboard";
 import {
   Overseer,
   GatekeeperClient,
@@ -3368,6 +3369,11 @@ export const ChatInput = ({
                 }
               }}
               onKeyDown={(e) => {
+                // Enter confirms the highlighted candidate in Chinese/Japanese/Korean IMEs. Let
+                // the browser finish that composition instead of selecting a slash command or
+                // submitting the message. keyCode 229 covers older browsers/WebViews that do not
+                // reliably expose KeyboardEvent.isComposing.
+                if (isImeComposing(e.nativeEvent)) return;
                 if (slashCommandPicker.open && e.key === "Escape") {
                   e.preventDefault();
                   slashCommandPicker.dismiss();

--- a/packages/workshop-frontend/src/components/chat/composer-keyboard.test.ts
+++ b/packages/workshop-frontend/src/components/chat/composer-keyboard.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isImeComposing } from "./composer-keyboard";
+
+describe("composer keyboard handling", () => {
+  it("recognizes a standards-based IME composition event", () => {
+    expect(isImeComposing({ isComposing: true, keyCode: 13 })).toBe(true);
+  });
+
+  it("recognizes the legacy IME process key used by older browsers", () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 229 })).toBe(true);
+  });
+
+  it("leaves an ordinary Enter key available for message submission", () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 13 })).toBe(false);
+  });
+});

--- a/packages/workshop-frontend/src/components/chat/composer-keyboard.ts
+++ b/packages/workshop-frontend/src/components/chat/composer-keyboard.ts
@@ -1,0 +1,8 @@
+/**
+ * IMEs use Enter and arrow keys while composing candidate text. React exposes the standard
+ * `isComposing` flag on the native keyboard event; keyCode 229 covers older browsers/WebViews
+ * that only report the legacy "process key" value.
+ */
+export function isImeComposing(event: Pick<KeyboardEvent, "isComposing" | "keyCode">): boolean {
+  return event.isComposing || event.keyCode === 229;
+}


### PR DESCRIPTION
## What does this change?

Prevents the chat composer from treating Enter and other keyboard shortcuts as commands while an IME composition is active. This fixes the existing bug reported in #81, where confirming a Chinese, Japanese, or Korean candidate could submit the message.

The guard covers both the standard `KeyboardEvent.isComposing` signal and the legacy process-key value (`keyCode === 229`). Focused tests cover composition Enter, legacy process-key Enter, and ordinary Enter.

## Why is this obviously correct and trivially verifiable?

The complete behavior is contained in one pure predicate and one early return in the existing keydown handler. When composition is active, the handler does nothing and leaves the event to the IME. When it is not active, execution continues through the unchanged keyboard handling path. The regression tests exercise both branches directly.

## Validation

- `pnpm --filter @gadgets/workshop-frontend exec tsc --noEmit`
- `pnpm --filter @gadgets/workshop-frontend test` (29 files, 153 tests passed)

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

Closes #81
