### PR TITLE
Make the Workshop UI fully responsive on phones

### DIFF
--- a/packages/workshop-frontend/index.html
+++ b/packages/workshop-frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
 
     <!-- Prevents Gadget UI frames from navigating away from their srcdoc. DO NOT REMOVE. -->
     <meta http-equiv="Content-Security-Policy" content="frame-src srcdoc:;">

--- a/packages/workshop-frontend/src/AddModelModal.tsx
+++ b/packages/workshop-frontend/src/AddModelModal.tsx
@@ -233,7 +233,7 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
 
   return (
     <Dialog.Root open={visible} onOpenChange={(open) => { if (!open) onCancel() }}>
-      <Dialog className="p-6" size="lg">
+      <Dialog className="responsive-dialog overflow-y-auto p-6" size="lg">
         <Dialog.Title className="text-lg font-semibold mb-4">
           Add AI Model
         </Dialog.Title>

--- a/packages/workshop-frontend/src/BlueprintLandingPage.tsx
+++ b/packages/workshop-frontend/src/BlueprintLandingPage.tsx
@@ -1004,7 +1004,7 @@ export default function BlueprintLandingPage({ rpcStub }: Props) {
       >
         <Dialog
           // The configurator iframe measures getBoundingClientRect(), which includes transforms.
-          className="!z-[1000] !top-[clamp(28px,10vh,96px)] !flex !max-h-[calc((100vh_-_clamp(28px,10vh,96px)_-_28px)_*_0.9)] !w-[min(760px,calc(100vw-32px))] !-translate-y-0 data-ending-style:!scale-100 data-starting-style:!scale-100 flex-col overflow-hidden bg-kumo-base p-0"
+          className="responsive-dialog !z-[1000] !top-[clamp(28px,10vh,96px)] !flex !max-h-[calc((100vh_-_clamp(28px,10vh,96px)_-_28px)_*_0.9)] !w-[min(760px,calc(100vw-32px))] !-translate-y-0 data-ending-style:!scale-100 data-starting-style:!scale-100 flex-col overflow-hidden bg-kumo-base p-0"
           size="lg"
         >
           {activeBinding && activeBindingName && authenticatedApi && (
@@ -1076,7 +1076,7 @@ export default function BlueprintLandingPage({ rpcStub }: Props) {
         open={showDeleteConfirm}
         onOpenChange={(open) => { if (!open) setShowDeleteConfirm(false) }}
       >
-        <Dialog className="p-8" size="sm">
+        <Dialog className="responsive-dialog overflow-y-auto p-8" size="sm">
           <Dialog.Title className="text-lg font-semibold">
             Delete blueprint
           </Dialog.Title>
@@ -1135,7 +1135,7 @@ function BlueprintScreenshotHero({
         )}
       />
       <Dialog
-        className="!z-[1200] !w-[min(1120px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0"
+        className="responsive-dialog !z-[1200] !w-[min(1120px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0"
         size="lg"
       >
         <Dialog.Title className="sr-only">Screenshot of {title}</Dialog.Title>
@@ -1154,7 +1154,7 @@ function BlueprintScreenshotHero({
           <img
             src={screenshotUrl}
             alt={`Screenshot of ${title}`}
-            className="max-h-[calc(100vh-96px)] w-full rounded-xl object-contain"
+            className="max-h-[calc(var(--app-height)-96px)] w-full rounded-xl object-contain"
           />
         </div>
       </Dialog>

--- a/packages/workshop-frontend/src/BlueprintModal.tsx
+++ b/packages/workshop-frontend/src/BlueprintModal.tsx
@@ -279,8 +279,8 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
 
   return (
     <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-      <Dialog className="!z-[1000] !w-[min(640px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[10%] !-translate-y-0" size="lg">
-          <div className="flex items-start justify-between gap-4 border-b border-kumo-line px-4 py-5 sm:px-6">
+      <Dialog className="responsive-dialog !z-[1000] !flex !w-[min(640px,calc(100vw-32px))] flex-col overflow-hidden bg-kumo-base p-0 !top-[10%] !-translate-y-0" size="lg">
+          <div className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-4 py-5 sm:px-6">
             <div className="flex min-w-0 items-start gap-3">
               <div className="min-w-0">
               <Dialog.Title className="text-[17px] leading-6 font-medium tracking-[-0.35px] text-kumo-default">
@@ -307,13 +307,10 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
             />
           </div>
 
-          <div
-            className={formMode !== 'list' ? 'flex flex-col' : ''}
-            style={formMode !== 'list' ? { maxHeight: 'calc(80vh - 80px)' } : undefined}
-          >
+          <div className="min-h-0 flex-1">
             {formMode !== 'list' ? (
-              <>
-                <div className="flex-1 overflow-y-auto chat-panel space-y-5 px-4 py-5 sm:px-6">
+              <div className="flex h-full min-h-0 flex-col">
+                <div className="chat-panel min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-5 sm:px-6">
                   <div className="space-y-3">
                     <WorkshopInput
                       placeholder="Title"
@@ -421,7 +418,7 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
                   ) : null}
                 </div>
 
-                <div className="border-t border-kumo-line px-4 py-4 sm:px-6">
+                <div className="shrink-0 border-t border-kumo-line px-4 py-4 sm:px-6">
                   {createError && (
                     <div className="mb-3 flex items-start gap-2 rounded-lg border border-l-2 border-l-kumo-brand border-y-kumo-line border-r-kumo-line bg-kumo-base px-3 py-2 text-[12px] leading-[18px] font-normal tracking-[-0.2px] text-kumo-default">
                       <Warning size={14} weight="fill" className="mt-0.5 shrink-0 text-kumo-brand" />
@@ -453,9 +450,9 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
                     </WorkshopButton>
                   </div>
                 </div>
-              </>
+              </div>
             ) : (
-              <div className="space-y-4 px-4 py-5 sm:px-6">
+              <div className="h-full min-h-0 space-y-4 overflow-y-auto px-4 py-5 sm:px-6">
               <button
                 type="button"
                 onClick={() => {

--- a/packages/workshop-frontend/src/BlueprintsPage.tsx
+++ b/packages/workshop-frontend/src/BlueprintsPage.tsx
@@ -76,8 +76,8 @@ export default function BlueprintsPage() {
   });
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-5xl flex-col px-6 sm:px-10">
-      <header className="flex items-end justify-between gap-4 px-3 pb-4 pt-10">
+    <div className="mx-auto flex h-full w-full max-w-5xl flex-col px-3 sm:px-10">
+      <header className="flex items-end justify-between gap-4 px-3 pb-4 pt-6 sm:pt-10">
         <div className="min-w-0">
           <h1 className="text-2xl font-semibold tracking-tight text-kumo-default">Explore</h1>
           <p className="mt-1 text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle">
@@ -93,7 +93,7 @@ export default function BlueprintsPage() {
         <span className="text-[12px] font-medium uppercase tracking-[0.08em] text-kumo-inactive">
           Featured
         </span>
-        <div className="relative sm:w-64">
+        <div className="relative min-w-0 flex-1 sm:w-64 sm:flex-none">
           <MagnifyingGlass
             size={16}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-kumo-inactive"
@@ -103,7 +103,7 @@ export default function BlueprintsPage() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search blueprints…"
-            className="h-9 w-full rounded-lg border border-kumo-line bg-kumo-base pl-9 pr-4 text-[13px] tracking-[-0.25px] text-kumo-default placeholder:text-kumo-inactive transition-[border-color,box-shadow] duration-150 ease-out focus:border-kumo-ring focus:outline-none focus:ring-[3px] focus:ring-kumo-ring/15"
+            className="h-10 w-full rounded-lg border border-kumo-line bg-kumo-base pl-9 pr-4 text-[16px] text-kumo-default placeholder:text-kumo-inactive transition-[border-color,box-shadow] duration-150 ease-out focus:border-kumo-ring focus:outline-none focus:ring-[3px] focus:ring-kumo-ring/15 sm:h-9 sm:text-[13px]"
           />
         </div>
       </div>

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -1350,7 +1350,7 @@ const AttachmentPreviewModal = memo(function AttachmentPreviewModal(
         if (event.target === event.currentTarget) onClose();
       }}
     >
-      <div ref={containerRef} className={`relative max-h-[calc(100vh-32px)] ${modalWidthClass} overflow-hidden ${modalSurfaceClass} p-0 shadow-[0_24px_80px_rgba(0,0,0,0.28)]`}>
+      <div ref={containerRef} className={`relative max-h-[calc(var(--app-height)-32px)] ${modalWidthClass} overflow-hidden ${modalSurfaceClass} p-0 shadow-[0_24px_80px_rgba(0,0,0,0.28)]`}>
         <button
           type="button"
           onClick={onClose}
@@ -1365,7 +1365,7 @@ const AttachmentPreviewModal = memo(function AttachmentPreviewModal(
             <img
               src={objectUrl}
               alt={title}
-              className="max-h-[calc(100vh-96px)] w-full rounded-xl object-contain"
+              className="max-h-[calc(var(--app-height)-96px)] w-full rounded-xl object-contain"
             />
           ) : (
             <div className="grid min-h-56 place-items-center rounded-xl border border-kumo-line/70 bg-kumo-elevated/40 p-6 py-10 text-center">
@@ -1763,7 +1763,7 @@ const ToolGroupRow = memo(function ToolGroupRow({
         )
       )}
       {footerChangeSequence !== undefined && footerTimestamp && footerLabel && onFooterRevert && (
-        <div className="ml-0 mt-0.5 flex items-center gap-1 opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus-within:opacity-100">
+        <div className="ml-0 mt-0.5 flex items-center gap-1 opacity-100 transition-opacity duration-150 ease-out sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
           <Tooltip content={footerLabel} asChild>
             <button
               type="button"
@@ -3188,7 +3188,7 @@ export const ChatInput = ({
     // captured-log floating chip with z-10, the textarea/mirror with z-[1])
     // so they can't paint on top of body-level portaled popovers like the
     // model picker dropdown opening above the composer.
-    <div className={`px-4 py-4 relative isolate ${styles.chatInputRoot}`}>
+    <div className={`relative isolate px-2 py-2 sm:px-4 sm:py-4 ${styles.chatInputRoot}`}>
       <input
         ref={attachmentInputRef}
         type="file"
@@ -3447,7 +3447,7 @@ export const ChatInput = ({
                   syncMirrorScroll(el);
                 }
               }}
-              className={`relative z-[1] w-full resize-none border-none bg-transparent p-0 text-[14px] leading-[22px] tracking-[-0.25px] outline-none placeholder:text-kumo-inactive disabled:cursor-not-allowed ${composerTextareaClass}`}
+              className={`relative z-[1] w-full resize-none border-none bg-transparent p-0 text-[16px] leading-[22px] outline-none placeholder:text-kumo-inactive disabled:cursor-not-allowed sm:text-[14px] ${composerTextareaClass}`}
             />
           </div>
         </div>
@@ -3488,7 +3488,7 @@ export const ChatInput = ({
                 render={
                   <button
                     type="button"
-                    className="group flex h-8 w-8 flex-shrink-0 cursor-pointer items-center justify-center rounded-lg text-kumo-inactive transition-[background-color,color,transform] duration-150 ease-out hover:bg-kumo-tint hover:text-kumo-subtle focus-visible:bg-kumo-tint focus-visible:text-kumo-subtle focus-visible:outline-none active:scale-[0.96] data-[popup-open]:bg-kumo-tint data-[popup-open]:text-kumo-subtle"
+                    className="group flex h-10 w-10 flex-shrink-0 cursor-pointer items-center justify-center rounded-lg text-kumo-inactive transition-[background-color,color,transform] duration-150 ease-out hover:bg-kumo-tint hover:text-kumo-subtle focus-visible:bg-kumo-tint focus-visible:text-kumo-subtle focus-visible:outline-none active:scale-[0.96] data-[popup-open]:bg-kumo-tint data-[popup-open]:text-kumo-subtle sm:h-8 sm:w-8"
                     aria-label="Open chat options"
                   >
                     <Plus size={18} />
@@ -3528,7 +3528,7 @@ export const ChatInput = ({
             <button
               type="button"
               onClick={handleAttachOpen}
-              className="inline-flex h-8 flex-shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-2 text-[13px] leading-none tracking-[-0.25px] text-kumo-inactive transition-[background-color,color,transform] duration-150 ease-out hover:bg-kumo-tint hover:text-kumo-subtle focus-visible:bg-kumo-tint focus-visible:text-kumo-subtle focus-visible:outline-none active:scale-[0.97]"
+              className="inline-flex h-10 flex-shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-2 text-[14px] leading-none text-kumo-inactive transition-[background-color,color,transform] duration-150 ease-out hover:bg-kumo-tint hover:text-kumo-subtle focus-visible:bg-kumo-tint focus-visible:text-kumo-subtle focus-visible:outline-none active:scale-[0.97] sm:h-8 sm:text-[13px]"
             >
               <Plug size={15} className="flex-shrink-0" />
               <span className={`leading-none ${styles.attachLabelText}`}>{attachLabel ?? "Add resource"}</span>
@@ -3542,7 +3542,7 @@ export const ChatInput = ({
                   render={
                     <button
                       type="button"
-                      className="group inline-flex h-8 min-w-0 max-w-[180px] cursor-pointer items-center gap-1.5 rounded-lg px-2 text-[13px] leading-5 tracking-[-0.25px] text-kumo-subtle transition-[background-color,color,transform] duration-150 ease-out hover:bg-kumo-tint hover:text-kumo-default focus-visible:bg-kumo-tint focus-visible:text-kumo-default focus-visible:outline-none active:scale-[0.97] data-[popup-open]:bg-kumo-tint data-[popup-open]:text-kumo-default"
+                      className="group inline-flex h-10 min-w-0 max-w-[110px] cursor-pointer items-center gap-1.5 rounded-lg px-2 text-[14px] leading-5 text-kumo-subtle transition-[background-color,color,transform] duration-150 ease-out hover:bg-kumo-tint hover:text-kumo-default focus-visible:bg-kumo-tint focus-visible:text-kumo-default focus-visible:outline-none active:scale-[0.97] data-[popup-open]:bg-kumo-tint data-[popup-open]:text-kumo-default sm:h-8 sm:max-w-[180px] sm:text-[13px]"
                       aria-label="Select model"
                     >
                       <span className="min-w-0 truncate">{selectedModelLabel}</span>
@@ -3586,7 +3586,7 @@ export const ChatInput = ({
                 <WorkshopIconButton
                   onClick={onStop}
                   tone="primary"
-                  className="!h-8 !w-8"
+                  className="!h-10 !w-10 sm:!h-8 sm:!w-8"
                   aria-label="Stop agent"
                 >
                   <svg
@@ -3603,7 +3603,7 @@ export const ChatInput = ({
                   onClick={submitMessage}
                   disabled={!canSend}
                   tone="primary"
-                  className="!h-8 !w-8 disabled:cursor-not-allowed disabled:opacity-30"
+                  className="!h-10 !w-10 disabled:cursor-not-allowed disabled:opacity-30 sm:!h-8 sm:!w-8"
                   aria-label="Send message"
                 >
                   {/* Arrow-up icon */}
@@ -6800,7 +6800,7 @@ function ChatInterface({
                             <WorkshopIconButton
                               aria-label={`Actions for ${chat.title}`}
                               onClick={(e) => e.stopPropagation()}
-                              className="!h-7 !w-7 flex-shrink-0 text-kumo-inactive opacity-0 focus:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100"
+                              className="!h-9 !w-9 flex-shrink-0 text-kumo-inactive opacity-100 focus:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100 sm:!h-7 sm:!w-7 sm:opacity-0"
                             >
                               <DotsThreeVertical size={14} />
                             </WorkshopIconButton>
@@ -6904,7 +6904,7 @@ function ChatInterface({
       {!sidebarMode && selectedChatId === null ? (
         chatListPanel
       ) : selectedChatId !== null ? (
-        <div className="flex-1 flex flex-col overflow-auto">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {/* Tab bar — in sidebar mode, show Chat / Connections tabs */}
           {sidebarMode && (
             <div className="flex h-12 flex-shrink-0 items-center gap-5 border-b border-kumo-line px-4">
@@ -7016,7 +7016,7 @@ function ChatInterface({
               <div
                 ref={messagesContainerRef}
                 onScroll={handleMessagesScroll}
-                className="flex-1 overflow-y-auto chat-panel"
+                className="chat-panel min-h-0 flex-1 overscroll-contain overflow-y-auto"
               >
                 {isLoading ? (
                   <div className="flex items-center justify-center py-10">
@@ -7024,7 +7024,7 @@ function ChatInterface({
                   </div>
                 ) : (
                   <div
-                    className={`flex flex-col px-6 pt-8 ${pendingConsoleLogCount > 0 ? "pb-16" : "pb-8"} ${useConstrainedChatWidth ? "mx-auto w-full max-w-[920px]" : ""}`}
+                    className={`flex flex-col px-3 pt-5 sm:px-6 sm:pt-8 ${pendingConsoleLogCount > 0 ? "pb-16" : "pb-8"} ${useConstrainedChatWidth ? "mx-auto w-full max-w-[920px]" : ""}`}
                   >
                     {isLoadingEarlier && (
                       <div className="mx-auto mb-6 text-[12px] leading-4 font-medium text-kumo-inactive">
@@ -7165,7 +7165,7 @@ function ChatInterface({
                               <span className="min-w-0 truncate font-medium">
                                 {label}
                               </span>
-                              <div className="flex flex-shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 ease-out group-hover/savedChanges:opacity-100 group-focus-within/savedChanges:opacity-100">
+                              <div className="flex flex-shrink-0 items-center gap-1 opacity-100 transition-opacity duration-150 ease-out sm:opacity-0 sm:group-hover/savedChanges:opacity-100 sm:group-focus-within/savedChanges:opacity-100">
                                 <Tooltip content={discardLabel} asChild>
                                   <button
                                     type="button"
@@ -7260,7 +7260,7 @@ function ChatInterface({
                                 />
                               </span>
                             </div>
-                            <div className="mt-0.5 flex items-center justify-end gap-2 pr-1 text-[11px] leading-4 text-kumo-inactive opacity-0 transition-opacity duration-150 ease-out group-hover/message:opacity-100 group-focus-within/message:opacity-100">
+                            <div className="mt-0.5 flex items-center justify-end gap-2 pr-1 text-[11px] leading-4 text-kumo-inactive opacity-100 transition-opacity duration-150 ease-out sm:opacity-0 sm:group-hover/message:opacity-100 sm:group-focus-within/message:opacity-100">
                               {!(hideOwnUserName && msg.author.id === currentUser?.id) && (
                                 <span className="font-medium">{msg.author.name}</span>
                               )}
@@ -7309,7 +7309,7 @@ function ChatInterface({
                                   </div>
                                 )}
                               </div>
-                              <div className="mt-0.5 flex items-center justify-end gap-2 pr-1 text-[11px] leading-4 text-kumo-inactive opacity-0 transition-opacity duration-150 ease-out group-hover/message:opacity-100 group-focus-within/message:opacity-100">
+                              <div className="mt-0.5 flex items-center justify-end gap-2 pr-1 text-[11px] leading-4 text-kumo-inactive opacity-100 transition-opacity duration-150 ease-out sm:opacity-0 sm:group-hover/message:opacity-100 sm:group-focus-within/message:opacity-100">
                                 {/* hideOwnUserName implies currentUser is non-null (see memo). */}
                                 {!(hideOwnUserName && msg.author.id === currentUser?.id) && (
                                   <span className="font-medium">{msg.author.name}</span>
@@ -7368,7 +7368,7 @@ function ChatInterface({
                                 <div className={`mt-0.5 -ml-1 flex items-center gap-1 transition-opacity duration-150 ease-out ${
                                   keepActionsVisible
                                     ? "opacity-100"
-                                    : "opacity-0 group-hover/agentMessage:opacity-100 group-focus-within/agentMessage:opacity-100"
+                                    : "opacity-100 sm:opacity-0 sm:group-hover/agentMessage:opacity-100 sm:group-focus-within/agentMessage:opacity-100"
                                 }`}>
                                   {hasMessageText && (
                                     <Tooltip content="Copy message" asChild>

--- a/packages/workshop-frontend/src/CodeDiffEditor.tsx
+++ b/packages/workshop-frontend/src/CodeDiffEditor.tsx
@@ -75,6 +75,7 @@ export default function CodeDiffEditor({
   const [editorMountVersion, setEditorMountVersion] = useState(0)
   const [originalEditorMountVersion, setOriginalEditorMountVersion] = useState(0)
   const [canSplitDiff, setCanSplitDiff] = useState(false)
+  const [isCompact, setIsCompact] = useState(false)
   const [diffLayoutPreference, setDiffLayoutPreference] = useState<DiffLayoutPreference>(getInitialDiffLayoutPreference)
   const [yjsVersion, setYjsVersion] = useState(0)
   const [lineChanges, setLineChanges] = useState<editor.ILineChange[] | null>(null)
@@ -118,7 +119,10 @@ export default function CodeDiffEditor({
     const container = containerRef.current
     if (!container) return
 
-    const update = (width: number) => setCanSplitDiff(width >= SPLIT_DIFF_MIN_WIDTH)
+    const update = (width: number) => {
+      setCanSplitDiff(width >= SPLIT_DIFF_MIN_WIDTH)
+      setIsCompact(width < 640)
+    }
     update(container.getBoundingClientRect().width)
 
     const observer = new ResizeObserver(entries => {
@@ -362,7 +366,7 @@ export default function CodeDiffEditor({
     fontFamily: monoFont,
     fontLigatures: false,
     minimap: { enabled: false },
-    wordWrap: 'off',
+    wordWrap: isCompact ? 'on' : 'off',
     scrollBeyondLastLine: false,
     renderLineHighlight: 'none',
     selectOnLineNumbers: true,
@@ -370,8 +374,8 @@ export default function CodeDiffEditor({
     cursorStyle: 'line',
     glyphMargin: false,
     folding: false,
-    lineDecorationsWidth: 12,
-    lineNumbersMinChars: 4,
+    lineDecorationsWidth: isCompact ? 8 : 12,
+    lineNumbersMinChars: isCompact ? 3 : 4,
     overviewRulerLanes: 0,
     hideCursorInOverviewRuler: true,
     renderValidationDecorations: 'editable',
@@ -391,7 +395,7 @@ export default function CodeDiffEditor({
     insertSpaces: true,
     contextmenu: true,
     mouseWheelZoom: false,
-  }), [])
+  }), [isCompact])
 
   const layoutButtonClass = (active: boolean, disabled = false) => (
     `inline-flex h-[22px] w-[22px] items-center justify-center rounded-md border transition-colors ${
@@ -415,7 +419,7 @@ export default function CodeDiffEditor({
   return (
     <div ref={containerRef} className="flex min-h-0 overflow-hidden bg-kumo-base" style={{ height }}>
       <div
-        className="gadgets-diff-surface relative m-4 min-h-0 flex-1 overflow-hidden rounded-[10px] border border-kumo-line bg-kumo-base"
+        className="gadgets-diff-surface relative min-h-0 flex-1 overflow-hidden bg-kumo-base md:m-4 md:rounded-[10px] md:border md:border-kumo-line"
         style={{ isolation: 'isolate' }}
       >
         <div className="absolute right-3 top-3 flex items-center gap-2" style={{ zIndex: 1 }}>

--- a/packages/workshop-frontend/src/ConnectAccountModal.tsx
+++ b/packages/workshop-frontend/src/ConnectAccountModal.tsx
@@ -76,7 +76,7 @@ export default function ConnectAccountModal({
 
   return (
     <Dialog.Root open={visible} onOpenChange={(open) => { if (!open) onCancel() }}>
-      <Dialog className="p-6" size="base">
+      <Dialog className="responsive-dialog overflow-y-auto p-6" size="base">
         <Dialog.Title className="text-lg font-semibold mb-4">Connect Account</Dialog.Title>
         {vendorsLoading ? (
           <div className="text-center py-8">

--- a/packages/workshop-frontend/src/Connections.tsx
+++ b/packages/workshop-frontend/src/Connections.tsx
@@ -555,7 +555,7 @@ function BlueprintAnnotationModal({
   return (
     <>
       <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-        <Dialog className="!z-[1000] !w-[min(480px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0" size="lg">
+        <Dialog className="responsive-dialog !z-[1000] !w-[min(480px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0" size="lg">
           <div className="flex items-start justify-between gap-4 border-b border-kumo-line px-4 py-4 sm:px-5">
             <div className="min-w-0">
               <Dialog.Title className="text-[15px] leading-5 font-medium tracking-[-0.3px] text-kumo-default">

--- a/packages/workshop-frontend/src/FileSidebar.tsx
+++ b/packages/workshop-frontend/src/FileSidebar.tsx
@@ -18,6 +18,8 @@ interface FileSidebarProps {
   onFileDelete: (filename: string) => void
   onFileRename: (oldName: string, newName: string) => void
   onFileDownload: (filename: string) => void
+  className?: string
+  onRequestClose?: () => void
   ref?: Ref<FileSidebarHandle>
 }
 
@@ -41,6 +43,8 @@ export default function FileSidebar({
   onFileDelete,
   onFileRename,
   onFileDownload,
+  className = '',
+  onRequestClose,
   ref,
 }: FileSidebarProps) {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
@@ -114,20 +118,31 @@ export default function FileSidebar({
   }
 
   return (
-    <div className="flex h-full w-[244px] flex-col border-r border-kumo-line bg-kumo-base">
+    <div className={`flex h-full w-[244px] flex-col border-r border-kumo-line bg-kumo-base ${className}`}>
       <div className="flex h-9 shrink-0 items-center justify-between gap-2 px-3 pt-3 pb-2">
         <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-kumo-inactive">
           Files
         </span>
-        <WorkshopIconButton
-          onClick={() => setIsCreateModalOpen(true)}
-          disabled={editLocked}
-          aria-label="New file"
-          title="New file"
-          className="!h-6 !w-6 text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default"
-        >
-          <Plus size={14} weight="bold" />
-        </WorkshopIconButton>
+        <div className="flex items-center gap-1">
+          <WorkshopIconButton
+            onClick={() => setIsCreateModalOpen(true)}
+            disabled={editLocked}
+            aria-label="New file"
+            title="New file"
+            className="!h-8 !w-8 text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default md:!h-6 md:!w-6"
+          >
+            <Plus size={14} weight="bold" />
+          </WorkshopIconButton>
+          {onRequestClose && (
+            <WorkshopIconButton
+              onClick={onRequestClose}
+              aria-label="Close files"
+              className="!h-8 !w-8 md:!hidden"
+            >
+              <X size={16} />
+            </WorkshopIconButton>
+          )}
+        </div>
       </div>
 
       <div className="flex-1 overflow-auto px-2 pb-3">
@@ -179,7 +194,7 @@ export default function FileSidebar({
         }}
       >
         <Dialog
-          className="!z-[1000] !w-[min(420px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[18%] !-translate-y-0"
+          className="responsive-dialog !z-[1000] !w-[min(420px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[18%] !-translate-y-0"
           size="sm"
         >
           <div className="flex items-start justify-between gap-4 border-b border-kumo-line px-5 py-4">
@@ -322,7 +337,7 @@ function FileRow({
   return (
     <div
       className={[
-        'group relative mb-[2px] flex h-7 items-center gap-2 rounded-md px-2 text-[13px] leading-[18px] tracking-[-0.2px] transition-[background-color,box-shadow,color,opacity] duration-150 ease-out',
+        'group relative mb-[2px] flex h-10 items-center gap-2 rounded-md px-2 text-[14px] leading-5 transition-[background-color,box-shadow,color,opacity] duration-150 ease-out md:h-7 md:text-[13px] md:leading-[18px]',
         isRenaming
           ? 'bg-kumo-base ring-1 ring-kumo-ring/40'
           : isActive
@@ -366,7 +381,7 @@ function FileRow({
           autoCapitalize="off"
           autoCorrect="off"
           aria-label={`Rename ${filename}`}
-          className="min-w-0 flex-1 bg-transparent text-[13px] leading-[18px] tracking-[-0.2px] text-kumo-default outline-none placeholder:text-kumo-inactive"
+          className="min-w-0 flex-1 bg-transparent text-[16px] leading-5 text-kumo-default outline-none placeholder:text-kumo-inactive md:text-[13px] md:leading-[18px]"
         />
       ) : (
         <button
@@ -396,7 +411,7 @@ function FileRow({
               <WorkshopIconButton
                 aria-label={`Actions for ${filename}`}
                 onClick={(event) => event.stopPropagation()}
-                className="!h-5 !w-5 text-kumo-inactive opacity-0 hover:bg-kumo-tint hover:text-kumo-default focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100"
+                className="!h-8 !w-8 text-kumo-inactive opacity-100 hover:bg-kumo-tint hover:text-kumo-default focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 data-[popup-open]:opacity-100 md:!h-5 md:!w-5 md:opacity-0"
               >
                 <DotsThree size={14} weight="bold" />
               </WorkshopIconButton>

--- a/packages/workshop-frontend/src/FrontendErrorBoundary.tsx
+++ b/packages/workshop-frontend/src/FrontendErrorBoundary.tsx
@@ -23,7 +23,7 @@ export default class FrontendErrorBoundary extends Component<Props, State> {
   render() {
     if (!this.state.crashed) return this.props.children
     return (
-      <main className="mx-auto flex min-h-screen max-w-lg flex-col items-center justify-center gap-4 px-6 text-center">
+      <main className="mx-auto flex min-h-full max-w-lg flex-col items-center justify-center gap-4 px-6 text-center">
         <h1 className="text-xl font-semibold">Something went wrong</h1>
         <p className="text-sm text-kumo-subtle">Reload the Workshop to start again.</p>
         <button className="rounded-md bg-kumo-brand px-4 py-2 text-sm" onClick={() => location.reload()}>

--- a/packages/workshop-frontend/src/GadgetCodeInterface.tsx
+++ b/packages/workshop-frontend/src/GadgetCodeInterface.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react'
 import { useKumoToastManager } from '@cloudflare/kumo'
-import { DownloadSimple } from '@phosphor-icons/react'
+import { DownloadSimple, List } from '@phosphor-icons/react'
 import { Overseer, CodeSubscriber, CodeUpdate } from '@gadgets/workshop-shared/api'
 import { RpcStub, RpcTarget } from 'capnweb'
 import * as Y from 'yjs'
@@ -157,7 +157,11 @@ export default function GadgetCodeInterface({ overseer, filesRoot, height = '100
   // React state for UI
   const [fileNames, setFileNames] = useState<string[]>([])
   const [activeFile, setActiveFile] = useState<string | null>(null)
+  const [fileDrawerOpen, setFileDrawerOpen] = useState(false)
+  const [compactLayout, setCompactLayout] = useState(false)
   const fileSidebarRef = useRef<FileSidebarHandle | null>(null)
+  const fileDrawerRef = useRef<HTMLDivElement | null>(null)
+  const fileDrawerTriggerRef = useRef<HTMLButtonElement | null>(null)
   const [isReady, setIsReady] = useState(false)
   const [loading, setLoading] = useState(true)
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
@@ -184,6 +188,53 @@ export default function GadgetCodeInterface({ overseer, filesRoot, height = '100
   const previewObserverCleanupRef = useRef<(() => void) | null>(null)
   const editableObserverCleanupRef = useRef<(() => void) | null>(null)
   const [changedFiles, setChangedFiles] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (!isVisible) setFileDrawerOpen(false)
+  }, [isVisible])
+
+  useEffect(() => {
+    if (!window.matchMedia) return
+    const query = window.matchMedia('(max-width: 767px)')
+    const update = () => {
+      setCompactLayout(query.matches)
+      if (!query.matches) setFileDrawerOpen(false)
+    }
+    update()
+    query.addEventListener('change', update)
+    return () => query.removeEventListener('change', update)
+  }, [])
+
+  useEffect(() => {
+    if (!compactLayout || !fileDrawerOpen) return
+    const drawer = fileDrawerRef.current
+    drawer?.focus()
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setFileDrawerOpen(false)
+        return
+      }
+      if (event.key !== 'Tab' || !drawer) return
+      const focusable = [...drawer.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )]
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (event.shiftKey && (document.activeElement === first || document.activeElement === drawer)) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      if (fileDrawerTriggerRef.current?.isConnected) fileDrawerTriggerRef.current.focus()
+    }
+  }, [compactLayout, fileDrawerOpen])
   // Sorted list of file names present in the currently-observed preview map (streaming preview or
   // editable branch doc). Tracked as state so the file sidebar updates when files are added/removed
   // mid-turn — the preview map is a mutable ref whose identity doesn't change on incremental edits.
@@ -859,40 +910,84 @@ export default function GadgetCodeInterface({ overseer, filesRoot, height = '100
           <span>Connection issue - changes will be saved when connection is restored</span>
         </div>
       )}
-      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
-        <FileSidebar
-          ref={fileSidebarRef}
-          files={displayedFiles}
-          activeFile={activeFile}
-          streamingActiveFile={streamingActiveFile}
-          dirtyFiles={new Set()}
-          changedFiles={changedFiles}
-          fileChangeStatuses={fileChangeStatuses}
-          isDiffMode={isDiffMode}
-          editLocked={isEditingLocked}
-          onFileSelect={handleFileSelect}
-          onFileCreate={handleFileCreate}
-          onFileDelete={handleFileDelete}
-          onFileRename={handleFileRename}
-          onFileDownload={handleFileDownload}
-        />
-        <div className="flex flex-col bg-kumo-base" style={{ flex: 1, minWidth: 0 }}>
-          {activeFile && (
-            <div className="flex h-9 shrink-0 items-center justify-between gap-3 border-b border-kumo-line bg-kumo-base px-3">
-              <div className="min-w-0 text-[12px] leading-4 tracking-[-0.2px] text-kumo-subtle">
-                {activeFileModeLabel} <span className="font-mono font-medium text-kumo-default">{activeFile}</span>
-              </div>
+      <div className="relative flex min-h-0 flex-1">
+        {fileDrawerOpen && (
+          <button
+            type="button"
+            aria-label="Close files"
+            onClick={() => setFileDrawerOpen(false)}
+            className="absolute inset-0 z-20 bg-black/25 md:hidden"
+          />
+        )}
+        <div
+          ref={fileDrawerRef}
+          role={compactLayout ? 'dialog' : undefined}
+          aria-modal={compactLayout ? true : undefined}
+          aria-label={compactLayout ? 'Files' : undefined}
+          aria-hidden={compactLayout && !fileDrawerOpen ? true : undefined}
+          inert={compactLayout && !fileDrawerOpen ? true : undefined}
+          tabIndex={compactLayout ? -1 : undefined}
+          className={`flex h-full shrink-0 outline-none max-md:absolute max-md:inset-y-0 max-md:left-0 max-md:z-30 max-md:w-[min(85vw,320px)] max-md:shadow-xl max-md:transition-transform max-md:duration-200 ${
+            fileDrawerOpen
+              ? 'max-md:visible max-md:translate-x-0'
+              : 'max-md:invisible max-md:-translate-x-full'
+          }`}
+        >
+          <FileSidebar
+            ref={fileSidebarRef}
+            files={displayedFiles}
+            activeFile={activeFile}
+            streamingActiveFile={streamingActiveFile}
+            dirtyFiles={new Set()}
+            changedFiles={changedFiles}
+            fileChangeStatuses={fileChangeStatuses}
+            isDiffMode={isDiffMode}
+            editLocked={isEditingLocked}
+            onFileSelect={(filename) => {
+              handleFileSelect(filename)
+              setFileDrawerOpen(false)
+            }}
+            onFileCreate={handleFileCreate}
+            onFileDelete={handleFileDelete}
+            onFileRename={handleFileRename}
+            onFileDownload={handleFileDownload}
+            onRequestClose={() => setFileDrawerOpen(false)}
+            className="max-md:!w-full"
+          />
+        </div>
+        <div
+          className="flex flex-col bg-kumo-base"
+          style={{ flex: 1, minWidth: 0 }}
+          inert={compactLayout && fileDrawerOpen ? true : undefined}
+          aria-hidden={compactLayout && fileDrawerOpen ? true : undefined}
+        >
+          <div className={`${activeFile ? 'flex' : 'flex md:hidden'} h-11 shrink-0 items-center justify-between gap-2 border-b border-kumo-line bg-kumo-base px-2 md:h-9 md:px-3`}>
+            <WorkshopIconButton
+              aria-label="Open files"
+              title="Files"
+              onClick={() => setFileDrawerOpen(true)}
+              ref={fileDrawerTriggerRef}
+              className="!h-9 !w-9 md:!hidden"
+            >
+              <List size={18} />
+            </WorkshopIconButton>
+            <div className="min-w-0 flex-1 truncate text-[13px] leading-4 text-kumo-subtle md:text-[12px]">
+              {activeFile ? (
+                <>{activeFileModeLabel} <span className="font-mono font-medium text-kumo-default">{activeFile}</span></>
+              ) : 'Files'}
+            </div>
+            {activeFile && (
               <WorkshopIconButton
                 aria-label={`Download ${activeFile}`}
                 title="Download file"
                 onClick={() => handleFileDownload(activeFile)}
                 disabled={!activeFileDownloadable}
-                className="!h-6 !w-6"
+                className="!h-9 !w-9 md:!h-6 md:!w-6"
               >
                 <DownloadSimple size={14} weight="bold" />
               </WorkshopIconButton>
-            </div>
-          )}
+            )}
+          </div>
           <div className="min-h-0 flex-1">
             {isReady && !loading && displayedFiles.length === 0 ? (
               <div className="flex h-full flex-col items-center justify-center bg-kumo-base px-6 text-center">

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef, type PointerEvent as ReactPointerEvent } from 'react'
 import { useParams, useNavigate, useSearch, Link } from '@tanstack/react-router'
-import { useKumoToastManager } from '@cloudflare/kumo'
+import { DropdownMenu, useKumoToastManager } from '@cloudflare/kumo'
 import {
   ShareNetwork,
   Pencil,
@@ -10,6 +10,7 @@ import {
   Blueprint,
   Trash,
   ArrowsOutSimple,
+  DotsThree,
   Pulse,
   type Icon,
 } from '@phosphor-icons/react'
@@ -56,6 +57,7 @@ import WorkspaceOpenErrorPage from './components/WorkspaceOpenErrorPage'
 import { useWorkspaceOpen } from './useWorkspaceOpen'
 import { reportIssue } from './errorReporting'
 import GadgetExportMenu from './GadgetExportMenu'
+import { MENU_CONTENT, MENU_ITEM, MENU_ITEM_DANGER, MENU_POSITIONER_STYLE } from './components/menuStyles'
 
 const NO_GADGETS: ReadonlySet<WorkpieceId> = new Set()
 
@@ -532,6 +534,7 @@ export default function GadgetEditor() {
   // Fullscreen overlay wrapper — we focus this on enter to move focus out of the now-occluded
   // Enter button. From here, Tab moves into the iframe.
   const fullscreenOverlayRef = useRef<HTMLDivElement>(null)
+  const mobileMenuButtonRef = useRef<HTMLButtonElement>(null)
 
   const enterGadgetFullscreen = useCallback(() => {
     if (window.location.hash !== '#fullscreen') {
@@ -558,7 +561,11 @@ export default function GadgetEditor() {
     if (isGadgetFullscreen) {
       fullscreenOverlayRef.current?.focus()
     } else if (focusBeforeFullscreenRef.current) {
-      focusBeforeFullscreenRef.current.focus()
+      if (focusBeforeFullscreenRef.current.isConnected) {
+        focusBeforeFullscreenRef.current.focus()
+      } else {
+        mobileMenuButtonRef.current?.focus()
+      }
       focusBeforeFullscreenRef.current = null
     }
   }, [isGadgetFullscreen])
@@ -1253,7 +1260,6 @@ export default function GadgetEditor() {
   // ── shared height tokens ──────────────────────────────────────────────────────
   const TOPBAR_H = 56   // h-14 (matches home page Header)
   const TABBAR_H = 48   // h-12
-  const RIGHT_CONTENT_H = `calc(100vh - ${TOPBAR_H}px - ${TABBAR_H}px)`
 
   // ── error / loading states ────────────────────────────────────────────────────
   if (error?.kind === 'open') {
@@ -1268,7 +1274,7 @@ export default function GadgetEditor() {
 
   if (error?.kind === 'message') {
     return (
-      <div className="min-h-screen flex items-center justify-center flex-col gap-4 bg-kumo-base">
+      <div className="flex min-h-full items-center justify-center flex-col gap-4 bg-kumo-base">
         {/* Observer-verification denials list one line per failed connection, so preserve newlines. */}
         <p className="text-sm text-kumo-danger whitespace-pre-line text-center max-w-lg">
           {error.message}
@@ -1290,7 +1296,7 @@ export default function GadgetEditor() {
   if (!metadata || !overseer || !workpiecesReady ||
       (selectedGadgetId !== null && gadget === null)) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-kumo-base">
+      <div className="flex min-h-full items-center justify-center bg-kumo-base">
         <div className="flex flex-col items-center gap-3">
           <div className="w-8 h-8 border-2 border-kumo-brand border-t-transparent rounded-full animate-spin" />
           <p className="text-sm text-kumo-subtle">Loading workspace…</p>
@@ -1323,9 +1329,17 @@ export default function GadgetEditor() {
     )
   }
 
+  const openMobilePane = (tab: RightTab) => {
+    handleTabSelect(tab)
+    if (selectedGadgetId !== null) setWorkspaceVisibility('open', selectedGadgetId)
+  }
+
+  const mobilePreviewActive = showFullEditor && !paneShowsActivity && activeTab === 'app'
+  const mobileMoreActive = showFullEditor && !paneShowsActivity && activeTab !== 'app'
+
   // ── always render the full two-pane edit layout; preview overlays on top ──────
   return (
-    <div className="flex flex-col h-screen overflow-hidden bg-kumo-base relative">
+    <div className="relative flex h-full flex-col overflow-hidden bg-kumo-base">
       {/* ═══ SHARED TOP BAR (visible in both modes) ════════════════════════════ */}
       <div
         className="relative flex items-center justify-between px-4 sm:px-6 backdrop-blur-md border-b border-kumo-line flex-shrink-0 gap-3"
@@ -1333,7 +1347,7 @@ export default function GadgetEditor() {
       >
         <TopBarNotice />
         {/* Left: logo / title */}
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           <Link
             to="/"
             aria-label="Home"
@@ -1347,7 +1361,7 @@ export default function GadgetEditor() {
           <span className="text-kumo-inactive flex-shrink-0">/</span>
 
           {isEditingTitle ? (
-            <div className="flex items-center gap-1">
+            <div className="flex min-w-0 items-center gap-1">
               <WorkshopInput
                 type="text"
                 value={titleInput}
@@ -1357,19 +1371,19 @@ export default function GadgetEditor() {
                   if (e.key === 'Escape') handleCancelEdit()
                 }}
                 autoFocus
-                className="!h-7 w-56 bg-kumo-tint text-[14px] leading-5 font-medium tracking-[-0.25px]"
+                className="!h-9 w-[min(14rem,45vw)] bg-kumo-tint text-[16px] leading-5 font-medium md:!h-7 md:text-[14px]"
               />
               <WorkshopIconButton
                 onClick={handleSaveTitle}
                 disabled={!titleInput.trim()}
-                className="!h-7 !w-7 hover:text-kumo-brand disabled:opacity-30"
+                className="!h-9 !w-9 hover:text-kumo-brand disabled:opacity-30 md:!h-7 md:!w-7"
                 aria-label="Save workspace title"
               >
                 <Check size={14} />
               </WorkshopIconButton>
               <WorkshopIconButton
                 onClick={handleCancelEdit}
-                className="!h-7 !w-7"
+                className="!h-9 !w-9 md:!h-7 md:!w-7"
                 aria-label="Cancel title edit"
               >
                 <X size={14} />
@@ -1380,26 +1394,28 @@ export default function GadgetEditor() {
               <span className="text-[14px] leading-5 font-medium tracking-[-0.25px] text-kumo-default truncate">
                 {metadata.title}
               </span>
-              <WorkshopIconButton
-                onClick={() => setIsEditingTitle(true)}
-                className="!h-7 !w-7 flex-shrink-0"
-                title="Rename workspace"
-                aria-label="Rename workspace"
-              >
-                <Pencil size={16} />
-              </WorkshopIconButton>
+              <span className="hidden md:inline-flex">
+                <WorkshopIconButton
+                  onClick={() => setIsEditingTitle(true)}
+                  className="!h-7 !w-7 flex-shrink-0"
+                  title="Rename workspace"
+                  aria-label="Rename workspace"
+                >
+                  <Pencil size={16} />
+                </WorkshopIconButton>
+              </span>
             </div>
           )}
 
           {metadata.owner && (
-            <span className="text-xs text-kumo-inactive flex-shrink-0">
+            <span className="hidden text-xs text-kumo-inactive sm:inline">
               by {metadata.owner.name}
             </span>
           )}
         </div>
 
         {/* Right: presence, cost, workspace, share, blueprints */}
-        <div className="flex items-center gap-1 flex-shrink-0">
+        <div className="hidden flex-shrink-0 items-center gap-1 md:flex">
           <GadgetPresence
             overseer={overseer.stub}
             authenticatedApi={authenticatedApi}
@@ -1448,11 +1464,131 @@ export default function GadgetEditor() {
             </WorkshopIconButton>
           )}
 
-          {/* User menu */}
-          <div className="ml-2">
-            <UserMenu />
-          </div>
         </div>
+        <div className="ml-1 flex shrink-0 items-center gap-2">
+          <span className="md:hidden">{connectionLost && <ReconnectingChip />}</span>
+          {/* Desktop reaches Export from the gadget pane's tab bar, which is hidden on phones. */}
+          <span className="md:hidden">
+            <GadgetExportMenu
+              gadget={selectedGadgetStub}
+              gadgetTitle={selectedGadgetSummary?.title ?? 'Gadget'}
+              chatId={previewChatId}
+            />
+          </span>
+          <UserMenu />
+        </div>
+      </div>
+
+      <div className="flex h-12 shrink-0 items-center gap-1 border-b border-kumo-line bg-kumo-base px-2 md:hidden">
+        <button
+          type="button"
+          onClick={() => setWorkspaceVisibility('closed')}
+          aria-current={!showFullEditor ? 'page' : undefined}
+          className={`flex h-9 min-w-0 flex-1 items-center justify-center rounded-lg px-3 text-[14px] font-medium ${
+            !showFullEditor ? 'bg-kumo-tint text-kumo-default' : 'text-kumo-subtle'
+          }`}
+        >
+          Chat
+        </button>
+        <button
+          type="button"
+          onClick={() => openMobilePane('app')}
+          disabled={!selectedGadgetStub}
+          aria-current={mobilePreviewActive ? 'page' : undefined}
+          className={`flex h-9 min-w-0 flex-1 items-center justify-center rounded-lg px-3 text-[14px] font-medium disabled:opacity-40 ${
+            mobilePreviewActive ? 'bg-kumo-tint text-kumo-default' : 'text-kumo-subtle'
+          }`}
+        >
+          Preview
+        </button>
+        <button
+          type="button"
+          onClick={() => openActivity(pendingActionsCount > 0 ? 'review' : 'history')}
+          aria-current={paneShowsActivity ? 'page' : undefined}
+          className={`relative flex h-9 min-w-0 flex-1 items-center justify-center rounded-lg px-3 text-[14px] font-medium ${
+            paneShowsActivity ? 'bg-kumo-tint text-kumo-default' : 'text-kumo-subtle'
+          }`}
+        >
+          Activity
+          {pendingActionsCount > 0 && (
+            <span className="ml-1.5 h-1.5 w-1.5 rounded-full bg-kumo-brand" />
+          )}
+        </button>
+        <DropdownMenu>
+          <DropdownMenu.Trigger
+            render={
+              <button
+                type="button"
+                ref={mobileMenuButtonRef}
+                aria-label="More workspace views and actions"
+                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-lg ${
+                  mobileMoreActive ? 'bg-kumo-tint text-kumo-default' : 'text-kumo-subtle'
+                }`}
+              >
+                <DotsThree size={20} weight="bold" />
+              </button>
+            }
+          />
+          <DropdownMenu.Content className={MENU_CONTENT} style={MENU_POSITIONER_STYLE}>
+            <DropdownMenu.Item
+              disabled={selectedFilesRoot === undefined}
+              onClick={() => openMobilePane('code')}
+              className={MENU_ITEM}
+            >
+              Code
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={!selectedGadgetStub}
+              onClick={() => openMobilePane('connections')}
+              className={MENU_ITEM}
+            >
+              Connections
+            </DropdownMenu.Item>
+            {visibleGadgets.length > 1 && <DropdownMenu.Separator />}
+            {visibleGadgets.length > 1 && visibleGadgets.map(workpiece => (
+              <DropdownMenu.Item
+                key={workpiece.id}
+                onClick={() => handleSelectWorkpiece(workpiece.id)}
+                className={MENU_ITEM}
+              >
+                {workpiece.title}
+              </DropdownMenu.Item>
+            ))}
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item onClick={() => setIsEditingTitle(true)} className={MENU_ITEM}>
+              Rename workspace
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => setShareModalOpen(true)} className={MENU_ITEM}>
+              Share workspace
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={!selectedGadgetStub}
+              onClick={() => setBlueprintModalOpen(true)}
+              className={MENU_ITEM}
+            >
+              Blueprints
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={!mobilePreviewActive}
+              onClick={enterGadgetFullscreen}
+              className={MENU_ITEM}
+            >
+              Full-screen preview
+            </DropdownMenu.Item>
+            {!metadata.owner && (
+              <>
+                <DropdownMenu.Separator />
+                <DropdownMenu.Item
+                  variant="danger"
+                  onClick={() => setDeleteDialogOpen(true)}
+                  className={MENU_ITEM_DANGER}
+                >
+                  Delete workspace
+                </DropdownMenu.Item>
+              </>
+            )}
+          </DropdownMenu.Content>
+        </DropdownMenu>
       </div>
 
       {/* ═══ BODY ═════════════════════════════════════════════════════════════ */}
@@ -1460,7 +1596,7 @@ export default function GadgetEditor() {
 
         {isAgentActive && (
           <div
-            className="absolute left-0 h-0 z-10"
+            className="absolute left-0 z-10 h-0 max-md:!right-0 max-md:!top-0"
             style={{ top: simpleMode ? 0 : TABBAR_H, right: outputRailWidth }}
           >
             <div className="absolute left-0 right-0 h-0.5 bg-kumo-fill overflow-hidden">
@@ -1471,7 +1607,7 @@ export default function GadgetEditor() {
 
         {/* ── LEFT: Chat pane ──────────────────────────────────────────────────── */}
         <div
-          className={`flex flex-col flex-shrink-0 ${workspaceTransitionClass} ${showFullEditor ? 'border-r border-kumo-line' : ''}`}
+          className={`flex flex-col flex-shrink-0 max-md:!w-full ${showFullEditor ? 'max-md:hidden' : ''} ${workspaceTransitionClass} ${showFullEditor ? 'border-r border-kumo-line' : ''}`}
           style={{
             width: showFullEditor
               ? chatWidth
@@ -1533,7 +1669,7 @@ export default function GadgetEditor() {
 
         {/* ── Resize handle ───────────────────────────────────────────────────── */}
         <div
-          className={`flex-shrink-0 overflow-visible bg-kumo-line cursor-col-resize relative touch-none ${workspaceTransitionClass}`}
+          className={`relative flex-shrink-0 touch-none cursor-col-resize overflow-visible bg-kumo-line max-md:hidden ${workspaceTransitionClass}`}
           style={{ width: showFullEditor ? 1 : 0 }}
           onPointerDown={handleResizePointerDown}
           onPointerMove={handleResizePointerMove}
@@ -1545,7 +1681,7 @@ export default function GadgetEditor() {
 
         {/* ── RIGHT: App / Code / Connections tabs ───────────────────────────── */}
         <div
-          className={`flex flex-shrink-0 min-w-0 overflow-hidden bg-kumo-base ${workspaceTransitionClass}`}
+          className={`flex flex-shrink-0 min-w-0 overflow-hidden bg-kumo-base max-md:!w-full max-md:!opacity-100 ${!showFullEditor ? 'max-md:hidden' : ''} ${workspaceTransitionClass}`}
           style={{
             width: showFullEditor ? `calc(100% - ${chatWidth}px - 1px)` : 0,
             opacity: showFullEditor ? 1 : 0,
@@ -1553,7 +1689,7 @@ export default function GadgetEditor() {
         >
           <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
           <div
-            className="flex items-center gap-2 border-b border-kumo-line px-3 flex-shrink-0"
+            className="hidden flex-shrink-0 items-center gap-2 border-b border-kumo-line px-3 md:flex"
             style={{ height: TABBAR_H }}
           >
             <div className="flex min-w-0 flex-1 items-center overflow-hidden">
@@ -1627,15 +1763,30 @@ export default function GadgetEditor() {
             </div>
           </div>
 
-          <div className="flex-1 min-h-0 overflow-hidden">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             {paneShowsActivity && (
-              <Activity
-                overseer={overseer.stub}
-                view={activityView}
-                onViewChange={setActivityView}
-                onAutoApproveChange={() => setAutoApproveReloadTrigger(t => t + 1)}
-                autoApproveReloadTrigger={autoApproveReloadTrigger}
-              />
+              <div className="flex h-11 items-center gap-1 overflow-x-auto border-b border-kumo-line px-2 md:hidden">
+                {ACTIVITY_TABS.map(tab => (
+                  <PaneTab
+                    key={tab.value}
+                    active={activityView === tab.value}
+                    label={tab.label}
+                    count={tab.value === 'review' ? pendingActionsCount : undefined}
+                    onClick={() => setActivityView(tab.value)}
+                  />
+                ))}
+              </div>
+            )}
+            {paneShowsActivity && (
+              <div className="min-h-0 flex-1">
+                <Activity
+                  overseer={overseer.stub}
+                  view={activityView}
+                  onViewChange={setActivityView}
+                  onAutoApproveChange={() => setAutoApproveReloadTrigger(t => t + 1)}
+                  autoApproveReloadTrigger={autoApproveReloadTrigger}
+                />
+              </div>
             )}
             <div className={paneShowsActivity ? 'hidden' : 'contents'}>
             <div
@@ -1648,7 +1799,7 @@ export default function GadgetEditor() {
                 activeTab !== 'app' || previewMode
                   ? 'hidden'
                   : isGadgetFullscreen
-                    ? 'fixed inset-0 z-20 bg-kumo-base outline-none'
+                    ? 'visual-viewport-fixed z-20 bg-kumo-base outline-none'
                     : 'h-full'
               }
             >
@@ -1656,7 +1807,7 @@ export default function GadgetEditor() {
                 <GadgetUI
                   key={selectedGadgetId}
                   gadget={selectedGadgetStub}
-                  height={isGadgetFullscreen ? '100%' : RIGHT_CONTENT_H}
+                  height="100%"
                   reloadTrigger={uiReloadTrigger}
                   isVisible={activeTab === 'app' && !previewMode}
                   chatId={previewChatId}
@@ -1664,7 +1815,7 @@ export default function GadgetEditor() {
                   onIframeEscape={isGadgetFullscreen ? exitGadgetFullscreen : undefined}
                 />
               ) : !previewMode && (
-                <NoGadgetPlaceholder height={RIGHT_CONTENT_H} />
+                <NoGadgetPlaceholder height="100%" />
               )}
               {isGadgetFullscreen && showFullscreenHint && (
                 <div
@@ -1684,7 +1835,7 @@ export default function GadgetEditor() {
                 <GadgetCodeInterface
                   overseer={overseer.stub}
                   filesRoot={selectedFilesRoot}
-                  height={RIGHT_CONTENT_H}
+                  height="100%"
                   onCodeChange={() => setUiReloadTrigger(t => t + 1)}
                   selectedChatId={effectiveSelectedChatId}
                   proposedChanges={proposedChanges}
@@ -1696,7 +1847,7 @@ export default function GadgetEditor() {
                   onHasCodeChange={setHasCode}
                 />
               ) : (
-                <NoGadgetPlaceholder height={RIGHT_CONTENT_H} />
+                <NoGadgetPlaceholder height="100%" />
               )}
             </div>
 
@@ -1713,7 +1864,7 @@ export default function GadgetEditor() {
                   onHasGatekeepersChange={setHasBindings}
                 />
               ) : (
-                <NoGadgetPlaceholder height={RIGHT_CONTENT_H} />
+                <NoGadgetPlaceholder height="100%" />
               )}
             </div>
 
@@ -1723,18 +1874,20 @@ export default function GadgetEditor() {
         </div>
 
         {showOutputRail && (
-          <WorkpiecePicker
-            gadgets={allGadgets}
-            selectedId={null}
-            agentEditingId={streamingActiveFile?.workpieceId ?? null}
-            hookedGadgetIds={hookedGadgetIds}
-            expanded={workpieceRailExpanded}
-            onExpandedChange={handleWorkpieceRailExpandedChange}
-            onSelect={handleSelectWorkpiece}
-            onRename={handleRenameWorkpiece}
-            pendingActivityCount={pendingActionsCount}
-            onOpenActivity={() => openActivity(pendingActionsCount > 0 ? 'review' : 'history')}
-          />
+          <div className="max-md:hidden">
+            <WorkpiecePicker
+              gadgets={allGadgets}
+              selectedId={null}
+              agentEditingId={streamingActiveFile?.workpieceId ?? null}
+              hookedGadgetIds={hookedGadgetIds}
+              expanded={workpieceRailExpanded}
+              onExpandedChange={handleWorkpieceRailExpandedChange}
+              onSelect={handleSelectWorkpiece}
+              onRename={handleRenameWorkpiece}
+              pendingActivityCount={pendingActionsCount}
+              onOpenActivity={() => openActivity(pendingActionsCount > 0 ? 'review' : 'history')}
+            />
+          </div>
         )}
       </div>
 

--- a/packages/workshop-frontend/src/GadgetUI.integration.test.tsx
+++ b/packages/workshop-frontend/src/GadgetUI.integration.test.tsx
@@ -176,6 +176,18 @@ describe('GadgetUI RPC recovery', () => {
     return child
   }
 
+  it('lays out gadget UI against the device-width viewport', async () => {
+    const gadget = fakeGadget('responsive', 'document.body.textContent = "responsive"')
+    await act(async () => {
+      root.render(<GadgetUI gadget={gadget.stub} height="100px" />)
+    })
+
+    await vi.waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    expect(container.querySelector('iframe')!.srcdoc).toContain(
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    )
+  })
+
   it('keeps the iframe while redirecting calls to the replacement gadget client', async () => {
     const first = fakeGadget('first', 'document.body.textContent = "first"')
     await act(async () => {

--- a/packages/workshop-frontend/src/GadgetUI.tsx
+++ b/packages/workshop-frontend/src/GadgetUI.tsx
@@ -106,6 +106,7 @@ const createSandboxedHtml = (jsCode: string): string => {
   return `<!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; frame-src 'none'; script-src data: 'unsafe-inline'; style-src data: 'unsafe-inline'; img-src data:; media-src data:; object-src 'none'; base-uri 'none'; form-action 'none'; connect-src 'none';">
 </head>
 <body>

--- a/packages/workshop-frontend/src/GadgetUseView.tsx
+++ b/packages/workshop-frontend/src/GadgetUseView.tsx
@@ -55,7 +55,7 @@ export default function GadgetUseView({
   currentUserId,
 }: Props) {
   return (
-    <div className="flex flex-col h-screen overflow-hidden bg-kumo-base relative">
+    <div className="relative flex h-full flex-col overflow-hidden bg-kumo-base">
       {/* ═══ TOP BAR ════════════════════════════════════════════════════════════ */}
       <div
         className="relative flex items-center justify-between px-4 sm:px-6 backdrop-blur-md border-b border-kumo-line flex-shrink-0 gap-3"
@@ -85,7 +85,7 @@ export default function GadgetUseView({
 
         {/* Center: gadget picker (only when there's a real choice) */}
         {gadgets.length > 1 && (
-          <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
+          <div className="hidden min-w-0 items-center gap-1 overflow-x-auto md:flex">
             {gadgets.map(g => (
               <button
                 key={g.id}
@@ -113,14 +113,36 @@ export default function GadgetUseView({
             gadget={gadget}
             gadgetTitle={gadgets.find(g => g.id === selectedGadgetId)?.title ?? 'Gadget'}
           />
-          <GadgetPresence
-            overseer={overseer}
-            authenticatedApi={authenticatedApi}
-            currentUserId={currentUserId}
-          />
+          <span className="hidden md:inline-flex">
+            <GadgetPresence
+              overseer={overseer}
+              authenticatedApi={authenticatedApi}
+              currentUserId={currentUserId}
+            />
+          </span>
           <UserMenu />
         </div>
       </div>
+
+      {gadgets.length > 1 && (
+        <div className="flex h-12 shrink-0 items-center gap-1 overflow-x-auto border-b border-kumo-line px-2 md:hidden">
+          {gadgets.map(g => (
+            <button
+              key={g.id}
+              type="button"
+              onClick={() => onSelectGadget(g.id)}
+              aria-current={g.id === selectedGadgetId ? 'true' : undefined}
+              className={`h-9 max-w-[180px] shrink-0 truncate rounded-lg px-3 text-[14px] font-medium ${
+                g.id === selectedGadgetId
+                  ? 'bg-kumo-tint text-kumo-default'
+                  : 'text-kumo-subtle'
+              }`}
+            >
+              {g.title}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* ═══ GADGET UI ══════════════════════════════════════════════════════════ */}
       <div className="flex-1 min-h-0 overflow-hidden">
@@ -128,7 +150,7 @@ export default function GadgetUseView({
           <GadgetUI
             key={selectedGadgetId}
             gadget={gadget}
-            height={`calc(100vh - ${TOPBAR_H}px)`}
+            height="100%"
             isVisible={true}
           />
         ) : (

--- a/packages/workshop-frontend/src/GatekeeperAppPage.tsx
+++ b/packages/workshop-frontend/src/GatekeeperAppPage.tsx
@@ -59,9 +59,9 @@ export default function GatekeeperAppPage({ appId }: { appId: string }) {
     return <div className="px-4 py-16 text-center text-sm text-kumo-subtle">Loading…</div>
   }
 
-  // Fill the viewport below the header so the embedded app can manage its own internal layout.
+  // Fill the routed area below the header so the embedded app can manage its own internal layout.
   return (
-    <div style={{ height: 'calc(100vh - 56px)' }}>
+    <div className="h-full">
       <SandboxedGatekeeperApp frame={state.frame} gatekeeperVendorId={appId} />
     </div>
   )

--- a/packages/workshop-frontend/src/GatekeeperModal.tsx
+++ b/packages/workshop-frontend/src/GatekeeperModal.tsx
@@ -326,9 +326,10 @@ export default function GatekeeperModal({
         const scrollStyle = getComputedStyle(scroll)
         const scrollPadding = parseFloat(scrollStyle.paddingTop) + parseFloat(scrollStyle.paddingBottom)
         const requested = header + footer + scrollContent.getBoundingClientRect().height + scrollPadding
-        // Cap at the viewport-derived max-height so we don't push the dialog off-screen.
-        const top = Math.max(28, Math.min(96, window.innerHeight * 0.1))
-        const maxAvailable = (window.innerHeight - top - 28) * 0.9
+        // Cap at the visible viewport so the keyboard cannot push the configurator off-screen.
+        const viewportHeight = window.visualViewport?.height ?? window.innerHeight
+        const top = Math.max(28, Math.min(96, viewportHeight * 0.1))
+        const maxAvailable = (viewportHeight - top - 28) * 0.9
         setDialogMinHeight(Math.ceil(Math.min(requested, maxAvailable)))
       })
     }
@@ -337,10 +338,12 @@ export default function GatekeeperModal({
     if (scrollContentRef.current) ro.observe(scrollContentRef.current)
     const onWindowResize = () => recompute()
     window.addEventListener('resize', onWindowResize)
+    window.visualViewport?.addEventListener('resize', onWindowResize)
     return () => {
       cancelAnimationFrame(frame)
       ro.disconnect()
       window.removeEventListener('resize', onWindowResize)
+      window.visualViewport?.removeEventListener('resize', onWindowResize)
     }
   }, [open, selectedConnectionId])
 
@@ -786,7 +789,7 @@ export default function GatekeeperModal({
   return (
     <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose() }}>
       <Dialog
-        className="!z-[1000] !top-[clamp(28px,10vh,96px)] !flex !max-h-[calc((100vh_-_clamp(28px,10vh,96px)_-_28px)_*_0.9)] !w-[min(760px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0"
+        className="responsive-dialog !z-[1000] !top-[clamp(28px,10vh,96px)] !flex !max-h-[calc((100vh_-_clamp(28px,10vh,96px)_-_28px)_*_0.9)] !w-[min(760px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0"
         style={dialogMinHeight > 0 ? { minHeight: `${dialogMinHeight}px` } : undefined}
         size="lg"
       >

--- a/packages/workshop-frontend/src/LoginPage.tsx
+++ b/packages/workshop-frontend/src/LoginPage.tsx
@@ -63,7 +63,7 @@ export default function LoginPage({ rpcStub, onLoginSuccess }: LoginPageProps) {
       return (
         <div
           role="alert"
-          className="min-h-screen flex flex-col items-center justify-center gap-4 bg-kumo-base px-4"
+          className="flex h-full min-h-0 flex-col items-center justify-center gap-4 overflow-y-auto bg-kumo-base px-4 py-8"
         >
           <p className="text-sm text-kumo-danger text-center">
             Couldn&apos;t load deployment settings.
@@ -73,7 +73,7 @@ export default function LoginPage({ rpcStub, onLoginSuccess }: LoginPageProps) {
       )
     }
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-kumo-base px-4">
+      <div className="flex h-full min-h-0 flex-col items-center justify-center gap-4 overflow-y-auto bg-kumo-base px-4 py-8">
         <Loader size="lg" />
         <p className="text-sm text-kumo-subtle text-center">
           {connectionLost ? "Can't reach the server. Retrying…" : 'Loading…'}
@@ -86,7 +86,7 @@ export default function LoginPage({ rpcStub, onLoginSuccess }: LoginPageProps) {
   const passwordAuthEnabled = serverConfig.passwordAuthEnabled
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-kumo-base px-4 relative overflow-hidden">
+    <div className="relative flex h-full min-h-0 flex-col items-center justify-start overflow-y-auto bg-kumo-base px-4 py-8">
       {/* Dot grid — fades from top to bottom */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -98,7 +98,7 @@ export default function LoginPage({ rpcStub, onLoginSuccess }: LoginPageProps) {
         }}
       />
 
-      <div className="w-full max-w-sm relative">
+      <div className="relative my-auto w-full max-w-sm">
         {/* Logo */}
         <div className="flex flex-col items-center mb-8">
           <SiteLogo size={40} className="mb-3">
@@ -115,6 +115,7 @@ export default function LoginPage({ rpcStub, onLoginSuccess }: LoginPageProps) {
             {/* Username / password form */}
             <form onSubmit={handleSubmit} className="space-y-4">
               <Input
+                className="w-full"
                 label="Username"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
@@ -125,6 +126,7 @@ export default function LoginPage({ rpcStub, onLoginSuccess }: LoginPageProps) {
               />
 
               <Input
+                className="w-full"
                 type="password"
                 label="Password"
                 value={password}

--- a/packages/workshop-frontend/src/ObserverConfigModal.tsx
+++ b/packages/workshop-frontend/src/ObserverConfigModal.tsx
@@ -313,7 +313,7 @@ export default function ObserverConfigModal({
 
   return (
     <Dialog.Root open disablePointerDismissal onOpenChange={open => { if (!open) onCancel() }}>
-      <Dialog className="p-6" size="lg">
+      <Dialog className="responsive-dialog overflow-y-auto p-6" size="lg">
         <Dialog.Title className="mb-2 text-lg font-semibold">
           {isRetry ? 'Verify your access again' : 'Verify your access'}
         </Dialog.Title>

--- a/packages/workshop-frontend/src/OnboardingWizard.tsx
+++ b/packages/workshop-frontend/src/OnboardingWizard.tsx
@@ -315,7 +315,8 @@ export default function OnboardingWizard({
 
   return (
     <>
-    <div className="fixed inset-0 bg-kumo-base dotted-bg flex items-center justify-center overflow-y-auto py-8">
+    {/* visual-viewport-fixed already insets by the safe areas, so plain padding suffices. */}
+    <div className="visual-viewport-fixed dotted-bg flex items-start justify-center overflow-y-auto bg-kumo-base p-4 sm:py-8">
       {/* Soft radial glow at the top for depth */}
       <div
         className="absolute inset-x-0 top-0 h-[50vh] pointer-events-none"
@@ -326,13 +327,13 @@ export default function OnboardingWizard({
       />
 
       <div
-        className={`relative w-full max-w-lg mx-4 transition-all duration-500 ease-out ${
+        className={`relative my-auto w-full max-w-lg transition-all duration-500 ease-out ${
           mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
         }`}
       >
         {/* Gadgets brand */}
         <div
-          className={`flex items-center justify-center gap-2 mb-10 transition-all duration-500 ${
+          className={`mb-6 flex items-center justify-center gap-2 transition-all duration-500 sm:mb-10 ${
             mounted ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1'
           }`}
         >
@@ -345,7 +346,7 @@ export default function OnboardingWizard({
         </div>
 
         {/* Header */}
-        <div className="text-center mb-8">
+        <div className="mb-6 text-center sm:mb-8">
           <h1
             className={`text-3xl font-semibold text-kumo-default tracking-tight transition-all duration-500 delay-100 ${
               mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
@@ -363,7 +364,7 @@ export default function OnboardingWizard({
         </div>
 
         {/* Step indicator */}
-        <div className="flex items-center justify-center gap-2 mb-8">
+        <div className="mb-6 flex items-center justify-center gap-2 sm:mb-8">
           {Array.from({ length: totalSteps }).map((_, i) => (
             <div
               key={i}
@@ -385,7 +386,7 @@ export default function OnboardingWizard({
             style={{ transform: `translateX(-${step * 100}%)` }}
           >
             {/* ── Step 0: Profile ───────────────────────────────────────────── */}
-            <div className="w-full flex-shrink-0 p-8 min-h-[420px]">
+            <div className="min-h-[320px] w-full flex-shrink-0 p-5 sm:min-h-[420px] sm:p-8">
               <h2 className="text-lg font-medium text-kumo-default mb-1">
                 Create your profile
               </h2>
@@ -394,7 +395,7 @@ export default function OnboardingWizard({
               </p>
 
               {/* Avatar + Display name side by side */}
-              <div className="flex items-start gap-5">
+              <div className="flex flex-col items-start gap-5 min-[380px]:flex-row">
                 {/* Avatar */}
                 <div className="flex flex-col items-center flex-shrink-0">
                   <button
@@ -466,14 +467,14 @@ export default function OnboardingWizard({
                     value={displayName}
                     onChange={(e) => setDisplayName(e.target.value)}
                     placeholder="How should we call you?"
-                    className="w-full px-3 py-2.5 text-sm rounded-lg border border-kumo-line bg-kumo-base text-kumo-default placeholder:text-kumo-inactive focus:outline-none focus:border-kumo-brand transition-colors"
+                    className="w-full rounded-lg border border-kumo-line bg-kumo-base px-3 py-2.5 text-[16px] text-kumo-default transition-colors placeholder:text-kumo-inactive focus:border-kumo-brand focus:outline-none sm:text-sm"
                   />
                 </div>
               </div>
             </div>
 
             {/* ── Step 1: Model selection ───────────────────────────────────── */}
-            <div className="w-full flex-shrink-0 p-8 min-h-[420px]">
+            <div className="min-h-[320px] w-full flex-shrink-0 p-5 sm:min-h-[420px] sm:p-8">
               <div>
                 <h2 className="text-lg font-medium text-kumo-default mb-1">
                   Choose your model
@@ -557,7 +558,7 @@ export default function OnboardingWizard({
             </div>
 
             {/* ── Step 2: Connections ───────────────────────────────────────── */}
-            <div className={`w-full flex-shrink-0 p-8 min-h-[420px] ${showConnectionsStep ? '' : 'hidden'}`}>
+            <div className={`min-h-[320px] w-full flex-shrink-0 p-5 sm:min-h-[420px] sm:p-8 ${showConnectionsStep ? '' : 'hidden'}`}>
               <div>
                 <h2 className="text-lg font-medium text-kumo-default mb-1">
                   Connect your services
@@ -577,7 +578,7 @@ export default function OnboardingWizard({
                     </p>
                   </div>
                 ) : (
-                  <div className="grid grid-cols-2 gap-2 max-h-64 overflow-y-auto pr-1">
+                  <div className="grid max-h-64 grid-cols-1 gap-2 overflow-y-auto pr-1 min-[360px]:grid-cols-2">
                     {sortedVendors.map((vendor) => {
                       const Logo = logoComponents[vendor.logoKey]
                       const isConnected = connectedVendorIds.has(vendor.id)
@@ -641,13 +642,13 @@ export default function OnboardingWizard({
             </div>
 
             {/* ── Final step: What you can do ────────────────────────────────── */}
-            <div className="w-full flex-shrink-0 p-8 min-h-[420px]">
+            <div className="min-h-[320px] w-full flex-shrink-0 p-5 sm:min-h-[420px] sm:p-8">
               <ShowcaseStep active={step === showcaseStep} siteName={siteName} />
             </div>
           </div>
 
           {/* Fixed footer — stays put across all steps */}
-          <div className="flex items-center justify-between gap-3 px-8 py-5 border-t border-kumo-line bg-kumo-elevated">
+          <div className="flex items-center justify-between gap-3 border-t border-kumo-line bg-kumo-elevated px-5 py-4 sm:px-8 sm:py-5">
             {/* Back button (hidden on first step) */}
             {step > 0 ? (
               <button

--- a/packages/workshop-frontend/src/ProtectedRoute.tsx
+++ b/packages/workshop-frontend/src/ProtectedRoute.tsx
@@ -26,7 +26,7 @@ export default function ProtectedRoute({ children, rpcStub }: ProtectedRouteProp
     return (
       <div
         style={{
-          minHeight: '100vh',
+          minHeight: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -46,7 +46,7 @@ export default function ProtectedRoute({ children, rpcStub }: ProtectedRouteProp
     return (
       <div
         style={{
-          minHeight: '100vh',
+          minHeight: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -75,7 +75,7 @@ export default function ProtectedRoute({ children, rpcStub }: ProtectedRouteProp
       return (
         <div
           style={{
-            minHeight: '100vh',
+            minHeight: '100%',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',

--- a/packages/workshop-frontend/src/SandboxedGatekeeperApp.tsx
+++ b/packages/workshop-frontend/src/SandboxedGatekeeperApp.tsx
@@ -58,9 +58,12 @@ function iframeStyleForOverlay(overlay: OverlayState): CSSProperties {
     return {
       ...baseIframeStyle,
       position: 'fixed',
-      inset: 0,
-      width: '100vw',
-      height: '100vh',
+      top: 'calc(var(--app-top) + env(safe-area-inset-top))',
+      right: 'env(safe-area-inset-right)',
+      bottom: 'calc(var(--app-bottom) + env(safe-area-inset-bottom))',
+      left: 'env(safe-area-inset-left)',
+      width: 'auto',
+      height: 'auto',
       zIndex: overlayZIndex,
     }
   }

--- a/packages/workshop-frontend/src/SettingsPage.tsx
+++ b/packages/workshop-frontend/src/SettingsPage.tsx
@@ -18,7 +18,7 @@ const PRIMARY_BTN =
 const ICON_BTN =
   'press grid h-8 w-8 shrink-0 cursor-pointer place-items-center rounded-lg text-kumo-inactive transition-colors hover:bg-kumo-tint hover:text-kumo-default'
 const INPUT =
-  'h-9 w-full rounded-lg border border-kumo-line bg-kumo-base px-3 text-[14px] tracking-[-0.25px] text-kumo-default placeholder:text-kumo-inactive transition-[border-color,box-shadow] focus:border-kumo-ring focus:outline-none focus:ring-[3px] focus:ring-kumo-ring/15'
+  'h-10 w-full rounded-lg border border-kumo-line bg-kumo-base px-3 text-[16px] text-kumo-default placeholder:text-kumo-inactive transition-[border-color,box-shadow] focus:border-kumo-ring focus:outline-none focus:ring-[3px] focus:ring-kumo-ring/15 sm:h-9 sm:text-[14px]'
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -246,8 +246,8 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-2xl flex-col px-6 pb-16 sm:px-10">
-      <header className="px-1 pb-2 pt-10">
+    <div className="mx-auto flex h-full w-full max-w-2xl flex-col px-4 pb-16 sm:px-10">
+      <header className="px-1 pb-2 pt-6 sm:pt-10">
         <h1 className="text-2xl font-semibold tracking-tight text-kumo-default">Profile</h1>
         <p className="mt-1 text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle">
           Manage your account details, avatar, and security.
@@ -272,7 +272,7 @@ export default function SettingsPage() {
                 ) : (
                   <User size={28} className="text-kumo-subtle" />
                 )}
-                <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+                <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
                   <Camera size={18} className="text-white" />
                 </div>
                 {avatarUploading && (

--- a/packages/workshop-frontend/src/ShareModal.tsx
+++ b/packages/workshop-frontend/src/ShareModal.tsx
@@ -749,7 +749,7 @@ export default function ShareModal({ open, onClose, overseer, metadata, currentU
   return (
     <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose() }}>
       <Dialog
-        className="!z-[1000] !top-[clamp(24px,10vh,80px)] !flex !max-h-[calc(100vh-clamp(24px,10vh,80px)-24px)] !w-[min(640px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0 !outline-none"
+        className="responsive-dialog !z-[1000] !top-[clamp(24px,10vh,80px)] !flex !max-h-[calc(100vh-clamp(24px,10vh,80px)-24px)] !w-[min(640px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0 !outline-none"
         size="lg"
       >
         <div className="flex shrink-0 items-start justify-between gap-4 overflow-hidden px-4 pb-4 pt-5 sm:px-6 sm:pt-6">

--- a/packages/workshop-frontend/src/SignupPage.tsx
+++ b/packages/workshop-frontend/src/SignupPage.tsx
@@ -82,7 +82,7 @@ export default function SignupPage({ rpcStub }: SignupPageProps) {
       return (
         <div
           role="alert"
-          className="min-h-screen flex flex-col items-center justify-center gap-4 bg-kumo-base px-4"
+          className="flex h-full min-h-0 flex-col items-center justify-center gap-4 overflow-y-auto bg-kumo-base px-4 py-8"
         >
           <p className="text-sm text-kumo-danger text-center">
             Couldn&apos;t load deployment settings.
@@ -92,7 +92,7 @@ export default function SignupPage({ rpcStub }: SignupPageProps) {
       );
     }
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-kumo-base px-4">
+      <div className="flex h-full min-h-0 flex-col items-center justify-center gap-4 overflow-y-auto bg-kumo-base px-4 py-8">
         <Loader size="lg" />
         <p className="text-sm text-kumo-subtle text-center">
           {connectionLost ? "Can't reach the server. Retrying…" : "Loading…"}
@@ -107,7 +107,7 @@ export default function SignupPage({ rpcStub }: SignupPageProps) {
   const passwordAuthEnabled = serverConfig.passwordAuthEnabled && signupsEnabled;
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-kumo-base px-4 relative overflow-hidden">
+    <div className="relative flex h-full min-h-0 flex-col items-center justify-start overflow-y-auto bg-kumo-base px-4 py-8">
       {/* Dot grid — fades from top to bottom */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -122,7 +122,7 @@ export default function SignupPage({ rpcStub }: SignupPageProps) {
         }}
       />
 
-      <div className="w-full max-w-sm relative">
+      <div className="relative my-auto w-full max-w-sm">
         {/* Logo */}
         <div className="flex flex-col items-center mb-8">
           <SiteLogo size={40} className="mb-3">
@@ -151,6 +151,7 @@ export default function SignupPage({ rpcStub }: SignupPageProps) {
             {/* Form */}
             <form onSubmit={handleSubmit} className="space-y-4">
               <Input
+                className="w-full"
                 label="Username"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
@@ -162,6 +163,7 @@ export default function SignupPage({ rpcStub }: SignupPageProps) {
               />
 
               <Input
+                className="w-full"
                 type="password"
                 label="Password"
                 value={password}
@@ -173,6 +175,7 @@ export default function SignupPage({ rpcStub }: SignupPageProps) {
               />
 
               <Input
+                className="w-full"
                 type="password"
                 label="Confirm Password"
                 value={confirmPassword}

--- a/packages/workshop-frontend/src/components/AnnouncementBanner.tsx
+++ b/packages/workshop-frontend/src/components/AnnouncementBanner.tsx
@@ -65,7 +65,7 @@ export default function AnnouncementBanner() {
 
   return (
     <div
-      className="px-4 py-2.5 flex items-start gap-3 border-b border-kumo-line"
+      className="flex shrink-0 items-start gap-3 border-b border-kumo-line px-4 py-2.5"
       style={COLOR_STYLES[color] ?? COLOR_STYLES.info}
     >
       <div className="flex-1 text-sm leading-snug text-center [&_a]:font-medium">

--- a/packages/workshop-frontend/src/components/AppShell/AppShell.tsx
+++ b/packages/workshop-frontend/src/components/AppShell/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouterState } from '@tanstack/react-router'
 import { List, X } from '@phosphor-icons/react'
 import TopBarNotice from '../../TopBarNotice'
@@ -32,6 +32,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState<boolean>(readCollapsed)
   const [mobileOpen, setMobileOpen] = useState(false)
   const [paletteOpen, setPaletteOpen] = useState(false)
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
   const connectionLost = useConnectionLost()
 
   const toggleCollapsed = useCallback(() => {
@@ -45,9 +47,35 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   // Close mobile drawer when escape is pressed.
   useEffect(() => {
     if (!mobileOpen) return
-    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') setMobileOpen(false) }
+    const previousFocus = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : menuButtonRef.current
+    drawerRef.current?.focus()
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setMobileOpen(false)
+        return
+      }
+      if (e.key !== 'Tab' || !drawerRef.current) return
+      const focusable = [...drawerRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )]
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (e.shiftKey && (document.activeElement === first || document.activeElement === drawerRef.current)) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
     document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
+    return () => {
+      document.removeEventListener('keydown', handler)
+      window.setTimeout(() => previousFocus?.focus(), 0)
+    }
   }, [mobileOpen])
 
   // Close the mobile drawer on navigation. Links in the drawer (primary nav, Gatekeepers, the user
@@ -79,7 +107,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }, [])
 
   return (
-    <div className="flex h-screen min-h-screen w-screen overflow-hidden bg-kumo-base">
+    <div className="flex h-full min-h-0 w-full overflow-hidden bg-kumo-base">
       {/* Desktop sidebar — hidden on mobile in favor of the drawer. */}
       <div className="hidden md:flex">
         <Sidebar collapsed={collapsed} onToggleCollapsed={toggleCollapsed} />
@@ -93,23 +121,35 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             onClick={() => setMobileOpen(false)}
             aria-hidden="true"
           />
-          <div className="fixed inset-y-0 left-0 z-50 md:hidden">
+          <div
+            ref={drawerRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Primary navigation"
+            tabIndex={-1}
+            className="fixed inset-y-0 left-0 z-50 outline-none md:hidden"
+          >
             <Sidebar collapsed={false} onToggleCollapsed={() => setMobileOpen(false)} />
           </div>
         </>
       )}
 
       {/* Main column */}
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div
+        className="flex min-w-0 flex-1 flex-col"
+        inert={mobileOpen ? true : undefined}
+        aria-hidden={mobileOpen ? true : undefined}
+      >
         {/* Top bar. Same height as the sidebar's brand row (h-14) so they read as one continuous
             chrome strip across the top. Mostly empty — carries the mobile hamburger on the left,
             any admin TopBarNotice centered, and the reconnecting chip on the right. */}
         <div className="relative flex h-14 shrink-0 items-center justify-between border-b border-kumo-line bg-kumo-base px-3">
           <button
             type="button"
+            ref={menuButtonRef}
             onClick={() => setMobileOpen((o) => !o)}
             aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-kumo-default transition-colors hover:bg-kumo-tint md:hidden"
+            className="flex h-11 w-11 items-center justify-center rounded-md text-kumo-default transition-colors hover:bg-kumo-tint md:hidden"
           >
             {mobileOpen ? <X size={16} /> : <List size={16} />}
           </button>
@@ -119,7 +159,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               left. */}
           <div className="ml-auto flex items-center gap-2">
             {connectionLost && <ReconnectingChip />}
-            <span aria-hidden="true" className="h-7 w-7 md:hidden" />
+            <span aria-hidden="true" className="h-11 w-11 md:hidden" />
           </div>
         </div>
 

--- a/packages/workshop-frontend/src/components/AppShell/Sidebar.tsx
+++ b/packages/workshop-frontend/src/components/AppShell/Sidebar.tsx
@@ -53,8 +53,8 @@ export default function Sidebar({
       className={[
         // Sidebar is the app chrome: a hair greyer than the (lighter) content canvas so the two
         // surfaces read as distinct without a heavy divider.
-        'flex h-screen flex-col border-r border-kumo-line bg-kumo-elevated',
-        collapsed ? 'w-[56px]' : 'w-[260px]',
+        'flex h-full flex-col border-r border-kumo-line bg-kumo-elevated',
+        collapsed ? 'w-[56px]' : 'w-[min(320px,100vw)] md:w-[260px]',
         'shrink-0 transition-[width] duration-200 ease-out',
       ].join(' ')}
     >

--- a/packages/workshop-frontend/src/components/AppShell/SidebarItem.tsx
+++ b/packages/workshop-frontend/src/components/AppShell/SidebarItem.tsx
@@ -48,7 +48,7 @@ export default function SidebarItem({
       {...linkProps}
       title={collapsed ? label : undefined}
       className={[
-        'group relative flex h-8 items-center gap-2.5 rounded-lg px-2.5 text-[13px] leading-[18px] tracking-[-0.25px] transition-colors',
+        'group relative flex h-11 items-center gap-2.5 rounded-lg px-2.5 text-[14px] leading-5 transition-colors md:h-8 md:text-[13px] md:leading-[18px]',
         isActive
           ? 'bg-kumo-fill font-medium text-kumo-strong'
           : 'font-normal text-kumo-default hover:bg-kumo-tint',

--- a/packages/workshop-frontend/src/components/AutoApproveConfirmDialog.tsx
+++ b/packages/workshop-frontend/src/components/AutoApproveConfirmDialog.tsx
@@ -33,7 +33,7 @@ export default function AutoApproveConfirmDialog({
       }}
     >
       <Dialog
-        className="!z-[1000] !w-[min(440px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[20%] !-translate-y-0"
+        className="responsive-dialog !z-[1000] !w-[min(440px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[20%] !-translate-y-0"
         size="sm"
       >
         <div className="flex items-start justify-between gap-4 border-b border-kumo-line px-5 py-4">

--- a/packages/workshop-frontend/src/components/BlueprintList.tsx
+++ b/packages/workshop-frontend/src/components/BlueprintList.tsx
@@ -259,7 +259,7 @@ export default function BlueprintList() {
       {/* Toolbar — search plus the page's actions. Hidden when the user has no blueprints, since
           the empty state carries its own copies of the same two actions. */}
       {!loading && items.length > 0 && (
-        <div className="mb-4 flex items-center gap-2 px-3">
+        <div className="mb-4 flex flex-col gap-2 px-3 sm:flex-row sm:items-center">
           <div className="relative flex-1">
             <MagnifyingGlass size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-kumo-inactive" />
             <input
@@ -272,7 +272,7 @@ export default function BlueprintList() {
           </div>
           {/* Grid, not flex: 1fr columns give the two buttons a matching width, where flex would
               size each to its own label. */}
-          <div className="grid shrink-0 grid-cols-2 gap-2">
+          <div className="grid w-full grid-cols-2 gap-2 sm:w-auto sm:shrink-0">
             <Link to="/explore" className={ACTION_BUTTON}>
               <Compass size={14} />
               Explore

--- a/packages/workshop-frontend/src/components/ConnectConnectorModal.tsx
+++ b/packages/workshop-frontend/src/components/ConnectConnectorModal.tsx
@@ -204,7 +204,7 @@ export default function ConnectConnectorModal({
       }}
     >
       <Dialog
-        className="!z-[1000] !top-[clamp(28px,8vh,80px)] !flex !max-h-[calc(100vh-clamp(28px,8vh,80px)-28px)] !w-[min(640px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0"
+        className="responsive-dialog !z-[1000] !top-[clamp(28px,8vh,80px)] !flex !max-h-[calc(100vh-clamp(28px,8vh,80px)-28px)] !w-[min(640px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0"
         size="lg"
       >
         <div className="shrink-0 flex items-start justify-between gap-4 border-b border-kumo-line px-5 py-4">

--- a/packages/workshop-frontend/src/components/DeleteConfirmationDialog.tsx
+++ b/packages/workshop-frontend/src/components/DeleteConfirmationDialog.tsx
@@ -34,7 +34,7 @@ export default function DeleteConfirmationDialog({
       }}
     >
       <Dialog
-        className="!z-[1000] !w-[min(420px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[20%] !-translate-y-0"
+        className="responsive-dialog !z-[1000] !w-[min(420px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[20%] !-translate-y-0"
         size="sm"
       >
         <div className="flex items-start justify-between gap-4 border-b border-kumo-line px-5 py-4">

--- a/packages/workshop-frontend/src/components/UserMenu.tsx
+++ b/packages/workshop-frontend/src/components/UserMenu.tsx
@@ -19,7 +19,7 @@ export default function UserMenu() {
       <DropdownMenu.Trigger
         render={
           <button
-            className="w-7 h-7 cursor-pointer rounded-full flex items-center justify-center bg-kumo-tint hover:bg-kumo-fill transition-colors overflow-hidden"
+            className="flex h-11 w-11 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-kumo-tint transition-colors hover:bg-kumo-fill md:h-7 md:w-7"
             title="Open profile menu"
             aria-label="Open profile menu"
           >

--- a/packages/workshop-frontend/src/components/WorkspaceOpenErrorPage.tsx
+++ b/packages/workshop-frontend/src/components/WorkspaceOpenErrorPage.tsx
@@ -57,7 +57,7 @@ export default function WorkspaceOpenErrorPage({ kind, onRetry, onGoToWorkspaces
   }, [])
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-kumo-base px-6 py-12">
+    <div className="flex min-h-full items-center justify-center bg-kumo-base px-6 py-12">
       <section
         aria-atomic="true"
         aria-describedby={descriptionId}

--- a/packages/workshop-frontend/src/components/billing/AccountSelectionModal.tsx
+++ b/packages/workshop-frontend/src/components/billing/AccountSelectionModal.tsx
@@ -70,7 +70,7 @@ export default function AccountSelectionModal() {
     // role="alertdialog" + no close affordance: the choice is mandatory, so it isn't dismissible by
     // clicking outside.
     <Dialog.Root open role="alertdialog">
-      <Dialog className="p-6 sm:w-[480px]" size="base">
+      <Dialog className="responsive-dialog overflow-y-auto p-6 sm:w-[480px]" size="base">
         <Dialog.Title className="text-lg font-semibold mb-2 flex items-center gap-2">
           <Warning size={22} weight="bold" className="text-kumo-warning" />
           Choose a Cloudflare account

--- a/packages/workshop-frontend/src/components/billing/OutOfCreditsModal.tsx
+++ b/packages/workshop-frontend/src/components/billing/OutOfCreditsModal.tsx
@@ -89,7 +89,7 @@ export default function OutOfCreditsModal({ open, onClose }: OutOfCreditsModalPr
 
   return (
     <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-      <Dialog className="p-6 sm:w-[560px]" size="base">
+      <Dialog className="responsive-dialog overflow-y-auto p-6 sm:w-[560px]" size="base">
         <Dialog.Title className="text-lg font-semibold mb-2 flex items-center gap-2">
           <CloudWarning size={22} weight="bold" className="text-kumo-warning" />
           You've reached your free usage limit

--- a/packages/workshop-frontend/src/components/chat/ConnectionConfigModal.tsx
+++ b/packages/workshop-frontend/src/components/chat/ConnectionConfigModal.tsx
@@ -39,7 +39,7 @@ export default function ConnectionConfigModal({
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog size="base" className="p-0 overflow-hidden">
+      <Dialog size="base" className="responsive-dialog overflow-hidden p-0">
         {/* Header */}
         <div className="flex items-center gap-3 px-5 pt-5 pb-4">
           <div

--- a/packages/workshop-frontend/src/main.tsx
+++ b/packages/workshop-frontend/src/main.tsx
@@ -130,6 +130,29 @@ function AppWithConnection() {
   const [serverConfigError, setServerConfigError] = useState(false);
 
   useEffect(() => {
+    const viewport = window.visualViewport;
+    const updateHeight = () => {
+      const height = viewport?.height ?? window.innerHeight;
+      const top = viewport?.offsetTop ?? 0;
+      document.documentElement.style.setProperty('--app-height', `${height}px`);
+      document.documentElement.style.setProperty('--app-top', `${top}px`);
+      document.documentElement.style.setProperty(
+        '--app-bottom',
+        `${Math.max(0, window.innerHeight - top - height)}px`,
+      );
+    };
+    updateHeight();
+    viewport?.addEventListener('resize', updateHeight);
+    viewport?.addEventListener('scroll', updateHeight);
+    window.addEventListener('resize', updateHeight);
+    return () => {
+      viewport?.removeEventListener('resize', updateHeight);
+      viewport?.removeEventListener('scroll', updateHeight);
+      window.removeEventListener('resize', updateHeight);
+    };
+  }, []);
+
+  useEffect(() => {
     let cb = () => setRpcState({ stub: currentStub, connectionLost: isConnectionLost });
     notifyCurrentStubUpdated.add(cb);
     return () => { notifyCurrentStubUpdated.delete(cb); };
@@ -167,8 +190,12 @@ function AppWithConnection() {
       <RpcContext.Provider value={rpcState}>
         <ServerConfigErrorContext.Provider value={serverConfigError}>
           <ServerConfigContext.Provider value={serverConfig}>
-            <AnnouncementBanner />
-            <RouterProvider router={router} />
+            <div className="app-viewport flex min-w-0 flex-col overflow-hidden">
+              <AnnouncementBanner />
+              <div className="h-full min-h-0 flex-1">
+                <RouterProvider router={router} />
+              </div>
+            </div>
           </ServerConfigContext.Provider>
         </ServerConfigErrorContext.Provider>
       </RpcContext.Provider>

--- a/packages/workshop-frontend/src/routes/__root.tsx
+++ b/packages/workshop-frontend/src/routes/__root.tsx
@@ -53,7 +53,7 @@ function RootComponent() {
   // Loading state
   if (isLoading && !standalone) {
     return (
-      <div className="min-h-screen flex items-center justify-center flex-col gap-4 bg-kumo-base">
+      <div className="flex min-h-full items-center justify-center flex-col gap-4 bg-kumo-base">
         <div className="w-8 h-8 border-2 border-kumo-brand border-t-transparent rounded-full animate-spin" />
         <p className="text-sm text-kumo-subtle">{connectionLost ? 'Waiting for server…' : 'Loading...'}</p>
       </div>
@@ -63,7 +63,7 @@ function RootComponent() {
   // Auth error
   if (error && !standalone) {
     return (
-      <div className="min-h-screen flex items-center justify-center flex-col gap-4 bg-kumo-base p-6">
+      <div className="flex min-h-full items-center justify-center flex-col gap-4 bg-kumo-base p-6">
         <p className="text-sm text-kumo-danger">Authentication error: {error}</p>
         <button
           onClick={() => window.location.reload()}
@@ -78,7 +78,7 @@ function RootComponent() {
   // CF Access mode: show spinner while pipelined auth resolves
   if (!isAuthenticated && CF_ACCESS_MODE && !standalone) {
     return (
-      <div className="min-h-screen flex items-center justify-center flex-col gap-4 bg-kumo-base">
+      <div className="flex min-h-full items-center justify-center flex-col gap-4 bg-kumo-base">
         <div className="w-8 h-8 border-2 border-kumo-brand border-t-transparent rounded-full animate-spin" />
         <p className="text-sm text-kumo-subtle">Authenticating...</p>
       </div>
@@ -96,8 +96,12 @@ function RootComponent() {
     return (
       <TooltipProvider>
         <Toasty>
-          {showHeader && <Header />}
-          <Outlet />
+          <div className="flex h-full min-h-0 flex-col">
+            {showHeader && <Header />}
+            <main className="min-h-0 flex-1 overflow-y-auto">
+              <Outlet />
+            </main>
+          </div>
         </Toasty>
       </TooltipProvider>
     )
@@ -153,7 +157,7 @@ function AuthenticatedShell({
   // Still checking onboarding status
   if (onboardingNeeded === null) {
     return (
-      <div className="min-h-screen flex items-center justify-center flex-col gap-4 bg-kumo-base">
+      <div className="flex min-h-full items-center justify-center flex-col gap-4 bg-kumo-base">
         <div className="w-8 h-8 border-2 border-kumo-brand border-t-transparent rounded-full animate-spin" />
       </div>
     )
@@ -172,7 +176,7 @@ function AuthenticatedShell({
     <>
       <AccountSelectionModal />
       {fullscreen ? (
-        <main>
+        <main className="h-full min-h-0">
           <Outlet />
         </main>
       ) : (

--- a/packages/workshop-frontend/src/routes/blueprints.tsx
+++ b/packages/workshop-frontend/src/routes/blueprints.tsx
@@ -14,9 +14,9 @@ export const Route = createFileRoute('/blueprints')({
 function BlueprintsRoutePage() {
   useDocumentTitle('Blueprints')
   return (
-    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-6 sm:px-10">
+    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-3 sm:px-10">
       {/* Title only — Explore and Upload sit together in the list's toolbar so they share a width. */}
-      <header className="min-w-0 px-3 pb-3 pt-10">
+      <header className="min-w-0 px-3 pb-3 pt-6 sm:pt-10">
         <h1 className="text-2xl font-semibold tracking-tight text-kumo-default">Blueprints</h1>
         <p className="mt-1 text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle">
           Reusable starting points you've published or saved. Spin up a workspace from any of them.

--- a/packages/workshop-frontend/src/routes/context.tsx
+++ b/packages/workshop-frontend/src/routes/context.tsx
@@ -61,8 +61,8 @@ function ContextPage() {
   useDocumentTitle('Context & Skills')
   const siteName = useSiteName()
   return (
-    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-6 sm:px-10">
-      <header className="px-3 pb-4 pt-10">
+    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-3 sm:px-10">
+      <header className="px-3 pb-4 pt-6 sm:pt-10">
         <h1 className="text-2xl font-semibold tracking-tight text-kumo-default">Context &amp; Skills</h1>
         <p className="mt-1 text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle">
           Curated collections of knowledge your agents read, plus reusable skills they can apply.

--- a/packages/workshop-frontend/src/routes/gatekeepers.tsx
+++ b/packages/workshop-frontend/src/routes/gatekeepers.tsx
@@ -715,8 +715,8 @@ function ConnectorsPage() {
     accounts.length === 0
 
   return (
-    <div className="min-h-[calc(100vh-3.5rem-1px)] bg-kumo-base">
-      <div className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-8 sm:py-14">
+    <div className="h-full overflow-y-auto bg-kumo-base">
+      <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-8 sm:py-14">
         <header className="mb-8 grid gap-8 lg:grid-cols-[minmax(0,540px)_444px] lg:items-center lg:justify-between">
           <div>
             <h1 className="m-0 text-3xl font-semibold leading-tight tracking-tight text-kumo-default sm:text-[34px]">

--- a/packages/workshop-frontend/src/routes/outputs.tsx
+++ b/packages/workshop-frontend/src/routes/outputs.tsx
@@ -338,7 +338,7 @@ function RenameOutputDialog({
   return (
     <Dialog.Root open={output !== null} onOpenChange={(open) => { if (!open && !busy) onClose() }}>
       <Dialog
-        className="!z-[1000] !w-[min(420px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[20%] !-translate-y-0"
+        className="responsive-dialog !z-[1000] !w-[min(420px,calc(100vw-32px))] overflow-hidden bg-kumo-base p-0 !top-[20%] !-translate-y-0"
         size="sm"
       >
         <form onSubmit={(event) => { event.preventDefault(); onSave() }}>
@@ -573,8 +573,8 @@ function OutputsPage() {
       || (showOwnerFilters && ownerFilter !== 'all')
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-5xl flex-col px-6 sm:px-10">
-      <header className="flex items-end justify-between gap-4 px-3 pb-4 pt-10">
+    <div className="mx-auto flex h-full w-full max-w-5xl flex-col px-3 sm:px-10">
+      <header className="flex items-end justify-between gap-4 px-3 pb-4 pt-6 sm:pt-10">
         <div className="min-w-0">
           <h1 className="text-2xl font-semibold tracking-tight text-kumo-default">Outputs</h1>
           <p className="mt-1 text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle">
@@ -605,7 +605,7 @@ function OutputsPage() {
             </>
           )}
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2 sm:shrink-0">
           {showOwnerFilters && (
             <ScopeSelect
               value={ownerFilter}
@@ -617,14 +617,14 @@ function OutputsPage() {
               onChange={setOwnerFilter}
             />
           )}
-          <div className="relative sm:w-56">
+          <div className="relative min-w-0 flex-1 sm:w-56 sm:flex-none">
             <MagnifyingGlass size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-kumo-inactive" />
             <input
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search outputs…"
-              className="h-9 w-full rounded-lg border border-kumo-line bg-kumo-base pl-9 pr-4 text-[13px] tracking-[-0.25px] text-kumo-default placeholder:text-kumo-inactive transition-[border-color,box-shadow] duration-150 ease-out focus:border-kumo-ring focus:outline-none focus:ring-[3px] focus:ring-kumo-ring/15"
+              className="h-10 w-full rounded-lg border border-kumo-line bg-kumo-base pl-9 pr-4 text-[16px] text-kumo-default placeholder:text-kumo-inactive transition-[border-color,box-shadow] duration-150 ease-out focus:border-kumo-ring focus:outline-none focus:ring-[3px] focus:ring-kumo-ring/15 sm:h-9 sm:text-[13px]"
             />
           </div>
         </div>
@@ -632,7 +632,7 @@ function OutputsPage() {
 
       <div className="chat-panel min-h-0 flex-1 overflow-y-auto pb-8 pt-1">
         {loading ? (
-          <div className="grid grid-cols-2 gap-4 px-3 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="grid grid-cols-1 gap-4 px-3 min-[400px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
             {[0, 1, 2, 3].map((i) => (
               <div key={i} className="aspect-[4/3] animate-pulse rounded-xl bg-kumo-elevated" />
             ))}
@@ -663,7 +663,7 @@ function OutputsPage() {
             {!isFiltered && <NewFormatRow label="Start with" />}
           </div>
         ) : view === 'grid' ? (
-          <div className="grid grid-cols-2 gap-4 px-3 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="grid grid-cols-1 gap-4 px-3 min-[400px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
             {filtered.map((output) => (
               <OutputCard key={outputKey(output)} output={output}
                           onOpen={() => openOutput(output)}

--- a/packages/workshop-frontend/src/routes/providers.tsx
+++ b/packages/workshop-frontend/src/routes/providers.tsx
@@ -213,15 +213,15 @@ function ProvidersPage() {
   })
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-6 sm:px-10">
-      <header className="flex items-end justify-between gap-4 px-3 pb-3 pt-10">
+    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-3 sm:px-10">
+      <header className="flex flex-col items-stretch gap-4 px-3 pb-3 pt-6 sm:flex-row sm:items-end sm:justify-between sm:pt-10">
         <div className="min-w-0">
           <h1 className="text-2xl font-semibold tracking-tight text-kumo-default">AI providers</h1>
           <p className="mt-1 text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle">
             Configure the AI models available to your workspaces.
           </p>
         </div>
-        <button type="button" onClick={() => setSheetOpen(true)} className={PRIMARY_BTN}>
+        <button type="button" onClick={() => setSheetOpen(true)} className={`${PRIMARY_BTN} h-11 justify-center text-[14px] sm:h-9 sm:text-[13px]`}>
           <Plus size={14} weight="bold" />
           Add provider
         </button>

--- a/packages/workshop-frontend/src/routes/workspaces.tsx
+++ b/packages/workshop-frontend/src/routes/workspaces.tsx
@@ -14,8 +14,8 @@ export const Route = createFileRoute('/workspaces')({
 function WorkspacesPage() {
   useDocumentTitle('Workspaces')
   return (
-    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-6 sm:px-10">
-      <header className="flex items-end justify-between gap-4 px-3 pb-3 pt-10">
+    <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-3 sm:px-10">
+      <header className="flex flex-col items-stretch gap-4 px-3 pb-3 pt-6 sm:flex-row sm:items-end sm:justify-between sm:pt-10">
         <div className="min-w-0">
           <h1 className="text-2xl font-semibold tracking-tight text-kumo-default">Workspaces</h1>
           <p className="mt-1 text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle">
@@ -25,7 +25,7 @@ function WorkspacesPage() {
         {/* "Create" just routes to Home (the new-workspace launcher) for now. */}
         <Link
           to="/"
-          className="press inline-flex h-9 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-kumo-brand px-3.5 text-[13px] font-medium tracking-[-0.25px] text-white transition-colors hover:bg-kumo-brand-hover"
+          className="press inline-flex h-11 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg bg-kumo-brand px-3.5 text-[14px] font-medium text-white transition-colors hover:bg-kumo-brand-hover sm:h-9 sm:text-[13px]"
         >
           <Plus size={14} weight="bold" />
           Create workspace

--- a/packages/workshop-frontend/src/styles.css
+++ b/packages/workshop-frontend/src/styles.css
@@ -216,11 +216,70 @@
     0 18px 40px 0 #00000033, 0 4px 12px 0 #0000002e;
 }
 
+:root {
+  --app-height: 100dvh;
+  --app-top: 0px;
+  --app-bottom: 0px;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  min-height: 0;
+}
+
 body {
   @apply m-0 antialiased;
+  overflow: hidden;
   font-family: var(--font-sans);
   background-color: var(--color-kumo-base);
   color: var(--text-color-kumo-default);
+}
+
+.app-viewport {
+  position: fixed;
+  top: var(--app-top);
+  right: 0;
+  left: 0;
+  box-sizing: border-box;
+  height: var(--app-height);
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.visual-viewport-fixed {
+  position: fixed;
+  top: calc(var(--app-top) + env(safe-area-inset-top));
+  right: env(safe-area-inset-right);
+  bottom: calc(var(--app-bottom) + env(safe-area-inset-bottom));
+  left: env(safe-area-inset-left);
+}
+
+@layer utilities {
+  /* Turns a Kumo Dialog into a keyboard-safe bottom sheet on phones (and very short windows).
+     The `body` prefix and !important are load-bearing: they out-rank both Kumo's own dialog
+     styles and the per-dialog Tailwind `!` utilities (same layer, lower specificity), which
+     still apply on desktop where this block is inactive. */
+  @media (max-width: 767px), (max-height: 520px) {
+    body .responsive-dialog {
+      top: auto !important;
+      right: env(safe-area-inset-right) !important;
+      bottom: calc(var(--app-bottom) + env(safe-area-inset-bottom)) !important;
+      left: env(safe-area-inset-left) !important;
+      width: calc(100vw - env(safe-area-inset-left) - env(safe-area-inset-right)) !important;
+      max-width: none !important;
+      max-height: calc(var(--app-height) - 8px - env(safe-area-inset-top)) !important;
+      border-bottom-right-radius: 0 !important;
+      border-bottom-left-radius: 0 !important;
+      translate: 0 0 !important;
+      transform: none !important;
+    }
+
+    body .responsive-dialog :is(input, textarea, select) {
+      font-size: 16px;
+    }
+  }
 }
 
 ::selection {


### PR DESCRIPTION
Makes the whole Workshop usable on a phone: pages reflow to narrow viewports, touch targets and font sizes are bumped, hover-only actions are always visible on touch, dialogs become bottom sheets, and the app stays keyboard-safe while typing. The workspace editor goes single-pane with a Chat / Preview / Activity bar plus an overflow menu for everything else — including full code editing, with the file sidebar as a drawer and a compact word-wrapped diff view. Gadget iframes get a `device-width` viewport meta so gadgets themselves render responsively (pairs with #181). Admin pages are out of scope.

## Screenshots

**Chat**
<img width="780" height="1688" alt="01-chat" src="https://github.com/user-attachments/assets/55927e94-3765-4265-a42c-396d10284dcd" />

**Preview**
<img width="780" height="1688" alt="02-preview" src="https://github.com/user-attachments/assets/fade8771-840d-474e-9629-69e7077145a7" />

**Code**
<img width="780" height="1688" alt="03-code" src="https://github.com/user-attachments/assets/eeefbc63-1441-4b27-9220-9b6931e55f86" />

**File 
<img width="780" height="1688" alt="04-file-drawer" src="https://github.com/user-attachments/assets/2e3a4ff5-8033-4a91-8672-5752adbe5526" />
drawer**

**Overflow menu**
<img width="780" height="1688" alt="05-more-menu" src="https://github.com/user-attachments/assets/c0ecb8d9-fdc9-4567-9c67-098dbe09e01e" />

**Share as bottom sheet**
<img width="780" height="1688" alt="06-share-sheet" src="https://github.com/user-attachments/assets/fac22d50-830a-489f-bc15-c4fab051a889" />


**Naviga
<img width="780" height="1688" alt="07-nav-drawer" src="https://github.com/user-attachments/assets/7e6d2dc7-42b1-416d-8ff1-58ae3df3d7cd" />
tion drawer**

**Hom
<img width="780" height="1688" alt="08-home" src="https://github.com/user-attachments/assets/87bdc36d-6207-4225-922b-6a8b305069e3" />
e**

**Landscape bottom sheet**
<img width="1334" height="750" alt="09-landscape-sheet" src="https://github.com/user-attachments/assets/f91a65f9-a653-4431-80c0-ff9f69b2e746" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-os/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->