### PR TITLE
Make sure we're pinned to the public NPM registry, and move CI onto setup-vp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,24 @@ jobs:
         with:
           persist-credentials: false
 
-      # Ahead of setup-node, which shells out to `pnpm store path` to find the directory it caches.
+      # Vite+ downloads its own pnpm for `vp install` and exposes no shim, so this is what puts
+      # `pnpm` on PATH for the steps below.
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # Vite+ resolves its own version from the `vite-plus` catalog entry, and installs the pnpm
+      # named in `packageManager` (integrity hash checked as Corepack does), so setup-node is not
+      # needed.
+      #
+      # No `cache` here, unlike `test`: this job is fast anyway, and both caching
+      # means they race to reserve the same lockfile-keyed entry.
+      # TODO(someday): It would be great if the setup-vp action could share a cache key with the test job but disable writes to cache
+      - name: Set up Vite+, Node.js and dependencies
+        uses: voidzero-dev/setup-vp@313600b80b104eadebb9111787d37a2e83e014ca # v1.17.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          cache: false
+          run-install: true
 
       - name: Lint
         run: pnpm lint:check
@@ -57,18 +63,20 @@ jobs:
         with:
           persist-credentials: false
 
-      # Ahead of setup-node, which shells out to `pnpm store path` to find the directory it caches.
+      # Vite+ downloads its own pnpm for `vp install` and exposes no shim, so this is what puts
+      # `pnpm` on PATH for the steps below.
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # Vite+ resolves its own version from the `vite-plus` catalog entry, and installs the pnpm
+      # named in `packageManager` (integrity hash checked as Corepack does), so setup-node is not
+      # needed.
+      - name: Set up Vite+, Node.js and dependencies
+        uses: voidzero-dev/setup-vp@313600b80b104eadebb9111787d37a2e83e014ca # v1.17.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          cache: true
+          run-install: true
 
       # Codegen, the frontend/SPA bundles, and the repo's single type check (`types:check` aliases this).
       - name: Build

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,8 +20,8 @@ name: Preview
 # that a future edit which weakens the trigger still does not leak the token. They are not what
 # makes this safe today.
 #
-# The `cache: pnpm` below is deliberate and is not a poisoning path: a fork PR's Actions cache is
-# scoped to `refs/pull/<n>/merge` and cannot be read from another PR or from `main`.
+# The setup-vp `cache: true` below is deliberate and is not a poisoning path: a fork PR's Actions
+# cache is scoped to `refs/pull/<n>/merge` and cannot be read from another PR or from `main`.
 
 on:
   pull_request:
@@ -80,18 +80,20 @@ jobs:
         with:
           persist-credentials: false
 
-      # Ahead of setup-node, which shells out to `pnpm store path` to find the directory it caches.
+      # Vite+ downloads its own pnpm for `vp install` and exposes no shim, so this is what puts
+      # `pnpm` on PATH — for the steps below, and for the bare `pnpm` preview.ts spawns.
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # Vite+ resolves its own version from the `vite-plus` catalog entry, and installs the pnpm
+      # named in `packageManager` (integrity hash checked as Corepack does), so setup-node is not
+      # needed.
+      - name: Set up Vite+, Node.js and dependencies
+        uses: voidzero-dev/setup-vp@313600b80b104eadebb9111787d37a2e83e014ca # v1.17.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          cache: true
+          run-install: true
 
       - name: Deploy preview
         env:
@@ -200,17 +202,20 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
+      # Vite+ downloads its own pnpm for `vp install` and exposes no shim, so this is what puts
+      # `pnpm` on PATH — for the steps below, and for the bare `pnpm` preview.ts spawns.
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # Vite+ resolves its own version from the `vite-plus` catalog entry, and installs the pnpm
+      # named in `packageManager` (integrity hash checked as Corepack does), so setup-node is not
+      # needed.
+      - name: Set up Vite+, Node.js and dependencies
+        uses: voidzero-dev/setup-vp@313600b80b104eadebb9111787d37a2e83e014ca # v1.17.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          cache: true
+          run-install: true
 
       - name: Delete preview
         env:
@@ -242,17 +247,20 @@ jobs:
         with:
           persist-credentials: false
 
+      # Vite+ downloads its own pnpm for `vp install` and exposes no shim, so this is what puts
+      # `pnpm` on PATH — for the steps below, and for the bare `pnpm` preview.ts spawns.
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # Vite+ resolves its own version from the `vite-plus` catalog entry, and installs the pnpm
+      # named in `packageManager` (integrity hash checked as Corepack does), so setup-node is not
+      # needed.
+      - name: Set up Vite+, Node.js and dependencies
+        uses: voidzero-dev/setup-vp@313600b80b104eadebb9111787d37a2e83e014ca # v1.17.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          cache: true
+          run-install: true
 
       - name: Sweep previews whose PR is closed, or older than 7 days
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# This repository is public therefore should only ever contain packages
+# from https://registry.npmjs.org/
+@cloudflare:registry=https://registry.npmjs.org/

--- a/scripts/registry-policy.test.ts
+++ b/scripts/registry-policy.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+// This repository is public, and every consumer of it — forks, CI, external contributors — can
+// only reach registry.npmjs.org, so every dependency has to resolve from there.
+const PUBLIC_REGISTRY = "https://registry.npmjs.org/";
+
+const lockfile = readFileSync(new URL("../pnpm-lock.yaml", import.meta.url), "utf8");
+const npmrc = readFileSync(new URL("../.npmrc", import.meta.url), "utf8");
+
+describe("registry policy", () => {
+  it("resolves every lockfile tarball from the public npm registry", () => {
+    const offenders = lockfile
+      .split("\n")
+      .filter((line) => /tarball: (?!https:\/\/registry\.npmjs\.org\/)/.test(line))
+      .map((line) => line.trim());
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `pnpm-lock.yaml resolves packages from a registry other than ${PUBLIC_REGISTRY}, which ` +
+        "forks, CI and external contributors cannot reach. Re-run the install with the " +
+        "repository's root .npmrc in effect rather than under a config that points a scope " +
+        "somewhere private.",
+    );
+  });
+
+  it("configures the @cloudflare scope, and nothing else, in the root .npmrc", () => {
+    const directives = npmrc
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line !== "" && !line.startsWith("#"));
+
+    assert.deepEqual(
+      directives,
+      [`@cloudflare:registry=${PUBLIC_REGISTRY}`],
+      "the root .npmrc must contain exactly the @cloudflare scope pin; it is what keeps a " +
+        "resolving install from rewriting pnpm-lock.yaml to a registry this repository's " +
+        "consumers cannot reach.",
+    );
+  });
+});


### PR DESCRIPTION
- [setup-vp](https://github.com/voidzero-dev/setup-vp) replaces corepack enable + setup-node + pnpm install, this should significantly speed up CI, as it can now leverage caching.

- Also added a project level .npmrc to ensure we're always pinned to the public NPM registry