### PR TITLE
harden missing export entrypoint error handling

### DIFF
--- a/packages/workshop-backend/__tests__/gadget-export.test.ts
+++ b/packages/workshop-backend/__tests__/gadget-export.test.ts
@@ -90,7 +90,7 @@ describe("Gadget export formats", () => {
     }])).toThrow("invalid content type");
   });
 
-  it("uses defaults only for an absent entrypoint and propagates handler failures", async () => {
+  it("uses defaults for missing-entrypoint errors and propagates other failures", async () => {
     const missing = {
       async getExportFormats() {
         throw new Error("Worker has no such entrypoint: ExportHandler");
@@ -104,6 +104,13 @@ describe("Gadget export formats", () => {
       },
     };
     await expect(readCustomExportFormats(broken, {})).rejects.toThrow("handler failed");
+
+    const internalError = {
+      async getExportFormats() {
+        throw new Error("internal error; reference = 9fcjmb0apkauhvfiron4rfaj");
+      },
+    };
+    await expect(readCustomExportFormats(internalError, {})).resolves.toBeNull();
   });
 
   it("times out format discovery", async () => {

--- a/packages/workshop-backend/src/gadget-export.ts
+++ b/packages/workshop-backend/src/gadget-export.ts
@@ -106,7 +106,7 @@ export function validateExportFormats(value: unknown): GadgetExportFormat[] {
   return result.data;
 }
 
-/** Reads custom formats, returning null only when the named entrypoint is absent. */
+/** Reads custom formats, returning null when the named entrypoint appears to be absent. */
 export async function readCustomExportFormats<Gadget>(
   handler: {getExportFormats(gadget: Gadget): Promise<unknown>},
   gadget: Gadget,
@@ -115,8 +115,15 @@ export async function readCustomExportFormats<Gadget>(
   try {
     return validateExportFormats(await deadline.race(handler.getExportFormats(gadget)));
   } catch (error) {
+    // TODO: Local dev doesn't match production here. This appears to be a
+    // runtime bug. When the entrypoint is missing in local dev, the first error
+    // message is returned. In production, "internal error; reference = ..." is
+    // returned instead. Until the runtime provides a more descriptive error
+    // message, we assume that all internal errors mean that the entrypoint is
+    // missing.
     if (error instanceof Error &&
-        error.message === `Worker has no such entrypoint: ${GADGET_EXPORT_ENTRYPOINT}`) {
+        (error.message === `Worker has no such entrypoint: ${GADGET_EXPORT_ENTRYPOINT}` ||
+          error.message.startsWith("internal error"))) {
       return null;
     }
     throw error;


### PR DESCRIPTION
- document error message gap between local dev and production
- treat internal errors as missing entrypoint errors