### PR TITLE
Don't send the chat message on an IME composition Enter

### DIFF
--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -3368,6 +3368,12 @@ export const ChatInput = ({
                 }
               }}
               onKeyDown={(e) => {
+                // An IME commits a composition with Enter, and the browser reports that as an
+                // ordinary keydown. Reading it as "send" truncates the message mid-word for every
+                // user who types through an IME, so hand the whole keystroke back to the IME: Enter
+                // is not the only key it owns -- Escape cancels a composition and the arrows move
+                // through candidates.
+                if (e.nativeEvent.isComposing) return;
                 if (slashCommandPicker.open && e.key === "Escape") {
                   e.preventDefault();
                   slashCommandPicker.dismiss();


### PR DESCRIPTION
## What does this change?

The chat textarea treats every un-shifted Enter as "send". An IME commits a composition with Enter, and the browser delivers that as an ordinary `keydown`, so the first Enter of a Japanese, Chinese or Korean sentence sends the message half-typed. Reproducing it needs only an IME: type かんじ, press Enter to pick the conversion, and the partial message is already on its way.

The same handler drives the slash-command picker, where Escape cancels a composition and the arrow keys walk the IME's candidate list — both are currently taken from the IME.

This returns early from the handler while a composition is in flight, handing the whole keystroke back to the IME.

## Why is this obviously correct and trivially verifiable?

`isComposing` is true only between `compositionstart` and `compositionend`. Outside a composition — which is every keystroke for anyone not typing through an IME — it is false, the guard falls through, and the handler below runs exactly as before. So the patch cannot change behaviour for existing users; the only difference is that keydowns delivered mid-composition no longer reach the handlers underneath.

Six added lines in one file. No new state, no new props, no API change. The property lives on the native event because React's synthetic `KeyboardEvent` does not re-expose it.

Verified against a deployment: composition Enter no longer sends, ordinary Enter still sends, Shift+Enter still breaks the line, and the slash-command picker's Enter, arrows and Escape are unchanged when no IME is involved.

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

---

There are ~24 other `key === 'Enter'` handlers in the frontend (renames, share dialogs, the command palette) with the same defect. I kept this to the chat input, where the damage is unrecoverable, rather than exceed the size the guidelines ask for. Happy to open a discussion about the rest.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-os/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->