### PR TITLE
disable export button when export is in progress

### DIFF
--- a/packages/workshop-frontend/src/GadgetExportMenu.test.tsx
+++ b/packages/workshop-frontend/src/GadgetExportMenu.test.tsx
@@ -47,7 +47,9 @@ vi.mock('@cloudflare/kumo', () => {
   )
   return {
     DropdownMenu,
-    Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Tooltip: ({ children, content }: { children: ReactNode; content: ReactNode }) => (
+      <div data-tooltip={content}>{children}</div>
+    ),
     useKumoToastManager: () => ({ add: mocks.toast }),
   }
 })
@@ -134,6 +136,42 @@ describe('GadgetExportMenu', () => {
       'Report.csv',
       { description: 'CSV', contentType: 'text/csv', extension: '.csv' },
     )
+  })
+
+  it('disables the export button and updates its tooltip while exporting', async () => {
+    let finishExport!: () => void
+    const pendingExport = new Promise<void>(resolve => { finishExport = resolve })
+    const format: GadgetExportFormat = {
+      id: 'csv',
+      label: 'CSV',
+      mode: 'server',
+      contentType: 'text/csv',
+      fileExtension: '.csv',
+    }
+    const client = gadget({
+      getExportFormats: vi.fn<(chatId?: number) => Promise<GadgetExportFormat[]>>(
+        async () => [format],
+      ),
+    })
+    mocks.saveStreamToFile.mockReturnValue(pendingExport)
+
+    await act(async () => {
+      root.render(<GadgetExportMenu gadget={client} gadgetTitle="Report" />)
+    })
+    await act(async () => { button('open export menu')?.click() })
+    await act(async () => { button('CSV')?.click() })
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label="Export Gadget"]')
+    expect(trigger?.disabled).toBe(true)
+    expect(trigger?.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('Exporting to CSV')
+
+    await act(async () => {
+      finishExport()
+      await pendingExport
+    })
+
+    expect(trigger?.disabled).toBe(false)
+    expect(trigger?.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('Export Gadget')
   })
 
   it('shows an empty state without hiding or disabling the export button', async () => {

--- a/packages/workshop-frontend/src/GadgetExportMenu.tsx
+++ b/packages/workshop-frontend/src/GadgetExportMenu.tsx
@@ -92,6 +92,7 @@ export default function GadgetExportMenu({ gadget, gadgetTitle, chatId }: Props)
             render={(
               <WorkshopIconButton
                 aria-label="Export Gadget"
+                disabled={exportingId !== null}
               >
                 <DownloadSimple size={17} />
               </WorkshopIconButton>


### PR DESCRIPTION
The export button is currently clickable while an export is progress, but doesn't do anything:

<img width="462" height="183" alt="image" src="https://github.com/user-attachments/assets/ca1e4426-0eea-4aa3-8e02-b64987d09aa5" />

It should be disabled instead.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-os/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->