### PR TITLE
Use GPT-5.6 Sol for Bonk

### DIFF
--- a/.github/workflows/bonk-pr.yml
+++ b/.github/workflows/bonk-pr.yml
@@ -148,10 +148,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"openai/gpt-5.6-sol":{}}}}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          model: "cloudflare-ai-gateway/openai/gpt-5.6-sol"
           variant: "high"
           forks: "false"
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -31,10 +31,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-8":{}}}}}'
+          OPENCODE_CONFIG_CONTENT: '{"provider":{"cloudflare-ai-gateway":{"models":{"openai/gpt-5.6-sol":{}}}}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          model: "cloudflare-ai-gateway/openai/gpt-5.6-sol"
           variant: "high"
           mentions: "/bonk,@ask-bonk"
           forks: "true"


### PR DESCRIPTION
## What does this change?

Switches both Bonk workflows from Claude Opus 4.8 to GPT-5.6 Sol through Cloudflare AI Gateway.

The change updates both the selected model and the explicit OpenCode provider registration to `cloudflare-ai-gateway/openai/gpt-5.6-sol`. OpenCode remains pinned to `1.18.18`.

## Why is this obviously correct and trivially verifiable?

The change is limited to the two workflow files that invoke Bonk. Both pass YAML parsing, `actionlint`, and `git diff --check`. OpenCode `1.18.18` model discovery recognizes the configured GPT-5.6 Sol identifier.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
