### PR TITLE
Defer chat composer keyboard handling to active IME composition

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -3368,6 +3368,7 @@ export const ChatInput = ({
                 }
               }}
               onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing || e.keyCode === 229) return;
                 if (slashCommandPicker.open && e.key === "Escape") {
                   e.preventDefault();
                   slashCommandPicker.dismiss();
@@ -6738,6 +6739,7 @@ function ChatInterface({
                             onChange={(e) => setRenamingInput(e.target.value)}
                             onClick={(e) => e.stopPropagation()}
                             onKeyDown={(e) => {
+                              if (e.nativeEvent.isComposing || e.keyCode === 229) return;
                               if (e.key === "Enter") {
                                 e.preventDefault();
                                 handleSaveListRename(chat.id);
@@ -6962,6 +6964,7 @@ function ChatInterface({
                         value={titleInput}
                         onChange={(e) => setTitleInput(e.target.value)}
                         onKeyDown={(e) => {
+                          if (e.nativeEvent.isComposing || e.keyCode === 229) return;
                           if (e.key === "Enter") handleSaveChatTitle();
                           if (e.key === "Escape") handleCancelTitleEdit();
                         }}


### PR DESCRIPTION
## What does this change?

When a user types Chinese (or other IME-composed text) in the chat composer and presses Enter to confirm a candidate character, the message was being sent instead of inserting the chosen character. The same bug affected the chat-list rename input and the chat-title edit input.

This adds a single early-return guard at the top of three `onKeyDown` handlers in `packages/workshop-frontend/src/ChatInterface.tsx`. While the IME is composing, the guard (`if (e.nativeEvent.isComposing || e.keyCode === 229) return;`) defers to the IME, so Enter confirms a CJK candidate, Backspace edits the IME buffer, and arrow keys move within the IME instead of triggering application shortcuts.

## Why is this obviously correct and trivially verifiable?

Three identical one-line guards in three known locations. The check is the standard, well-known IME-composition pattern used by antd, Radix, and GitHub Primer. `isComposing` is the modern spec-correct flag; `keyCode === 229` is the legacy fallback for browsers / IMEs that fail to set it.

The complete effects are:

- The composer `<textarea>` `onKeyDown` defers to the IME while composing. This covers Enter-send, Enter-on-slash-picker, Backspace-on-token, ArrowLeft/Right-on-token, and Escape-on-slash-picker — all of which were at risk of misfiring during composition.
- The chat-list rename `<input>` `onKeyDown` defers to the IME, so Enter no longer prematurely saves the rename while the user is still picking CJK characters.
- The chat-title edit `<input>` `onKeyDown` defers to the IME, with the same effect for chat titles.

`pnpm types:check` and `pnpm lint:check` both pass on the change.

## Checklist

- [x] This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] I have read and followed the contribution guidelines.