### PR TITLE
Fix optional account resource discovery

### DIFF
--- a/packages/workshop-frontend/src/components/ConnectConnectorModal.tsx
+++ b/packages/workshop-frontend/src/components/ConnectConnectorModal.tsx
@@ -90,7 +90,9 @@ export default function ConnectConnectorModal({
         ),
       )
     } else {
-      setSelected(new Set(grantableResources.map((r) => r.urlPattern)))
+      setSelected(new Set(grantableResources
+        .filter((r) => r.selectedByDefault !== false)
+        .map((r) => r.urlPattern)))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, isManage, grantableKey, grantedKey])

--- a/packages/workshop-frontend/src/routes/gatekeepers.tsx
+++ b/packages/workshop-frontend/src/routes/gatekeepers.tsx
@@ -647,9 +647,7 @@ function ConnectorsPage() {
   const filteredAccounts = useMemo(() => {
     const matchesSearch = (text: string | undefined) =>
       !searchLower || (text ?? '').toLowerCase().includes(searchLower)
-    const resourcesForAccountFilter = (account: AccountEntry) =>
-      vendors.find((v) => v.id === account.vendorId)?.supportedResources ??
-      account.supportedResources
+    const resourcesForAccountFilter = (account: AccountEntry) => account.supportedResources
 
     return accounts.filter((a) => {
       const resources = resourcesForAccountFilter(a)
@@ -694,9 +692,10 @@ function ConnectorsPage() {
     modalTarget?.kind === 'connect'
       ? availableVendors.find((v) => v.id === modalTarget.vendorId)
       : activeAccount
-      ? availableVendors.find((v) => v.id === activeAccount.vendorId) ?? {
+      ? {
           id: activeAccount.vendorId,
-          description: activeAccount.vendorDescription,
+          description: availableVendors.find((v) => v.id === activeAccount.vendorId)?.description ??
+            activeAccount.vendorDescription,
           supportedResources: activeAccount.supportedResources,
         }
       : undefined

--- a/packages/workshop-shared/src/gatekeeper.ts
+++ b/packages/workshop-shared/src/gatekeeper.ts
@@ -254,6 +254,9 @@ export type SupportedResource = {
    * If omitted/false, the resource type is not separately grantable.
    */
   grantable?: boolean;
+
+  /** Whether a grantable resource is selected initially when connecting an account. Defaults true. */
+  selectedByDefault?: boolean;
 }
 
 /** Removes every trailing slash from a string in linear time. */


### PR DESCRIPTION
A vendor may disclose all possible resource types before connection while a connected account returns a capability-dependent subset. The Gatekeepers page currently replaces the account-specific list with the vendor list in manage mode, and the connection modal has no way to disclose a grantable resource without selecting it.

This adds an optional `selectedByDefault` hint (defaulting to the existing selected behavior), honors it during connection, and uses connected-account resources when searching/managing an account.

Verification:
- `pnpm --filter @gadgets/workshop-frontend test` (150 tests)
- `pnpm --filter @gadgets/workshop-frontend build`
- `pnpm lint:check` (0 errors)