### PR TITLE
store context files as byte arrays instead of JS strings

### DIFF
--- a/packages/gatekeeper-context/__tests__/artifact-sync-fetch.test.ts
+++ b/packages/gatekeeper-context/__tests__/artifact-sync-fetch.test.ts
@@ -1,0 +1,61 @@
+import { promises as fsp } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const git = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  listFiles: vi.fn(),
+  listServerRefs: vi.fn(),
+  readBlob: vi.fn(),
+}));
+
+vi.mock("isomorphic-git", () => ({
+  clone: vi.fn(),
+  fetch: git.fetch,
+  listFiles: git.listFiles,
+  listServerRefs: git.listServerRefs,
+  readBlob: git.readBlob,
+  resolveRef: vi.fn(),
+}));
+
+vi.mock("isomorphic-git/http/web", () => ({ request: vi.fn() }));
+
+import { readArtifactRepoDocuments } from "../src/artifact-sync.js";
+
+const dir = "/tmp/artifacts/fetch-test";
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await fsp.rm(dir, { recursive: true, force: true });
+});
+
+describe("artifact repository refresh", () => {
+  it("reads the fetched commit instead of stale local HEAD", async () => {
+    await fsp.mkdir(`${dir}/.git`, { recursive: true });
+    git.listServerRefs.mockResolvedValue([{ ref: "refs/heads/main", oid: "new-commit" }]);
+    git.fetch.mockResolvedValue({ fetchHead: "new-commit" });
+    git.listFiles.mockResolvedValue(["readme.md"]);
+    git.readBlob.mockResolvedValue({ blob: new TextEncoder().encode("# Updated") });
+    const revokeToken = vi.fn().mockResolvedValue(true);
+    const artifacts = {
+      async get() {
+        return {
+          async createToken() { return { id: "token", plaintext: "secret" }; },
+          revokeToken,
+        };
+      },
+    } as unknown as Artifacts;
+
+    const result = await readArtifactRepoDocuments(
+      artifacts,
+      "fetch-test",
+      "https://example.com/repo.git",
+      "main",
+      "old-commit",
+    );
+
+    expect(result).toMatchObject({ changed: true, commit: "new-commit" });
+    expect(git.listFiles).toHaveBeenCalledWith(expect.objectContaining({ ref: "new-commit" }));
+    expect(git.readBlob).toHaveBeenCalledWith(expect.objectContaining({ oid: "new-commit" }));
+    expect(revokeToken).toHaveBeenCalledWith("token");
+  });
+});

--- a/packages/gatekeeper-context/__tests__/artifact-sync-fetch.test.ts
+++ b/packages/gatekeeper-context/__tests__/artifact-sync-fetch.test.ts
@@ -2,19 +2,21 @@ import { promises as fsp } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const git = vi.hoisted(() => ({
+  clone: vi.fn(),
   fetch: vi.fn(),
   listFiles: vi.fn(),
   listServerRefs: vi.fn(),
   readBlob: vi.fn(),
+  resolveRef: vi.fn(),
 }));
 
 vi.mock("isomorphic-git", () => ({
-  clone: vi.fn(),
+  clone: git.clone,
   fetch: git.fetch,
   listFiles: git.listFiles,
   listServerRefs: git.listServerRefs,
   readBlob: git.readBlob,
-  resolveRef: vi.fn(),
+  resolveRef: git.resolveRef,
 }));
 
 vi.mock("isomorphic-git/http/web", () => ({ request: vi.fn() }));
@@ -24,7 +26,7 @@ import { readArtifactRepoDocuments } from "../src/artifact-sync.js";
 const dir = "/tmp/artifacts/fetch-test";
 
 afterEach(async () => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   await fsp.rm(dir, { recursive: true, force: true });
 });
 
@@ -56,6 +58,40 @@ describe("artifact repository refresh", () => {
     expect(result).toMatchObject({ changed: true, commit: "new-commit" });
     expect(git.listFiles).toHaveBeenCalledWith(expect.objectContaining({ ref: "new-commit" }));
     expect(git.readBlob).toHaveBeenCalledWith(expect.objectContaining({ oid: "new-commit" }));
+    expect(revokeToken).toHaveBeenCalledWith("token");
+  });
+
+  it("reclones instead of returning an empty collection when fetch has no head", async () => {
+    await fsp.mkdir(`${dir}/.git`, { recursive: true });
+    git.listServerRefs.mockResolvedValue([{ ref: "refs/heads/main", oid: "new-commit" }]);
+    git.fetch.mockResolvedValue({ fetchHead: null });
+    git.resolveRef.mockResolvedValue("recloned-commit");
+    git.listFiles.mockResolvedValue(["readme.md"]);
+    git.readBlob.mockResolvedValue({ blob: new TextEncoder().encode("# Recovered") });
+    const revokeToken = vi.fn().mockResolvedValue(true);
+    const artifacts = {
+      async get() {
+        return {
+          async createToken() { return { id: "token", plaintext: "secret" }; },
+          revokeToken,
+        };
+      },
+    } as unknown as Artifacts;
+
+    const result = await readArtifactRepoDocuments(
+      artifacts,
+      "fetch-test",
+      "https://example.com/repo.git",
+      "main",
+      "old-commit",
+    );
+
+    expect(git.clone).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      changed: true,
+      commit: "recloned-commit",
+      documents: [{ path: "readme.md", body: new TextEncoder().encode("# Recovered") }],
+    });
     expect(revokeToken).toHaveBeenCalledWith("token");
   });
 });

--- a/packages/gatekeeper-context/__tests__/context-storage.worker.test.ts
+++ b/packages/gatekeeper-context/__tests__/context-storage.worker.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeStoredContextBody, encodeStoredContextBody,
+} from "../src/context-storage.js";
+import { artifactContextDocument } from "../src/artifact-sync.js";
+
+describe("context document storage", () => {
+  it("encodes mixed-Unicode text as UTF-8 bytes and reads it back", () => {
+    const body = "Cloudflare cafe 日本語 🚀\n".repeat(4_200);
+    const stored = encodeStoredContextBody("application/json", body);
+
+    expect(stored).toBeInstanceOf(Uint8Array);
+    expect(decodeStoredContextBody("application/json", stored)).toBe(body);
+  });
+
+  it("reads legacy string records", () => {
+    expect(decodeStoredContextBody("text/markdown", "legacy body")).toBe("legacy body");
+  });
+
+  it("stores binary base64 bodies as bytes and reads them back", () => {
+    const stored = encodeStoredContextBody("image/png", "AQID");
+    expect(stored).toEqual(new Uint8Array([1, 2, 3]));
+    expect(decodeStoredContextBody("image/png", stored)).toBe("AQID");
+  });
+
+  it("reads legacy binary base64 strings", () => {
+    expect(decodeStoredContextBody("image/png", "AQID")).toBe("AQID");
+  });
+
+  it("keeps git text and binary blobs as their original bytes", () => {
+    const text = new TextEncoder().encode("# Title\n\nDescription");
+    const binary = new Uint8Array([1, 2, 3]);
+
+    expect(artifactContextDocument("readme.md", text).body).toBe(text);
+    expect(artifactContextDocument("image.png", binary).body).toBe(binary);
+  });
+});

--- a/packages/gatekeeper-context/__tests__/context-storage.worker.test.ts
+++ b/packages/gatekeeper-context/__tests__/context-storage.worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  decodeStoredContextBody, encodeStoredContextBody,
+  decodeStoredContextBody, encodeStoredContextBody, truncateContextDescription,
 } from "../src/context-storage.js";
 import { artifactContextDocument } from "../src/artifact-sync.js";
 
@@ -23,6 +23,14 @@ describe("context document storage", () => {
     expect(decodeStoredContextBody("image/png", stored)).toBe("AQID");
   });
 
+  it("measures binary storage by decoded bytes rather than base64 length", () => {
+    const body = "AAAA".repeat(450_001);
+    const stored = encodeStoredContextBody("image/png", body);
+
+    expect(body.length).toBeGreaterThan(1_800_000);
+    expect(stored.byteLength).toBe(1_350_003);
+  });
+
   it("reads legacy binary base64 strings", () => {
     expect(decodeStoredContextBody("image/png", "AQID")).toBe("AQID");
   });
@@ -33,5 +41,15 @@ describe("context document storage", () => {
 
     expect(artifactContextDocument("readme.md", text).body).toBe(text);
     expect(artifactContextDocument("image.png", binary).body).toBe(binary);
+  });
+
+  it("truncates descriptions", () => {
+    const description = "x".repeat(16_001);
+    expect(truncateContextDescription(description)).toBe("x".repeat(16_000));
+  });
+
+  it("truncates descriptions derived from git documents", () => {
+    const body = new TextEncoder().encode(`description: |\n  ${"x".repeat(20_000)}\nnext: true\n`);
+    expect(artifactContextDocument("context.yaml", body).description).toBe("x".repeat(16_000));
   });
 });

--- a/packages/gatekeeper-context/package.json
+++ b/packages/gatekeeper-context/package.json
@@ -10,7 +10,7 @@
     "typecheck:app": "tsc -p tsconfig.app.json && tsc -p tsconfig.vite.json",
     "build": "pnpm run typecheck:app && vp run --cache build:app && tsc",
     "clean": "rm -rf dist src/generated",
-    "test:run": "vitest run"
+    "test:run": "vitest run && vitest run -c vitest.node.config.ts"
   },
   "dependencies": {
     "@gadgets/backend-utils": "workspace:*",
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@cloudflare/kumo": "^2.9.2",
+    "@cloudflare/vitest-pool-workers": "catalog:",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",

--- a/packages/gatekeeper-context/src/artifact-sync.ts
+++ b/packages/gatekeeper-context/src/artifact-sync.ts
@@ -7,6 +7,7 @@ import { posix as posixPath } from "node:path";
 import {
   MAX_DOCUMENT_BODY_BYTES, contentTypeFromPath, isTextContentType, VENDOR_ID,
 } from "./context-types.js";
+import { truncateContextDescription } from "./context-storage.js";
 import { extractDescription } from "./description-extractors.js";
 import { obsContext } from "./observability.js";
 
@@ -111,7 +112,9 @@ export function artifactContextDocument(path: string, blob: Uint8Array): Artifac
   return {
     path,
     name: posixPath.basename(path),
-    description: body === undefined ? "" : extractDescription(contentType, body) ?? "",
+    description: truncateContextDescription(
+      body === undefined ? "" : extractDescription(contentType, body) ?? "",
+    ),
     contentType,
     body: blob,
     lastUpdated: new Date(),

--- a/packages/gatekeeper-context/src/artifact-sync.ts
+++ b/packages/gatekeeper-context/src/artifact-sync.ts
@@ -166,7 +166,8 @@ async function fetchRepo(dir: string, url: string, branch: string, onAuth: () =>
     prune: true,
     onAuth,
   });
-  return result.fetchHead ?? "";
+  if (!result.fetchHead) throw new Error("Git fetch did not return a commit.");
+  return result.fetchHead;
 }
 
 async function fetchOrRecloneRepo(dir: string, url: string, branch: string, onAuth: () => { username: string; password: string }): Promise<string> {

--- a/packages/gatekeeper-context/src/artifact-sync.ts
+++ b/packages/gatekeeper-context/src/artifact-sync.ts
@@ -155,7 +155,7 @@ async function recloneRepo(dir: string, url: string, branch: string, onAuth: () 
 }
 
 async function fetchRepo(dir: string, url: string, branch: string, onAuth: () => { username: string; password: string }, maxBytes: number): Promise<string> {
-  await fetch({
+  let result = await fetch({
     fs,
     http: makeHttp(maxBytes),
     dir,
@@ -166,7 +166,7 @@ async function fetchRepo(dir: string, url: string, branch: string, onAuth: () =>
     prune: true,
     onAuth,
   });
-  return resolveRef({ fs, dir, ref: "HEAD" });
+  return result.fetchHead ?? "";
 }
 
 async function fetchOrRecloneRepo(dir: string, url: string, branch: string, onAuth: () => { username: string; password: string }): Promise<string> {

--- a/packages/gatekeeper-context/src/artifact-sync.ts
+++ b/packages/gatekeeper-context/src/artifact-sync.ts
@@ -1,12 +1,11 @@
 import { clone, fetch, listFiles as listGitFiles, listServerRefs, readBlob, resolveRef } from "isomorphic-git";
 import { request as baseHttpRequest } from "isomorphic-git/http/web";
 import type { GitHttpResponse, HttpClient } from "isomorphic-git/http/web";
-import { Buffer } from "node:buffer";
 import * as fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import { posix as posixPath } from "node:path";
 import {
-  ContextDocument, MAX_DOCUMENT_BODY_BYTES, contentTypeFromPath, isTextContentType, VENDOR_ID,
+  MAX_DOCUMENT_BODY_BYTES, contentTypeFromPath, isTextContentType, VENDOR_ID,
 } from "./context-types.js";
 import { extractDescription } from "./description-extractors.js";
 import { obsContext } from "./observability.js";
@@ -97,8 +96,30 @@ function isEnoent(err: unknown): boolean {
   return err instanceof Error && "code" in err && err.code === "ENOENT";
 }
 
+export type ArtifactContextDocument = {
+  path: string;
+  name: string;
+  description: string;
+  contentType: string;
+  body: Uint8Array;
+  lastUpdated: Date;
+};
+
+export function artifactContextDocument(path: string, blob: Uint8Array): ArtifactContextDocument {
+  let contentType = contentTypeFromPath(path);
+  let body = isTextContentType(contentType) ? new TextDecoder().decode(blob) : undefined;
+  return {
+    path,
+    name: posixPath.basename(path),
+    description: body === undefined ? "" : extractDescription(contentType, body) ?? "",
+    contentType,
+    body: blob,
+    lastUpdated: new Date(),
+  };
+}
+
 export type ArtifactRepoReadResult =
-  | { commit: string; changed: true; documents: ContextDocument[] }
+  | { commit: string; changed: true; documents: ArtifactContextDocument[] }
   | { commit: string; changed: false };
 
 async function cloneRepo(dir: string, url: string, branch: string, onAuth: () => { username: string; password: string }): Promise<void> {
@@ -173,12 +194,6 @@ async function fetchOrRecloneRepo(dir: string, url: string, branch: string, onAu
   }
 }
 
-function encodedBodyBytes(contentType: string, blob: Uint8Array): number {
-  return isTextContentType(contentType)
-    ? blob.byteLength
-    : Math.ceil(blob.byteLength / 3) * 4;
-}
-
 export function readArtifactRepoDocuments(
   artifacts: Artifacts,
   repoName: string,
@@ -233,11 +248,10 @@ async function readArtifactRepoDocumentsWithContext(
     if (!commit) return { commit: "", changed: true, documents: [] };
 
     let filepaths = await listGitFiles({ fs, dir, ref: commit });
-    let documents: ContextDocument[] = [];
+    let documents: ArtifactContextDocument[] = [];
     for (let filepath of filepaths) {
       let { blob } = await readBlob({ fs, dir, oid: commit, filepath });
-      let contentType = contentTypeFromPath(filepath);
-      let bodyBytes = encodedBodyBytes(contentType, blob);
+      let bodyBytes = blob.byteLength;
       if (bodyBytes > MAX_DOCUMENT_BODY_BYTES) {
         logger.warn("skipping oversized mirrored context file", {
           event: "context.file.oversized.skipped",
@@ -247,15 +261,7 @@ async function readArtifactRepoDocumentsWithContext(
         });
         continue;
       }
-      let body = isTextContentType(contentType) ? new TextDecoder().decode(blob) : Buffer.from(blob).toString("base64");
-      documents.push({
-        path: filepath,
-        name: posixPath.basename(filepath),
-        description: isTextContentType(contentType) ? extractDescription(contentType, body) ?? "" : "",
-        contentType,
-        body,
-        lastUpdated: new Date(),
-      });
+      documents.push(artifactContextDocument(filepath, blob));
     }
 
     return { commit, changed: true, documents };

--- a/packages/gatekeeper-context/src/context-collection.ts
+++ b/packages/gatekeeper-context/src/context-collection.ts
@@ -12,11 +12,14 @@ import {
 } from "./context-types.js";
 import { metadataToSummary } from "./collection-kv.js";
 import { domainName } from "./domain.js";
-import { readArtifactRepoDocuments } from "./artifact-sync.js";
+import {
+  readArtifactRepoDocuments, type ArtifactContextDocument,
+} from "./artifact-sync.js";
 import {
   isSkillManifestPath, parseSkillManifest, type SkillIndexEntry,
 } from "./agent-skill.js";
 import { obsContext } from "./observability.js";
+import { decodeStoredContextBody, encodeStoredContextBody } from "./context-storage.js";
 
 const logger = obsContext.createLogger({
   component: "gatekeeper.context", vendorId: VENDOR_ID,
@@ -74,9 +77,18 @@ type ContextRecord = {
   name: string;
   description: string;
   contentType: string;
-  body: string;
+  // Text is stored as UTF-8 and binary as raw bytes to keep SQLite values close to source size.
+  // Legacy records have string bodies: literal text or base64 for binary content.
+  body: string | Uint8Array;
   lastUpdated: Date;
 };
+
+function contextRecord(document: ContextDocument): ContextRecord {
+  return {
+    ...document,
+    body: encodeStoredContextBody(document.contentType, document.body),
+  };
+}
 
 // Old records that predate git-based collections won't have `content` set in storage.
 // Unset `content` is defaulted to { "source": "web" } at the API layer, which is why
@@ -204,7 +216,10 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
       return undefined;
     }
     try {
-      return parseSkillManifest(record.path, record.body);
+      return parseSkillManifest(
+        record.path,
+        decodeStoredContextBody(record.contentType, record.body),
+      );
     } catch {
       return undefined;
     }
@@ -345,7 +360,7 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
       name: record.name,
       description: manifest?.description ?? record.description,
       contentType,
-      body: record.body,
+      body: decodeStoredContextBody(contentType, record.body),
       ...(manifest ? {skillName: manifest.name} : {}),
       lastUpdated: record.lastUpdated,
     };
@@ -363,9 +378,10 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
     }
 
     let contentType = doc.contentType || contentTypeFromPath(path);
-    let record: ContextRecord = {
-      path, name: baseName(path), description: doc.description, contentType, body: doc.body, lastUpdated: new Date(),
-    };
+    let record = contextRecord({
+      path, name: baseName(path), description: doc.description, contentType, body: doc.body,
+      lastUpdated: new Date(),
+    });
 
     this.storage.transaction(() => {
       let isNew = !this.storage.documents.get(path);
@@ -529,7 +545,7 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
     return promise;
   }
 
-  #replaceArtifactDocuments(commit: string, documents: ContextDocument[]): void {
+  #replaceArtifactDocuments(commit: string, documents: ArtifactContextDocument[]): void {
     this.storage.transaction(() => {
       for (let record of this.storage.documents.list()) {
         this.storage.documents.delete(record.path);
@@ -610,7 +626,10 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
       let isText = isTextContentType(record.contentType ?? DEFAULT_DOCUMENT_CONTENT_TYPE);
       let nameLower = record.name.toLowerCase();
       let descLower = record.description.toLowerCase();
-      let bodyLower = isText ? record.body.toLowerCase() : "";
+      let body = isText
+        ? decodeStoredContextBody(record.contentType ?? DEFAULT_DOCUMENT_CONTENT_TYPE, record.body)
+        : "";
+      let bodyLower = body.toLowerCase();
 
       for (let token of tokens) {
         if (nameLower.includes(token)) score += 10;
@@ -620,8 +639,8 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
           score += 1;
           if (!snippet) {
             let start = Math.max(0, bodyIdx - 40);
-            let end = Math.min(record.body.length, bodyIdx + token.length + 80);
-            snippet = (start > 0 ? "..." : "") + record.body.slice(start, end) + (end < record.body.length ? "..." : "");
+            let end = Math.min(body.length, bodyIdx + token.length + 80);
+            snippet = (start > 0 ? "..." : "") + body.slice(start, end) + (end < body.length ? "..." : "");
           }
         }
       }

--- a/packages/gatekeeper-context/src/context-collection.ts
+++ b/packages/gatekeeper-context/src/context-collection.ts
@@ -19,7 +19,9 @@ import {
   isSkillManifestPath, parseSkillManifest, type SkillIndexEntry,
 } from "./agent-skill.js";
 import { obsContext } from "./observability.js";
-import { decodeStoredContextBody, encodeStoredContextBody } from "./context-storage.js";
+import {
+  decodeStoredContextBody, encodeStoredContextBody, truncateContextDescription,
+} from "./context-storage.js";
 
 const logger = obsContext.createLogger({
   component: "gatekeeper.context", vendorId: VENDOR_ID,
@@ -83,9 +85,10 @@ type ContextRecord = {
   lastUpdated: Date;
 };
 
-function contextRecord(document: ContextDocument): ContextRecord {
+function contextRecord(document: ContextDocument): ContextRecord & { body: Uint8Array } {
   return {
     ...document,
+    description: truncateContextDescription(document.description),
     body: encodeStoredContextBody(document.contentType, document.body),
   };
 }
@@ -218,7 +221,7 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
     try {
       return parseSkillManifest(
         record.path,
-        decodeStoredContextBody(record.contentType, record.body),
+        decodeStoredContextBody(record.contentType ?? DEFAULT_DOCUMENT_CONTENT_TYPE, record.body),
       );
     } catch {
       return undefined;
@@ -371,17 +374,15 @@ export class ContextCollectionDurableObject extends DurableObject<Cloudflare.Env
       doc: { description: string; body: string; contentType?: string }): Promise<void> {
     this.#assertWebWritable();
     validateDocumentPath(path);
-    // Enforce real UTF-8 bytes, not UTF-16 code units.
-    let byteLength = new TextEncoder().encode(doc.body).length;
-    if (byteLength > MAX_DOCUMENT_BODY_BYTES) {
-      throw new Error(`Document is too large (${byteLength} bytes; max ${MAX_DOCUMENT_BODY_BYTES}).`);
-    }
-
     let contentType = doc.contentType || contentTypeFromPath(path);
     let record = contextRecord({
       path, name: baseName(path), description: doc.description, contentType, body: doc.body,
       lastUpdated: new Date(),
     });
+    let byteLength = record.body.byteLength;
+    if (byteLength > MAX_DOCUMENT_BODY_BYTES) {
+      throw new Error(`Document is too large (${byteLength} bytes; max ${MAX_DOCUMENT_BODY_BYTES}).`);
+    }
 
     this.storage.transaction(() => {
       let isNew = !this.storage.documents.get(path);

--- a/packages/gatekeeper-context/src/context-storage.ts
+++ b/packages/gatekeeper-context/src/context-storage.ts
@@ -3,6 +3,12 @@ import { isTextContentType } from "./context-types.js";
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
+const MAX_DOCUMENT_DESCRIPTION_CHARS = 16_000;
+
+/** Bound descriptions to preserve storage headroom. */
+export function truncateContextDescription(description: string): string {
+  return description.slice(0, MAX_DOCUMENT_DESCRIPTION_CHARS);
+}
 
 export function decodeStoredContextBody(
   contentType: string,

--- a/packages/gatekeeper-context/src/context-storage.ts
+++ b/packages/gatekeeper-context/src/context-storage.ts
@@ -1,0 +1,21 @@
+import { Buffer } from "node:buffer";
+import { isTextContentType } from "./context-types.js";
+
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
+export function decodeStoredContextBody(
+  contentType: string,
+  body: string | Uint8Array,
+): string {
+  if (typeof body === "string") return body;
+  return isTextContentType(contentType)
+    ? textDecoder.decode(body)
+    : Buffer.from(body).toString("base64");
+}
+
+export function encodeStoredContextBody(contentType: string, body: string): Uint8Array {
+  return isTextContentType(contentType)
+    ? textEncoder.encode(body)
+    : new Uint8Array(Buffer.from(body, "base64"));
+}

--- a/packages/gatekeeper-context/src/context-types.ts
+++ b/packages/gatekeeper-context/src/context-types.ts
@@ -208,8 +208,8 @@ export type EnabledCollectionInfo = {
 
 export const DEFAULT_DOCUMENT_CONTENT_TYPE = "text/markdown";
 
-/** UTF-8 bytes of stored body; base64 overhead caps raw binary around 1 MB. */
-export const MAX_DOCUMENT_BODY_BYTES = 1_400_000;
+/** Raw stored body bytes, leaving headroom below SQLite's 2 MB serialized-value limit. */
+export const MAX_DOCUMENT_BODY_BYTES = 1_800_000;
 
 // Map of file extensions (without the dot, lowercased) to MIME types we recognize.
 //

--- a/packages/gatekeeper-context/src/context-types.ts
+++ b/packages/gatekeeper-context/src/context-types.ts
@@ -158,7 +158,7 @@ export type ContextDocument = {
   /** File name derived from the path. */
   name: string;
 
-  /** What this document covers and when to use it. */
+  /** What this document covers and when to use it. Values over 16,000 characters are truncated. */
   description: string;
 
   /** Determines whether `body` is text or base64. */

--- a/packages/gatekeeper-context/vite.config.ts
+++ b/packages/gatekeeper-context/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     tasks: {
       // Shared by every package whose tests run under vitest; see the module for why the two
       // vitest scratch paths have to be excluded for this to cache at all.
-      test: vitestTask('vitest run'),
+      test: vitestTask(['vitest run', 'vitest run -c vitest.node.config.ts']),
       // Uncached: a cache hit restores archived outputs but never deletes files, so the sourcemap
       // artifacts of an enabled-reporting build (dist-app/gatekeeper-context.js + .js.map) would
       // survive a later disabled-reporting cache hit and could be collected as if they matched the

--- a/packages/gatekeeper-context/vitest.config.ts
+++ b/packages/gatekeeper-context/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [capnwebValidate(), cloudflareTest({
     miniflare: {
       compatibilityDate: "2026-02-02",
-      compatibilityFlags: ["allow_irrevocable_stub_storage", "nodejs_als"],
+      compatibilityFlags: ["nodejs_compat", "allow_irrevocable_stub_storage"],
     },
   })],
   test: {

--- a/packages/gatekeeper-context/vitest.config.ts
+++ b/packages/gatekeeper-context/vitest.config.ts
@@ -1,0 +1,18 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import capnwebValidate from "capnweb-validate/vite";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [capnwebValidate(), cloudflareTest({
+    miniflare: {
+      compatibilityDate: "2026-02-02",
+      compatibilityFlags: ["allow_irrevocable_stub_storage", "nodejs_als"],
+    },
+  })],
+  test: {
+    fileParallelism: false,
+    exclude: ["__tests__/vite-config.test.ts"],
+    include: ["__tests__/*.test.ts"],
+    setupFiles: ["../../scripts/assert-workerd.ts"],
+  },
+});

--- a/packages/gatekeeper-context/vitest.node.config.ts
+++ b/packages/gatekeeper-context/vitest.node.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/vite-config.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@cloudflare/kumo':
         specifier: ^2.9.2
         version: 2.9.2(@date-fns/tz@1.5.0)(@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      '@cloudflare/vitest-pool-workers':
+        specifier: 'catalog:'
+        version: 0.20.3(@cloudflare/workers-types@5.20260808.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@codemirror/commands':
         specifier: ^6.10.4
         version: 6.10.4
@@ -1169,7 +1172,7 @@ packages:
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@cloudflare/kumo@2.9.2':
-    resolution: {integrity: sha512-c3RZBmx0TqxTKAPT4PWyTgVwPcDVW+KrFmf4mKCnwWBe6OIc0vWn+wMhnaARarJz/2kvsx87tMGmNRBsCn7pUA==, tarball: https://registry.npmjs.org/@cloudflare/kumo/-/kumo-2.9.2.tgz}
+    resolution: {integrity: sha512-c3RZBmx0TqxTKAPT4PWyTgVwPcDVW+KrFmf4mKCnwWBe6OIc0vWn+wMhnaARarJz/2kvsx87tMGmNRBsCn7pUA==}
     hasBin: true
     peerDependencies:
       '@phosphor-icons/react': ^2.1.10
@@ -1184,15 +1187,15 @@ packages:
         optional: true
 
   '@cloudflare/kv-asset-handler@0.5.0':
-    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz}
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
   '@cloudflare/puppeteer@1.3.0':
-    resolution: {integrity: sha512-NBrJEUnqe082nopLh0eqnTXK4DjwsTsZGzoAcs71NFnBgzWU6Yb/ibUJHveCHV4AyAkM+mE/DChFev5gwaKZEg==, tarball: https://registry.npmjs.org/@cloudflare/puppeteer/-/puppeteer-1.3.0.tgz}
+    resolution: {integrity: sha512-NBrJEUnqe082nopLh0eqnTXK4DjwsTsZGzoAcs71NFnBgzWU6Yb/ibUJHveCHV4AyAkM+mE/DChFev5gwaKZEg==}
     engines: {node: '>=18'}
 
   '@cloudflare/unenv-preset@2.16.1':
-    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==, tarball: https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz}
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: '>1.20260305.0 <2.0.0-0'
@@ -1201,44 +1204,44 @@ packages:
         optional: true
 
   '@cloudflare/vitest-pool-workers@0.20.3':
-    resolution: {integrity: sha512-aCMvM5zQ3MTz8SorSZB6ZxjVK2Gof6UhIc2Z1z9zbX/obucSYwDUkx8A0MUOod4I7clfB0QLarKBjRdIczK3vg==, tarball: https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.20.3.tgz}
+    resolution: {integrity: sha512-aCMvM5zQ3MTz8SorSZB6ZxjVK2Gof6UhIc2Z1z9zbX/obucSYwDUkx8A0MUOod4I7clfB0QLarKBjRdIczK3vg==}
     peerDependencies:
       '@vitest/runner': ^4.1.0
       '@vitest/snapshot': ^4.1.0
       vitest: ^4.1.0
 
   '@cloudflare/workerd-darwin-64@1.20260801.1':
-    resolution: {integrity: sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260801.1.tgz}
+    resolution: {integrity: sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260801.1':
-    resolution: {integrity: sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260801.1.tgz}
+    resolution: {integrity: sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20260801.1':
-    resolution: {integrity: sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260801.1.tgz}
+    resolution: {integrity: sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260801.1':
-    resolution: {integrity: sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260801.1.tgz}
+    resolution: {integrity: sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-windows-64@1.20260801.1':
-    resolution: {integrity: sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260801.1.tgz}
+    resolution: {integrity: sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
   '@cloudflare/workers-types@5.20260808.1':
-    resolution: {integrity: sha512-DN7G9SMyeOq031YhQexoExFAK78ms74cFiFF1teDlTK4+LjHgIc5Z8VbvXQtcCIP//o38btxzxW0b9MGPA83CA==, tarball: https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260808.1.tgz}
+    resolution: {integrity: sha512-DN7G9SMyeOq031YhQexoExFAK78ms74cFiFF1teDlTK4+LjHgIc5Z8VbvXQtcCIP//o38btxzxW0b9MGPA83CA==}
 
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}


### PR DESCRIPTION
This fixes a bug where file length was validated based on UTF-8 byte length, but then files were serialized as UTF-16 in DO storage. With the UTF-8 file length limit set to 1.4MB and DO row size limited to 2MB, a 1.1MB UTF-8 file would pass the length check but fail when written to DO storage.

The short term fix here is to store all files as byte arrays instead of strings. For text files, we control the encoding directly and use UTF-8 instead of UTF-16. For binary files, we avoid the double overhead of base64 and UTF-16 encoding. This lets us raise the supported file size limit to 1.8MB, and closes the gap that 1.1MB files previously snuck through.

This is not a long term solution though, since we will want to support files larger than 1.8MB in the future. We'll need to switch to a DO-based filesystem implementation that supports chunking files larger than 1.8MB over multiple rows, or stop using DO storage for files.
