### PR TITLE
Support Workflow definitions in release manifests

### DIFF
--- a/scripts/release-manifest.test.js
+++ b/scripts/release-manifest.test.js
@@ -13,7 +13,8 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { collectAssets, collectModules, stableStringify } from "./release/hash-lib.mjs";
 import {
-  findDeployablePackages, generateManifest, readDeployInputs, readWranglerConfig,
+  buildWorkerEntry, findDeployablePackages, generateManifest, readDeployInputs,
+  readWranglerConfig,
 } from "./release/manifest-lib.mjs";
 
 const SCRIPTS = dirname(fileURLToPath(import.meta.url));
@@ -83,8 +84,40 @@ test("every $-token in binding templates and vars uses known placeholder syntax"
   for (const [name, entry] of Object.entries(manifest.workers)) {
     check(entry.bindings, `${name}.bindings`);
     check(entry.vars, `${name}.vars`);
+    check(entry.workflowDefinitions ?? {}, `${name}.workflowDefinitions`);
     check(entry.gatekeeperBindingExpansion ?? {}, `${name}.gatekeeperBindingExpansion`);
   }
+});
+
+test("same-script Workflows are part of the deploy contract", () => {
+  const entry = buildWorkerEntry({
+    pkgName: "workshop-backend",
+    config: {
+      name: "workshop-backend",
+      main: "src/server.ts",
+      compatibility_date: "2026-08-01",
+      workflows: [{
+        name: "workshop-backend-agent-turn",
+        binding: "AGENT_TURN_WORKFLOW",
+        class_name: "AgentTurnWorkflow",
+      }],
+    },
+    mainModule: "server.js",
+    modules: [],
+  });
+
+  assert.deepEqual(
+      entry.bindings.find((binding) => binding.name === "AGENT_TURN_WORKFLOW"),
+      {
+        type: "workflow",
+        name: "AGENT_TURN_WORKFLOW",
+        workflow_name: "$WORKER_NAME(workshop-backend)-agent-turn",
+        class_name: "AgentTurnWorkflow",
+      });
+  assert.deepEqual(entry.workflowDefinitions, [{
+    name: "$WORKER_NAME(workshop-backend)-agent-turn",
+    className: "AgentTurnWorkflow",
+  }]);
 });
 
 test("worker entries carry the deploy contract", () => {

--- a/scripts/release/manifest-lib.mjs
+++ b/scripts/release/manifest-lib.mjs
@@ -20,14 +20,14 @@ import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { parse } from "jsonc-parser";
 
-export const MANIFEST_VERSION = 1;
+export const MANIFEST_VERSION = 2;
 
 // wrangler.jsonc keys this generator understands. Anything else fails closed — a new config key
 // on a deployable worker needs an explicit decision about how customer instances get it.
 const HANDLED_CONFIG_KEYS = new Set([
   "$schema", "name", "main", "build", "compatibility_date", "compatibility_flags", "rules",
   "migrations", "observability", "kv_namespaces", "r2_buckets", "worker_loaders", "services",
-  "assets", "vars",
+  "workflows", "assets", "vars",
   // Browser Rendering (Gadget PDF exports). Unlike artifacts it is generally available, so it
   // passes through to customer instances as a placeholder-free binding, like the AI binding.
   "browser",
@@ -162,6 +162,34 @@ export function buildWorkerEntry({ pkgName, config, mainModule, modules, deployI
       ...(svc.entrypoint ? { entrypoint: svc.entrypoint } : {}),
     });
   }
+  const releaseWorkflowName = (workflow) => {
+    if (workflow.script_name && workflow.script_name !== config.name) return workflow.name;
+    let suffix = workflow.name.startsWith(config.name)
+      ? workflow.name.slice(config.name.length)
+      : `-${workflow.name}`;
+    return `$WORKER_NAME(${pkgName})${suffix}`;
+  };
+  for (const workflow of config.workflows ?? []) {
+    bindings.push({
+      type: "workflow",
+      name: workflow.binding,
+      workflow_name: releaseWorkflowName(workflow),
+      class_name: workflow.class_name,
+      ...(workflow.script_name ? {script_name: workflow.script_name} : {}),
+    });
+  }
+
+  // Same-script Workflow definitions require a Workflows API operation after Worker upload. Keep
+  // that operation explicit in the release contract; the binding alone cannot create a Workflow
+  // in a fresh customer account.
+  const workflowDefinitions = (config.workflows ?? [])
+      .filter((workflow) => !workflow.script_name || workflow.script_name === config.name)
+      .map((workflow) => ({
+        name: releaseWorkflowName(workflow),
+        className: workflow.class_name,
+        ...(workflow.limits ? {limits: workflow.limits} : {}),
+        ...(workflow.schedules ? {schedules: workflow.schedules} : {}),
+      }));
 
   let assetsConfig;
   if (config.assets) {
@@ -245,6 +273,7 @@ export function buildWorkerEntry({ pkgName, config, mainModule, modules, deployI
     bindings,
     vars,
     observability: config.observability ?? { enabled: false },
+    ...(workflowDefinitions.length > 0 ? {workflowDefinitions} : {}),
     ...(gatekeeperBindingExpansion ? { gatekeeperBindingExpansion } : {}),
     ...(assetsConfig ? { assetsConfig } : {}),
     ...(inputs ? { inputs } : {}),

--- a/scripts/testdata/golden-manifest.json
+++ b/scripts/testdata/golden-manifest.json
@@ -15,7 +15,7 @@
   },
   "commit": "0000000000000000000000000000000000000000",
   "createdAt": "2026-01-01T00:00:00.000Z",
-  "manifestVersion": 1,
+  "manifestVersion": 2,
   "releaseId": "r000000-fixture",
   "workers": {
     "gatekeeper-cloudflare": {


### PR DESCRIPTION
Part of #205.

## What does this change?

This adds Workflow bindings and same-Worker Workflow definitions to release manifest version 2. Workflow names use the deployed Worker name, so each installation receives the correct binding and definition.

The change also adds a focused manifest test. It does not enable a Workflow in any Worker.

## Why is this obviously correct and trivially verifiable?

A Workflow binding does not create a same-Worker Workflow during a fresh installation. The deploy service needs the definition after it uploads the Worker. The manifest now carries that definition next to the binding, and the test checks the complete output.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.