### PR TITLE
Fix oxlint plugin test on Windows

### DIFF
--- a/scripts/oxlint-plugin.test.js
+++ b/scripts/oxlint-plugin.test.js
@@ -1,11 +1,14 @@
 import { describe, it } from "node:test";
 import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import { preferJsdoc } from "./oxlint-plugin.mjs";
 
 const require = createRequire(import.meta.url);
 const vitePlusRequire = createRequire(require.resolve("vite-plus/package.json"));
 // Test against Vite+'s pinned oxlint without adding a second direct dependency that can drift.
-const { RuleTester } = await import(vitePlusRequire.resolve("oxlint/plugins-dev"));
+const { RuleTester } = await import(
+  pathToFileURL(vitePlusRequire.resolve("oxlint/plugins-dev")),
+);
 
 RuleTester.describe = describe;
 RuleTester.it = it;


### PR DESCRIPTION
## What does this change?

Fixes #220.

Convert the absolute path returned by `require.resolve()` to a `file:` URL before dynamically importing Vite+'s pinned oxlint plugin test helper. This lets the test file start on Windows, where a raw drive-letter path is not a valid ESM specifier.

## Why is this obviously correct and trivially verifiable?

`pathToFileURL()` is Node's standard conversion from a filesystem path to an importable file URL. The resolved module and all test behavior remain unchanged; only the representation passed to `import()` changes. The patch adds one standard-library import and wraps the existing resolved path.

Verification on Windows with Node 22.22.3 and pnpm 11.17.0:

- `node --test scripts/oxlint-plugin.test.js` — 32 passed
- `pnpm lint:check` — passed (existing warnings only)
- `pnpm lint` — lint passed, but the recursive type/build phase hit the existing `spawnSync pnpm ENOENT` failure in unchanged `packages/gatekeeper-scheduler/build-app.mjs` tracked by #19 and #107

AI tools assisted the investigation, patch drafting, and review. The failure and verification results above were reproduced locally.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.