### PR TITLE
Tell the agent a file path names an output, not a file

### DIFF
--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -5833,7 +5833,10 @@ class OverseerImpl implements AgentHooks {
         `workspace already contains Gadgets, since the user is asking for a new output alongside ` +
         `them rather than for an existing one to be repurposed. If the Gadget they are talking ` +
         `about already *is* one of these, work on that one instead: asking to change an existing ` +
-        `output is not a request for a second one.\n\n` +
+        `output is not a request for a second one. When an instruction names a file path for the ` +
+        `result ("save it to notes.md"), that names the output to produce, not a file to write: ` +
+        `there is no path to write it to, so use the matching format below -- creating it when the ` +
+        `workspace has none -- and fill it in through its RPC methods.\n\n` +
         formats.map(format =>
             `* ${format.output.noun} (plural: ${format.output.plural}) — blueprintId: ` +
             `${format.blueprintId}` + (format.agentHint ? `; ${format.agentHint}` : ``)).join("\n");


### PR DESCRIPTION
## What does this change?

An instruction that names a file path for its result has no defined behaviour, because there is no
path to write to.

`writeFile` takes a `workpiece` — every write goes inside one specific Gadget, as one of that
Gadget's source files. There is no free-standing file path, and the system prompt never says so. When
a skill or a user says "save it to `notes.md`", the agent is left to invent a destination: sometimes
it answers in chat, sometimes it writes a `.md` into a Gadget's source tree where it renders as code
rather than as a document, sometimes it creates the right output. It varies between runs.

This is not hypothetical for skill libraries. In the one this deployment publishes, 93 of 97 skills
end by naming a file path for their deliverable.

The standard-formats section is where the mapping belongs: it already lists the deployment's formats
with their nouns and blueprint IDs immediately below, and it is already the place that tells the
agent to instantiate a format rather than build an equivalent.

## Why is this obviously correct and trivially verifiable?

Four added lines of prompt text in one function, and no code path changes. The complete effect is the
sentence itself, read in place.

The wording names no particular path convention, so it does not encode any one library's habits — it
states the rule that follows from `writeFile` requiring a workpiece. It reuses the vocabulary already
present in the surrounding prompt (`createGadget`, "format", RPC methods), and defers to the format
list rendered directly beneath it rather than hard-coding any blueprint ID or extension.

`describeStandardFormats()` has no test seam, and neither does any other prompt text in this file;
adding one would mean extracting the method purely to assert prose, which would be a larger and
less obvious change than the patch itself. Verified with `pnpm lint` (lint plus type-check) and
`pnpm test`, both clean.

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
