### PR TITLE
Handle batched code mode tail events

### DIFF
--- a/packages/workshop-backend/__tests__/code-mode-tail.test.ts
+++ b/packages/workshop-backend/__tests__/code-mode-tail.test.ts
@@ -1,10 +1,8 @@
 import { expect, it, vi } from "vitest";
 import { CodeModeTailLoopback } from "../src/overseer.js";
-
 const trace = (rpcMethod: string) => ({
   event: { rpcMethod }, logs: [], exceptions: [], diagnosticsChannelEvents: [],
 }) as unknown as TraceItem;
-
 it("delivers only a run paired with one verify", async () => {
   const deliverCodeModeTrace = vi.fn(async () => undefined);
   const loopback = { ctx: {

--- a/packages/workshop-backend/__tests__/code-mode-tail.test.ts
+++ b/packages/workshop-backend/__tests__/code-mode-tail.test.ts
@@ -1,0 +1,25 @@
+import { expect, it, vi } from "vitest";
+import { CodeModeTailLoopback } from "../src/overseer.js";
+
+const trace = (rpcMethod: string) => ({
+  event: { rpcMethod }, logs: [], exceptions: [], diagnosticsChannelEvents: [],
+}) as unknown as TraceItem;
+
+it("delivers only a run paired with one verify", async () => {
+  const deliverCodeModeTrace = vi.fn(async () => undefined);
+  const loopback = { ctx: {
+    props: { executionId: "execution", overseerId: "overseer" },
+    exports: { OverseerDurableObject: {
+      idFromString: (id: string) => id,
+      get: () => ({ deliverCodeModeTrace }),
+    } },
+  } };
+  const tail = (...methods: string[]) => CodeModeTailLoopback.prototype.tail.call(
+    loopback as unknown as CodeModeTailLoopback, methods.map(trace));
+  await tail("verify", "run");
+  expect(deliverCodeModeTrace).toHaveBeenCalledOnce();
+  expect(deliverCodeModeTrace.mock.calls[0]?.[1]).toMatchObject({ event: { rpcMethod: "run" } });
+  for (const methods of [["verify", "other"], ["verify", "verify", "run"], ["run", "run"]]) {
+    deliverCodeModeTrace.mockClear(); await tail(...methods); expect(deliverCodeModeTrace).not.toHaveBeenCalled();
+  }
+});

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -7235,10 +7235,12 @@ export class CodeModeTailLoopback extends WorkerEntrypoint<Cloudflare.Env, CodeM
   //   on workerd console, need to fix that first.
 
   async tail(events: TraceItem[]) {
-    const methods = events.map(event => event.event && "rpcMethod" in event.event
-        ? event.event.rpcMethod : undefined);
-    if (events.length === 2 && methods.includes("verify") && methods.includes("run")) {
-      events = [events[methods.indexOf("run")]];
+    if (events.length === 2) {
+      const [first, second] = events;
+      const firstMethod = first.event && "rpcMethod" in first.event ? first.event.rpcMethod : undefined;
+      const secondMethod = second.event && "rpcMethod" in second.event ? second.event.rpcMethod : undefined;
+      if (firstMethod === "verify" && secondMethod === "run") events = [second];
+      else if (firstMethod === "run" && secondMethod === "verify") events = [first];
     }
     if (events.length != 1) {
       logger.error("unexpected code mode trace size", {

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -7235,6 +7235,11 @@ export class CodeModeTailLoopback extends WorkerEntrypoint<Cloudflare.Env, CodeM
   //   on workerd console, need to fix that first.
 
   async tail(events: TraceItem[]) {
+    const methods = events.map(event => event.event && "rpcMethod" in event.event
+        ? event.event.rpcMethod : undefined);
+    if (events.length === 2 && methods.includes("verify") && methods.includes("run")) {
+      events = [events[methods.indexOf("run")]];
+    }
     if (events.length != 1) {
       logger.error("unexpected code mode trace size", {
         event: "code.mode.trace.size.unexpected",


### PR DESCRIPTION
## What does this change?

Part of #209.

When a code-mode Tail batch consists of exactly one `verify()` and one `run()`, keeps the run trace
before applying the existing exactly-one-event validation. This avoids discarding the valid run
output while all other unexpected batches still fail closed.

## Why is this obviously correct and trivially verifiable?

The special case requires exactly two events and both expected RPC method names. The existing
singleton validation and single-verify early return remain unchanged for every other case. The
regression test asserts one delivery for `[verify, run]` and no delivery for malformed batches.
No bindings, authorization, or execution policy changes.

Verification: focused RED/GREEN reproduction, Workshop unit tests (285/285), integration tests
(2 passed, 4 existing skips), Workshop build/typecheck, full repository tests and lint, and
`git diff --check` all pass on Node 24.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
