### PR TITLE
Fix frontend build cleanup on Windows

### DIFF
--- a/packages/workshop-frontend/vite.config.ts
+++ b/packages/workshop-frontend/vite.config.ts
@@ -14,7 +14,10 @@ const ownDist = { pattern: '!dist/**', base: 'package' } as const
 const runConfig = {
   run: {
     tasks: {
-      'clean:dist': { command: 'rm -rf dist', cache: false },
+      'clean:dist': {
+        command: `node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"`,
+        cache: false,
+      },
       /**
        * `build` is a task rather than a package.json script so `env` can declare the `VITE_*` flags
        * it reads: a cached `vp` run executes scripts in a clean environment, and the values would be


### PR DESCRIPTION
## What does this change?

Fixes #250.

Replace the POSIX-only `rm` executable in the `workshop-frontend` Vite+ `clean:dist` task with Node's built-in recursive filesystem removal. This lets the frontend build, and therefore `pnpm lint`, run on Windows without changing the task's cleanup behavior.

## Why is this obviously correct and trivially verifiable?

`fs.rmSync(..., { recursive: true, force: true })` has the two properties this task needs from `rm -rf`: it removes the complete `dist` tree and does not fail when the path is absent. Node is already the runtime for every repository task, so the replacement adds no dependency or platform-specific executable. The task remains uncached and remains the `build` dependency; only its command changes.

Verification on Windows 11 with Node 24.19.0 and pnpm 11.17.0:

- before: `pnpm exec vp run -F @gadgets/workshop-frontend --no-cache build` failed with `Failed to find executable rm`;
- after: the same command completed both TypeScript checks and the production Vite build;
- a stale sentinel placed under `dist/` before the run was removed;
- `pnpm lint` completed successfully (existing warnings only).

AI tools assisted the investigation, patch drafting, and review. The failure and verification results above were reproduced locally.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
