### PR TITLE
Fix executeCode return values

### DIFF
--- a/packages/workshop-backend/__tests__/code-mode-return.test.ts
+++ b/packages/workshop-backend/__tests__/code-mode-return.test.ts
@@ -1,7 +1,9 @@
 import { expect, it } from "vitest";
-import { appendCodeModeReturnValue, CODE_MODE_HARNESS } from "../src/overseer.js";
+import { appendCodeModeReturnValue } from "../src/overseer.js";
 it("preserves code mode return values", () => {
-  expect(CODE_MODE_HARNESS).toContain("return await agent");
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
   expect(appendCodeModeReturnValue("", 1n)).toBe("1");
   expect(appendCodeModeReturnValue("started", { ok: true })).toBe('started\n{"ok":true}');
+  expect(appendCodeModeReturnValue("", circular)).toBe("[unserializable return value]");
 });

--- a/packages/workshop-backend/__tests__/code-mode-return.test.ts
+++ b/packages/workshop-backend/__tests__/code-mode-return.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from "vitest";
+import { appendCodeModeReturnValue, CODE_MODE_HARNESS } from "../src/overseer.js";
+it("preserves code mode return values", () => {
+  expect(CODE_MODE_HARNESS).toContain("return await agent");
+  expect(appendCodeModeReturnValue("", 1n)).toBe("1");
+  expect(appendCodeModeReturnValue("started", { ok: true })).toBe('started\n{"ok":true}');
+});

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -50,7 +50,7 @@ import { renderGadgetPdf } from "./browser-export";
 const logger = createWorkshopLogger("workshop.overseer");
 export const AGENT_RUNNING_ERROR_MESSAGE = "Agent is running, wait for it to finish.";
 
-export const CODE_MODE_HARNESS =
+let CODE_MODE_HARNESS =
 `import { WorkerEntrypoint, restore } from "cloudflare:workers";
 import agent from "agent.js";
 

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -50,7 +50,7 @@ import { renderGadgetPdf } from "./browser-export";
 const logger = createWorkshopLogger("workshop.overseer");
 export const AGENT_RUNNING_ERROR_MESSAGE = "Agent is running, wait for it to finish.";
 
-let CODE_MODE_HARNESS =
+export const CODE_MODE_HARNESS =
 `import { WorkerEntrypoint, restore } from "cloudflare:workers";
 import agent from "agent.js";
 
@@ -84,7 +84,7 @@ export default class extends WorkerEntrypoint {
         }
       }
     }
-    await agent(self, env, this.ctx);
+    return await agent(self, env, this.ctx);
   }
 }
 `;
@@ -161,7 +161,19 @@ interface CodeModeEntrypoint extends WorkerEntrypoint {
         resolve: NativeRpcStub<(v: unknown) => void>,
         reject: NativeRpcStub<(e: unknown) => void>
       }>,
-      restoreForger?: NativeRpcStub<RestoreForgerImpl>): Promise<void>;
+      restoreForger?: NativeRpcStub<RestoreForgerImpl>): Promise<unknown>;
+}
+
+/** Appends a code-mode module's return value to its console output. */
+export function appendCodeModeReturnValue(log: string, value: unknown): string {
+  if (value === undefined) return log;
+  let rendered: string;
+  try {
+    let json = value !== null && typeof value === "object" &&
+        (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype);
+    rendered = json ? JSON.stringify(value) : String(value);
+  } catch { rendered = "[unserializable return value]"; }
+  return `${log}${log && rendered ? "\n" : ""}${rendered}`;
 }
 
 interface RestoreForgerEntrypoint extends WorkerEntrypoint {
@@ -5554,10 +5566,11 @@ class OverseerImpl implements AgentHooks {
       }
 
       let error: string | undefined;
+      let returnValue: unknown;
       try {
         // The forger is a transient stub argument, so the capability to forge persistent
         // gadget-restore stubs lives exactly as long as this run() call.
-        await entrypoint.run(selfStub, callbackResolvers,
+        returnValue = await entrypoint.run(selfStub, callbackResolvers,
             new RestoreForgerImpl(this, chatId, bindings));
       } catch (err) {
         if (err instanceof Error && err.stack) {
@@ -5587,7 +5600,7 @@ class OverseerImpl implements AgentHooks {
         log += `\n\nUncaught exception: ${error}`;
       }
 
-      return log;
+      return appendCodeModeReturnValue(log, returnValue);
     } finally {
       this.#codeModeOutputSubscribers.delete(executionId);
       this.#codeModeResolvers.delete(executionId);


### PR DESCRIPTION
## What does this change?

Part of #209.

During a live Cloudflare OS session, several `executeCode` steps completed with no visible output.
That symptom can have more than one cause. This PR addresses one independently reproducible case:
a code-mode module returns a value without calling `console.log()`, but the dynamic Worker harness
awaits and discards that value, so the completed invocation renders blank output.

The patch returns the module value from the harness, carries it through `executeCodeMode()`, and
appends it to existing console output. Plain objects and arrays use JSON; other RPC-supported values
use their string representation, with an explicit fallback if rendering throws. `undefined` keeps
the existing console-only behavior.

This PR does not claim to explain every blank or timed-out code-mode step.

## Why is this obviously correct and trivially verifiable?

The patch follows the existing call path directly: the harness returns `agent(...)`, the RPC type
accepts that value, `executeCodeMode()` captures it, and one small formatter appends it. The test
checks structured and non-JSON return rendering, plus a circular plain object that exercises the
explicit serialization fallback. No bindings, outbound access, authorization, or execution policy
changes.

Verification: Workshop unit tests (285/285), integration tests (2 passed, 4 existing skips),
Workshop build/typecheck, full repository tests and lint, and `git diff --check` all pass on Node 24.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
