### PR TITLE
Report malformed percent-escapes in Google resource URLs

### DIFF
--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -160,6 +160,18 @@ function validateGmailQueryForGrouping(query: string): void {
   if (quote || stack.length > 0) throw new Error("Gmail query has unterminated grouping or quotes.");
 }
 
+// decodeURIComponent(), but an undecodable percent-sequence names the offending part of the
+// resource URL instead of leaking a bare URIError. A literal `%` in a Gmail search or label
+// ("50% off") hits this whenever it is not escaped as `%25`.
+function decodeResourceUrlPart(encoded: string, what: string): string {
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    throw new Error(
+        `Invalid ${what}: it cannot be percent-decoded. Encode a literal "%" as "%25".`);
+  }
+}
+
 function getBaseUrl(env: Env) {
   return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/google");
 }
@@ -872,7 +884,7 @@ export class GatekeeperUserImpl extends WorkerEntrypoint<Env, GatekeeperUserImpl
     }
 
     if (parsed.hostname === "calendar.google.com" && parsed.pathname.startsWith("/calendar/")) {
-      let calendarId = decodeURIComponent(parsed.pathname.split("/")[2] ?? "");
+      let calendarId = decodeResourceUrlPart(parsed.pathname.split("/")[2] ?? "", "Google Calendar URL");
       if (!calendarId) {
         throw new Error("Invalid Google Calendar URL: no calendar ID found");
       }
@@ -905,7 +917,7 @@ export class GatekeeperUserImpl extends WorkerEntrypoint<Env, GatekeeperUserImpl
 
       // Synthetic path: /<projectId>/<datasetId>/<tableId> (each segment optional after the first).
       let segments = parsed.pathname.replace(/^\/+|\/+$/g, "").split("/").filter(Boolean)
-          .map(segment => decodeURIComponent(segment));
+          .map(segment => decodeResourceUrlPart(segment, "BigQuery resource URL"));
       if (segments.length > 3) {
         throw new Error(
             "BigQuery resource URLs must be /<projectId>, /<projectId>/<datasetId>, " +
@@ -944,11 +956,11 @@ export class GatekeeperUserImpl extends WorkerEntrypoint<Env, GatekeeperUserImpl
       // Gmail's own UI encodes spaces in hash searches as `+`, while
       // decodeURIComponent() only decodes `%20`. Normalize both forms.
       const encodedQuery = hash.slice("#search/".length).replace(/\+/g, " ");
-      const query = decodeURIComponent(encodedQuery);
+      const query = decodeResourceUrlPart(encodedQuery, "Gmail search query");
       validateGmailQueryForGrouping(query);
       props.searchQuery = query;
     } else if (hash.startsWith("#label/")) {
-      const labelName = decodeURIComponent(hash.slice("#label/".length));
+      const labelName = decodeResourceUrlPart(hash.slice("#label/".length), "Gmail label name");
       if (!labelName || new TextEncoder().encode(labelName).byteLength > 320) {
         throw new Error("Gmail label name must be between 1 and 320 bytes.");
       }


### PR DESCRIPTION
## What does this change?

Binding a Google resource from a URL containing a bare `%` throws an unhandled `URIError: URI malformed` instead of the explanatory errors every sibling validation path in `getGatekeeperClassFor()` raises. `https://mail.google.com/mail/u/0/#search/50%off` is the reproduction reported in #55.

This adds a `decodeResourceUrlPart()` helper — `decodeURIComponent()` in a `try`, rethrowing as `Invalid <part>: it cannot be percent-decoded. Encode a literal "%" as "%25".` — and uses it at the four bare decode sites in `getGatekeeperClassFor()`: the Gmail `#search/` query, the Gmail `#label/` name, the Google Calendar path segment, and the BigQuery path segments.

#55 notes the same bare-decode pattern in other gatekeeper packages; this PR deliberately stays on the reported backend path to remain a small, single-concern change.

Fixes #55

## Why is this obviously correct and trivially verifiable?

The success path returns exactly what `decodeURIComponent()` returned, unchanged. The only behavioral difference is that a thrown `URIError` becomes an `Error` whose message follows the wording style of the sibling validation messages in the same function. There are no control-flow, dependency, or API changes.

Verified on Windows 11 (Node 22.22.3, pnpm 11.17.0) against `4288713`: `tsc -p packages/gatekeeper-google` and full `pnpm lint` pass.

AI tools authored this patch under human direction, and an independent AI review approved it before submission; the verification commands above were run locally.

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-os/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->