### PR TITLE
feat: automatic Ollama model sync for the workshop model picker

### DIFF
--- a/packages/workshop-backend/src/env.d.ts
+++ b/packages/workshop-backend/src/env.d.ts
@@ -85,6 +85,14 @@ declare global {
       // Minimum connected-account balance (USD) to proceed via BYOK. Defaults to
       // MINIMUM_CLOUDFLARE_BALANCE.
       MINIMUM_CLOUDFLARE_BALANCE?: string;
+
+      // Optional automatic Ollama model sync: when OLLAMA_AUTO_SYNC_URL is set (and AI Gateway
+      // mode is off), the user's model list is refreshed from that Ollama server's /v1/models on
+      // listModels() (rate-limited), so every model pulled on the server appears in the picker
+      // without manual Add Model entries. OLLAMA_AUTO_SYNC_TOKEN is the bearer token for the
+      // endpoint (e.g. the ollama.cdnet.uk auth-Worker shared secret); omit when unauthenticated.
+      OLLAMA_AUTO_SYNC_URL?: string;
+      OLLAMA_AUTO_SYNC_TOKEN?: string;
     }
   }
 }

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -19,6 +19,10 @@ const logger = createWorkshopLogger("workshop.user");
 // listOutputs() call wakes and how long it waits. The client calls again until catch-up is done.
 const OUTPUTS_BACKFILL_PAGE = 16;
 
+// How often the automatic Ollama model sync refetches /v1/models per user DO. Keeps picker loads
+// cheap (one fetch per window at most) while still picking up newly pulled models promptly.
+const OLLAMA_AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+
 type ConnectedAccountRecord = {
   id: number;
   account: Fetcher<GatekeeperUser>;
@@ -221,6 +225,11 @@ function makeUserStorage(storage: DurableObjectStorage) {
       //
       // null = password disabled (e.g. because some other auth mechanism is used)
       passwordHashHash: <Uint8Array | null>null,
+
+      // Last time the automatic Ollama model sync ran (unix ms), for rate-limiting. Null until the
+      // first sync. Written even on failure so a down Ollama server can't cause a fetch on every
+      // picker load.
+      ollamaSyncAt: <number | null>null,
     }
   });
 }
@@ -525,7 +534,74 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     this.storage.profile.put(profile);
   }
 
+  // Refresh the user's configured models from the configured Ollama server (OLLAMA_AUTO_SYNC_URL),
+  // persisting any model the server has that the user doesn't already have configured. Runs at most
+  // once per OLLAMA_AUTO_SYNC_INTERVAL_MS and never throws: a failure (server down, bad token) is
+  // logged and the existing model list is returned unchanged, so the picker is never blocked.
+  //
+  // Persisting (rather than just listing) is what makes the auto-discovered models fully usable:
+  // getChatContext()/setPreferredModel()/deleteModel() all resolve through storage.aiModels, so a
+  // model that only existed in the list would throw "No such model" the moment it was selected.
+  // Deleting an auto-synced model is therefore a no-op in effect — the next sync re-adds it while
+  // it still exists on the server, which is the desired behavior for a live catalog.
+  async #syncAutoOllamaModels(): Promise<void> {
+    // Requires an explicit URL and only applies outside AI Gateway mode (Ollama is not a gateway
+    // provider; addModel() rejects it there, so auto-adding would just fail).
+    if (!this.env.OLLAMA_AUTO_SYNC_URL || getAiGatewayConfig(this.env)) return;
+
+    let lastSync = this.storage.ollamaSyncAt.get();
+    if (lastSync !== null && Date.now() - lastSync < OLLAMA_AUTO_SYNC_INTERVAL_MS) return;
+
+    try {
+      let url = `${this.env.OLLAMA_AUTO_SYNC_URL.replace(/\/+$/, "")}/v1/models`;
+      let headers: Record<string, string> = {"Accept": "application/json"};
+      if (this.env.OLLAMA_AUTO_SYNC_TOKEN) {
+        headers["Authorization"] = `Bearer ${this.env.OLLAMA_AUTO_SYNC_TOKEN}`;
+      }
+      let response = await fetch(url, {headers});
+      if (!response.ok) {
+        logger.warn("ollama auto-sync fetch failed", {
+          event: "ollama.autoSync.fetch.failed",
+          statusCode: response.status,
+          error: new Error(`GET ${this.env.OLLAMA_AUTO_SYNC_URL}/v1/models returned ${response.status}`),
+        });
+        return;
+      }
+      let body: {data?: Array<{id: string}>} = await response.json();
+      if (!Array.isArray(body.data)) return;
+
+      let added = 0;
+      for (let entry of body.data) {
+        if (!entry || typeof entry.id !== "string" || !entry.id) continue;
+        if (this.storage.aiModels.get(entry.id)) continue;
+        this.storage.aiModels.put({
+          profile: {type: "agent", id: entry.id, name: `${entry.id} (Ollama)`},
+          config: {
+            provider: "ollama",
+            model: entry.id,
+            apiToken: this.env.OLLAMA_AUTO_SYNC_TOKEN || "",
+            apiUrl: this.env.OLLAMA_AUTO_SYNC_URL,
+          },
+        });
+        ++added;
+      }
+      if (added > 0) {
+        logger.info("ollama auto-sync added models", {
+          event: "ollama.autoSync.added", size: added,
+        });
+      }
+    } catch (err) {
+      logger.warn("ollama auto-sync failed", {
+        event: "ollama.autoSync.failed", error: err,
+      });
+    } finally {
+      this.storage.ollamaSyncAt.put(Date.now());
+    }
+  }
+
   async listModels(): Promise<AiChatAuthorInfo[]> {
+    await this.#syncAutoOllamaModels();
+
     let result: AiChatAuthorInfo[] = [];
 
     // When AI Gateway mode is active, include all suggested models for enabled providers.


### PR DESCRIPTION
## What does this change?

When a self-hosted Ollama server backs the workshop (outside AI Gateway mode), users previously had to add every pulled model manually via **Add Model**. With `OLLAMA_AUTO_SYNC_URL` set, `listModels()` mirrors the Ollama server's `/v1/models` into the user's model config automatically, so every model pulled on the server appears in the model picker without manual entry.

The change is confined to two files in `packages/workshop-backend`:

- `src/user.ts` (76 lines added): on `listModels()`, if `OLLAMA_AUTO_SYNC_URL` is set and the last sync is older than 5 minutes, fetch `/v1/models` and persist any new models into the user's model config. Models are persisted (not merely listed) so chat, preferred-model selection, and deletion resolve them exactly like manually-added models. Failures are logged and swallowed — a down Ollama server never blocks the model picker.
- `src/env.d.ts` (8 lines added): the optional `OLLAMA_AUTO_SYNC_URL` and `OLLAMA_AUTO_SYNC_TOKEN` env vars, mirroring the existing AI Gateway env var declarations.

## Why is this obviously correct and trivially verifiable?

- The sync is opt-in: nothing runs unless `OLLAMA_AUTO_SYNC_URL` is set (AI Gateway mode is untouched).
- Every added code path is a straightforward extension of the existing `listModels()` / model-persistence helpers already in `user.ts`; no other module is affected.
- Failures are caught and logged, so an unreachable Ollama server degrades to the current behavior.
- A quick local test: set `OLLAMA_AUTO_SYNC_URL`, pull a model on the Ollama server, and confirm it appears in the picker within 5 minutes.

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

## Notes

- The deployment-side env wiring and docs for this feature live in `cloudflare-os-starter` (separate change, will be PR'd there).
- A prior version of this branch also carried a local @vitest alignment fix; it has been dropped from this PR and is preserved separately on the fork (`ollama-auto-sync-vitest-backup`).
