### PR TITLE
Give break-glass write access to PR labels

### DIFF
--- a/.github/workflows/bonk-pr.yml
+++ b/.github/workflows/bonk-pr.yml
@@ -24,7 +24,7 @@ jobs:
       actions: write
       checks: write
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Skip Bonk review
         env:


### PR DESCRIPTION
Break-glass 403s adding `bonk-break-glass` because the job only has `pull-requests: read`. Grant write so the existing label step can succeed.