### PR TITLE
Name the document an invoked Agent Skill came from

### DIFF
--- a/packages/gatekeeper-context/__tests__/agent-skill.test.ts
+++ b/packages/gatekeeper-context/__tests__/agent-skill.test.ts
@@ -235,35 +235,43 @@ describe("skill manifest content types", () => {
 });
 
 describe("buildAgentSkillMessage", () => {
+  // A quote in the path is why the root is named in prose rather than an element attribute.
+  let docId = 'lib/skills/de"ck/SKILL.md';
+  let root = 'skill root: lib/skills/de"ck/ — read the documents it references before following ' +
+    "it: prefix skill-local paths with this root, shared paths with the collection ID alone. " +
+    "Read by ID.";
+
   it("replaces $ARGUMENT with the full argument text", () => {
     expect(buildAgentSkillMessage(
+      docId,
       "Create a presentation about $ARGUMENT.",
       "CloudflareOS",
     )).toBe(
-      "<agent_skill>\nCreate a presentation about CloudflareOS.\n</agent_skill>",
+      `<agent_skill>\nCreate a presentation about CloudflareOS.\n</agent_skill>\n\n${root}`,
     );
   });
 
   it("inserts dollar signs without replacement-string expansion", () => {
     let args = "$& $$ $` $' $1";
-    expect(buildAgentSkillMessage("Use $ARGUMENT exactly.", args)).toBe(
-      `<agent_skill>\nUse ${args} exactly.\n</agent_skill>`,
+    expect(buildAgentSkillMessage(docId, "Use $ARGUMENT exactly.", args)).toBe(
+      `<agent_skill>\nUse ${args} exactly.\n</agent_skill>\n\n${root}`,
     );
   });
 
   it("appends the argument when the skill has no placeholder", () => {
     expect(buildAgentSkillMessage(
+      docId,
       "Create a clear presentation.",
       "Make it nice and clean",
     )).toBe(
-      "<agent_skill>\nCreate a clear presentation.\n</agent_skill>\n\n" +
+      `<agent_skill>\nCreate a clear presentation.\n</agent_skill>\n\n${root}\n\n` +
       "ARGUMENT: Make it nice and clean",
     );
   });
 
   it("does not append an empty argument", () => {
-    expect(buildAgentSkillMessage("Create a clear presentation.", "")).toBe(
-      "<agent_skill>\nCreate a clear presentation.\n</agent_skill>",
+    expect(buildAgentSkillMessage(docId, "Create a clear presentation.", "")).toBe(
+      `<agent_skill>\nCreate a clear presentation.\n</agent_skill>\n\n${root}`,
     );
   });
 });

--- a/packages/gatekeeper-context/src/agent-skill.ts
+++ b/packages/gatekeeper-context/src/agent-skill.ts
@@ -2,7 +2,7 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import type { SlashCommandDescriptor } from "@gadgets/workshop-shared/gatekeeper";
 import type { EnabledCollectionInfo } from "./context-types.js";
-import { encodeDocId } from "./context-types.js";
+import { docIdRoot, encodeDocId } from "./context-types.js";
 
 const AGENT_SKILL_NAME_MAX_LENGTH = 64;
 
@@ -63,11 +63,18 @@ export function buildAgentSkillCatalogEntries(
 /**
  * Context builds this complete message. Workshop stores it as normal chat text.
  * $ARGUMENT uses the raw command text. If missing, the text is appended after the skill.
+ *
+ * The slash-command record is display-only, so this message is the agent's only input: it names the
+ * document the skill came from, because otherwise the paths the skill cites resolve to nothing. The
+ * name is prose rather than an element attribute since a document path may contain quotes.
  */
-export function buildAgentSkillMessage(content: string, args: string): string {
+export function buildAgentSkillMessage(docId: string, content: string, args: string): string {
   let usesArgument = /\$ARGUMENT(?![A-Za-z0-9_[])/.test(content);
   let expanded = content.replace(/\$ARGUMENT(?![A-Za-z0-9_[])/g, () => args);
-  let message = `<agent_skill>\n${expanded}\n</agent_skill>`;
+  let message = `<agent_skill>\n${expanded}\n</agent_skill>\n\n` +
+    `skill root: ${docIdRoot(docId)} — read the documents it references ` +
+    `before following it: prefix skill-local paths with this root, shared paths with the ` +
+    `collection ID alone. Read by ID.`;
   return !usesArgument && args ? `${message}\n\nARGUMENT: ${args}` : message;
 }
 

--- a/packages/gatekeeper-context/src/context-types.ts
+++ b/packages/gatekeeper-context/src/context-types.ts
@@ -72,6 +72,11 @@ export function encodeDocId(collectionId: string, path: string): string {
   return `${collectionId}/${path}`;
 }
 
+/** The ID prefix every document beside this one shares, trailing slash included. */
+export function docIdRoot(docId: string): string {
+  return docId.slice(0, docId.lastIndexOf("/") + 1);
+}
+
 /** Invalid IDs resolve to no document. */
 export function decodeDocId(docId: string): {collectionId: string; path: string} | null {
   let slashIndex = docId.indexOf("/");

--- a/packages/gatekeeper-context/src/library-gatekeeper.ts
+++ b/packages/gatekeeper-context/src/library-gatekeeper.ts
@@ -313,7 +313,7 @@ export class ContextGatekeeper
     let manifest = parseSkillManifest(document.path, document.content);
     return {
       skillName: manifest.name,
-      message: buildAgentSkillMessage(document.content, args),
+      message: buildAgentSkillMessage(id, document.content, args),
     };
   }
 


### PR DESCRIPTION
## What does this change?

Currently, for a skill invoked via slash commands, the agent never sees the actual document ID/path, and thus any relative files/resources referred in the skill also don't make sense to the agent. This PR fixes that.

## Why is this obviously correct and trivially verifiable?

Just simply adds the docId to the prompt

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
