### PR TITLE
Point the observer comments at the doc's current name

### DIFF
--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -394,7 +394,7 @@ function oneLineReason(reason: string): string {
 // and passed all `addObserver` checks -- i.e. is actually set up to observe data the Gadget has
 // read. This is distinct from the sharing table (which records the owner's *intent* that a user
 // have access): opening requires BOTH a reachable role in the sharing graph AND a complete
-// observer record. See observers-implementation-plan.md §3.
+// observer record. See docs/observers.md §3.
 type ObserverRecord = {
   // The sharing-table key for this user (their profile.id). Primary key of the collection.
   profileId: string;
@@ -2758,7 +2758,7 @@ class OverseerImpl implements AgentHooks {
     // v1 has no per-thread hiding, the only way to let such an observation proceed is if the named
     // observer has already lost access in the sharing graph. If any named observer is still
     // authorized, we cannot prevent them from seeing it, so we block the observation. See
-    // observers-implementation-plan.md §5 Step 5.
+    // docs/observers.md §5 Step 5.
     if (description.excludeObservers && description.excludeObservers.length > 0) {
       await this.#enforceExcludeObservers(description.excludeObservers);
     }
@@ -6043,7 +6043,7 @@ class OverseerImpl implements AgentHooks {
   // observer record: best-effort removeObserver on all gatekeeper facets, then delete the record.
   // All calls are best-effort -- an orphaned observer entry only causes superfluous future checks,
   // never a data leak (the leak-relevant gate is authorizeObservation, keyed off the live sharing
-  // graph). See observers-implementation-plan.md §5 Step 6.
+  // graph). See docs/observers.md §5 Step 6.
   async tearDownLostObservers(affected: AffectedCollaborator[]): Promise<void> {
     let gatekeeperIds = [...this.storage.gatekeepers.list()].map(gk => gk.id);
     for (let entry of affected) {
@@ -6089,7 +6089,7 @@ class OverseerImpl implements AgentHooks {
   // already-configured bindings on every open, catching revocation of the user's underlying
   // resource access promptly. Returns when fully verified; throws to deny access.
   //
-  // See observers-implementation-plan.md §5 Step 3.
+  // See docs/observers.md §5 Step 3.
   async ensureObserver(
       profileId: string,
       clientUser: DurableObjectStub<UserDurableObject>,


### PR DESCRIPTION
## What does this change?

Four comments in `overseer.ts` cite `observers-implementation-plan.md`, but the file is checked in as `docs/observers.md` — so following the reference finds nothing. I hit this while reading `ensureObserver()` and went looking for a file that isn't there.

Retargeted all four, matching how `blueprint-archive.ts` already cites `docs/blueprints.md`:

| line | now cites |
|---|---|
| 397 | `docs/observers.md` §3 |
| 2761 | `docs/observers.md` §5 Step 5 |
| 6046 | `docs/observers.md` §5 Step 6 |
| 6092 | `docs/observers.md` §5 Step 3 |

## Why is this obviously correct and trivially verifiable?

The patch is four comment lines; no code changes, so behaviour cannot move.

Both halves are checkable from the tree alone:

- `docs/observers.md` exists and `observers-implementation-plan.md` does not.
- Every cited section still exists under the new name — `## 3. Concepts & terminology`, `### Step 3`, `### Step 5`, `### Step 6` — so each reference resolves to the passage it was always pointing at.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
