### PR TITLE
Tell the agent how to use catalogs and where outputs go

### DIFF
--- a/packages/workshop-backend/__tests__/agent-catalog.test.ts
+++ b/packages/workshop-backend/__tests__/agent-catalog.test.ts
@@ -80,6 +80,17 @@ describe("normalizeAgentCatalog", () => {
     // A resource with no catalog gets just its env line, nothing inlined.
     expect(message).toContain("- Empty: `env.EMPTY`");
     expect(message).not.toContain("- Empty: `env.EMPTY`\n{");
+    expect(message).toContain("Check the entries listed above before starting a task");
+    expect(message).toContain('A catalog marked `"truncated":true` is partial');
+  });
+
+  it("describes the catalogs only when a resource published entries", () => {
+    let message = formatAlwaysAvailableResourcesPrompt([
+      {title: "Empty", name: "EMPTY", catalog: null},
+    ]);
+
+    expect(message).toContain("- Empty: `env.EMPTY`");
+    expect(message).not.toContain("Check the entries listed above");
   });
 });
 

--- a/packages/workshop-backend/src/agent-catalog.ts
+++ b/packages/workshop-backend/src/agent-catalog.ts
@@ -91,9 +91,16 @@ export function formatAlwaysAvailableResourcesPrompt(resources: Array<{
 }>): string {
   let lines = resources.map(resource =>
     `- ${resource.title}: \`env.${resource.name}\`${formatAgentCatalogPrompt(resource.catalog)}`);
+  // Only describe the catalogs when a resource actually published entries, so a deployment whose
+  // resources offer none doesn't get told to consult a list that isn't there.
+  let catalogs = resources.some(resource => resource.catalog?.entries.length)
+    ? ` Check the entries listed above before starting a task and use a relevant one even when the ` +
+      `user did not name it. A catalog marked \`"truncated":true\` is partial, so reach what it ` +
+      `omits through the binding's own search or listing methods.`
+    : ``;
   return `The following resources are always available as bindings in your env for use with the ` +
     `executeCode tool (you don't need to request them):\n${lines.join("\n")}\n` +
     `When one is relevant, use describeBinding with the binding's name to learn its API before ` +
-    `using it. If a Gadget's persistent code needs one, wire it into that gadget with ` +
+    `using it.${catalogs} If a Gadget's persistent code needs one, wire it into that gadget with ` +
     `setGadgetBinding.`;
 }

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -5834,6 +5834,11 @@ class OverseerImpl implements AgentHooks {
         `them rather than for an existing one to be repurposed. If the Gadget they are talking ` +
         `about already *is* one of these, work on that one instead: asking to change an existing ` +
         `output is not a request for a second one.\n\n` +
+        `An instruction that names a file path for the result ("save it to notes.md") names the ` +
+        `output to produce, not a file to write: there is no path to write to. Use the matching ` +
+        `format below, creating it when the workspace has none, then fill it in through its RPC ` +
+        `methods, reusing any ready-made layout its code documents rather than positioning ` +
+        `content yourself.\n\n` +
         formats.map(format =>
             `* ${format.output.noun} (plural: ${format.output.plural}) — blueprintId: ` +
             `${format.blueprintId}` + (format.agentHint ? `; ${format.agentHint}` : ``)).join("\n");


### PR DESCRIPTION
## What does this change?

Two things the agent is given but never told how to use.

**Outputs.** `writeFile` takes a `workpiece`, so every write lands inside one specific Gadget as one
of its source files. There is no free-standing file path, and nothing in the prompt says so. When an
instruction says "save it to `notes.md`" the agent has no defined behaviour: sometimes it answers in
chat, sometimes it writes a `.md` into a Gadget's source tree where it renders as code rather than a
document, sometimes it creates the right output. This states the rule as its own paragraph in the
section that already explains the deployment's formats, directly above the list it refers to.

**Catalogs.** A resource's discovery catalog is inlined into the system prompt, and `truncated` is
emitted as a bare JSON key with nothing explaining it. The agent is told to `describeBinding` a
resource when one is relevant, but never to consult the entries first, and never that a partial list
has a remainder reachable through the binding's own API. So a listed item goes unused unless the user
names it, and a truncated list looks complete.

## Why is this obviously correct and trivially verifiable?

Prompt text only: 13 added lines across two functions, no code path changes. The complete effect is
the wording, read in place.

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
