### PR TITLE
Update Bonk to OpenCode 1.18.18

### DIFF
--- a/.github/workflows/bonk-pr.yml
+++ b/.github/workflows/bonk-pr.yml
@@ -148,6 +148,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
@@ -156,4 +157,4 @@ jobs:
           permissions: write
           token_permissions: NO_PUSH
           agent: bonk
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          opencode_version: 1.18.18

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -31,6 +31,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
@@ -40,4 +41,4 @@ jobs:
           permissions: write
           token_permissions: NO_PUSH
           agent: bonk
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          opencode_version: 1.18.18


### PR DESCRIPTION
## What does this change?

Updates both Bonk workflows from OpenCode `1.15.13` to the current `1.18.18` release and explicitly registers the configured Claude Opus 4.8 model with the Cloudflare AI Gateway provider.

A validation run confirmed `1.18.18` installs, but OpenCode's provider registry did not recognize `cloudflare-ai-gateway/anthropic/claude-opus-4-8`. The inline `OPENCODE_CONFIG_CONTENT` registration fixes that without changing the selected model.

## Why is this obviously correct and trivially verifiable?

The change is limited to the two workflow files that invoke Bonk. Both pass YAML parsing, `actionlint`, and `git diff --check`. OpenCode `1.18.18` model discovery also accepts the explicit provider registration.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
