### PR TITLE
Lay the foundation for a Google Drive gatekeeper

### DIFF
--- a/packages/gatekeeper-google/__tests__/configurator-url.test.ts
+++ b/packages/gatekeeper-google/__tests__/configurator-url.test.ts
@@ -1,0 +1,82 @@
+// A configurator's `resourceUrl` mints the string that `parseResourceUrl` then turns into a
+// capability, and its `initialValuesFromResourceUrl` reads a URL the user pasted back into form
+// values. Neither can import `resources.ts`: `scripts/build-gatekeeper-configurator.ts` transpiles
+// each configurator module on its own, stripping only `@gadgets/configurator-ui` and type-only
+// imports, so a runtime import would not resolve inside the sandboxed frame. The duplication is
+// deliberate; this test is what keeps the copies honest. Drift on either side -- a lost
+// `encodeURIComponent`, a normalization one side does and the other does not -- shows up here
+// rather than as a resource the backend rejects after the user has filled the form.
+
+import { describe, expect, it } from "vitest";
+import gmailConfigurator from "../src/configurator/gmail-configurator-ui";
+import { GMAIL_RESOURCE, parseResourceUrl } from "../src/resources";
+
+// The configurators never call `ui` from these two methods; it is present only to satisfy the
+// context type, and touching it is a bug.
+const noUi = new Proxy({}, {
+  get() { throw new Error("must not call the ui capability"); },
+}) as never;
+
+const gmailUrl = (values: Record<string, unknown>) =>
+  gmailConfigurator.resourceUrl!({ values, ui: noUi }) as string;
+
+const gmailValues = (resourceUrl: string) =>
+  gmailConfigurator.initialValuesFromResourceUrl!({
+    resourceUrl, resourceUrlPattern: GMAIL_RESOURCE.urlPattern, ui: noUi,
+  });
+
+describe("Gmail configurator URLs", () => {
+  it.for([
+    ["the whole mailbox", { mode: "all" }, { kind: "gmail" }],
+    ["a search", { mode: "search", query: "from:alerts@example.com" },
+      { kind: "gmail", searchQuery: "from:alerts@example.com" }],
+    ["a search with spaces", { mode: "search", query: "is:unread subject:invoice" },
+      { kind: "gmail", searchQuery: "is:unread subject:invoice" }],
+    // A literal `+` in an address must survive as a `+`, not become a space.
+    ["a search naming a plus address", { mode: "search", query: "to:nathan+receipts@example.com" },
+      { kind: "gmail", searchQuery: "to:nathan+receipts@example.com" }],
+    ["a label", { mode: "label", label: "Receipts" }, { kind: "gmail", labelName: "Receipts" }],
+    ["a label with a slash", { mode: "label", label: "Work/Invoices" },
+      { kind: "gmail", labelName: "Work/Invoices" }],
+  ] as const)("builds a URL the server parses back for %s", ([, values, target]) => {
+    expect(parseResourceUrl(gmailUrl(values))).toEqual(target);
+  });
+
+  it.for([
+    [{ mode: "search", query: "is:unread subject:invoice" }],
+    [{ mode: "search", query: "to:nathan+receipts@example.com" }],
+    [{ mode: "label", label: "Work/Invoices" }],
+    [{ mode: "all" }],
+  ] as const)("round-trips %o through the URL and back to the same values", ([values]) => {
+    expect(gmailValues(gmailUrl(values))).toEqual(values);
+  });
+
+  // Gmail's own UI writes spaces as `+`, so this is the shape of a URL copied from the address bar
+  // rather than one this configurator built. Both sides have to read it the same way, or the form
+  // prefills a query that differs from the one the capability was granted for.
+  it("reads a pasted Gmail URL the way the server does", () => {
+    const pasted = "https://mail.google.com/mail/u/0/#search/is%3Aunread+subject%3Ainvoice";
+
+    expect(gmailValues(pasted)).toEqual({ mode: "search", query: "is:unread subject:invoice" });
+    expect(parseResourceUrl(pasted)).toEqual({
+      kind: "gmail", searchQuery: "is:unread subject:invoice",
+    });
+  });
+
+  it("keeps an escaped plus literal in a pasted URL", () => {
+    const pasted = "https://mail.google.com/mail/u/0/#search/to%3Anathan%2Breceipts%40example.com";
+
+    expect(gmailValues(pasted))
+      .toEqual({ mode: "search", query: "to:nathan+receipts@example.com" });
+    expect(parseResourceUrl(pasted)).toEqual({
+      kind: "gmail", searchQuery: "to:nathan+receipts@example.com",
+    });
+  });
+
+  it("treats the inbox hash Gmail lands on as the whole mailbox, as the server does", () => {
+    const inbox = "https://mail.google.com/mail/u/0/#inbox";
+
+    expect(gmailValues(inbox)).toEqual({ mode: "all" });
+    expect(parseResourceUrl(inbox)).toEqual({ kind: "gmail" });
+  });
+});

--- a/packages/gatekeeper-google/__tests__/cursor.test.ts
+++ b/packages/gatekeeper-google/__tests__/cursor.test.ts
@@ -134,8 +134,10 @@ describe("malformed provider responses", () => {
     await expect(pager.next()).rejects.toThrow("TestProvider returned a repeated page token.");
   });
 
-  it("allows a token that merely repeats an earlier, non-adjacent one", async () => {
-    let tokens = ["1", "2", "1", undefined];
+  // A longer cycle is the same bug wearing a hat, and the empty-page cap does not catch it: the
+  // pages come back full, so a drain would serve duplicates forever.
+  it("refuses a token it followed earlier, not just the one it just sent", async () => {
+    let tokens = ["1", "2", "1", "2"];
     let step = 0;
     let pager = new CursorPager<string, string>({
       provider: "TestProvider",
@@ -143,7 +145,14 @@ describe("malformed provider responses", () => {
       buildEntries: async items => items,
       authorize: async () => {},
     });
-    expect(await drain(pager)).toEqual(["p0", "p1", "p2", "p3"]);
+    expect(await pager.next()).toEqual(["p0"]);
+    expect(await pager.next()).toEqual(["p1"]);
+    await expect(pager.next()).rejects.toThrow("TestProvider returned a repeated page token.");
+  });
+
+  it("still walks a long run of distinct tokens", async () => {
+    let pager = makePager(Array.from({ length: 30 }, (_, i) => [`p${i}`])).pager;
+    expect(await drain(pager)).toHaveLength(30);
   });
 });
 

--- a/packages/gatekeeper-google/__tests__/cursor.test.ts
+++ b/packages/gatekeeper-google/__tests__/cursor.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+import { CursorPager, DEFAULT_MAX_EMPTY_PAGES } from "../src/cursor";
+import type { CursorPage, CursorPagerOptions } from "../src/cursor";
+
+/** Serves a fixed script of pages, keyed by the token used to ask for them. */
+function pageServer(pages: string[][]) {
+  let requested: (string | undefined)[] = [];
+  let fetchPage = async (pageToken: string | undefined): Promise<CursorPage<string>> => {
+    requested.push(pageToken);
+    let index = pageToken === undefined ? 0 : Number(pageToken);
+    return {
+      items: pages[index] ?? [],
+      ...(index + 1 < pages.length ? { nextPageToken: String(index + 1) } : {}),
+    };
+  };
+  return { fetchPage, requested };
+}
+
+function makePager(
+  pages: string[][],
+  overrides: Partial<CursorPagerOptions<string, string>> = {},
+) {
+  let server = pageServer(pages);
+  let authorized: string[][] = [];
+  let pager = new CursorPager<string, string>({
+    provider: "TestProvider",
+    fetchPage: server.fetchPage,
+    buildEntries: async items => items,
+    authorize: async entries => { authorized.push(entries); },
+    ...overrides,
+  });
+  return { pager, authorized, requested: server.requested };
+}
+
+/** Drains a pager, guarding against a cursor that never terminates. */
+async function drain(pager: CursorPager<string, string>, limit = 50): Promise<string[]> {
+  let all: string[] = [];
+  for (let i = 0; i < limit; i++) {
+    let page = await pager.next();
+    if (page === null) return all;
+    all.push(...page);
+  }
+  throw new Error("cursor did not terminate");
+}
+
+describe("paging", () => {
+  it("asks for the first page with no token", async () => {
+    let { pager, requested } = makePager([["a"]]);
+    await pager.next();
+    expect(requested).toEqual([undefined]);
+  });
+
+  it("walks the pages in order and then ends", async () => {
+    let { pager } = makePager([["a"], ["b"], ["c"]]);
+    expect(await drain(pager)).toEqual(["a", "b", "c"]);
+  });
+
+  it("carries the provider's token into the following request", async () => {
+    let { pager, requested } = makePager([["a"], ["b"]]);
+    await pager.next();
+    await pager.next();
+    expect(requested).toEqual([undefined, "1"]);
+  });
+
+  it("stops asking once exhausted", async () => {
+    let { pager, requested } = makePager([["a"]]);
+    await pager.next();
+    expect(await pager.next()).toBeNull();
+    expect(await pager.next()).toBeNull();
+    expect(requested).toEqual([undefined]);
+  });
+
+  it("reports the end immediately when the only page is empty", async () => {
+    let { pager, authorized } = makePager([[]]);
+    expect(await pager.next()).toBeNull();
+    expect(authorized).toEqual([]);
+  });
+});
+
+describe("pages with no usable results", () => {
+  it("walks past pages the provider returned empty", async () => {
+    let { pager, requested } = makePager([[], [], ["a"]]);
+    expect(await pager.next()).toEqual(["a"]);
+    expect(requested).toEqual([undefined, "1", "2"]);
+  });
+
+  // Drive filters each page against the bound folder, so a page can arrive full and end up empty.
+  // That is not the end of the results, and must not be reported as one.
+  it("walks past pages that a scope filter emptied", async () => {
+    let { pager } = makePager([["skip"], ["skip"], ["keep"]], {
+      buildEntries: async items => items.filter(item => item !== "skip"),
+    });
+    expect(await pager.next()).toEqual(["keep"]);
+  });
+
+  it("ends cleanly when the filter discards everything and no pages remain", async () => {
+    let { pager } = makePager([["skip"], ["skip"]], {
+      buildEntries: async () => [],
+    });
+    expect(await pager.next()).toBeNull();
+  });
+
+  it("gives up after the configured number of fruitless pages", async () => {
+    let empty = Array.from({ length: 10 }, () => [] as string[]);
+    let { pager } = makePager([...empty, ["a"]], {
+      maxEmptyPages: 3,
+    });
+    await expect(pager.next()).rejects.toThrow(
+      "TestProvider returned 3 pages with no usable results.");
+  });
+
+  it("defaults the budget to DEFAULT_MAX_EMPTY_PAGES", async () => {
+    let pages = Array.from({ length: DEFAULT_MAX_EMPTY_PAGES + 1 }, () => [] as string[]);
+    let { pager, requested } = makePager(pages.concat([["a"]]));
+    await expect(pager.next()).rejects.toThrow(`returned ${DEFAULT_MAX_EMPTY_PAGES} pages`);
+    expect(requested).toHaveLength(DEFAULT_MAX_EMPTY_PAGES);
+  });
+
+  it("counts the budget per call, not for the cursor's lifetime", async () => {
+    let { pager } = makePager([[], ["a"], [], ["b"]], { maxEmptyPages: 2 });
+    expect(await pager.next()).toEqual(["a"]);
+    expect(await pager.next()).toEqual(["b"]);
+  });
+});
+
+describe("malformed provider responses", () => {
+  it("refuses a page token identical to the one just sent", async () => {
+    let pager = new CursorPager<string, string>({
+      provider: "TestProvider",
+      fetchPage: async pageToken => ({ items: [], nextPageToken: pageToken ?? "loop" }),
+      buildEntries: async items => items,
+      authorize: async () => {},
+    });
+    await expect(pager.next()).rejects.toThrow("TestProvider returned a repeated page token.");
+  });
+
+  it("allows a token that merely repeats an earlier, non-adjacent one", async () => {
+    let tokens = ["1", "2", "1", undefined];
+    let step = 0;
+    let pager = new CursorPager<string, string>({
+      provider: "TestProvider",
+      fetchPage: async () => ({ items: [`p${step}`], nextPageToken: tokens[step++] }),
+      buildEntries: async items => items,
+      authorize: async () => {},
+    });
+    expect(await drain(pager)).toEqual(["p0", "p1", "p2", "p3"]);
+  });
+});
+
+describe("authorization", () => {
+  it("authorizes each disclosed page with the entries it will return", async () => {
+    let { pager, authorized } = makePager([["a", "b"], ["c"]]);
+    await drain(pager);
+    expect(authorized).toEqual([["a", "b"], ["c"]]);
+  });
+
+  it("authorizes the surviving entries, not the raw page", async () => {
+    let { pager, authorized } = makePager([["keep", "skip"]], {
+      buildEntries: async items => items.filter(item => item !== "skip"),
+    });
+    await pager.next();
+    expect(authorized).toEqual([["keep"]]);
+  });
+
+  it("does not ask about pages it walked past", async () => {
+    let { pager, authorized } = makePager([[], [], ["a"]]);
+    await pager.next();
+    expect(authorized).toEqual([["a"]]);
+  });
+
+  // A denied read must not consume the page: the caller may retry after getting approval.
+  it("leaves the position untouched when disclosure is denied", async () => {
+    let denied = true;
+    let { pager, requested } = makePager([["a"], ["b"]], {
+      authorize: async () => {
+        if (denied) throw new Error("denied");
+      },
+    });
+
+    await expect(pager.next()).rejects.toThrow("denied");
+    denied = false;
+    expect(await pager.next()).toEqual(["a"]);
+    expect(requested).toEqual([undefined, undefined]);
+  });
+
+  it("does not mark the cursor exhausted when the final page is denied", async () => {
+    let denied = true;
+    let { pager } = makePager([["a"]], {
+      authorize: async () => {
+        if (denied) throw new Error("denied");
+      },
+    });
+
+    await expect(pager.next()).rejects.toThrow("denied");
+    denied = false;
+    expect(await pager.next()).toEqual(["a"]);
+    expect(await pager.next()).toBeNull();
+  });
+});
+
+describe("serialization", () => {
+  it("never runs two fetches at once", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    let server = pageServer([["a"], ["b"], ["c"]]);
+    let pager = new CursorPager<string, string>({
+      provider: "TestProvider",
+      fetchPage: async token => {
+        peak = Math.max(peak, ++inFlight);
+        await Promise.resolve();
+        inFlight--;
+        return server.fetchPage(token);
+      },
+      buildEntries: async items => items,
+      authorize: async () => {},
+    });
+
+    await Promise.all([pager.next(), pager.next(), pager.next()]);
+    expect(peak).toBe(1);
+  });
+
+  it("hands successive pages to callers that did not await", async () => {
+    let { pager } = makePager([["a"], ["b"], ["c"]]);
+    let pages = await Promise.all([pager.next(), pager.next(), pager.next()]);
+    expect(pages).toEqual([["a"], ["b"], ["c"]]);
+  });
+
+  it("keeps serving after a rejected call rather than wedging the queue", async () => {
+    let attempt = 0;
+    let { pager } = makePager([["a"], ["b"]], {
+      authorize: async () => {
+        if (attempt++ === 0) throw new Error("denied");
+      },
+    });
+
+    let [first, second] = await Promise.allSettled([pager.next(), pager.next()]);
+    expect(first.status).toBe("rejected");
+    expect(second).toMatchObject({ status: "fulfilled", value: ["a"] });
+  });
+});
+
+describe("buildEntries", () => {
+  it("is given the raw items of exactly one page", async () => {
+    let buildEntries = vi.fn(async (items: string[]) => items);
+    let { pager } = makePager([["a", "b"], ["c"]], { buildEntries });
+    await drain(pager);
+    expect(buildEntries.mock.calls).toEqual([[["a", "b"]], [["c"]]]);
+  });
+
+  it("is not called again once the cursor is exhausted", async () => {
+    let buildEntries = vi.fn(async (items: string[]) => items);
+    let { pager } = makePager([["a"]], { buildEntries });
+    await drain(pager);
+    await pager.next();
+    expect(buildEntries).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gatekeeper-google/__tests__/doc-fixture.ts
+++ b/packages/gatekeeper-google/__tests__/doc-fixture.ts
@@ -1,0 +1,56 @@
+import type {
+  GoogleDocsDocument, ParagraphElement, StructuralElement, TextStyle,
+} from "../src/docs-api";
+
+/** A styled span of text within a paragraph. */
+export type Run = { text: string; style?: TextStyle };
+
+type ParagraphSpec = {
+  runs: (Run | string)[];
+  namedStyleType?: string;
+  bullet?: { listId: string; nestingLevel: number };
+};
+
+/**
+ * Builds a `GoogleDocsDocument` with the index bookkeeping the real API applies: a section break
+ * occupies index 0, and every paragraph's runs are laid out contiguously from index 1.
+ *
+ * Every paragraph's last run must end in "\n", as Google's own responses do.
+ */
+export function buildDoc(
+  paragraphs: ParagraphSpec[],
+  lists: GoogleDocsDocument["lists"] = {},
+): GoogleDocsDocument {
+  let index = 1;
+  let content: StructuralElement[] = [{ startIndex: 0, endIndex: 1, sectionBreak: {} }];
+
+  for (let spec of paragraphs) {
+    let start = index;
+    let elements: ParagraphElement[] = spec.runs.map(run => {
+      let { text, style } = typeof run === "string" ? { text: run, style: undefined } : run;
+      let runStart = index;
+      index += text.length;
+      return {
+        startIndex: runStart,
+        endIndex: index,
+        textRun: { content: text, textStyle: style ?? {} },
+      };
+    });
+    content.push({
+      startIndex: start,
+      endIndex: index,
+      paragraph: {
+        elements,
+        paragraphStyle: { namedStyleType: spec.namedStyleType ?? "NORMAL_TEXT" },
+        bullet: spec.bullet,
+      },
+    });
+  }
+
+  return { documentId: "doc-1", title: "Fixture", revisionId: "rev-1", body: { content }, lists };
+}
+
+/** A single-level bullet list definition, for paragraphs carrying a matching `bullet`. */
+export const BULLET_LIST: GoogleDocsDocument["lists"] = {
+  L1: { listProperties: { nestingLevels: [{ glyphSymbol: "\u25cf" }] } },
+};

--- a/packages/gatekeeper-google/__tests__/drive-api.test.ts
+++ b/packages/gatekeeper-google/__tests__/drive-api.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DRIVE_FILE_FIELDS, DriveApi, DriveApiDisabledError, buildDriveQuery, escapeDriveQueryLiteral,
+} from "../src/drive-api";
+
+const DRIVE_DISABLED_BODY = JSON.stringify({
+  error: { message: "Google Drive API has not been used in project 1234 before or it is disabled." },
+});
+
+/** Installs a fetch stub and returns the URLs and headers it was called with. */
+function stubFetch(responses: Response[] | (() => Response)) {
+  let calls: { url: URL; headers: Headers }[] = [];
+  let queue = Array.isArray(responses) ? [...responses] : null;
+  vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+    calls.push({ url: new URL(url), headers: new Headers(init.headers) });
+    if (queue) {
+      let next = queue.shift();
+      if (!next) throw new Error("unexpected extra fetch");
+      return next;
+    }
+    return (responses as () => Response)();
+  });
+  return calls;
+}
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status });
+
+const api = (token = "tok") => new DriveApi(async () => token);
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe("escapeDriveQueryLiteral", () => {
+  it("leaves an ordinary value alone", () => {
+    expect(escapeDriveQueryLiteral("Quarterly Report")).toBe("Quarterly Report");
+  });
+
+  // A name that closes the literal could append its own clauses and read outside the scope.
+  it("escapes a quote so it cannot close the literal", () => {
+    expect(escapeDriveQueryLiteral("Bob's notes")).toBe("Bob\\'s notes");
+  });
+
+  it("escapes backslashes before quotes, so an escape cannot be neutralized", () => {
+    expect(escapeDriveQueryLiteral("a\\'b")).toBe("a\\\\\\'b");
+  });
+
+  it("defuses an injected clause", () => {
+    let injected = "x' or name contains 'secret";
+    expect(buildDriveQuery({ nameContains: injected }))
+      .toBe("trashed = false and name contains 'x\\' or name contains \\'secret'");
+  });
+});
+
+describe("buildDriveQuery", () => {
+  it("always excludes trashed files", () => {
+    expect(buildDriveQuery({})).toBe("trashed = false");
+  });
+
+  it("ANDs the mime type and the name fragment", () => {
+    expect(buildDriveQuery({ mimeType: "application/vnd.google-apps.document", nameContains: "q3" }))
+      .toBe(
+        "trashed = false and mimeType = 'application/vnd.google-apps.document' " +
+        "and name contains 'q3'");
+  });
+
+  it("ignores a blank or whitespace-only name fragment", () => {
+    expect(buildDriveQuery({ nameContains: "   " })).toBe("trashed = false");
+  });
+
+  it("trims the name fragment", () => {
+    expect(buildDriveQuery({ nameContains: "  q3  " })).toBe("trashed = false and name contains 'q3'");
+  });
+});
+
+describe("listFiles", () => {
+  it("requests the field mask that DriveFile describes", async () => {
+    let calls = stubFetch([jsonResponse({ files: [] })]);
+    await api().listFiles();
+    expect(calls[0].url.searchParams.get("fields")).toBe(DRIVE_FILE_FIELDS);
+  });
+
+  it("sends the bearer token", async () => {
+    let calls = stubFetch([jsonResponse({ files: [] })]);
+    await api("secret-token").listFiles();
+    expect(calls[0].headers.get("Authorization")).toBe("Bearer secret-token");
+  });
+
+  it("includes shared drives", async () => {
+    let calls = stubFetch([jsonResponse({ files: [] })]);
+    await api().listFiles();
+    let params = calls[0].url.searchParams;
+    expect(params.get("supportsAllDrives")).toBe("true");
+    expect(params.get("includeItemsFromAllDrives")).toBe("true");
+  });
+
+  it("defaults to the hundred most recently modified", async () => {
+    let calls = stubFetch([jsonResponse({ files: [] })]);
+    await api().listFiles();
+    expect(calls[0].url.searchParams.get("pageSize")).toBe("100");
+    expect(calls[0].url.searchParams.get("orderBy")).toBe("modifiedTime desc");
+  });
+
+  it("omits the page token on the first request", async () => {
+    let calls = stubFetch([jsonResponse({ files: [] })]);
+    await api().listFiles();
+    expect(calls[0].url.searchParams.has("pageToken")).toBe(false);
+  });
+
+  it("forwards a page token when given one", async () => {
+    let calls = stubFetch([jsonResponse({ files: [] })]);
+    await api().listFiles({ pageToken: "next" });
+    expect(calls[0].url.searchParams.get("pageToken")).toBe("next");
+  });
+
+  it("returns the files and the continuation token", async () => {
+    stubFetch([jsonResponse({ files: [{ id: "1", name: "a" }], nextPageToken: "p2" })]);
+    expect(await api().listFiles())
+      .toEqual({ files: [{ id: "1", name: "a" }], nextPageToken: "p2" });
+  });
+
+  it("treats a response with no files array as an empty page", async () => {
+    stubFetch([jsonResponse({})]);
+    expect(await api().listFiles()).toEqual({ files: [] });
+  });
+
+  it("omits nextPageToken on the last page rather than reporting it undefined", async () => {
+    stubFetch([jsonResponse({ files: [] })]);
+    expect("nextPageToken" in await api().listFiles()).toBe(false);
+  });
+});
+
+describe("error handling", () => {
+  it("distinguishes the API-not-enabled 403, which the admin must fix", async () => {
+    stubFetch([new Response(DRIVE_DISABLED_BODY, { status: 403 })]);
+    await expect(api().listFiles()).rejects.toBeInstanceOf(DriveApiDisabledError);
+  });
+
+  it("reports an ordinary 403 as a plain failure", async () => {
+    stubFetch([new Response("insufficient scope", { status: 403 })]);
+    let error = await api().listFiles().catch(e => e);
+    expect(error).not.toBeInstanceOf(DriveApiDisabledError);
+    expect(error.message).toContain("403");
+  });
+
+  it("surfaces the status and body of an unexpected failure", async () => {
+    stubFetch([new Response("boom", { status: 400 })]);
+    await expect(api().listFiles())
+      .rejects.toThrow("Google Drive API request failed: 400 boom");
+  });
+});
+
+// Bypassing fetchWithAuthRetry was the bug that motivated this module: the configurator talked to
+// Drive with a raw fetch, so a stale token 401'd instead of refreshing.
+describe("auth retry", () => {
+  it("refreshes once on a 401 and replays the request", async () => {
+    let issued = ["stale", "fresh"];
+    let drive = new DriveApi(async opts => issued[opts?.forceRefresh ? 1 : 0]);
+    let calls = stubFetch([
+      new Response("expired", { status: 401 }),
+      jsonResponse({ files: [{ id: "1", name: "a" }] }),
+    ]);
+
+    expect((await drive.listFiles()).files).toHaveLength(1);
+    expect(calls.map(call => call.headers.get("Authorization")))
+      .toEqual(["Bearer stale", "Bearer fresh"]);
+  });
+
+  it("tells the authority which token was rejected", async () => {
+    let requests: unknown[] = [];
+    let drive = new DriveApi(async opts => {
+      requests.push(opts);
+      return opts?.forceRefresh ? "fresh" : "stale";
+    });
+    stubFetch([new Response("expired", { status: 401 }), jsonResponse({ files: [] })]);
+
+    await drive.listFiles();
+    expect(requests).toEqual([undefined, { forceRefresh: true, staleToken: "stale" }]);
+  });
+
+  it("gives up rather than looping when the refreshed token is also rejected", async () => {
+    let drive = new DriveApi(async () => "tok");
+    let calls = stubFetch(() => new Response("expired", { status: 401 }));
+
+    await expect(drive.listFiles()).rejects.toThrow("401");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("retries a 429, which a raw fetch would have surfaced as a failure", async () => {
+    let drive = new DriveApi(async () => "tok");
+    let calls = stubFetch([
+      new Response("slow down", { status: 429, headers: { "Retry-After": "0" } }),
+      jsonResponse({ files: [{ id: "1", name: "a" }] }),
+    ]);
+
+    expect((await drive.listFiles()).files).toHaveLength(1);
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/packages/gatekeeper-google/__tests__/drive-api.test.ts
+++ b/packages/gatekeeper-google/__tests__/drive-api.test.ts
@@ -3,8 +3,13 @@ import {
   DRIVE_FILE_FIELDS, DriveApi, DriveApiDisabledError, buildDriveQuery, escapeDriveQueryLiteral,
 } from "../src/drive-api";
 
-const DRIVE_DISABLED_BODY = JSON.stringify({
-  error: { message: "Google Drive API has not been used in project 1234 before or it is disabled." },
+/** Google's real error envelope for an API that is not enabled on the project. */
+const API_DISABLED_BODY = JSON.stringify({
+  error: {
+    code: 403,
+    message: "Google Drive API has not been used in project 1234 before or it is disabled.",
+    errors: [{ domain: "usageLimits", reason: "accessNotConfigured" }],
+  },
 });
 
 /** Installs a fetch stub and returns the URLs and headers it was called with. */
@@ -130,22 +135,80 @@ describe("listFiles", () => {
 });
 
 describe("error handling", () => {
-  it("distinguishes the API-not-enabled 403, which the admin must fix", async () => {
-    stubFetch([new Response(DRIVE_DISABLED_BODY, { status: 403 })]);
+  it("distinguishes the API-not-enabled 403 by Google's reason, which the admin must fix", async () => {
+    stubFetch([new Response(API_DISABLED_BODY, { status: 403 })]);
     await expect(api().listFiles()).rejects.toBeInstanceOf(DriveApiDisabledError);
   });
 
-  it("reports an ordinary 403 as a plain failure", async () => {
-    stubFetch([new Response("insufficient scope", { status: 403 })]);
+  it("does not mistake another 403 for the API being disabled", async () => {
+    stubFetch([new Response(JSON.stringify({
+      error: { errors: [{ reason: "insufficientPermissions" }] },
+    }), { status: 403 })]);
     let error = await api().listFiles().catch(e => e);
     expect(error).not.toBeInstanceOf(DriveApiDisabledError);
-    expect(error.message).toContain("403");
+    expect(error.message).toBe("Google Drive API request failed: 403 (insufficientPermissions)");
   });
 
-  it("surfaces the status and body of an unexpected failure", async () => {
-    stubFetch([new Response("boom", { status: 400 })]);
+  it("reports the status alone when Google declared no reason", async () => {
+    stubFetch([new Response("{}", { status: 404 })]);
     await expect(api().listFiles())
-      .rejects.toThrow("Google Drive API request failed: 400 boom");
+      .rejects.toThrow("Google Drive API request failed: 404");
+  });
+
+  // The provider's prose can quote the `q` we sent, and this error reaches a UI that may forward
+  // it to the error reporter.
+  it("never puts the response body in the error", async () => {
+    let body = JSON.stringify({
+      error: {
+        message: "Invalid query: name contains 'Acme Q3 acquisition'",
+        errors: [{ reason: "invalid" }],
+      },
+    });
+    stubFetch([new Response(body, { status: 400 })]);
+    let error = await api().listFiles().catch(e => e);
+    expect(error.message).toBe("Google Drive API request failed: 400 (invalid)");
+    expect(error.message).not.toContain("Acme");
+  });
+
+  it("survives a non-JSON error body", async () => {
+    stubFetch([new Response("<html>400 Bad Request</html>", { status: 400 })]);
+    await expect(api().listFiles())
+      .rejects.toThrow("Google Drive API request failed: 400");
+  });
+
+  it("survives an empty error body", async () => {
+    stubFetch([new Response("", { status: 403 })]);
+    let error = await api().listFiles().catch(e => e);
+    expect(error).not.toBeInstanceOf(DriveApiDisabledError);
+    expect(error.message).toBe("Google Drive API request failed: 403");
+  });
+
+  it("ignores a reason that is not a plain identifier", async () => {
+    stubFetch([new Response(JSON.stringify({
+      error: { errors: [{ reason: "not an identifier: leaked 'secret'" }] },
+    }), { status: 400 })]);
+    let error = await api().listFiles().catch(e => e);
+    expect(error.message).toBe("Google Drive API request failed: 400");
+  });
+
+  it("ignores a non-string reason", async () => {
+    stubFetch([new Response(JSON.stringify({
+      error: { errors: [{ reason: { nested: true } }] },
+    }), { status: 400 })]);
+    await expect(api().listFiles())
+      .rejects.toThrow("Google Drive API request failed: 400");
+  });
+
+  // A body large enough that parsing it whole would be the expensive part of failing.
+  it("caps how much of an oversized body it parses", async () => {
+    let padded = "x".repeat(64 * 1024);
+    stubFetch([new Response(JSON.stringify({
+      error: { message: padded, errors: [{ reason: "invalid" }] },
+    }), { status: 400 })]);
+    let error = await api().listFiles().catch(e => e);
+    // Truncation makes the JSON unparseable, so no reason survives — and no body leaks either.
+    expect(error.message).toBe("Google Drive API request failed: 400");
+    expect(error.message).not.toContain("x");
   });
 });
 
@@ -194,5 +257,16 @@ describe("auth retry", () => {
 
     expect((await drive.listFiles()).files).toHaveLength(1);
     expect(calls).toHaveLength(2);
+  });
+
+  it("retries a 5xx, then reports it sanitized once the budget runs out", async () => {
+    let drive = new DriveApi(async () => "tok");
+    let calls = stubFetch(() => new Response(JSON.stringify({
+      error: { errors: [{ reason: "backendError" }] },
+    }), { status: 503 }));
+
+    await expect(drive.listFiles())
+      .rejects.toThrow("Google Drive API request failed: 503 (backendError)");
+    expect(calls).toHaveLength(3);
   });
 });

--- a/packages/gatekeeper-google/__tests__/gmail-validate.test.ts
+++ b/packages/gatekeeper-google/__tests__/gmail-validate.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_GMAIL_ADDRESS_BYTES, MAX_GMAIL_BODY_BYTES, MAX_GMAIL_LABEL_BYTES, MAX_GMAIL_QUERY_BYTES,
+  MAX_GMAIL_RECIPIENTS, MAX_GMAIL_SUBJECT_BYTES, validateGmailAddress, validateGmailBody,
+  validateGmailLabelName, validateGmailQueryForGrouping, validateGmailRecipientCount,
+  validateOutboundInput,
+} from "../src/gmail-validate";
+
+// Multi-byte, so a byte limit and a length limit can be told apart.
+const wide = (bytes: number) => "\u00e9".repeat(bytes / 2);
+
+describe("validateGmailQueryForGrouping", () => {
+  it.each([
+    ["empty", ""],
+    ["plain terms", "from:someone subject:hello"],
+    ["balanced parens", "(a OR b) AND c"],
+    ["balanced braces", "{a b} c"],
+    ["nested", "((a) {b})"],
+    ["quoted paren", 'subject:"a ) b"'],
+    ["single-quoted brace", "subject:'a } b'"],
+    ["escaped quote", 'subject:\\"'],
+    ["escaped paren", "a \\( b"],
+  ])("accepts %s", (_name, query) => {
+    expect(() => validateGmailQueryForGrouping(query)).not.toThrow();
+  });
+
+  it.each([
+    ["unclosed paren", "(a"],
+    ["unopened paren", "a)"],
+    ["unclosed brace", "{a"],
+    ["crossed delimiters", "({a)}"],
+    ["unterminated double quote", 'subject:"a'],
+    ["unterminated single quote", "subject:'a"],
+    ["escaped closing quote leaves it open", 'subject:"a\\"'],
+  ])("rejects %s", (_name, query) => {
+    expect(() => validateGmailQueryForGrouping(query)).toThrow();
+  });
+
+  // The base and caller queries are combined as `(base) (caller)`, so an unbalanced delimiter in
+  // either would swallow the other's parentheses and escape the binding's restriction.
+  it("rejects a query that would close the wrapping group early", () => {
+    expect(() => validateGmailQueryForGrouping(") OR (")).toThrow();
+  });
+
+  it("counts the query limit in bytes, not characters", () => {
+    expect(() => validateGmailQueryForGrouping(wide(MAX_GMAIL_QUERY_BYTES))).not.toThrow();
+    expect(() => validateGmailQueryForGrouping(wide(MAX_GMAIL_QUERY_BYTES + 2))).toThrow(/at most/);
+  });
+});
+
+describe("validateGmailLabelName", () => {
+  it("accepts a name at the byte limit", () => {
+    expect(() => validateGmailLabelName(wide(MAX_GMAIL_LABEL_BYTES))).not.toThrow();
+  });
+
+  it.each([["empty", ""], ["over the limit", wide(MAX_GMAIL_LABEL_BYTES + 2)]])(
+    "rejects %s", (_name, label) => {
+      expect(() => validateGmailLabelName(label)).toThrow(/between 1 and/);
+    });
+});
+
+describe("validateGmailAddress", () => {
+  it("accepts an address at the byte limit", () => {
+    expect(() => validateGmailAddress(wide(MAX_GMAIL_ADDRESS_BYTES))).not.toThrow();
+  });
+
+  it.each([["empty", ""], ["over the limit", wide(MAX_GMAIL_ADDRESS_BYTES + 2)]])(
+    "rejects %s", (_name, address) => {
+      expect(() => validateGmailAddress(address)).toThrow();
+    });
+});
+
+describe("validateGmailBody", () => {
+  it("accepts an empty body and one at the byte limit", () => {
+    expect(() => validateGmailBody("")).not.toThrow();
+    expect(() => validateGmailBody(wide(MAX_GMAIL_BODY_BYTES))).not.toThrow();
+  });
+
+  it("rejects a body over the byte limit", () => {
+    expect(() => validateGmailBody(wide(MAX_GMAIL_BODY_BYTES + 2))).toThrow(/at most/);
+  });
+});
+
+describe("validateGmailRecipientCount", () => {
+  it("accepts 1 and the maximum", () => {
+    expect(() => validateGmailRecipientCount(["a@b.com"])).not.toThrow();
+    expect(() => validateGmailRecipientCount(Array(MAX_GMAIL_RECIPIENTS).fill("a@b.com")))
+      .not.toThrow();
+  });
+
+  it.each([["none", 0], ["one over the maximum", MAX_GMAIL_RECIPIENTS + 1]])(
+    "rejects %s", (_name, count) => {
+      expect(() => validateGmailRecipientCount(Array(count).fill("a@b.com")))
+        .toThrow(/between 1 and/);
+    });
+});
+
+describe("validateOutboundInput", () => {
+  it("accepts a well-formed message", () => {
+    expect(() => validateOutboundInput(["a@b.com"], "Subject", "Body")).not.toThrow();
+  });
+
+  it("rejects an empty recipient among valid ones", () => {
+    expect(() => validateOutboundInput(["a@b.com", ""], "s", "b")).toThrow();
+  });
+
+  it("applies the subject limit in bytes", () => {
+    expect(() => validateOutboundInput(["a@b.com"], wide(MAX_GMAIL_SUBJECT_BYTES), "b"))
+      .not.toThrow();
+    expect(() => validateOutboundInput(["a@b.com"], wide(MAX_GMAIL_SUBJECT_BYTES + 2), "b"))
+      .toThrow(/subject/);
+  });
+});

--- a/packages/gatekeeper-google/__tests__/markdown-converter.test.ts
+++ b/packages/gatekeeper-google/__tests__/markdown-converter.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { computeReplaceOperations, docToMarkdown } from "../src/markdown-converter";
+import type { Segment } from "../src/markdown-converter";
+import { BULLET_LIST, buildDoc } from "./doc-fixture";
+
+/** A segment with a document counterpart, as opposed to a Markdown-syntax-only one. */
+type ContentSegment = Exclude<Segment, { syntaxOnly: true }>;
+
+const isContent = (seg: Segment): seg is ContentSegment => !("syntaxOnly" in seg);
+
+/**
+ * The document text as Google stores it, aligned so that a string index equals a doc index: index
+ * 0 is the section break, and run text begins at 1.
+ */
+function docText(runs: string[]): string {
+  return "\u0000" + runs.join("");
+}
+
+describe("docToMarkdown", () => {
+  it("renders headings, inline styles, links and bullets", () => {
+    let snapshot = docToMarkdown(buildDoc([
+      { runs: ["Title\n"], namedStyleType: "HEADING_1" },
+      { runs: ["Sub\n"], namedStyleType: "HEADING_2" },
+      { runs: [
+        "Hello ",
+        { text: "bold", style: { bold: true } },
+        " and ",
+        { text: "it", style: { italic: true } },
+        " and ",
+        { text: "link", style: { link: { url: "https://e.com" } } },
+        ".\n",
+      ] },
+      { runs: ["one\n"], bullet: { listId: "L1", nestingLevel: 0 } },
+      { runs: ["two\n"], bullet: { listId: "L1", nestingLevel: 0 } },
+    ], BULLET_LIST));
+
+    expect(snapshot.markdown).toBe(
+      "# Title\n\n## Sub\n\nHello **bold** and *it* and [link](https://e.com).\n\n- one\n- two\n");
+  });
+
+  it("carries the title, revision and body end index through", () => {
+    let snapshot = docToMarkdown(buildDoc([{ runs: ["abc\n"] }]));
+    expect(snapshot.title).toBe("Fixture");
+    expect(snapshot.revisionId).toBe("rev-1");
+    // Section break (1) + "abc\n" (4).
+    expect(snapshot.bodyEndIndex).toBe(5);
+  });
+});
+
+// These are what keeps an edit from landing on the wrong characters. A content segment claims a
+// 1:1 mapping between Markdown and document indices, and computeReplaceOperations trusts it.
+describe("source map invariants", () => {
+  let snapshot = docToMarkdown(buildDoc([
+    { runs: ["Title\n"], namedStyleType: "HEADING_1" },
+    { runs: [
+      "Hello ",
+      { text: "bold", style: { bold: true } },
+      " and ",
+      { text: "link", style: { link: { url: "https://e.com" } } },
+      ".\n",
+    ] },
+    { runs: ["one\n"], bullet: { listId: "L1", nestingLevel: 0 } },
+  ], BULLET_LIST));
+  let text = docText(["Title\n", "Hello ", "bold", " and ", "link", ".\n", "one\n"]);
+  let segments = snapshot.sourceMap.blocks.flatMap(b => b.segments);
+  let contentSegments = segments.filter(isContent);
+
+  it("gives every content segment equal length in both spaces", () => {
+    for (let seg of contentSegments) {
+      expect(seg.mdEnd - seg.mdStart).toBe(seg.docEnd - seg.docStart);
+    }
+  });
+
+  it("maps every content segment to the same text in both spaces", () => {
+    for (let seg of contentSegments) {
+      expect(snapshot.markdown.slice(seg.mdStart, seg.mdEnd))
+        .toBe(text.slice(seg.docStart, seg.docEnd));
+    }
+  });
+
+  it("keeps segments non-overlapping and ordered in both spaces", () => {
+    let mdCursor = 0;
+    let docCursor = 0;
+    for (let seg of segments) {
+      expect(seg.mdStart).toBeGreaterThanOrEqual(mdCursor);
+      expect(seg.mdEnd).toBeGreaterThanOrEqual(seg.mdStart);
+      mdCursor = seg.mdEnd;
+      if ("syntaxOnly" in seg) continue;
+      expect(seg.docStart).toBeGreaterThanOrEqual(docCursor);
+      docCursor = seg.docEnd;
+    }
+  });
+
+  it("keeps each block's segments inside the block's own ranges", () => {
+    for (let block of snapshot.sourceMap.blocks) {
+      for (let seg of block.segments) {
+        expect(seg.mdStart).toBeGreaterThanOrEqual(block.mdStart);
+        expect(seg.mdEnd).toBeLessThanOrEqual(block.mdEnd);
+        if ("syntaxOnly" in seg) continue;
+        expect(seg.docStart).toBeGreaterThanOrEqual(block.docStart);
+        expect(seg.docEnd).toBeLessThanOrEqual(block.docEnd);
+      }
+    }
+  });
+});
+
+describe("computeReplaceOperations", () => {
+  let snapshot = docToMarkdown(buildDoc([
+    { runs: ["Title\n"], namedStyleType: "HEADING_1" },
+    { runs: ["Hello ", { text: "bold", style: { bold: true } }, " world.\n"] },
+  ]));
+  let md = snapshot.markdown;
+  let replace = (oldText: string, newText: string) => {
+    let start = md.indexOf(oldText);
+    expect(start).toBeGreaterThanOrEqual(0);
+    return computeReplaceOperations(
+      snapshot.sourceMap, md, start, start + oldText.length, newText);
+  };
+
+  it("renders the fixture as expected", () => {
+    expect(md).toBe("# Title\n\nHello **bold** world.\n");
+  });
+
+  it("emits nothing when the text is unchanged", () => {
+    expect(replace("world", "world")).toEqual({ requests: [], trimmedOld: "", trimmedNew: "" });
+  });
+
+  it("deletes then re-inserts at the mapped document range", () => {
+    expect(replace("world", "there")).toEqual({
+      trimmedOld: "world",
+      trimmedNew: "there",
+      requests: [
+        { deleteContentRange: { range: { startIndex: 18, endIndex: 23 } } },
+        { insertText: { location: { index: 18 }, text: "there" } },
+      ],
+    });
+  });
+
+  it("trims a shared prefix down to a bare insert", () => {
+    expect(replace("world", "worlds")).toEqual({
+      trimmedOld: "",
+      trimmedNew: "s",
+      requests: [{ insertText: { location: { index: 23 }, text: "s" } }],
+    });
+  });
+
+  it("emits only a delete when the replacement is empty", () => {
+    expect(replace("world", "")).toEqual({
+      trimmedOld: "world",
+      trimmedNew: "",
+      requests: [{ deleteContentRange: { range: { startIndex: 18, endIndex: 23 } } }],
+    });
+  });
+
+  // BUG (pre-existing, unfixed): when the replaced range touches Markdown syntax, mdRangeToDocRange
+  // widens the delete to the whole enclosing block but computeReplaceOperations still inserts only
+  // the caller's replacement text, so the rest of the paragraph is destroyed. The approval preview
+  // uses a plain string splice and shows the correct result, so the user approves "Hello plain
+  // world." and the document becomes "plain".
+  //
+  // `it.fails` records the correct expectation without failing CI. Delete the `.fails` when fixed.
+  it.fails("preserves surrounding text when the range spans Markdown syntax", () => {
+    let result = replace("**bold**", "plain");
+    let deleted = result.requests[0].deleteContentRange.range;
+    let inserted = result.requests[1].insertText.text;
+    // The delete covers "Hello bold world.\n" (doc 7..25), so the insert must restore all of it.
+    expect({ deleted, inserted }).toEqual({
+      deleted: { startIndex: 7, endIndex: 25 },
+      inserted: "Hello plain world.\n",
+    });
+  });
+
+  it("currently truncates the paragraph in that case", () => {
+    let result = replace("**bold**", "plain");
+    expect(result.requests).toEqual([
+      { deleteContentRange: { range: { startIndex: 7, endIndex: 25 } } },
+      { insertText: { location: { index: 7 }, text: "plain" } },
+    ]);
+  });
+});

--- a/packages/gatekeeper-google/__tests__/observers.test.ts
+++ b/packages/gatekeeper-google/__tests__/observers.test.ts
@@ -239,34 +239,49 @@ describe("addObserver", () => {
       for (let i = 0; i < count; i++) kv.put(`set:s${i}`, "observed");
     };
 
-    it("admits at the cap", async () => {
+    // The cap bounds what addObserver has to verify, but enforcing it there would deny every
+    // collaborator on every reopen once passed -- including the ones already using the gadget,
+    // with no way back, since tracked sets are never dropped. So the read is what fails.
+    it("refuses to record a read that would pass the cap, naming the remedy", async () => {
+      fill(3);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      await expect(tracker.prepareObservation(["extra"]))
+        .rejects.toThrow(/read 3 distinct items.*Bind a narrower scope/s);
+    });
+
+    it("records a read that lands exactly on the cap", async () => {
+      fill(2);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      expect((await tracker.prepareObservation(["extra"])).pendingSets).toEqual(["extra"]);
+    });
+
+    it("counts the whole batch, not one set at a time", async () => {
+      fill(2);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      await expect(tracker.prepareObservation(["x", "y"])).rejects.toThrow(/narrower scope/);
+      expect(kv.get("set:x")).toBeUndefined();
+      expect(kv.get("set:y")).toBeUndefined();
+    });
+
+    // Re-reading what the binding already tracks costs nothing new, so the cap must not turn a
+    // binding sitting on the limit into one that can no longer read its own data.
+    it("keeps serving reads of sets it already tracks", async () => {
+      fill(3);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      expect((await tracker.prepareObservation(["s0", "s1"])).pendingSets).toEqual([]);
+    });
+
+    it("does not count a duplicate within one batch twice", async () => {
+      fill(2);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      expect((await tracker.prepareObservation(["dup", "dup"])).pendingSets).toEqual(["dup"]);
+    });
+
+    // A binding at the cap is still shareable -- that is the whole point of capping the read.
+    it("admits observers at the cap", async () => {
       fill(3);
       let tracker = makeTracker({ maxTrackedSets: 3 });
       await expect(tracker.addObserver("reader", allow("s0", "s1", "s2"))).resolves.toBeUndefined();
-    });
-
-    // Verifying costs a round trip per tracked set on every open, so an unbounded set makes
-    // opening the gadget unboundedly expensive. Fail closed rather than degrade.
-    it("refuses a new observer past the cap, naming the remedy", async () => {
-      fill(4);
-      let tracker = makeTracker({ maxTrackedSets: 3 });
-      await expect(tracker.addObserver("reader", allow("s0", "s1", "s2", "s3")))
-        .rejects.toThrow(/read 4 distinct items.*Bind a narrower scope/s);
-    });
-
-    it("leaves existing observers in place when the cap is passed", async () => {
-      let tracker = makeTracker({ maxTrackedSets: 3 });
-      await tracker.addObserver("existing", allow());
-      fill(4);
-
-      await expect(tracker.addObserver("newcomer", allow())).rejects.toThrow(/narrower scope/);
-      expect([...tracker.observers()].map(([id]) => id)).toEqual(["existing"]);
-    });
-
-    it("still records reads past the cap so nothing goes unverified", async () => {
-      fill(4);
-      let tracker = makeTracker({ maxTrackedSets: 3 });
-      expect((await tracker.prepareObservation(["extra"])).pendingSets).toEqual(["extra"]);
     });
   });
 });

--- a/packages/gatekeeper-google/__tests__/observers.test.ts
+++ b/packages/gatekeeper-google/__tests__/observers.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ObserverTracker } from "../src/observers";
+import type { ObserverKv } from "../src/observers";
+
+/** An in-memory stand-in for a Durable Object's `ctx.storage.kv`, preserving insertion order. */
+class FakeKv implements ObserverKv {
+  entries = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.entries.get(key) as T | undefined;
+  }
+  put<T>(key: string, value: T): void {
+    this.entries.set(key, value);
+  }
+  delete(key: string): void {
+    this.entries.delete(key);
+  }
+  list<T>({ prefix }: { prefix: string }): Iterable<[string, T]> {
+    return [...this.entries]
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([key, value]) => [key, value as T]);
+  }
+}
+
+/** A verifier that grants access to a fixed allow-list, and records what it was asked. */
+class FakeVerifier {
+  asked: string[] = [];
+  constructor(public allowed: Set<string>) {}
+  async check(value: string): Promise<boolean> {
+    this.asked.push(value);
+    return this.allowed.has(value);
+  }
+}
+
+let kv: FakeKv;
+
+function makeTracker(overrides: Partial<{
+  maxTrackedSets: number;
+  concurrency: number;
+  recordObservers: boolean;
+  hasAccess: (verifier: FakeVerifier, value: string) => Promise<boolean>;
+}> = {}) {
+  return new ObserverTracker<string, FakeVerifier>(kv, {
+    setPrefix: "set:",
+    encode: value => encodeURIComponent(value),
+    decode: encoded => decodeURIComponent(encoded),
+    hasAccess: overrides.hasAccess ?? ((verifier, value) => verifier.check(value)),
+    deniedMessage: value => `no access to ${value}`,
+    ...overrides,
+  });
+}
+
+const allow = (...values: string[]) => new FakeVerifier(new Set(values));
+const states = () => [...kv.list<string>({ prefix: "set:" })];
+
+beforeEach(() => { kv = new FakeKv(); });
+
+describe("construction", () => {
+  it("refuses a set prefix that would collide with the observer records", () => {
+    expect(() => new ObserverTracker<string, FakeVerifier>(kv, {
+      setPrefix: "observer:",
+      encode: v => v,
+      decode: v => v,
+      hasAccess: async () => true,
+      deniedMessage: () => "denied",
+    })).toThrow(/must not collide/);
+  });
+});
+
+describe("prepareObservation", () => {
+  it("marks unknown sets pending and reports them", async () => {
+    let check = await makeTracker().prepareObservation(["a", "b"]);
+    expect(check.pendingSets).toEqual(["a", "b"]);
+    expect(states()).toEqual([["set:a", "pending"], ["set:b", "pending"]]);
+  });
+
+  it("deduplicates repeated values", async () => {
+    let check = await makeTracker().prepareObservation(["a", "a", "b", "a"]);
+    expect(check.pendingSets).toEqual(["a", "b"]);
+  });
+
+  it("promotes pending to observed only on commit", async () => {
+    let tracker = makeTracker();
+    let check = await tracker.prepareObservation(["a"]);
+    expect(states()).toEqual([["set:a", "pending"]]);
+    check.commit();
+    expect(states()).toEqual([["set:a", "observed"]]);
+  });
+
+  // A read that was never authorized must not permanently narrow who may observe this binding.
+  it("re-reports a set left pending by an unauthorized read", async () => {
+    let tracker = makeTracker();
+    await tracker.prepareObservation(["a"]);
+    expect((await tracker.prepareObservation(["a"])).pendingSets).toEqual(["a"]);
+  });
+
+  it("skips a set already observed", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a"])).commit();
+    let check = await tracker.prepareObservation(["a", "b"]);
+    expect(check.pendingSets).toEqual(["b"]);
+  });
+
+  it("treats the legacy `true` state as observed", async () => {
+    kv.put("set:a", true);
+    expect((await makeTracker().prepareObservation(["a"])).pendingSets).toEqual([]);
+  });
+
+  it("reports no exclusions and does not write when nothing is new", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a"])).commit();
+    let verifier = allow("a");
+    await tracker.addObserver("obs", verifier);
+    verifier.asked.length = 0;
+
+    let check = await tracker.prepareObservation(["a"]);
+    expect(check.excludeObservers).toBeUndefined();
+    expect(verifier.asked).toEqual([]);
+  });
+
+  describe("forward exclusion", () => {
+    it("excludes an existing observer who cannot reach a newly-read set", async () => {
+      let tracker = makeTracker();
+      await tracker.addObserver("reader", allow("a"));
+      await tracker.addObserver("outsider", allow());
+
+      let check = await tracker.prepareObservation(["a"]);
+      expect(check.excludeObservers).toEqual(["outsider"]);
+    });
+
+    it("keeps an observer who can reach every pending set", async () => {
+      let tracker = makeTracker();
+      await tracker.addObserver("reader", allow("a", "b"));
+
+      let check = await tracker.prepareObservation(["a", "b"]);
+      expect(check.excludeObservers).toBeUndefined();
+    });
+
+    it("excludes an observer missing any one of several pending sets", async () => {
+      let tracker = makeTracker();
+      await tracker.addObserver("partial", allow("a"));
+
+      let check = await tracker.prepareObservation(["a", "b"]);
+      expect(check.excludeObservers).toEqual(["partial"]);
+    });
+
+    it("reports each excluded observer once", async () => {
+      let tracker = makeTracker();
+      await tracker.addObserver("outsider", allow());
+
+      let check = await tracker.prepareObservation(["a", "b", "c"]);
+      expect(check.excludeObservers).toEqual(["outsider"]);
+    });
+  });
+});
+
+describe("addObserver", () => {
+  it("admits and records an observer who can reach every tracked set", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a", "b"])).commit();
+
+    await tracker.addObserver("reader", allow("a", "b"));
+    expect([...tracker.observers()].map(([id]) => id)).toEqual(["reader"]);
+  });
+
+  it("admits against an empty tracked set without asking anything", async () => {
+    let verifier = allow();
+    await makeTracker().addObserver("reader", verifier);
+    expect(verifier.asked).toEqual([]);
+  });
+
+  it("throws naming the first set the observer cannot reach", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a", "b"])).commit();
+
+    await expect(tracker.addObserver("outsider", allow("a")))
+      .rejects.toThrow("no access to b");
+    expect([...tracker.observers()]).toEqual([]);
+  });
+
+  // Sets left pending by an in-flight read still count: the data may yet be disclosed.
+  it("verifies against pending sets, not just observed ones", async () => {
+    let tracker = makeTracker();
+    await tracker.prepareObservation(["a"]);
+    await expect(tracker.addObserver("outsider", allow())).rejects.toThrow("no access to a");
+  });
+
+  // The overseer re-runs addObserver on every open, which is what makes revocation take effect.
+  it("re-checks every tracked set on each call rather than caching", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a"])).commit();
+    let verifier = allow("a");
+
+    await tracker.addObserver("reader", verifier);
+    await tracker.addObserver("reader", verifier);
+    expect(verifier.asked).toEqual(["a", "a"]);
+
+    verifier.allowed.delete("a");
+    await expect(tracker.addObserver("reader", verifier)).rejects.toThrow("no access to a");
+  });
+
+  // Otherwise a set first read during the round trip would never be verified for this observer.
+  it("picks up a set that became tracked while it was awaiting", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a"])).commit();
+
+    let verifier = allow("a");
+    let injected = false;
+    let racy = makeTracker({
+      hasAccess: async (v, value) => {
+        if (!injected) {
+          injected = true;
+          kv.put("set:b", "observed");
+        }
+        return v.check(value);
+      },
+    });
+
+    await expect(racy.addObserver("reader", verifier)).rejects.toThrow("no access to b");
+  });
+
+  it("does not re-ask about sets already checked in this call", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a", "b"])).commit();
+    let verifier = allow("a", "b");
+
+    await tracker.addObserver("reader", verifier);
+    expect(verifier.asked.toSorted()).toEqual(["a", "b"]);
+  });
+
+  it("omits the observer record when the caller has nobody to forward-exclude", async () => {
+    let tracker = makeTracker({ recordObservers: false });
+    await tracker.addObserver("reader", allow());
+    expect([...tracker.observers()]).toEqual([]);
+  });
+
+  describe("cardinality cap", () => {
+    let fill = (count: number) => {
+      for (let i = 0; i < count; i++) kv.put(`set:s${i}`, "observed");
+    };
+
+    it("admits at the cap", async () => {
+      fill(3);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      await expect(tracker.addObserver("reader", allow("s0", "s1", "s2"))).resolves.toBeUndefined();
+    });
+
+    // Verifying costs a round trip per tracked set on every open, so an unbounded set makes
+    // opening the gadget unboundedly expensive. Fail closed rather than degrade.
+    it("refuses a new observer past the cap, naming the remedy", async () => {
+      fill(4);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      await expect(tracker.addObserver("reader", allow("s0", "s1", "s2", "s3")))
+        .rejects.toThrow(/read 4 distinct items.*Bind a narrower scope/s);
+    });
+
+    it("leaves existing observers in place when the cap is passed", async () => {
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      await tracker.addObserver("existing", allow());
+      fill(4);
+
+      await expect(tracker.addObserver("newcomer", allow())).rejects.toThrow(/narrower scope/);
+      expect([...tracker.observers()].map(([id]) => id)).toEqual(["existing"]);
+    });
+
+    it("still records reads past the cap so nothing goes unverified", async () => {
+      fill(4);
+      let tracker = makeTracker({ maxTrackedSets: 3 });
+      expect((await tracker.prepareObservation(["extra"])).pendingSets).toEqual(["extra"]);
+    });
+  });
+});
+
+describe("removeObserver", () => {
+  it("drops the record and stops forward-excluding them", async () => {
+    let tracker = makeTracker();
+    await tracker.addObserver("outsider", allow());
+    tracker.removeObserver("outsider");
+
+    expect([...tracker.observers()]).toEqual([]);
+    expect((await tracker.prepareObservation(["a"])).excludeObservers).toBeUndefined();
+  });
+
+  it("is a no-op for an unknown id", () => {
+    expect(() => makeTracker().removeObserver("nobody")).not.toThrow();
+  });
+});
+
+describe("listTracked", () => {
+  it("round-trips values through encode and decode", async () => {
+    let tracker = makeTracker();
+    (await tracker.prepareObservation(["a/b", "c d", "e:f"])).commit();
+    expect(tracker.listTracked()).toEqual(["a/b", "c d", "e:f"]);
+  });
+
+  it("does not confuse observer records for tracked sets", async () => {
+    let tracker = makeTracker();
+    await tracker.addObserver("reader", allow());
+    expect(tracker.listTracked()).toEqual([]);
+  });
+});
+
+describe("concurrency", () => {
+  /** Counts peak overlap of `hasAccess` calls. */
+  function tracking(limit: number) {
+    let inFlight = 0;
+    let peak = 0;
+    let tracker = makeTracker({
+      concurrency: limit,
+      hasAccess: async () => {
+        peak = Math.max(peak, ++inFlight);
+        await Promise.resolve();
+        inFlight--;
+        return true;
+      },
+    });
+    return { tracker, peak: () => peak };
+  }
+
+  it("bounds the fan-out when verifying a joining observer", async () => {
+    for (let i = 0; i < 20; i++) kv.put(`set:s${i}`, "observed");
+    let { tracker, peak } = tracking(4);
+    await tracker.addObserver("reader", allow());
+    expect(peak()).toBeLessThanOrEqual(4);
+  });
+
+  // The pairs are observers x sets, so nesting two unbounded Promise.alls multiplies out.
+  it("bounds the fan-out across observers and pending sets together", async () => {
+    let seed = makeTracker();
+    for (let i = 0; i < 5; i++) await seed.addObserver(`obs${i}`, allow());
+
+    let { tracker, peak } = tracking(4);
+    await tracker.prepareObservation(Array.from({ length: 6 }, (_, i) => `s${i}`));
+    expect(peak()).toBeLessThanOrEqual(4);
+  });
+
+  it("still checks every pair", async () => {
+    let seed = makeTracker();
+    for (let i = 0; i < 3; i++) await seed.addObserver(`obs${i}`, allow("a", "b"));
+
+    let hasAccess = vi.fn(async () => true);
+    let tracker = makeTracker({ concurrency: 2, hasAccess });
+    await tracker.prepareObservation(["a", "b"]);
+    expect(hasAccess).toHaveBeenCalledTimes(6);
+  });
+});

--- a/packages/gatekeeper-google/__tests__/resources.test.ts
+++ b/packages/gatekeeper-google/__tests__/resources.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import {
+  BIGQUERY_RESOURCE, GMAIL_RESOURCE, GOOGLE_CALENDAR_RESOURCE, GOOGLE_DOC_RESOURCE,
+  GOOGLE_SHEETS_RESOURCE, IDENTITY_SCOPES, LEGACY_GRANTED_RESOURCE_URL_PATTERNS, RESOURCE_BY_KIND,
+  RESOURCE_SCOPES, SUPPORTED_RESOURCES, grantedResourcesFromScopes, parseResourceUrl,
+  resourceUrlPatternsToOAuthScopes, validateResourceUrlPatterns,
+} from "../src/resources";
+
+describe("resource declarations", () => {
+  // A urlPattern is permanent identity: it keys admin disable-sets, blueprint typeUrlPatterns and
+  // recorded grants, so changing one after deploy orphans every binding that used it.
+  it("pins every grantable resource's urlPattern", () => {
+    expect(SUPPORTED_RESOURCES.map(r => r.urlPattern)).toEqual([
+      "https://mail.google.com/*",
+      "https://docs.google.com/document/d/:docId/*",
+      "https://docs.google.com/spreadsheets/d/:spreadsheetId/*",
+      "https://calendar.google.com/calendar/:calendarId/*",
+      "https://bigquery.googleapis.com/:projectId/*",
+    ]);
+  });
+
+  it("has a distinct pattern per resource", () => {
+    let patterns = SUPPORTED_RESOURCES.map(r => r.urlPattern);
+    expect(new Set(patterns).size).toBe(patterns.length);
+  });
+
+  // Adding an entry short-circuits ensureResources, so a legacy account would be treated as
+  // already holding a grant it never made and would never be re-prompted for consent.
+  it("keeps the legacy granted set frozen at Gmail, Doc and BigQuery", () => {
+    expect(LEGACY_GRANTED_RESOURCE_URL_PATTERNS).toEqual([
+      GMAIL_RESOURCE.urlPattern,
+      GOOGLE_DOC_RESOURCE.urlPattern,
+      BIGQUERY_RESOURCE.urlPattern,
+    ]);
+  });
+
+  it("maps every parse kind to a declared resource", () => {
+    for (let resource of Object.values(RESOURCE_BY_KIND)) {
+      expect(SUPPORTED_RESOURCES).toContain(resource);
+    }
+    expect(new Set(Object.values(RESOURCE_BY_KIND)).size).toBe(SUPPORTED_RESOURCES.length);
+  });
+});
+
+describe("resourceUrlPatternsToOAuthScopes", () => {
+  it("always includes the identity scopes", () => {
+    expect(resourceUrlPatternsToOAuthScopes([])).toEqual(IDENTITY_SCOPES);
+  });
+
+  // undefined means "every resource"; [] means "none". Conflating them would silently grant a
+  // billing-only connection full resource access, or strip a full one.
+  it("distinguishes undefined (all resources) from [] (none)", () => {
+    expect(resourceUrlPatternsToOAuthScopes(undefined).length)
+      .toBeGreaterThan(resourceUrlPatternsToOAuthScopes([]).length);
+  });
+
+  it("returns exactly the requested resource's scopes plus identity", () => {
+    expect(resourceUrlPatternsToOAuthScopes([BIGQUERY_RESOURCE.urlPattern])).toEqual([
+      ...IDENTITY_SCOPES,
+      "https://www.googleapis.com/auth/bigquery",
+    ]);
+  });
+
+  it("deduplicates scopes shared between resources", () => {
+    let scopes = resourceUrlPatternsToOAuthScopes(
+      [GOOGLE_DOC_RESOURCE.urlPattern, GOOGLE_SHEETS_RESOURCE.urlPattern]);
+    expect(scopes).toContain("https://www.googleapis.com/auth/drive.metadata.readonly");
+    expect(new Set(scopes).size).toBe(scopes.length);
+  });
+
+  it("rejects an unknown pattern rather than silently ignoring it", () => {
+    expect(() => resourceUrlPatternsToOAuthScopes(["https://drive.google.com/*"]))
+      .toThrow(/Unknown grantable resource/);
+  });
+});
+
+describe("grantedResourcesFromScopes", () => {
+  it("round-trips every resource through its own scopes", () => {
+    for (let { resource } of RESOURCE_SCOPES) {
+      let scopes = resourceUrlPatternsToOAuthScopes([resource.urlPattern]);
+      expect(grantedResourcesFromScopes(scopes)).toContain(resource.urlPattern);
+    }
+  });
+
+  it("round-trips the full grant", () => {
+    expect(grantedResourcesFromScopes(resourceUrlPatternsToOAuthScopes(undefined)))
+      .toEqual(SUPPORTED_RESOURCES.map(r => r.urlPattern));
+  });
+
+  it("reports nothing for identity scopes alone", () => {
+    expect(grantedResourcesFromScopes(IDENTITY_SCOPES)).toEqual([]);
+  });
+
+  // Recording a wider grant than was actually made makes ensureResources short-circuit into a
+  // binding that 403s, with no way to re-prompt.
+  it("fails closed on a partial grant", () => {
+    let calendar = RESOURCE_SCOPES.find(e => e.resource === GOOGLE_CALENDAR_RESOURCE)!;
+    expect(calendar.scopes.length).toBeGreaterThan(1);
+    expect(grantedResourcesFromScopes(calendar.scopes.slice(0, 1)))
+      .not.toContain(GOOGLE_CALENDAR_RESOURCE.urlPattern);
+  });
+
+  it("ignores scopes it does not know", () => {
+    expect(grantedResourcesFromScopes(["https://www.googleapis.com/auth/drive"])).toEqual([]);
+  });
+});
+
+describe("validateResourceUrlPatterns", () => {
+  it("accepts undefined and every known pattern", () => {
+    expect(() => validateResourceUrlPatterns(undefined)).not.toThrow();
+    expect(() => validateResourceUrlPatterns(SUPPORTED_RESOURCES.map(r => r.urlPattern)))
+      .not.toThrow();
+  });
+
+  it("names each unknown pattern", () => {
+    expect(() => validateResourceUrlPatterns(["https://a.example/", "https://b.example/"]))
+      .toThrow(/https:\/\/a\.example\/, https:\/\/b\.example\//);
+  });
+});
+
+describe("parseResourceUrl", () => {
+  describe("unsupported URLs", () => {
+    // Regression: Gmail used to be the fallback branch, so any unrecognised Google URL minted a
+    // full mailbox binding. The caller derives the resource -- and hence the admin disable check
+    // and the recorded typeUrlPattern -- from what this returns.
+    it.each([
+      "https://drive.google.com/drive/folders/abc",
+      "https://drive.google.com/file/d/abc/view",
+      "https://groups.google.com/g/team",
+      "https://mail.google.com.evil.example/",
+      "https://example.com/",
+    ])("rejects %s instead of falling back to Gmail", url => {
+      expect(() => parseResourceUrl(url)).toThrow(/Unsupported Google resource URL/);
+    });
+
+    it("rejects a docs.google.com path that is neither a doc nor a sheet", () => {
+      expect(() => parseResourceUrl("https://docs.google.com/presentation/d/abc/edit"))
+        .toThrow(/Unsupported Google Docs resource URL/);
+    });
+
+    it("rejects a calendar.google.com path outside /calendar/", () => {
+      expect(() => parseResourceUrl("https://calendar.google.com/other/abc"))
+        .toThrow(/Unsupported Google Calendar resource URL/);
+    });
+
+    it("rejects a non-https URL", () => {
+      expect(() => parseResourceUrl("http://mail.google.com/")).toThrow(/must use https/);
+    });
+
+    it("rejects a string that is not a URL", () => {
+      expect(() => parseResourceUrl("mail.google.com")).toThrow(/Not a valid resource URL/);
+    });
+  });
+
+  describe("gmail", () => {
+    it("treats a bare mailbox and #inbox as unscoped", () => {
+      expect(parseResourceUrl("https://mail.google.com/")).toEqual({ kind: "gmail" });
+      expect(parseResourceUrl("https://mail.google.com/#inbox")).toEqual({ kind: "gmail" });
+    });
+
+    it("decodes a search scope, normalizing Gmail's + for space", () => {
+      expect(parseResourceUrl("https://mail.google.com/#search/from%3Aa%40b.com+urgent"))
+        .toEqual({ kind: "gmail", searchQuery: "from:a@b.com urgent" });
+    });
+
+    it("decodes a label scope and keeps it opaque", () => {
+      expect(parseResourceUrl("https://mail.google.com/#label/Team%2FAlerts"))
+        .toEqual({ kind: "gmail", labelName: "Team/Alerts" });
+    });
+
+    // A label is resolved to an ID at session start, so a name that looks like search syntax must
+    // survive parsing intact rather than being validated as a query.
+    it("does not apply query validation to a label name", () => {
+      expect(parseResourceUrl("https://mail.google.com/#label/a(b"))
+        .toEqual({ kind: "gmail", labelName: "a(b" });
+    });
+
+    it("rejects a search scope with unbalanced grouping", () => {
+      expect(() => parseResourceUrl("https://mail.google.com/#search/%28a"))
+        .toThrow(/unterminated grouping/);
+    });
+
+    it("rejects an empty label", () => {
+      expect(() => parseResourceUrl("https://mail.google.com/#label/")).toThrow(/label name/);
+    });
+
+    it("rejects an unrecognised view", () => {
+      expect(() => parseResourceUrl("https://mail.google.com/#sent"))
+        .toThrow(/Unsupported Gmail view/);
+    });
+  });
+
+  describe("docs and sheets", () => {
+    it("extracts a document ID, ignoring trailing path", () => {
+      expect(parseResourceUrl("https://docs.google.com/document/d/DOC123/edit?usp=sharing"))
+        .toEqual({ kind: "doc", documentId: "DOC123" });
+    });
+
+    it("extracts a spreadsheet ID", () => {
+      expect(parseResourceUrl("https://docs.google.com/spreadsheets/d/SHEET123/edit#gid=0"))
+        .toEqual({ kind: "sheets", spreadsheetId: "SHEET123" });
+    });
+
+    it.each([
+      ["document", "https://docs.google.com/document/d/"],
+      ["spreadsheet", "https://docs.google.com/spreadsheets/d/"],
+    ])("rejects a %s URL with no ID", (_name, url) => {
+      expect(() => parseResourceUrl(url)).toThrow(/no .* ID found/);
+    });
+  });
+
+  describe("calendar", () => {
+    it("decodes the calendar ID and defaults to the narrow availability mode", () => {
+      expect(parseResourceUrl("https://calendar.google.com/calendar/a%40b.com"))
+        .toEqual({ kind: "calendar", calendarId: "a@b.com", availabilityMode: "thisCalendar" });
+    });
+
+    it("opts into allVisible only on the exact query value", () => {
+      expect(parseResourceUrl("https://calendar.google.com/calendar/c1?availability=allVisible"))
+        .toMatchObject({ availabilityMode: "allVisible" });
+      expect(parseResourceUrl("https://calendar.google.com/calendar/c1?availability=yes"))
+        .toMatchObject({ availabilityMode: "thisCalendar" });
+    });
+
+    // "primary" resolves per account, so a binding using it would not name a stable calendar.
+    it("rejects the account-relative primary alias", () => {
+      expect(() => parseResourceUrl("https://calendar.google.com/calendar/primary"))
+        .toThrow(/stable calendar ID/);
+    });
+
+    it("rejects a missing calendar ID", () => {
+      expect(() => parseResourceUrl("https://calendar.google.com/calendar/"))
+        .toThrow(/no calendar ID found/);
+    });
+  });
+
+  describe("bigquery", () => {
+    it.each([
+      ["project", "https://bigquery.googleapis.com/proj",
+        { projectId: "proj", datasetId: undefined, tableId: undefined }],
+      ["dataset", "https://bigquery.googleapis.com/proj/ds",
+        { projectId: "proj", datasetId: "ds", tableId: undefined }],
+      ["table", "https://bigquery.googleapis.com/proj/ds/tbl",
+        { projectId: "proj", datasetId: "ds", tableId: "tbl" }],
+    ])("scopes to a %s", (_name, url, expected) => {
+      expect(parseResourceUrl(url)).toEqual({ kind: "bigquery", ...expected });
+    });
+
+    it("tolerates redundant slashes and decodes segments", () => {
+      expect(parseResourceUrl("https://bigquery.googleapis.com//proj//my%20ds/"))
+        .toEqual({ kind: "bigquery", projectId: "proj", datasetId: "my ds", tableId: undefined });
+    });
+
+    it.each([
+      ["no project", "https://bigquery.googleapis.com/", /must include a project ID/],
+      ["too many segments", "https://bigquery.googleapis.com/a/b/c/d", /must be/],
+      ["a query string", "https://bigquery.googleapis.com/proj?x=1", /query strings or fragments/],
+      ["a fragment", "https://bigquery.googleapis.com/proj#x", /query strings or fragments/],
+    ])("rejects %s", (_name, url, message) => {
+      expect(() => parseResourceUrl(url)).toThrow(message);
+    });
+  });
+});

--- a/packages/gatekeeper-google/__tests__/resources.test.ts
+++ b/packages/gatekeeper-google/__tests__/resources.test.ts
@@ -6,6 +6,16 @@ import {
   resourceUrlPatternsToOAuthScopes, validateResourceUrlPatterns,
 } from "../src/resources";
 
+/** The message `parseResourceUrl` rejects `url` with. Fails the test if it accepts it. */
+function messageFor(url: string): string {
+  try {
+    parseResourceUrl(url);
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error(`expected ${url} to be rejected`);
+}
+
 describe("resource declarations", () => {
   // A urlPattern is permanent identity: it keys admin disable-sets, blueprint typeUrlPatterns and
   // recorded grants, so changing one after deploy orphans every binding that used it.
@@ -149,6 +159,43 @@ describe("parseResourceUrl", () => {
 
     it("rejects a string that is not a URL", () => {
       expect(() => parseResourceUrl("mail.google.com")).toThrow(/Not a valid resource URL/);
+    });
+
+    // These errors reach the Workshop UI and are logged by their catchers, so the parts of a
+    // caller-supplied URL that carry content or credentials must not ride along.
+    describe("error messages", () => {
+
+      it("omits the fragment, which for Gmail is a search query", () => {
+        let message = messageFor(
+          "https://docs.google.com/presentation/d/abc/edit#search/acquisition+target");
+        expect(message).not.toContain("acquisition");
+        expect(message).toContain("docs.google.com/presentation/d/abc/edit");
+      });
+
+      it("omits query parameters", () => {
+        expect(messageFor("https://calendar.google.com/other?token=sekrit"))
+          .not.toContain("sekrit");
+      });
+
+      it("omits credentials embedded in the authority", () => {
+        let message = messageFor("https://user:hunter2@docs.google.com/presentation/d/abc");
+        expect(message).not.toContain("hunter2");
+        expect(message).not.toContain("user");
+      });
+
+      it("quotes back nothing at all from an unparseable string", () => {
+        expect(messageFor("not a url at all sekrit")).toBe("Not a valid resource URL.");
+      });
+
+      it("names only the host for an unsupported one", () => {
+        expect(messageFor("https://groups.google.com/g/team?invite=sekrit"))
+          .toBe("Unsupported Google resource URL host: groups.google.com");
+      });
+
+      it("names only the scheme for a non-https URL", () => {
+        expect(messageFor("http://mail.google.com/#search/sekrit"))
+          .toBe("Google resource URLs must use https, not http:");
+      });
     });
   });
 

--- a/packages/gatekeeper-google/package.json
+++ b/packages/gatekeeper-google/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "echo \"run 'pnpm dev-server' in the root directory instead\" >&2 && exit 1",
     "deploy": "vp run --no-cache build:configurator && wrangler deploy",
-    "clean": "rm -rf dist src/generated"
+    "clean": "rm -rf dist src/generated",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@gadgets/backend-utils": "workspace:*",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "wrangler": "catalog:"
   }
 }

--- a/packages/gatekeeper-google/src/configurator/gmail-configurator-ui.tsx
+++ b/packages/gatekeeper-google/src/configurator/gmail-configurator-ui.tsx
@@ -12,10 +12,16 @@ export default {
     return false;
   },
 
+  // Must mirror `parseGmailUrl` in resources.ts, which is what actually mints the capability. This
+  // module is transpiled on its own and cannot import that parser, so `__tests__/configurator-url
+  // .test.ts` is what keeps the copies honest.
   initialValuesFromResourceUrl({ resourceUrl }) {
     const hash = new URL(resourceUrl).hash.replace(/^#/, "");
     if (hash.startsWith("search/")) {
-      return { mode: "search", query: decodeURIComponent(hash.slice("search/".length)) };
+      // Gmail encodes spaces in hash searches as `+`, which decodeURIComponent leaves alone. The
+      // substitution has to precede the decode so an escaped `%2B` still yields a literal `+`.
+      const query = hash.slice("search/".length).replace(/\+/g, " ");
+      return { mode: "search", query: decodeURIComponent(query) };
     }
     if (hash.startsWith("label/")) {
       return { mode: "label", label: decodeURIComponent(hash.slice("label/".length)) };

--- a/packages/gatekeeper-google/src/cursor.ts
+++ b/packages/gatekeeper-google/src/cursor.ts
@@ -73,7 +73,9 @@ export class CursorPager<Item, Entry> implements Pager<Entry> {
    */
   next(): Promise<Entry[] | null> {
     let result = this.#tail.then(() => this.#nextPage());
-    this.#tail = result.catch(() => {});
+    // Chain on completion, not on the value: holding the resolved page here would pin a page of
+    // results in memory until the next call.
+    this.#tail = result.then(() => undefined, () => undefined);
     return result;
   }
 

--- a/packages/gatekeeper-google/src/cursor.ts
+++ b/packages/gatekeeper-google/src/cursor.ts
@@ -57,6 +57,9 @@ export class CursorPager<Item, Entry> implements Pager<Entry> {
   #options: CursorPagerOptions<Item, Entry>;
   #maxEmptyPages: number;
   #pageToken: string | undefined;
+  // Every token the provider has handed back. A cursor stops at the first repeat, so this grows
+  // only with genuinely distinct pages.
+  #seenTokens = new Set<string>();
   #exhausted = false;
   #tail: Promise<unknown> = Promise.resolve();
 
@@ -84,16 +87,23 @@ export class CursorPager<Item, Entry> implements Pager<Entry> {
 
     let { provider, fetchPage, buildEntries, authorize } = this.#options;
     let pageToken = this.#pageToken;
+    // Tokens followed during this call. Merged into the committed set only once the page is
+    // approved: a denied read rewinds the cursor, and the retry re-derives these same tokens.
+    let followed = new Set<string>();
     let entries: Entry[];
 
     for (let fetched = 1; ; fetched++) {
-      let previousToken = pageToken;
       let page = await fetchPage(pageToken);
       pageToken = page.nextPageToken;
 
-      // A provider that hands back the token we just sent would page forever.
-      if (pageToken !== undefined && pageToken === previousToken) {
-        throw new Error(`${provider} returned a repeated page token.`);
+      // A token we have already followed would page forever. Comparing only against the token we
+      // just sent would catch a self-loop but not a longer cycle, and the empty-page cap is no
+      // backstop: the pages in a cycle come back full.
+      if (pageToken !== undefined) {
+        if (this.#seenTokens.has(pageToken) || followed.has(pageToken)) {
+          throw new Error(`${provider} returned a repeated page token.`);
+        }
+        followed.add(pageToken);
       }
 
       entries = await buildEntries(page.items);
@@ -113,6 +123,7 @@ export class CursorPager<Item, Entry> implements Pager<Entry> {
     // Advance only once the page has been approved. A denied read leaves the cursor where it was,
     // so retrying re-offers the same page instead of silently skipping over it.
     await authorize(entries);
+    for (let token of followed) this.#seenTokens.add(token);
     this.#pageToken = pageToken;
     this.#exhausted = pageToken === undefined;
     return entries;

--- a/packages/gatekeeper-google/src/cursor.ts
+++ b/packages/gatekeeper-google/src/cursor.ts
@@ -1,0 +1,118 @@
+// The paging engine behind every `Cursor` this gatekeeper hands out.
+//
+// A cursor is a capability: the call that creates it authorizes its existence, and each page it
+// yields is separately authorized before it is disclosed. This module owns the parts of that
+// which are the same for every provider — serializing concurrent `next()` calls, walking past
+// pages that yield nothing, refusing to loop forever, and holding the cursor's position back
+// until the page it would advance over has actually been approved.
+//
+// It deliberately imports nothing from `cloudflare:workers`, so it can be tested outside workerd.
+// google.ts wraps it in the one-method `RpcTarget` that crosses the wire.
+
+/** One page as the provider returned it, before any scope filtering. */
+export type CursorPage<Item> = {
+  items: Item[];
+  /** Absent once the provider has no more pages. */
+  nextPageToken?: string;
+};
+
+export type CursorPagerOptions<Item, Entry> = {
+  /** Provider name, used only to make error messages legible. */
+  provider: string;
+
+  /** Fetch one raw page. `pageToken` is undefined for the first. */
+  fetchPage(pageToken: string | undefined): Promise<CursorPage<Item>>;
+
+  /**
+   * Turn a raw page into the entries the caller sees.
+   *
+   * May return fewer entries than it was given: dropping items outside the binding's scope
+   * belongs here, and a page that empties out that way is walked past rather than mistaken for
+   * the end of the results. Enriching entries with extra requests belongs here too, so it is
+   * never paid for items that were about to be dropped.
+   */
+  buildEntries(items: Item[]): Promise<Entry[]>;
+
+  /** Authorize disclosure of a non-empty page. Throws to deny. */
+  authorize(entries: Entry[]): Promise<void>;
+
+  /** How many result-less pages to walk past before giving up. */
+  maxEmptyPages?: number;
+};
+
+/**
+ * Pages to walk past before concluding the provider is wasting our time.
+ *
+ * Reached either because the provider itself keeps returning empty pages, or because a scope
+ * filter keeps discarding everything on them.
+ */
+export const DEFAULT_MAX_EMPTY_PAGES = 20;
+
+/** The one method a `Cursor` exposes. `CursorPager` implements it; google.ts wraps it for RPC. */
+export interface Pager<Entry> {
+  next(): Promise<Entry[] | null>;
+}
+
+export class CursorPager<Item, Entry> implements Pager<Entry> {
+  #options: CursorPagerOptions<Item, Entry>;
+  #maxEmptyPages: number;
+  #pageToken: string | undefined;
+  #exhausted = false;
+  #tail: Promise<unknown> = Promise.resolve();
+
+  constructor(options: CursorPagerOptions<Item, Entry>) {
+    this.#options = options;
+    this.#maxEmptyPages = options.maxEmptyPages ?? DEFAULT_MAX_EMPTY_PAGES;
+  }
+
+  /**
+   * The next page of entries, or null once there are none left.
+   *
+   * Calls are serialized: a caller that fires several without awaiting gets successive pages
+   * rather than a race over the cursor's position.
+   */
+  next(): Promise<Entry[] | null> {
+    let result = this.#tail.then(() => this.#nextPage());
+    this.#tail = result.catch(() => {});
+    return result;
+  }
+
+  async #nextPage(): Promise<Entry[] | null> {
+    if (this.#exhausted) return null;
+
+    let { provider, fetchPage, buildEntries, authorize } = this.#options;
+    let pageToken = this.#pageToken;
+    let entries: Entry[];
+
+    for (let fetched = 1; ; fetched++) {
+      let previousToken = pageToken;
+      let page = await fetchPage(pageToken);
+      pageToken = page.nextPageToken;
+
+      // A provider that hands back the token we just sent would page forever.
+      if (pageToken !== undefined && pageToken === previousToken) {
+        throw new Error(`${provider} returned a repeated page token.`);
+      }
+
+      entries = await buildEntries(page.items);
+      if (entries.length > 0) break;
+
+      if (pageToken === undefined) {
+        this.#pageToken = undefined;
+        this.#exhausted = true;
+        return null;
+      }
+      if (fetched >= this.#maxEmptyPages) {
+        throw new Error(
+          `${provider} returned ${fetched} pages with no usable results.`);
+      }
+    }
+
+    // Advance only once the page has been approved. A denied read leaves the cursor where it was,
+    // so retrying re-offers the same page instead of silently skipping over it.
+    await authorize(entries);
+    this.#pageToken = pageToken;
+    this.#exhausted = pageToken === undefined;
+    return entries;
+  }
+}

--- a/packages/gatekeeper-google/src/drive-api.ts
+++ b/packages/gatekeeper-google/src/drive-api.ts
@@ -1,0 +1,113 @@
+// Google Drive API client.
+//
+// Drive is reached from the resource configurator today, and from the Drive session later. Both go
+// through here so neither bypasses the 401 refresh and 429 backoff in `fetchWithAuthRetry`.
+
+import { AccessTokenProvider, fetchWithAuthRetry } from "./auth-retry";
+
+const DRIVE_API_BASE = "https://www.googleapis.com/drive/v3";
+
+/** The subset of Drive's file resource this gatekeeper asks for. */
+export type DriveFile = {
+  id: string;
+  name: string;
+  mimeType?: string;
+  modifiedTime?: string;
+  owners?: { displayName?: string; emailAddress?: string }[];
+};
+
+/** Drive returns only the fields it is asked for, so the mask and `DriveFile` travel together. */
+export const DRIVE_FILE_FIELDS =
+  "nextPageToken,files(id,name,mimeType,modifiedTime,owners(displayName,emailAddress))";
+
+/**
+ * What to match. Every field is optional and they are AND-ed.
+ *
+ * Callers pass values, never query syntax: `q` is assembled here so nothing user-supplied can
+ * introduce a clause of its own.
+ */
+export type DriveFileQuery = {
+  mimeType?: string;
+  nameContains?: string;
+};
+
+export type DriveListFilesOptions = DriveFileQuery & {
+  pageSize?: number;
+  pageToken?: string;
+  orderBy?: string;
+};
+
+export type DriveFileList = {
+  files: DriveFile[];
+  /** Absent on the last page. */
+  nextPageToken?: string;
+};
+
+/**
+ * Drive refused because the Drive API is not enabled on this OAuth project.
+ *
+ * Distinguished from other 403s because it is the deployment admin's to fix, not the user's, and
+ * callers word that differently.
+ */
+export class DriveApiDisabledError extends Error {}
+
+/**
+ * Escapes a value for interpolation into a Drive `q` string literal.
+ *
+ * Drive literals are single-quoted, and Google documents `\'` and `\\` as the escapes. Without
+ * this, a file name containing a quote could close the literal and append clauses of its own —
+ * which for a scoped binding means reading outside the scope.
+ */
+export function escapeDriveQueryLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+/** Assembles a Drive `q`. Trashed files are always excluded. */
+export function buildDriveQuery({ mimeType, nameContains }: DriveFileQuery): string {
+  let clauses = ["trashed = false"];
+  if (mimeType) clauses.push(`mimeType = '${escapeDriveQueryLiteral(mimeType)}'`);
+  let name = nameContains?.trim();
+  if (name) clauses.push(`name contains '${escapeDriveQueryLiteral(name)}'`);
+  return clauses.join(" and ");
+}
+
+export class DriveApi {
+  constructor(private getAccessToken: AccessTokenProvider) {}
+
+  /** One page of matching files, most recently modified first by default. */
+  async listFiles(options: DriveListFilesOptions = {}): Promise<DriveFileList> {
+    let params = new URLSearchParams({
+      q: buildDriveQuery(options),
+      pageSize: String(options.pageSize ?? 100),
+      fields: DRIVE_FILE_FIELDS,
+      orderBy: options.orderBy ?? "modifiedTime desc",
+      // A file on a shared drive is an ordinary result as far as a binding is concerned.
+      supportsAllDrives: "true",
+      includeItemsFromAllDrives: "true",
+    });
+    if (options.pageToken) params.set("pageToken", options.pageToken);
+
+    let body = await this.#get<{ files?: DriveFile[]; nextPageToken?: string }>("/files", params);
+    return {
+      files: body.files ?? [],
+      ...(body.nextPageToken ? { nextPageToken: body.nextPageToken } : {}),
+    };
+  }
+
+  async #get<T>(path: string, params: URLSearchParams): Promise<T> {
+    let response = await fetchWithAuthRetry(
+      `${DRIVE_API_BASE}${path}?${params}`,
+      { headers: { Accept: "application/json" } },
+      this.getAccessToken);
+
+    if (!response.ok) {
+      let text = await response.text();
+      if (response.status === 403 && text.includes("Google Drive API has not been used")) {
+        throw new DriveApiDisabledError(
+          "the Google Drive API is not enabled for this OAuth project");
+      }
+      throw new Error(`Google Drive API request failed: ${response.status} ${text}`);
+    }
+    return await response.json<T>();
+  }
+}

--- a/packages/gatekeeper-google/src/drive-api.ts
+++ b/packages/gatekeeper-google/src/drive-api.ts
@@ -52,6 +52,61 @@ export type DriveFileList = {
 export class DriveApiDisabledError extends Error {}
 
 /**
+ * How much of an error body we are willing to parse.
+ *
+ * The body is never surfaced, so this only caps the work done to read a machine-readable reason
+ * out of it.
+ */
+const MAX_ERROR_BODY_CHARS = 4096;
+
+/** Google's `reason` for "the API is not enabled on this project". */
+const API_DISABLED_REASON = "accessNotConfigured";
+
+/**
+ * Google's error envelope. Only `reason` is read: it is the stable machine-readable field, whereas
+ * `message` is prose that can quote the request back.
+ */
+type GoogleErrorPayload = {
+  error?: { errors?: { reason?: unknown }[] };
+};
+
+/**
+ * Google's own `reason` for a failed response, if it declared one.
+ *
+ * Tolerant by design — an error path must not throw a second error — so a body that is truncated,
+ * not JSON, or shaped differently simply yields no reason.
+ */
+async function errorReason(response: Response): Promise<string | undefined> {
+  let text = (await response.text().catch(() => "")).slice(0, MAX_ERROR_BODY_CHARS);
+  let payload: GoogleErrorPayload;
+  try {
+    payload = JSON.parse(text) as GoogleErrorPayload;
+  } catch {
+    return undefined;
+  }
+  let reason = payload.error?.errors?.[0]?.reason;
+  // Constrained to an identifier so a reason cannot smuggle arbitrary text into the message.
+  return typeof reason === "string" && /^\w{1,64}$/.test(reason) ? reason : undefined;
+}
+
+/**
+ * Turns a failed Drive response into an error safe to hand back.
+ *
+ * Only the status and Google's `reason` travel with it. The response body is deliberately dropped:
+ * Drive quotes the `q` it was sent back in some messages, and this error crosses the configurator
+ * RPC boundary into a UI that may forward it to the error reporter.
+ */
+async function driveError(response: Response): Promise<Error> {
+  let reason = await errorReason(response);
+  if (response.status === 403 && reason === API_DISABLED_REASON) {
+    return new DriveApiDisabledError(
+      "the Google Drive API is not enabled for this OAuth project");
+  }
+  return new Error(
+    `Google Drive API request failed: ${response.status}${reason ? ` (${reason})` : ""}`);
+}
+
+/**
  * Escapes a value for interpolation into a Drive `q` string literal.
  *
  * Drive literals are single-quoted, and Google documents `\'` and `\\` as the escapes. Without
@@ -100,14 +155,7 @@ export class DriveApi {
       { headers: { Accept: "application/json" } },
       this.getAccessToken);
 
-    if (!response.ok) {
-      let text = await response.text();
-      if (response.status === 403 && text.includes("Google Drive API has not been used")) {
-        throw new DriveApiDisabledError(
-          "the Google Drive API is not enabled for this OAuth project");
-      }
-      throw new Error(`Google Drive API request failed: ${response.status} ${text}`);
-    }
+    if (!response.ok) throw await driveError(response);
     return await response.json<T>();
   }
 }

--- a/packages/gatekeeper-google/src/gmail-validate.ts
+++ b/packages/gatekeeper-google/src/gmail-validate.ts
@@ -1,0 +1,97 @@
+/**
+ * Input limits and validators for Gmail-facing arguments.
+ *
+ * Separate from `google.ts` so the resource-URL parser and the session both reach them without a
+ * cycle, and so the boundaries are unit-testable.
+ */
+
+/** Maximum recipients on a single outbound message. */
+export const MAX_GMAIL_RECIPIENTS = 100;
+/** Maximum subject length, in UTF-8 bytes (RFC 5322 line limit). */
+export const MAX_GMAIL_SUBJECT_BYTES = 998;
+/** Maximum body length, in UTF-8 bytes. */
+export const MAX_GMAIL_BODY_BYTES = 64 * 1024;
+/** Maximum search query length, in UTF-8 bytes. */
+export const MAX_GMAIL_QUERY_BYTES = 4096;
+/** Maximum email address length, in UTF-8 bytes (RFC 3696 path limit). */
+export const MAX_GMAIL_ADDRESS_BYTES = 320;
+/** Maximum label name length, in UTF-8 bytes. */
+export const MAX_GMAIL_LABEL_BYTES = 320;
+/** Maximum messages returned for a single thread. */
+export const MAX_GMAIL_VISIBLE_THREAD_MESSAGES = 100;
+
+const utf8Bytes = (value: string) => new TextEncoder().encode(value).byteLength;
+
+/**
+ * Rejects a query whose quotes or grouping delimiters are unbalanced.
+ *
+ * A binding may restrict a session to a base query, which is then combined with the caller's as
+ * `(base) (caller)`. An unterminated quote or bracket in either would swallow the other's
+ * parentheses and let the caller escape the restriction.
+ */
+export function validateGmailQueryForGrouping(query: string): void {
+  if (utf8Bytes(query) > MAX_GMAIL_QUERY_BYTES) {
+    throw new Error(`Gmail search query must be at most ${MAX_GMAIL_QUERY_BYTES} bytes.`);
+  }
+  const stack: string[] = [];
+  let quote: string | undefined;
+  let escaped = false;
+  for (const char of query) {
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (quote) {
+      if (char === quote) quote = undefined;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === "(" || char === "{") {
+      stack.push(char);
+    } else if (char === ")" || char === "}") {
+      if (stack.pop() !== (char === ")" ? "(" : "{")) {
+        throw new Error("Gmail query has mismatched grouping delimiters.");
+      }
+    }
+  }
+  if (quote || stack.length > 0) {
+    throw new Error("Gmail query has unterminated grouping or quotes.");
+  }
+}
+
+/** Rejects a label name that is empty or over the byte limit. */
+export function validateGmailLabelName(labelName: string): void {
+  if (!labelName || utf8Bytes(labelName) > MAX_GMAIL_LABEL_BYTES) {
+    throw new Error(`Gmail label name must be between 1 and ${MAX_GMAIL_LABEL_BYTES} bytes.`);
+  }
+}
+
+/** Rejects an address that is empty or over the byte limit. */
+export function validateGmailAddress(address: string): void {
+  if (!address || utf8Bytes(address) > MAX_GMAIL_ADDRESS_BYTES) {
+    throw new Error(`Email address must be at most ${MAX_GMAIL_ADDRESS_BYTES} bytes.`);
+  }
+}
+
+/** Rejects a body over the byte limit. */
+export function validateGmailBody(body: string): void {
+  if (utf8Bytes(body) > MAX_GMAIL_BODY_BYTES) {
+    throw new Error(`Email body must be at most ${MAX_GMAIL_BODY_BYTES} bytes.`);
+  }
+}
+
+/** Rejects a recipient list that is empty or over the count limit. */
+export function validateGmailRecipientCount(to: readonly string[]): void {
+  if (to.length === 0 || to.length > MAX_GMAIL_RECIPIENTS) {
+    throw new Error(`Email must have between 1 and ${MAX_GMAIL_RECIPIENTS} recipients.`);
+  }
+}
+
+/** Rejects any out-of-bounds field of an outbound message. */
+export function validateOutboundInput(to: string[], subject: string, body: string): void {
+  validateGmailRecipientCount(to);
+  for (const address of to) validateGmailAddress(address);
+  if (utf8Bytes(subject) > MAX_GMAIL_SUBJECT_BYTES) {
+    throw new Error(`Email subject must be at most ${MAX_GMAIL_SUBJECT_BYTES} UTF-8 bytes.`);
+  }
+  validateGmailBody(body);
+}

--- a/packages/gatekeeper-google/src/google-configurators.ts
+++ b/packages/gatekeeper-google/src/google-configurators.ts
@@ -94,7 +94,9 @@ async function listDriveFiles(
     ({ files } = await drive.listFiles({ mimeType, nameContains: query }));
   } catch (error) {
     if (error instanceof DriveApiDisabledError) {
-      throw new Error(`${resourceName} search requires ${error.message}.`, { cause: error });
+      throw new Error(
+        `${resourceName} search requires the Google Drive API to be enabled for this OAuth ` +
+        "project.", { cause: error });
     }
     throw error;
   }

--- a/packages/gatekeeper-google/src/google-configurators.ts
+++ b/packages/gatekeeper-google/src/google-configurators.ts
@@ -3,6 +3,8 @@ import { validateRpc } from "capnweb-validate";
 import { BigQueryApi } from "./bigquery-api";
 import { GoogleCalendarApi } from "./calendar-api";
 import { GoogleAccessToken } from "./google-api";
+import { AccessTokenProvider, AccessTokenRequest } from "./auth-retry";
+import { DriveApi, DriveApiDisabledError } from "./drive-api";
 import type { BigQueryConfiguratorRpc } from "./configurator/bigquery-configurator-types";
 import type { CalendarConfiguratorRpc } from "./configurator/calendar-configurator-types";
 import type { GmailConfiguratorRpc } from "./configurator/gmail-configurator-types";
@@ -10,7 +12,13 @@ import type { GoogleDocConfiguratorRpc } from "./configurator/google-doc-configu
 import type { GoogleSheetsConfiguratorRpc } from "./configurator/google-sheets-configurator-types";
 
 type ConfiguratorOption = { value: string; title: string; subtitle?: string; meta?: string };
-const googleTokenGetters = new WeakMap<object, () => Promise<GoogleAccessToken>>();
+/**
+ * Mints an access token for a configurator, forwarding `AccessTokenRequest` to the `UserAccount`
+ * so a client built on it can heal a 401 by asking for a fresh one.
+ */
+type ConfiguratorTokenGetter = (opts?: AccessTokenRequest) => Promise<GoogleAccessToken>;
+
+const googleTokenGetters = new WeakMap<object, ConfiguratorTokenGetter>();
 const calendarConfiguratorCaches = new WeakMap<object, Promise<ConfiguratorOption[]>>();
 const bigQueryConfiguratorCaches = new WeakMap<object, Map<string, ConfiguratorOption[]>>();
 const BIGQUERY_CONFIGURATOR_CACHE_MAX_ENTRIES = 200;
@@ -21,11 +29,19 @@ function bigQueryConfiguratorListOptions(query: string) {
   return query.trim() ? BIGQUERY_CONFIGURATOR_SEARCH_LIST_OPTIONS : BIGQUERY_CONFIGURATOR_EMPTY_LIST_OPTIONS;
 }
 
-function googleToken(target: object): Promise<GoogleAccessToken> {
+function googleToken(target: object, opts?: AccessTokenRequest): Promise<GoogleAccessToken> {
   let getToken = googleTokenGetters.get(target);
   if (!getToken) throw new Error("Google configurator is not initialized.");
-  return getToken();
+  return getToken(opts);
 }
+
+/** A provider that re-asks on every call, so `fetchWithAuthRetry` can refresh a rejected token. */
+function googleTokenProvider(target: object): AccessTokenProvider {
+  return async opts => (await googleToken(target, opts)).token;
+}
+
+// TODO: BigQuery and Calendar freeze one token for the configurator's lifetime, so their clients
+// cannot heal a 401. Give them `googleTokenProvider` too.
 
 async function bigQueryApi(target: object): Promise<BigQueryApi> {
   let token = await googleToken(target);
@@ -71,53 +87,25 @@ async function listDriveFiles(
   mimeType: string,
   resourceName: string,
 ): Promise<ConfiguratorOption[]> {
-  let token = await googleToken(target);
-  let url = new URL("https://www.googleapis.com/drive/v3/files");
-  url.searchParams.set("pageSize", "100");
-  url.searchParams.set("fields", "files(id,name,modifiedTime,owners(displayName,emailAddress))");
-  url.searchParams.set("orderBy", "modifiedTime desc");
-  url.searchParams.set("supportsAllDrives", "true");
-  url.searchParams.set("includeItemsFromAllDrives", "true");
-  let q = `mimeType = '${mimeType}' and trashed = false`;
-  let trimmed = query.trim();
-  if (trimmed) {
-    // Drive query strings use single-quoted literals; Google documents escaping ' as \'.
-    let escaped = trimmed.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
-    q += ` and name contains '${escaped}'`;
-  }
-  url.searchParams.set("q", q);
+  let drive = new DriveApi(googleTokenProvider(target));
 
-  let response = await fetch(url.toString(), {
-    headers: { "Authorization": `Bearer ${token.token}` },
-  });
-  if (!response.ok) {
-    let text = await response.text();
-    if (response.status === 403 && text.includes("Google Drive API has not been used")) {
-      throw new Error(
-        `${resourceName} search requires the Google Drive API to be enabled for this OAuth project.`,
-      );
+  let files;
+  try {
+    ({ files } = await drive.listFiles({ mimeType, nameContains: query }));
+  } catch (error) {
+    if (error instanceof DriveApiDisabledError) {
+      throw new Error(`${resourceName} search requires ${error.message}.`, { cause: error });
     }
-    throw new Error(`Failed to search ${resourceName}: ${response.status} ${text}`);
+    throw error;
   }
-  let body = await response.json<{
-    files?: {
-      id: string,
-      name: string,
-      modifiedTime?: string,
-      owners?: { displayName?: string, emailAddress?: string }[],
-    }[],
-  }>();
-  return (body.files ?? []).map(file => {
+
+  return files.map(file => {
     let owner = file.owners?.[0];
-    let subtitleParts = [
+    let subtitle = [
       owner?.displayName ?? owner?.emailAddress,
       file.modifiedTime ? `Modified ${new Date(file.modifiedTime).toLocaleDateString()}` : undefined,
-    ].filter(Boolean);
-    return {
-      value: file.id,
-      title: file.name,
-      subtitle: subtitleParts.join(" · "),
-    };
+    ].filter(Boolean).join(" · ");
+    return { value: file.id, title: file.name, subtitle };
   });
 }
 

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -47,6 +47,16 @@ import GOOGLE_SHEETS_CONFIGURATOR_HTML from "./generated/google-sheets-configura
 import GOOGLE_LOGO_SVG from "./google-logo.svg";
 import { obsContext } from "./observability.js";
 import { AccessTokenCache, AccessTokenRequest, ACCESS_TOKEN_EXPIRY_SAFETY_MS } from "./auth-retry";
+import {
+  MAX_GMAIL_VISIBLE_THREAD_MESSAGES, validateGmailAddress, validateGmailBody,
+  validateGmailQueryForGrouping, validateGmailRecipientCount, validateOutboundInput,
+} from "./gmail-validate";
+import {
+  AUTH_SCOPES, BIGQUERY_HOST, BIGQUERY_RESOURCE, GMAIL_RESOURCE, GOOGLE_CALENDAR_RESOURCE,
+  GOOGLE_DOC_RESOURCE, GOOGLE_SHEETS_RESOURCE, LEGACY_GRANTED_RESOURCE_URL_PATTERNS,
+  RESOURCE_BY_KIND, SUPPORTED_RESOURCES, grantedResourcesFromScopes, parseResourceUrl,
+  resourceUrlPatternsToOAuthScopes,
+} from "./resources";
 
 // Vendor id = GATEKEEPER_<NAME> binding suffix (lowercased).
 const VENDOR_ID = "google";
@@ -128,38 +138,6 @@ function toLabelObjects(labelIds: string[], labelMap: Map<string, string>): Gmai
   });
 }
 
-function validateGmailQueryForGrouping(query: string): void {
-  if (new TextEncoder().encode(query).byteLength > MAX_GMAIL_QUERY_BYTES) {
-    throw new Error(`Gmail search query must be at most ${MAX_GMAIL_QUERY_BYTES} bytes.`);
-  }
-  const stack: string[] = [];
-  let quote: string | undefined;
-  let escaped = false;
-  for (const char of query) {
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (char === '\\') {
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      if (char === quote) quote = undefined;
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-    } else if (char === '(' || char === '{') {
-      stack.push(char);
-    } else if (char === ')' || char === '}') {
-      const expected = char === ')' ? '(' : '{';
-      if (stack.pop() !== expected) throw new Error("Gmail query has mismatched grouping delimiters.");
-    }
-  }
-  if (quote || stack.length > 0) throw new Error("Gmail query has unterminated grouping or quotes.");
-}
-
 function getBaseUrl(env: Env) {
   return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/google");
 }
@@ -209,140 +187,6 @@ const NOT_CONFIGURED_HTML = `<!DOCTYPE html>
     </div>
   </body>
 </html>`;
-
-// OAuth scopes we always request, used to identify the account (name, email, avatar). Not tied to
-// any resource type.
-const IDENTITY_SCOPES = [
-  "openid",
-  "https://www.googleapis.com/auth/userinfo.profile",
-  "https://www.googleapis.com/auth/userinfo.email",
-];
-
-// Minimal scopes for sign-in only (verify the user's email). Used when connecting in "auth" mode;
-// the resulting grant is transient. (Same as IDENTITY_SCOPES — sign-in needs no resource scopes.)
-const AUTH_SCOPES = IDENTITY_SCOPES;
-
-const BIGQUERY_HOST = "bigquery.googleapis.com";
-
-const GMAIL_RESOURCE: SupportedResource = {
-  urlPattern: "https://mail.google.com/*",
-  title: "Gmail Mailbox",
-  description: "Read emails and apply labels.",
-  grantable: true,
-};
-
-const GOOGLE_DOC_RESOURCE: SupportedResource = {
-  urlPattern: "https://docs.google.com/document/d/:docId/*",
-  title: "Google Doc",
-  description:
-      "Read and edit documents you choose.",
-  grantable: true,
-};
-
-const GOOGLE_SHEETS_RESOURCE: SupportedResource = {
-  urlPattern: "https://docs.google.com/spreadsheets/d/:spreadsheetId/*",
-  title: "Google Spreadsheet",
-  description: "Read values from a spreadsheet you choose.",
-  grantable: true,
-};
-
-const GOOGLE_CALENDAR_RESOURCE: SupportedResource = {
-  urlPattern: "https://calendar.google.com/calendar/:calendarId/*",
-  title: "Google Calendar",
-  description:
-      "Read and manage a Google Calendar.",
-  grantable: true,
-};
-
-const BIGQUERY_RESOURCE: SupportedResource = {
-  urlPattern: `https://${BIGQUERY_HOST}/:projectId/*`,
-  title: "BigQuery",
-  description: "Choose a Google Cloud project, then optionally narrow access to a dataset or table.",
-  grantable: true,
-};
-
-// Accounts connected before per-resource scope tracking received scopes for exactly these
-// resources.
-const LEGACY_GRANTED_RESOURCE_URL_PATTERNS = [
-  GMAIL_RESOURCE.urlPattern,
-  GOOGLE_DOC_RESOURCE.urlPattern,
-  BIGQUERY_RESOURCE.urlPattern,
-];
-
-const RESOURCE_SCOPES: {resource: SupportedResource, scopes: string[]}[] = [
-  {
-    resource: GMAIL_RESOURCE,
-    scopes: [
-      "https://www.googleapis.com/auth/gmail.labels",
-      "https://www.googleapis.com/auth/gmail.modify",
-    ],
-  },
-  {
-    resource: GOOGLE_DOC_RESOURCE,
-    scopes: [
-      "https://www.googleapis.com/auth/documents",
-      // Read-only Drive file metadata, used to power the doc picker when connecting a Google Doc.
-      "https://www.googleapis.com/auth/drive.metadata.readonly",
-    ],
-  },
-  {
-    resource: GOOGLE_SHEETS_RESOURCE,
-    scopes: [
-      "https://www.googleapis.com/auth/spreadsheets.readonly",
-      // Read-only Drive file metadata, used to power the spreadsheet picker.
-      "https://www.googleapis.com/auth/drive.metadata.readonly",
-    ],
-  },
-  {
-    resource: GOOGLE_CALENDAR_RESOURCE,
-    scopes: [
-      // Read-only calendar list, used to power the calendar picker when connecting a calendar.
-      "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
-      "https://www.googleapis.com/auth/calendar.events",
-    ],
-  },
-  {
-    resource: BIGQUERY_RESOURCE,
-    scopes: [
-      // `bigquery` (not `bigquery.readonly`): dry-runs go through `jobs.insert` for scope
-      // enforcement, which `readonly` doesn't permit. Read-only is enforced at the API layer.
-      "https://www.googleapis.com/auth/bigquery",
-    ],
-  },
-];
-
-const SUPPORTED_RESOURCES: SupportedResource[] = RESOURCE_SCOPES.map(entry => entry.resource);
-
-function validateResourceUrlPatterns(resourceUrlPatterns?: string[]): void {
-  if (resourceUrlPatterns === undefined) return;
-
-  let knownPatterns = new Set(RESOURCE_SCOPES.map(entry => entry.resource.urlPattern));
-  let unknownPatterns = resourceUrlPatterns.filter(pattern => !knownPatterns.has(pattern));
-  if (unknownPatterns.length > 0) {
-    throw new Error(`Unknown grantable resource URL pattern(s): ${unknownPatterns.join(", ")}`);
-  }
-}
-
-// The OAuth scopes to request for the given grantable resource `urlPattern`s.
-function resourceUrlPatternsToOAuthScopes(resourceUrlPatterns?: string[]): string[] {
-  validateResourceUrlPatterns(resourceUrlPatterns);
-
-  let scopes = new Set<string>(IDENTITY_SCOPES);
-  for (let entry of RESOURCE_SCOPES) {
-    if (resourceUrlPatterns === undefined ||
-        resourceUrlPatterns.includes(entry.resource.urlPattern)) {
-      for (let scope of entry.scopes) scopes.add(scope);
-    }
-  }
-  return [...scopes];
-}
-
-function grantedResourcesFromScopes(grantedOAuthScopes: string[]): string[] {
-  let granted = new Set(grantedOAuthScopes);
-  return RESOURCE_SCOPES
-      .filter(entry => entry.scopes.every(scope => granted.has(scope)))
-      .map(entry => entry.resource.urlPattern);
-}
 
 const GOOGLE_LOGO_URL = `data:image/svg+xml,${encodeURIComponent(GOOGLE_LOGO_SVG)}`;
 
@@ -839,126 +683,43 @@ export class GatekeeperUserImpl extends WorkerEntrypoint<Env, GatekeeperUserImpl
     class: DurableObjectClass<Gatekeeper<any>>;
     resource: SupportedResource;
   }> {
-    let parsed = new URL(url);
+    let target = parseResourceUrl(url);
+    let resource = RESOURCE_BY_KIND[target.kind];
+    let userObjectId = this.ctx.props.userObjectId;
 
-    if (parsed.hostname === "docs.google.com" &&
-        parsed.pathname.startsWith("/document/d/")) {
-      // Extract document ID from URL path: /document/d/{documentId}/...
-      let documentId = parsed.pathname.split("/")[3];
-      if (!documentId) {
-        throw new Error("Invalid Google Docs URL: no document ID found");
+    switch (target.kind) {
+      case "gmail": {
+        let props: GmailGatekeeperImplProps = {
+          userObjectId, searchQuery: target.searchQuery, labelName: target.labelName,
+        };
+        return {class: this.ctx.exports.GmailGatekeeperImpl({props}), resource};
       }
-      let props: GoogleDocGatekeeperImplProps = {
-        userObjectId: this.ctx.props.userObjectId,
-        documentId,
-      };
-      return {class: this.ctx.exports.GoogleDocGatekeeperImpl({props}), resource: GOOGLE_DOC_RESOURCE};
+      case "doc": {
+        let props: GoogleDocGatekeeperImplProps = {userObjectId, documentId: target.documentId};
+        return {class: this.ctx.exports.GoogleDocGatekeeperImpl({props}), resource};
+      }
+      case "sheets": {
+        let props: GoogleSheetsGatekeeperImplProps = {
+          userObjectId, spreadsheetId: target.spreadsheetId,
+        };
+        return {class: this.ctx.exports.GoogleSheetsGatekeeperImpl({props}), resource};
+      }
+      case "calendar": {
+        let props: GoogleCalendarGatekeeperImplProps = {
+          userObjectId, calendarId: target.calendarId, availabilityMode: target.availabilityMode,
+        };
+        return {class: this.ctx.exports.GoogleCalendarGatekeeperImpl({props}), resource};
+      }
+      case "bigquery": {
+        let props: BigQueryGatekeeperImplProps = {
+          userObjectId,
+          scopedProjectId: target.projectId,
+          scopedDatasetId: target.datasetId,
+          scopedTableId: target.tableId,
+        };
+        return {class: this.ctx.exports.BigQueryGatekeeperImpl({props}), resource};
+      }
     }
-
-    if (parsed.hostname === "docs.google.com" &&
-        parsed.pathname.startsWith("/spreadsheets/d/")) {
-      let spreadsheetId = parsed.pathname.split("/")[3];
-      if (!spreadsheetId) {
-        throw new Error("Invalid Google Sheets URL: no spreadsheet ID found");
-      }
-      let props: GoogleSheetsGatekeeperImplProps = {
-        userObjectId: this.ctx.props.userObjectId,
-        spreadsheetId,
-      };
-      return {
-        class: this.ctx.exports.GoogleSheetsGatekeeperImpl({ props }),
-        resource: GOOGLE_SHEETS_RESOURCE,
-      };
-    }
-
-    if (parsed.hostname === "calendar.google.com" && parsed.pathname.startsWith("/calendar/")) {
-      let calendarId = decodeURIComponent(parsed.pathname.split("/")[2] ?? "");
-      if (!calendarId) {
-        throw new Error("Invalid Google Calendar URL: no calendar ID found");
-      }
-      if (calendarId === "primary") {
-        throw new Error(
-          "Google Calendar bindings must use a stable calendar ID, not the account-relative " +
-          "\"primary\" alias.");
-      }
-      // Default to the least-privilege scope unless the URL explicitly opts into all calendars.
-      let availabilityMode: CalendarAvailabilityMode =
-          parsed.searchParams.get("availability") === "allVisible" ? "allVisible" : "thisCalendar";
-      let props: GoogleCalendarGatekeeperImplProps = {
-        userObjectId: this.ctx.props.userObjectId,
-        calendarId,
-        availabilityMode,
-      };
-      return {
-        class: this.ctx.exports.GoogleCalendarGatekeeperImpl({props}),
-        resource: GOOGLE_CALENDAR_RESOURCE,
-      };
-    }
-
-    if (parsed.hostname === BIGQUERY_HOST) {
-      if (parsed.protocol !== "https:") {
-        throw new Error(`BigQuery resource URLs must use https: ${url}`);
-      }
-      if (parsed.search || parsed.hash) {
-        throw new Error("BigQuery resource URLs must not include query strings or fragments.");
-      }
-
-      // Synthetic path: /<projectId>/<datasetId>/<tableId> (each segment optional after the first).
-      let segments = parsed.pathname.replace(/^\/+|\/+$/g, "").split("/").filter(Boolean)
-          .map(segment => decodeURIComponent(segment));
-      if (segments.length > 3) {
-        throw new Error(
-            "BigQuery resource URLs must be /<projectId>, /<projectId>/<datasetId>, " +
-            "or /<projectId>/<datasetId>/<tableId>.");
-      }
-      let projectId = segments[0] || undefined;
-      let datasetId = segments[1] || undefined;
-      let tableId = segments[2] || undefined;
-      if (!projectId) {
-        throw new Error("BigQuery resource URLs must include a project ID.");
-      }
-      if (tableId && !datasetId) {
-        throw new Error("Cannot scope to a table without specifying a dataset.");
-      }
-
-      let props: BigQueryGatekeeperImplProps = {
-        userObjectId: this.ctx.props.userObjectId,
-        scopedProjectId: projectId,
-        scopedDatasetId: datasetId,
-        scopedTableId: tableId,
-      };
-      return {
-        class: this.ctx.exports.BigQueryGatekeeperImpl({props}),
-        resource: BIGQUERY_RESOURCE,
-      };
-    }
-
-    // Default: Gmail
-    let props: GmailGatekeeperImplProps = {...this.ctx.props};
-
-    // Parse the URL hash to extract a search or label scope. Keep labels as
-    // opaque names; startSession resolves them to Gmail label IDs so label text
-    // can never be interpreted as search syntax.
-    let hash = parsed.hash;
-    if (hash.startsWith("#search/")) {
-      // Gmail's own UI encodes spaces in hash searches as `+`, while
-      // decodeURIComponent() only decodes `%20`. Normalize both forms.
-      const encodedQuery = hash.slice("#search/".length).replace(/\+/g, " ");
-      const query = decodeURIComponent(encodedQuery);
-      validateGmailQueryForGrouping(query);
-      props.searchQuery = query;
-    } else if (hash.startsWith("#label/")) {
-      const labelName = decodeURIComponent(hash.slice("#label/".length));
-      if (!labelName || new TextEncoder().encode(labelName).byteLength > 320) {
-        throw new Error("Gmail label name must be between 1 and 320 bytes.");
-      }
-      props.labelName = labelName;
-    } else if (hash && hash !== "#inbox") {
-      throw new Error(
-        "Unsupported Gmail view. Connect the inbox, an explicit search, or an explicit label.");
-    }
-
-    return {class: this.ctx.exports.GmailGatekeeperImpl({props}), resource: GMAIL_RESOURCE};
   }
 
   async startResourceConfigurator(
@@ -1268,29 +1029,6 @@ type GmailSessionContext = {
 
 // ── GmailSessionImpl ────────────────────────────────────────────────
 
-const MAX_GMAIL_RECIPIENTS = 100;
-const MAX_GMAIL_SUBJECT_BYTES = 998;
-const MAX_GMAIL_BODY_BYTES = 64 * 1024;
-const MAX_GMAIL_QUERY_BYTES = 4096;
-const MAX_GMAIL_ADDRESS_BYTES = 320;
-const MAX_GMAIL_VISIBLE_THREAD_MESSAGES = 100;
-
-function validateOutboundInput(to: string[], subject: string, body: string): void {
-  if (to.length === 0 || to.length > MAX_GMAIL_RECIPIENTS) {
-    throw new Error(`Email must have between 1 and ${MAX_GMAIL_RECIPIENTS} recipients.`);
-  }
-  if (to.some(address => address.length === 0 ||
-      new TextEncoder().encode(address).byteLength > MAX_GMAIL_ADDRESS_BYTES)) {
-    throw new Error("Invalid recipient address length.");
-  }
-  if (new TextEncoder().encode(subject).byteLength > MAX_GMAIL_SUBJECT_BYTES) {
-    throw new Error(`Email subject must be at most ${MAX_GMAIL_SUBJECT_BYTES} UTF-8 bytes.`);
-  }
-  if (new TextEncoder().encode(body).byteLength > MAX_GMAIL_BODY_BYTES) {
-    throw new Error(`Email body must be at most ${MAX_GMAIL_BODY_BYTES} bytes.`);
-  }
-}
-
 @validateRpc()
 class GmailSessionImpl extends RpcTarget implements GmailSession {
   #ctx: GmailSessionContext;
@@ -1553,9 +1291,7 @@ class GmailThreadStub extends RpcTarget implements GmailThread {
   }
 
   async messagesVisibleTo(address: string): Promise<GmailMessage[]> {
-    if (new TextEncoder().encode(address).byteLength > MAX_GMAIL_ADDRESS_BYTES) {
-      throw new Error(`Email address must be at most ${MAX_GMAIL_ADDRESS_BYTES} bytes.`);
-    }
+    validateGmailAddress(address);
     const [normalizedAddress] = normalizeEmailRecipients([address]);
     const thread = await this.#ctx.gmailApi.getThread(this.#threadId);
 
@@ -1703,9 +1439,7 @@ class GmailMessageStub extends RpcTarget implements GmailMessage {
   }
 
   async reply(body: string): Promise<void> {
-    if (new TextEncoder().encode(body).byteLength > MAX_GMAIL_BODY_BYTES) {
-      throw new Error(`Email body must be at most ${MAX_GMAIL_BODY_BYTES} bytes.`);
-    }
+    validateGmailBody(body);
     const original = await this.#getRaw();
     await this.#ctx.approvalQueue.authorizeObservation({
       title: "Read message headers to prepare reply",
@@ -1730,9 +1464,7 @@ class GmailMessageStub extends RpcTarget implements GmailMessage {
   }
 
   async replyAll(body: string): Promise<void> {
-    if (new TextEncoder().encode(body).byteLength > MAX_GMAIL_BODY_BYTES) {
-      throw new Error(`Email body must be at most ${MAX_GMAIL_BODY_BYTES} bytes.`);
-    }
+    validateGmailBody(body);
     const original = await this.#getRaw();
     await this.#ctx.approvalQueue.authorizeObservation({
       title: "Read message headers to prepare reply-all",
@@ -1758,12 +1490,8 @@ class GmailMessageStub extends RpcTarget implements GmailMessage {
 
   async forward(to: string[], body?: string): Promise<void> {
     const normalizedTo = normalizeEmailRecipients(to);
-    if (normalizedTo.length === 0 || normalizedTo.length > MAX_GMAIL_RECIPIENTS) {
-      throw new Error(`Email must have between 1 and ${MAX_GMAIL_RECIPIENTS} recipients.`);
-    }
-    if (new TextEncoder().encode(body ?? '').byteLength > MAX_GMAIL_BODY_BYTES) {
-      throw new Error(`Email body must be at most ${MAX_GMAIL_BODY_BYTES} bytes.`);
-    }
+    validateGmailRecipientCount(normalizedTo);
+    validateGmailBody(body ?? '');
     const original = await this.#getRaw();
     await this.#ctx.approvalQueue.authorizeObservation({
       title: "Read message to prepare forward",

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -57,6 +57,8 @@ import {
   RESOURCE_BY_KIND, SUPPORTED_RESOURCES, grantedResourcesFromScopes, parseResourceUrl,
   resourceUrlPatternsToOAuthScopes,
 } from "./resources";
+import { ObserverCheck, ObserverTracker } from "./observers";
+import { CursorPager, Pager } from "./cursor";
 
 // Vendor id = GATEKEEPER_<NAME> binding suffix (lowercased).
 const VENDOR_ID = "google";
@@ -724,10 +726,10 @@ export class GatekeeperUserImpl extends WorkerEntrypoint<Env, GatekeeperUserImpl
 
   async startResourceConfigurator(
       resourceUrlPattern: string): Promise<ResourceConfiguratorFrame> {
-    let getToken = async () => {
+    let getToken = async (opts?: AccessTokenRequest) => {
       let id = this.ctx.exports.UserAccount.idFromString(this.ctx.props.userObjectId);
       let obj = this.ctx.exports.UserAccount.get(id);
-      return await obj.getAccessToken();
+      return await obj.getAccessToken(opts);
     };
 
     if (resourceUrlPattern === BIGQUERY_RESOURCE.urlPattern) {
@@ -861,14 +863,6 @@ export interface GoogleVerifierApi extends GatekeeperUserVerifier {
   hasCalendarFreeBusyAccess(calendarId: string): Promise<boolean>;
   hasDatasetAccess(projectId: string, datasetId: string): Promise<boolean>;
 }
-
-type ObserverCheck<T> = {
-  excludeObservers?: string[];
-  pendingSets: T[];
-  commit(): void;
-};
-
-type ObservedSetState = true | "pending" | "observed";
 
 @validateRpc()
 export class GoogleVerifier extends WorkerEntrypoint<Env, GoogleVerifierProps>
@@ -1062,7 +1056,7 @@ class GmailSessionImpl extends RpcTarget implements GmailSession {
     const labelIds = this.#ctx.labelId
       ? [this.#ctx.labelId]
       : (!this.#ctx.searchQuery ? ["INBOX"] : undefined);
-    return new GmailThreadCursorImpl(this.#ctx, this.#ctx.searchQuery, labelIds);
+    return gmailThreadCursor(this.#ctx, this.#ctx.searchQuery, labelIds);
   }
 
   async search(query: string): Promise<Cursor<GmailThreadEntry>> {
@@ -1089,7 +1083,7 @@ class GmailSessionImpl extends RpcTarget implements GmailSession {
     // A full-mailbox binding may search all mail. Only an explicit label scope
     // attenuates search results; listThreads() separately defaults to INBOX.
     const labelIds = this.#ctx.labelId ? [this.#ctx.labelId] : undefined;
-    return new GmailThreadCursorImpl(this.#ctx, effectiveQuery, labelIds);
+    return gmailThreadCursor(this.#ctx, effectiveQuery, labelIds);
   }
 
   async send(to: string[], subject: string, body: string): Promise<void> {
@@ -1159,89 +1153,64 @@ async function submitGmailAction(
   }
 }
 
-// ── GmailThreadCursorImpl ───────────────────────────────────────────
-// Lazily fetches pages from the Gmail API as the gadget calls next().
-// Each next() returns a batch of GmailThreadEntry objects (thread info +
-// capability), or null when exhausted. Pages are fetched in batches of 20.
-//
-// The cursor itself is a capability. The initial listThreads()/search() call
-// authorizes creation; each next() separately authorizes the page it returns.
+// ── Cursors ─────────────────────────────────────────────────────────
+// A cursor is a capability. The listThreads()/search() call authorizes its creation; CursorPager
+// separately authorizes each page before disclosing it. See cursor.ts.
 
 @validateRpc()
-class GmailThreadCursorImpl extends RpcTarget implements Cursor<GmailThreadEntry> {
-  #ctx: GmailSessionContext;
-  #query: string | undefined;
-  #labelIds: string[] | undefined;
-  #pageToken: string | undefined;
-  #exhausted = false;
-  #tail: Promise<void> = Promise.resolve();
+class RpcCursor<Entry> extends RpcTarget implements Cursor<Entry> {
+  #pager: Pager<Entry>;
 
-  constructor(ctx: GmailSessionContext, query: string | undefined, labelIds?: string[]) {
+  constructor(pager: Pager<Entry>) {
     super();
-    this.#ctx = ctx;
-    this.#query = query;
-    this.#labelIds = labelIds;
+    this.#pager = pager;
   }
 
-  next(): Promise<GmailThreadEntry[] | null> {
-    const result = this.#tail.then(() => this.#nextPage());
-    this.#tail = result.then(() => undefined, () => undefined);
-    return result;
+  // `next()` takes no arguments, so there is no argument surface to validate.
+  @skipRpcValidation()
+  next(): Promise<Entry[] | null> {
+    return this.#pager.next();
   }
+}
 
-  async #nextPage(): Promise<GmailThreadEntry[] | null> {
-    if (this.#exhausted) return null;
+type GmailThreadRef = { id: string; snippet?: string };
 
-    let result: {threads: Array<{id: string; snippet?: string}>; nextPageToken?: string};
-    let pageToken = this.#pageToken;
-    let exhausted = false;
-    let skippedPages = 0;
-    do {
-      const previousToken = pageToken;
-      result = await this.#ctx.gmailApi.listThreads(
-        20, this.#query, pageToken, this.#labelIds);
-      pageToken = result.nextPageToken;
-      exhausted = !result.nextPageToken;
-      if (result.nextPageToken && result.nextPageToken === previousToken) {
-        throw new Error("Gmail returned a repeated thread page token.");
+/** Threads matching the scope, 20 at a time, each enriched with its metadata. */
+function gmailThreadCursor(
+    ctx: GmailSessionContext, query: string | undefined, labelIds?: string[],
+): Cursor<GmailThreadEntry> {
+  return new RpcCursor(new CursorPager<GmailThreadRef, GmailThreadEntry>({
+    provider: "Gmail",
+
+    async fetchPage(pageToken) {
+      let { threads, nextPageToken } =
+          await ctx.gmailApi.listThreads(20, query, pageToken, labelIds);
+      return { items: threads, nextPageToken };
+    },
+
+    async buildEntries(threads) {
+      // Stay below the Workers six-outgoing-connection limit while enriching the page.
+      let entries: GmailThreadEntry[] = [];
+      for (let i = 0; i < threads.length; i += 5) {
+        entries.push(...await Promise.all(threads.slice(i, i + 5).map(async thread => {
+          let metadata = await ctx.gmailApi.getThreadInfo(thread.id);
+          let info: GmailThreadInfo = {
+            ...metadata,
+            ...(thread.snippet !== undefined ? { snippet: thread.snippet } : {}),
+          };
+          return { info, thread: new GmailThreadStub(ctx, thread.id, info) };
+        })));
       }
-      skippedPages++;
-    } while (result.threads.length === 0 && !exhausted && skippedPages < 20);
+      return entries;
+    },
 
-    if (result.threads.length === 0) {
-      if (!exhausted) throw new Error("Gmail returned too many empty thread pages.");
-      this.#pageToken = pageToken;
-      this.#exhausted = true;
-      return null;
-    }
-
-    // Stay below the Workers six-outgoing-connection limit while enriching the
-    // page with metadata.
-    const entries: GmailThreadEntry[] = [];
-    for (let i = 0; i < result.threads.length; i += 5) {
-      const batch = await Promise.all(result.threads.slice(i, i + 5).map(async thread => {
-        const metadata = await this.#ctx.gmailApi.getThreadInfo(thread.id);
-        const info: GmailThreadInfo = {
-          ...metadata,
-          ...(thread.snippet !== undefined ? {snippet: thread.snippet} : {}),
-        };
-        const stub = new GmailThreadStub(this.#ctx, thread.id, info);
-        return { info, thread: stub };
-      }));
-      entries.push(...batch);
-    }
-
-    await this.#ctx.approvalQueue.authorizeObservation({
+    authorize: entries => ctx.approvalQueue.authorizeObservation({
       title: `Read ${entries.length} Gmail threads`,
       description:
-        `Fetch the next page of Gmail threads.\n\n` +
+        "Fetch the next page of Gmail threads.\n\n" +
         formatApprovalField("Subjects", entries.map(entry => entry.info.subject).join("\n")),
-    });
-
-    this.#pageToken = pageToken;
-    this.#exhausted = exhausted;
-    return entries;
-  }
+    }),
+  }));
 }
 
 // ── GmailThreadStub ─────────────────────────────────────────────────
@@ -2624,7 +2593,7 @@ export class GoogleCalendarGatekeeperImpl
       this.ctx.props.availabilityMode,
       approvalQueue.dup(),
       pendingActions,
-      calendarIds => this.#prepareAvailabilityCalendarObservation(calendarIds),
+      calendarIds => this.#observers.prepareObservation(calendarIds),
     );
   }
 
@@ -2715,60 +2684,19 @@ export class GoogleCalendarGatekeeperImpl
   // TODO: Let the binding owner choose whether private events are included. A public-only mode
   // could admit readers instead of requiring writer access from every collaborator.
 
-  #observerKey(id: string): string { return `observer:${id}`; }
-  #availabilityCalendarKey(calendarId: string): string {
-    return `observedAvailabilityCalendar:${encodeURIComponent(calendarId)}`;
-  }
-
-  #isAvailabilityCalendarObserved(calendarId: string): boolean {
-    let state = this.ctx.storage.kv.get<ObservedSetState>(this.#availabilityCalendarKey(calendarId));
-    return state === true || state === "observed";
-  }
-
-  #listTrackedAvailabilityCalendars(): string[] {
-    let prefix = "observedAvailabilityCalendar:";
-    return [...this.ctx.storage.kv.list<ObservedSetState>({prefix})]
-        .map(([key]) => decodeURIComponent(key.slice(prefix.length)));
-  }
-
-  *#listObservers(): IterableIterator<[string, Fetcher<GoogleVerifierApi>]> {
-    let prefix = "observer:";
-    for (let [key, verifier] of this.ctx.storage.kv.list<Fetcher<GoogleVerifierApi>>({prefix})) {
-      yield [key.slice(prefix.length), verifier];
-    }
-  }
-
-  async #prepareAvailabilityCalendarObservation(
-    calendarIds: string[],
-  ): Promise<ObserverCheck<string>> {
-    let pendingCalendarIds = [...new Set(calendarIds)]
-        .filter(calendarId => !this.#isAvailabilityCalendarObserved(calendarId));
-    if (pendingCalendarIds.length === 0) return {pendingSets: pendingCalendarIds, commit() {}};
-
-    for (let calendarId of pendingCalendarIds) {
-      let key = this.#availabilityCalendarKey(calendarId);
-      if (this.ctx.storage.kv.get<ObservedSetState>(key) === undefined) {
-        this.ctx.storage.kv.put(key, "pending");
-      }
-    }
-
-    let observerAccess = await Promise.all([...this.#listObservers()].map(async ([id, verifier]) => {
-      let access = await Promise.all(pendingCalendarIds.map(
-        calendarId => verifier.hasCalendarFreeBusyAccess(calendarId),
-      ));
-      return [id, access.every(hasAccess => hasAccess)] as const;
-    }));
-    let excluded = observerAccess.filter(([, hasAccess]) => !hasAccess).map(([id]) => id);
-
-    return {
-      excludeObservers: excluded.length > 0 ? excluded : undefined,
-      pendingSets: pendingCalendarIds,
-      commit: () => {
-        for (let calendarId of pendingCalendarIds) {
-          this.ctx.storage.kv.put(this.#availabilityCalendarKey(calendarId), "observed");
-        }
-      },
-    };
+  get #observers(): ObserverTracker<string, Fetcher<GoogleVerifierApi>> {
+    return new ObserverTracker(this.ctx.storage.kv, {
+      setPrefix: "observedAvailabilityCalendar:",
+      encode: calendarId => encodeURIComponent(calendarId),
+      decode: encoded => decodeURIComponent(encoded),
+      hasAccess: (verifier, calendarId) => verifier.hasCalendarFreeBusyAccess(calendarId),
+      deniedMessage: calendarId =>
+        `This collaborator cannot see free/busy availability for ${calendarId}, whose ` +
+        "availability this workspace has read, so they cannot be allowed to observe it.",
+      // In thisCalendar mode no foreign calendar is ever read, so there is never anyone to
+      // forward-exclude and nothing to remember an observer for.
+      recordObservers: this.ctx.props.availabilityMode === "allVisible",
+    });
   }
 
   async addObserver(id: string, user: Fetcher<GatekeeperUserVerifier>): Promise<void> {
@@ -2778,31 +2706,11 @@ export class GoogleCalendarGatekeeperImpl
         "This collaborator does not have writer access to the bound Google Calendar, so they " +
         "cannot be allowed to observe its event details.");
     }
-    let checked = new Set<string>();
-    while (true) {
-      let calendarIds = this.#listTrackedAvailabilityCalendars()
-          .filter(calendarId => !checked.has(calendarId));
-      if (calendarIds.length === 0) {
-        if (this.ctx.props.availabilityMode === "allVisible") {
-          this.ctx.storage.kv.put(this.#observerKey(id), verifier);
-        }
-        return;
-      }
-      let availabilityAccess = await Promise.all(
-        calendarIds.map(calendarId => verifier.hasCalendarFreeBusyAccess(calendarId)));
-      for (let [index, calendarId] of calendarIds.entries()) {
-        if (!availabilityAccess[index]) {
-          throw new Error(
-            `This collaborator cannot see free/busy availability for ${calendarId}, whose ` +
-            "availability this workspace has read, so they cannot be allowed to observe it.");
-        }
-      }
-      for (let calendarId of calendarIds) checked.add(calendarId);
-    }
+    await this.#observers.addObserver(id, verifier);
   }
 
   async removeObserver(id: string): Promise<void> {
-    this.ctx.storage.kv.delete(this.#observerKey(id));
+    this.#observers.removeObserver(id);
   }
 }
 
@@ -2990,6 +2898,9 @@ class GoogleCalendarSessionImpl extends RpcTarget implements GoogleCalendarSessi
 // `maximumBytesBilled` before actually executing — defense in depth, since BigQuery will also
 // enforce maximumBytesBilled server-side.
 
+/** One BigQuery dataset, the unit at which observer access is tracked. */
+type BigQueryDatasetRef = { projectId: string; datasetId: string };
+
 type BigQueryGatekeeperImplProps = {
   userObjectId: string;
   // When set, narrows the session's authority. Project is required for any narrower scope.
@@ -3047,7 +2958,7 @@ export class BigQueryGatekeeperImpl
       this.ctx.props.scopedProjectId,
       this.ctx.props.scopedDatasetId,
       this.ctx.props.scopedTableId,
-      datasets => this.#prepareDatasetObservation(datasets),
+      datasets => this.#observers.prepareObservation(datasets),
     );
   }
 
@@ -3059,107 +2970,34 @@ export class BigQueryGatekeeperImpl
   }
 
   // -------------------------------------------------------------------------
-  // Observer tracking — strategy C (data-set tracking by dataset). Even a project- or table-scoped
-  // binding is tracked at dataset granularity: users may have IAM access to different datasets, so we
-  // record which datasets' data the Gadget has actually observed and verify each observer against
-  // them. addObserver requires access to every already-observed dataset; later, the first observation
-  // of a *new* dataset excludes any observer lacking it (see #prepareDatasetObservation). Verified
-  // observers are remembered (their verifier stored) so that forward-exclusion re-check can run. The
-  // overseer re-runs addObserver on every open, catching loss of access promptly.
+  // Observer tracking — strategy C, by dataset. Even a project- or table-scoped binding is tracked
+  // at dataset granularity: users may have IAM access to different datasets, so we record which
+  // datasets' data the gadget has actually read and verify each observer against them.
 
-  #observerKey(id: string): string { return `observer:${id}`; }
-  // A dataset is identified by project + dataset id; "/" cannot appear in either, so it is an
-  // unambiguous separator.
-  #datasetKey(projectId: string, datasetId: string): string {
-    return `observedDataset:${projectId}/${datasetId}`;
-  }
-
-  #isDatasetObserved(projectId: string, datasetId: string): boolean {
-    let state = this.ctx.storage.kv.get<ObservedSetState>(this.#datasetKey(projectId, datasetId));
-    return state === true || state === "observed";
-  }
-
-  #listTrackedDatasets(): { projectId: string; datasetId: string }[] {
-    let prefix = "observedDataset:";
-    return [...this.ctx.storage.kv.list<ObservedSetState>({ prefix })].map(([key]) => {
-      let rest = key.slice(prefix.length);
-      let slash = rest.indexOf("/");
-      return { projectId: rest.slice(0, slash), datasetId: rest.slice(slash + 1) };
-    });
-  }
-
-  *#listObservers(): IterableIterator<[string, Fetcher<GoogleVerifierApi>]> {
-    let prefix = "observer:";
-    for (let [key, verifier] of this.ctx.storage.kv.list<Fetcher<GoogleVerifierApi>>({ prefix })) {
-      yield [key.slice(prefix.length), verifier];
-    }
-  }
-
-  // Marks unknown datasets pending and returns current observers who cannot access any pending
-  // dataset in this attempt. Authorization promotes them; failed attempts remain pending and are
-  // rechecked on retry.
-  async #prepareDatasetObservation(
-    datasets: { projectId: string; datasetId: string }[],
-  ): Promise<ObserverCheck<{ projectId: string; datasetId: string }>> {
-    let seen = new Set<string>();
-    let pendingDatasets = datasets.filter(d => {
-      let key = `${d.projectId}/${d.datasetId}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return !this.#isDatasetObserved(d.projectId, d.datasetId);
-    });
-    if (pendingDatasets.length === 0) return {pendingSets: pendingDatasets, commit() {}};
-    for (let d of pendingDatasets) {
-      let key = this.#datasetKey(d.projectId, d.datasetId);
-      if (this.ctx.storage.kv.get<ObservedSetState>(key) === undefined) {
-        this.ctx.storage.kv.put(key, "pending");
-      }
-    }
-    let observerAccess = await Promise.all([...this.#listObservers()].map(async ([id, verifier]) => {
-      let access = await Promise.all(pendingDatasets.map(
-        d => verifier.hasDatasetAccess(d.projectId, d.datasetId),
-      ));
-      return [id, access.every(hasAccess => hasAccess)] as const;
-    }));
-    let excluded = observerAccess.filter(([, hasAccess]) => !hasAccess).map(([id]) => id);
-    return {
-      excludeObservers: excluded.length > 0 ? excluded : undefined,
-      pendingSets: pendingDatasets,
-      commit: () => {
-        for (let d of pendingDatasets) {
-          this.ctx.storage.kv.put(this.#datasetKey(d.projectId, d.datasetId), "observed");
-        }
+  get #observers(): ObserverTracker<BigQueryDatasetRef, Fetcher<GoogleVerifierApi>> {
+    return new ObserverTracker(this.ctx.storage.kv, {
+      setPrefix: "observedDataset:",
+      // "/" cannot appear in either id, so it is an unambiguous separator.
+      encode: ({ projectId, datasetId }) => `${projectId}/${datasetId}`,
+      decode: encoded => {
+        let slash = encoded.indexOf("/");
+        return { projectId: encoded.slice(0, slash), datasetId: encoded.slice(slash + 1) };
       },
-    };
+      hasAccess: (verifier, { projectId, datasetId }) =>
+        verifier.hasDatasetAccess(projectId, datasetId),
+      deniedMessage: ({ projectId, datasetId }) =>
+        "This collaborator does not have access to the BigQuery dataset " +
+        `\`${projectId}.${datasetId}\`, whose data this workspace has read, so they cannot be ` +
+        "allowed to observe it.",
+    });
   }
 
   async addObserver(id: string, user: Fetcher<GatekeeperUserVerifier>): Promise<void> {
-    let verifier = user as unknown as Fetcher<GoogleVerifierApi>;
-    let checked = new Set<string>();
-    while (true) {
-      let datasets = this.#listTrackedDatasets()
-          .filter(d => !checked.has(`${d.projectId}/${d.datasetId}`));
-      if (datasets.length === 0) {
-        this.ctx.storage.kv.put(this.#observerKey(id), verifier);
-        return;
-      }
-      let access = await Promise.all(datasets.map(
-        d => verifier.hasDatasetAccess(d.projectId, d.datasetId),
-      ));
-      for (let [index, d] of datasets.entries()) {
-        if (!access[index]) {
-          throw new Error(
-            `This collaborator does not have access to the BigQuery dataset ` +
-            `\`${d.projectId}.${d.datasetId}\`, whose data this workspace has read, so they cannot be ` +
-            `allowed to observe it.`);
-        }
-        checked.add(`${d.projectId}/${d.datasetId}`);
-      }
-    }
+    await this.#observers.addObserver(id, user as unknown as Fetcher<GoogleVerifierApi>);
   }
 
   async removeObserver(id: string): Promise<void> {
-    this.ctx.storage.kv.delete(this.#observerKey(id));
+    this.#observers.removeObserver(id);
   }
 }
 
@@ -3170,10 +3008,8 @@ class BigQuerySessionImpl extends RpcTarget implements BigQuerySession {
   #scopedProjectId?: string;
   #scopedDatasetId?: string;
   #scopedTableId?: string;
-  // Records the datasets an observation reveals and returns observers to exclude (see
-  // BigQueryGatekeeperImpl.#prepareDatasetObservation).
-  #observe: (datasets: { projectId: string; datasetId: string }[]) =>
-    Promise<ObserverCheck<{ projectId: string; datasetId: string }>>;
+  // Records the datasets an observation reveals and returns observers to exclude.
+  #observe: (datasets: BigQueryDatasetRef[]) => Promise<ObserverCheck<BigQueryDatasetRef>>;
 
   constructor(
     api: BigQueryApi,
@@ -3181,8 +3017,7 @@ class BigQuerySessionImpl extends RpcTarget implements BigQuerySession {
     scopedProjectId: string | undefined,
     scopedDatasetId: string | undefined,
     scopedTableId: string | undefined,
-    observe: (datasets: { projectId: string; datasetId: string }[]) =>
-      Promise<ObserverCheck<{ projectId: string; datasetId: string }>>,
+    observe: (datasets: BigQueryDatasetRef[]) => Promise<ObserverCheck<BigQueryDatasetRef>>,
   ) {
     super();
     this.#api = api;

--- a/packages/gatekeeper-google/src/observers.ts
+++ b/packages/gatekeeper-google/src/observers.ts
@@ -59,11 +59,14 @@ export type ObserverTrackerOptions<T, V> = {
    */
   recordObservers?: boolean;
   /**
-   * Tracked sets beyond which {@link ObserverTracker.addObserver} refuses to admit anyone new.
+   * Distinct sets this binding may track before {@link ObserverTracker.prepareObservation} starts
+   * refusing reads.
    *
-   * Verifying a joining observer costs one round trip per tracked set, and the overseer re-runs it
-   * on every open, so an unbounded set makes opening the gadget unboundedly expensive. Failing
-   * closed keeps existing observers working while telling the user to bind a narrower scope.
+   * Verifying an observer costs one round trip per tracked set, and the overseer re-runs it on
+   * every open, so an unbounded set makes opening the gadget unboundedly expensive. The cap is
+   * enforced when a set is *recorded* rather than when an observer joins, because the alternative
+   * is worse: a binding that has already read past the cap can never be verified against, which
+   * locks out the collaborators already using it as well as new ones, with no way back.
    */
   maxTrackedSets?: number;
   /** Concurrent verifier round trips. Bounded to stay inside the Workers subrequest limits. */
@@ -145,6 +148,10 @@ export class ObserverTracker<T, V> {
    *
    * Pending rather than observed, because the read may still be denied: promoting eagerly would
    * permanently narrow who may observe this binding on the strength of a read that never happened.
+   *
+   * Throws if recording these sets would take the binding past {@link
+   * ObserverTrackerOptions.maxTrackedSets}. Recording anyway would disclose data no observer is
+   * ever verified against; not recording it would do the same silently.
    */
   async prepareObservation(values: readonly T[]): Promise<ObserverCheck<T>> {
     let seen = new Set<string>();
@@ -156,10 +163,15 @@ export class ObserverTracker<T, V> {
     });
     if (pendingSets.length === 0) return { pendingSets, commit() {} };
 
-    for (let value of pendingSets) {
-      let key = this.#setKey(value);
-      if (this.#kv.get<ObservedSetState>(key) === undefined) this.#kv.put(key, "pending");
+    let untracked = pendingSets.filter(
+      value => this.#kv.get<ObservedSetState>(this.#setKey(value)) === undefined);
+    let tracked = this.listTracked().length;
+    if (tracked + untracked.length > this.#maxTrackedSets) {
+      throw new Error(
+        `This binding has read ${tracked} distinct items, the most it can track while remaining ` +
+        "shareable. Bind a narrower scope.");
     }
+    for (let value of untracked) this.#kv.put(this.#setKey(value), "pending");
 
     // One flat queue over (observer, set) pairs: nesting two Promise.alls would multiply out to an
     // unbounded number of concurrent round trips.
@@ -187,17 +199,13 @@ export class ObserverTracker<T, V> {
    * Admits `id` as an observer, or throws naming the first set they cannot reach.
    *
    * Re-lists after each round of checks, so a set observed while this was awaiting is covered too.
+   * The tracked set is bounded by {@link ObserverTrackerOptions.maxTrackedSets} at record time, so
+   * this needs no bound of its own.
    */
   async addObserver(id: string, verifier: V): Promise<void> {
     let checked = new Set<string>();
     for (;;) {
       let tracked = this.listTracked();
-      if (tracked.length > this.#maxTrackedSets) {
-        throw new Error(
-          `This binding has read ${tracked.length} distinct items, more than the ` +
-          `${this.#maxTrackedSets} a new collaborator can be verified against. Bind a narrower ` +
-          "scope to share it.");
-      }
 
       let pending = tracked.filter(value => !checked.has(this.#options.encode(value)));
       if (pending.length === 0) {

--- a/packages/gatekeeper-google/src/observers.ts
+++ b/packages/gatekeeper-google/src/observers.ts
@@ -1,0 +1,222 @@
+/**
+ * Strategy C observer tracking: record which units of data a binding has actually read, and admit a
+ * collaborator as an observer only if their own credentials reach every one of them.
+ *
+ * Two directions, both required:
+ *
+ *  - **Backward.** {@link ObserverTracker.addObserver} verifies a joining observer against every
+ *    already-tracked set. The overseer re-runs it on every open, so losing access to source data
+ *    promptly locks the collaborator out.
+ *  - **Forward.** {@link ObserverTracker.prepareObservation} marks newly-read sets pending and
+ *    reports which *existing* observers cannot reach them, so the caller can exclude them before
+ *    the data is disclosed. Sets are promoted to observed only once the read is authorized, so a
+ *    failed attempt is re-checked on retry rather than being trusted.
+ *
+ * The tracker deliberately does not cache verifier answers. Re-checking on every open is what makes
+ * revocation take effect, and the sets tracked by today's callers are few. A caller that tracks
+ * high-cardinality units (one entry per file, say) needs a different answer, not a longer TTL.
+ */
+
+const OBSERVER_PREFIX = "observer:";
+
+/** Persisted state of one tracked set. `true` is the pre-"pending" legacy encoding of observed. */
+export type ObservedSetState = true | "pending" | "observed";
+
+/**
+ * The outcome of preparing to observe some sets: who must be excluded from the disclosure, and a
+ * `commit` the caller invokes once the read is actually authorized.
+ */
+export type ObserverCheck<T> = {
+  /** Observers who cannot reach at least one pending set. Absent when none must be excluded. */
+  excludeObservers?: string[];
+  /** The sets newly marked pending by this call. */
+  pendingSets: T[];
+  /** Promotes the pending sets to observed. Call only after the read is authorized. */
+  commit(): void;
+};
+
+/** The storage surface the tracker needs, satisfied by a Durable Object's `ctx.storage.kv`. */
+export interface ObserverKv {
+  get<T>(key: string): T | undefined;
+  put<T>(key: string, value: T): void;
+  delete(key: string): void;
+  list<T>(options: { prefix: string }): Iterable<[string, T]>;
+}
+
+export type ObserverTrackerOptions<T, V> = {
+  /** Key prefix for tracked sets. Must not be `observer:`, which holds the observers themselves. */
+  setPrefix: string;
+  /** Reversible encoding of one set's identity. Must round-trip through {@link decode}. */
+  encode(value: T): string;
+  decode(encoded: string): T;
+  /** Whether the observer's own credentials reach this set. */
+  hasAccess(verifier: V, value: T): Promise<boolean>;
+  /** The error thrown when a joining observer cannot reach `value`. */
+  deniedMessage(value: T): string;
+  /**
+   * Whether to remember verified observers so the forward check can consult them later. Callers
+   * that can never read a set beyond the one they are bound to have nobody to forward-exclude.
+   */
+  recordObservers?: boolean;
+  /**
+   * Tracked sets beyond which {@link ObserverTracker.addObserver} refuses to admit anyone new.
+   *
+   * Verifying a joining observer costs one round trip per tracked set, and the overseer re-runs it
+   * on every open, so an unbounded set makes opening the gadget unboundedly expensive. Failing
+   * closed keeps existing observers working while telling the user to bind a narrower scope.
+   */
+  maxTrackedSets?: number;
+  /** Concurrent verifier round trips. Bounded to stay inside the Workers subrequest limits. */
+  concurrency?: number;
+};
+
+const DEFAULT_MAX_TRACKED_SETS = 1000;
+const DEFAULT_CONCURRENCY = 6;
+
+/** Runs `fn` over `items` with at most `limit` in flight, preserving input order in the result. */
+async function mapWithConcurrency<In, Out>(
+  items: readonly In[],
+  limit: number,
+  fn: (item: In) => Promise<Out>,
+): Promise<Out[]> {
+  let results: Out[] = Array.from({ length: items.length });
+  let next = 0;
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      let index = next++;
+      results[index] = await fn(items[index]);
+    }
+  }));
+  return results;
+}
+
+/**
+ * Tracks the sets a binding has observed and gates observers against them.
+ *
+ * `T` is the unit of tracking (a dataset, a calendar, a file); `V` is the verifier capability the
+ * overseer hands to `addObserver`.
+ */
+export class ObserverTracker<T, V> {
+  #kv: ObserverKv;
+  #options: ObserverTrackerOptions<T, V>;
+
+  constructor(kv: ObserverKv, options: ObserverTrackerOptions<T, V>) {
+    if (options.setPrefix === OBSERVER_PREFIX) {
+      throw new Error(`setPrefix must not collide with the observer prefix ${OBSERVER_PREFIX}`);
+    }
+    this.#kv = kv;
+    this.#options = options;
+  }
+
+  get #maxTrackedSets(): number {
+    return this.#options.maxTrackedSets ?? DEFAULT_MAX_TRACKED_SETS;
+  }
+
+  get #concurrency(): number {
+    return this.#options.concurrency ?? DEFAULT_CONCURRENCY;
+  }
+
+  #setKey(value: T): string {
+    return `${this.#options.setPrefix}${this.#options.encode(value)}`;
+  }
+
+  #isObserved(value: T): boolean {
+    let state = this.#kv.get<ObservedSetState>(this.#setKey(value));
+    return state === true || state === "observed";
+  }
+
+  /** Every set this binding has read or is attempting to read, in storage order. */
+  listTracked(): T[] {
+    let prefix = this.#options.setPrefix;
+    return [...this.#kv.list<ObservedSetState>({ prefix })]
+        .map(([key]) => this.#options.decode(key.slice(prefix.length)));
+  }
+
+  /** The observers admitted so far, paired with the verifier each was admitted with. */
+  *observers(): IterableIterator<[string, V]> {
+    for (let [key, verifier] of this.#kv.list<V>({ prefix: OBSERVER_PREFIX })) {
+      yield [key.slice(OBSERVER_PREFIX.length), verifier];
+    }
+  }
+
+  /**
+   * Marks any not-yet-observed set among `values` pending, and reports the current observers who
+   * cannot reach at least one of them.
+   *
+   * Pending rather than observed, because the read may still be denied: promoting eagerly would
+   * permanently narrow who may observe this binding on the strength of a read that never happened.
+   */
+  async prepareObservation(values: readonly T[]): Promise<ObserverCheck<T>> {
+    let seen = new Set<string>();
+    let pendingSets = values.filter(value => {
+      let encoded = this.#options.encode(value);
+      if (seen.has(encoded)) return false;
+      seen.add(encoded);
+      return !this.#isObserved(value);
+    });
+    if (pendingSets.length === 0) return { pendingSets, commit() {} };
+
+    for (let value of pendingSets) {
+      let key = this.#setKey(value);
+      if (this.#kv.get<ObservedSetState>(key) === undefined) this.#kv.put(key, "pending");
+    }
+
+    // One flat queue over (observer, set) pairs: nesting two Promise.alls would multiply out to an
+    // unbounded number of concurrent round trips.
+    let observers = [...this.observers()];
+    let pairs = observers.flatMap(
+      ([id, verifier]) => pendingSets.map(value => ({ id, verifier, value })));
+    let access = await mapWithConcurrency(
+      pairs, this.#concurrency, pair => this.#options.hasAccess(pair.verifier, pair.value));
+
+    let denied = new Set<string>();
+    for (let [index, pair] of pairs.entries()) {
+      if (!access[index]) denied.add(pair.id);
+    }
+
+    return {
+      excludeObservers: denied.size > 0 ? [...denied] : undefined,
+      pendingSets,
+      commit: () => {
+        for (let value of pendingSets) this.#kv.put(this.#setKey(value), "observed");
+      },
+    };
+  }
+
+  /**
+   * Admits `id` as an observer, or throws naming the first set they cannot reach.
+   *
+   * Re-lists after each round of checks, so a set observed while this was awaiting is covered too.
+   */
+  async addObserver(id: string, verifier: V): Promise<void> {
+    let checked = new Set<string>();
+    for (;;) {
+      let tracked = this.listTracked();
+      if (tracked.length > this.#maxTrackedSets) {
+        throw new Error(
+          `This binding has read ${tracked.length} distinct items, more than the ` +
+          `${this.#maxTrackedSets} a new collaborator can be verified against. Bind a narrower ` +
+          "scope to share it.");
+      }
+
+      let pending = tracked.filter(value => !checked.has(this.#options.encode(value)));
+      if (pending.length === 0) {
+        if (this.#options.recordObservers ?? true) {
+          this.#kv.put(`${OBSERVER_PREFIX}${id}`, verifier);
+        }
+        return;
+      }
+
+      let access = await mapWithConcurrency(
+        pending, this.#concurrency, value => this.#options.hasAccess(verifier, value));
+      let deniedIndex = access.indexOf(false);
+      if (deniedIndex >= 0) throw new Error(this.#options.deniedMessage(pending[deniedIndex]));
+
+      for (let value of pending) checked.add(this.#options.encode(value));
+    }
+  }
+
+  removeObserver(id: string): void {
+    this.#kv.delete(`${OBSERVER_PREFIX}${id}`);
+  }
+}

--- a/packages/gatekeeper-google/src/resources.ts
+++ b/packages/gatekeeper-google/src/resources.ts
@@ -1,0 +1,296 @@
+/**
+ * The grantable resource types this gatekeeper offers, the OAuth scopes each needs, and the parser
+ * that turns a bound resource URL into the parameters its gatekeeper Durable Object takes.
+ *
+ * A resource's `urlPattern` is permanent identity: it keys admin disable-sets, blueprint
+ * `typeUrlPattern`s, and recorded grants. Never change one after deploy.
+ */
+
+import type { SupportedResource } from "@gadgets/workshop-shared/gatekeeper";
+import type { CalendarAvailabilityMode } from "./calendar-types";
+import { validateGmailLabelName, validateGmailQueryForGrouping } from "./gmail-validate";
+
+/** Host serving the synthetic BigQuery resource URLs. */
+export const BIGQUERY_HOST = "bigquery.googleapis.com";
+
+/**
+ * Scopes requested on every connection, to identify the account (name, email, avatar). Tied to no
+ * resource type.
+ */
+export const IDENTITY_SCOPES = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "https://www.googleapis.com/auth/userinfo.email",
+];
+
+/**
+ * Scopes for sign-in only, where the resulting grant is transient. Identical to
+ * {@link IDENTITY_SCOPES}: verifying an email needs no resource access.
+ */
+export const AUTH_SCOPES = IDENTITY_SCOPES;
+
+/** A whole Gmail mailbox, optionally narrowed to one search or label. */
+export const GMAIL_RESOURCE: SupportedResource = {
+  urlPattern: "https://mail.google.com/*",
+  title: "Gmail Mailbox",
+  description: "Read emails and apply labels.",
+  grantable: true,
+};
+
+/** A single Google Doc. */
+export const GOOGLE_DOC_RESOURCE: SupportedResource = {
+  urlPattern: "https://docs.google.com/document/d/:docId/*",
+  title: "Google Doc",
+  description: "Read and edit documents you choose.",
+  grantable: true,
+};
+
+/** A single Google Sheet. */
+export const GOOGLE_SHEETS_RESOURCE: SupportedResource = {
+  urlPattern: "https://docs.google.com/spreadsheets/d/:spreadsheetId/*",
+  title: "Google Spreadsheet",
+  description: "Read values from a spreadsheet you choose.",
+  grantable: true,
+};
+
+/** A single Google Calendar. */
+export const GOOGLE_CALENDAR_RESOURCE: SupportedResource = {
+  urlPattern: "https://calendar.google.com/calendar/:calendarId/*",
+  title: "Google Calendar",
+  description: "Read and manage a Google Calendar.",
+  grantable: true,
+};
+
+/** A BigQuery project, optionally narrowed to a dataset or table. */
+export const BIGQUERY_RESOURCE: SupportedResource = {
+  urlPattern: `https://${BIGQUERY_HOST}/:projectId/*`,
+  title: "BigQuery",
+  description:
+      "Choose a Google Cloud project, then optionally narrow access to a dataset or table.",
+  grantable: true,
+};
+
+/**
+ * The resources an account connected before per-resource scope tracking implicitly received.
+ *
+ * Frozen. Adding an entry short-circuits `ensureResources`, so a legacy account would be reported
+ * as already holding a grant it never made and would never be re-prompted for consent.
+ */
+export const LEGACY_GRANTED_RESOURCE_URL_PATTERNS = [
+  GMAIL_RESOURCE.urlPattern,
+  GOOGLE_DOC_RESOURCE.urlPattern,
+  BIGQUERY_RESOURCE.urlPattern,
+];
+
+/** The OAuth scopes each grantable resource needs. */
+export const RESOURCE_SCOPES: {resource: SupportedResource, scopes: string[]}[] = [
+  {
+    resource: GMAIL_RESOURCE,
+    scopes: [
+      "https://www.googleapis.com/auth/gmail.labels",
+      "https://www.googleapis.com/auth/gmail.modify",
+    ],
+  },
+  {
+    resource: GOOGLE_DOC_RESOURCE,
+    scopes: [
+      "https://www.googleapis.com/auth/documents",
+      // Read-only Drive file metadata, used to power the doc picker when connecting a Google Doc.
+      "https://www.googleapis.com/auth/drive.metadata.readonly",
+    ],
+  },
+  {
+    resource: GOOGLE_SHEETS_RESOURCE,
+    scopes: [
+      "https://www.googleapis.com/auth/spreadsheets.readonly",
+      // Read-only Drive file metadata, used to power the spreadsheet picker.
+      "https://www.googleapis.com/auth/drive.metadata.readonly",
+    ],
+  },
+  {
+    resource: GOOGLE_CALENDAR_RESOURCE,
+    scopes: [
+      // Read-only calendar list, used to power the calendar picker when connecting a calendar.
+      "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+      "https://www.googleapis.com/auth/calendar.events",
+    ],
+  },
+  {
+    resource: BIGQUERY_RESOURCE,
+    scopes: [
+      // `bigquery` (not `bigquery.readonly`): dry-runs go through `jobs.insert` for scope
+      // enforcement, which `readonly` doesn't permit. Read-only is enforced at the API layer.
+      "https://www.googleapis.com/auth/bigquery",
+    ],
+  },
+];
+
+/** Every grantable resource, in declaration order. */
+export const SUPPORTED_RESOURCES: SupportedResource[] = RESOURCE_SCOPES.map(entry => entry.resource);
+
+/** Rejects any pattern that is not a known grantable resource. */
+export function validateResourceUrlPatterns(resourceUrlPatterns?: string[]): void {
+  if (resourceUrlPatterns === undefined) return;
+
+  let known = new Set(RESOURCE_SCOPES.map(entry => entry.resource.urlPattern));
+  let unknown = resourceUrlPatterns.filter(pattern => !known.has(pattern));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown grantable resource URL pattern(s): ${unknown.join(", ")}`);
+  }
+}
+
+/**
+ * The OAuth scopes to request for the given grantable resource `urlPattern`s.
+ *
+ * `undefined` means every resource, which is distinct from `[]` (identity scopes only).
+ */
+export function resourceUrlPatternsToOAuthScopes(resourceUrlPatterns?: string[]): string[] {
+  validateResourceUrlPatterns(resourceUrlPatterns);
+
+  let scopes = new Set<string>(IDENTITY_SCOPES);
+  for (let entry of RESOURCE_SCOPES) {
+    if (resourceUrlPatterns === undefined ||
+        resourceUrlPatterns.includes(entry.resource.urlPattern)) {
+      for (let scope of entry.scopes) scopes.add(scope);
+    }
+  }
+  return [...scopes];
+}
+
+/**
+ * The resources fully covered by a set of granted scopes.
+ *
+ * Fails closed: a resource whose scopes are only partially present is not reported as granted.
+ */
+export function grantedResourcesFromScopes(grantedOAuthScopes: string[]): string[] {
+  let granted = new Set(grantedOAuthScopes);
+  return RESOURCE_SCOPES
+      .filter(entry => entry.scopes.every(scope => granted.has(scope)))
+      .map(entry => entry.resource.urlPattern);
+}
+
+/** A resource URL resolved to the binding parameters its gatekeeper takes. */
+export type ResourceTarget =
+  | { kind: "gmail"; searchQuery?: string; labelName?: string }
+  | { kind: "doc"; documentId: string }
+  | { kind: "sheets"; spreadsheetId: string }
+  | { kind: "calendar"; calendarId: string; availabilityMode: CalendarAvailabilityMode }
+  | { kind: "bigquery"; projectId: string; datasetId?: string; tableId?: string };
+
+/** The grantable resource each {@link ResourceTarget} kind belongs to. */
+export const RESOURCE_BY_KIND: Record<ResourceTarget["kind"], SupportedResource> = {
+  gmail: GMAIL_RESOURCE,
+  doc: GOOGLE_DOC_RESOURCE,
+  sheets: GOOGLE_SHEETS_RESOURCE,
+  calendar: GOOGLE_CALENDAR_RESOURCE,
+  bigquery: BIGQUERY_RESOURCE,
+};
+
+/**
+ * Parses a bound resource URL into the target its gatekeeper needs.
+ *
+ * Throws on any URL that does not name a supported resource. There is deliberately no fallback
+ * kind: the caller derives the resource — and hence the admin disable check and the recorded
+ * `typeUrlPattern` — from what this returns, so guessing would mint a capability the URL never
+ * described.
+ */
+export function parseResourceUrl(url: string): ResourceTarget {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Not a valid resource URL: ${url}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Google resource URLs must use https: ${url}`);
+  }
+
+  switch (parsed.hostname) {
+    case "mail.google.com": return parseGmailUrl(parsed);
+    case "docs.google.com": return parseDocsUrl(parsed);
+    case "calendar.google.com": return parseCalendarUrl(parsed);
+    case BIGQUERY_HOST: return parseBigQueryUrl(parsed);
+  }
+  throw new Error(`Unsupported Google resource URL: ${url}`);
+}
+
+/**
+ * Gmail's own UI writes a hash of `#inbox`, `#search/<query>` or `#label/<name>`.
+ *
+ * The label is kept as an opaque name and resolved to an ID at session start, so label text can
+ * never be interpreted as search syntax.
+ */
+function parseGmailUrl(parsed: URL): ResourceTarget {
+  let hash = parsed.hash;
+  if (hash.startsWith("#search/")) {
+    // Gmail encodes spaces in hash searches as `+`, which decodeURIComponent does not decode.
+    let query = decodeURIComponent(hash.slice("#search/".length).replace(/\+/g, " "));
+    validateGmailQueryForGrouping(query);
+    return { kind: "gmail", searchQuery: query };
+  }
+  if (hash.startsWith("#label/")) {
+    let labelName = decodeURIComponent(hash.slice("#label/".length));
+    validateGmailLabelName(labelName);
+    return { kind: "gmail", labelName };
+  }
+  if (hash && hash !== "#inbox") {
+    throw new Error(
+      "Unsupported Gmail view. Connect the inbox, an explicit search, or an explicit label.");
+  }
+  return { kind: "gmail" };
+}
+
+function parseDocsUrl(parsed: URL): ResourceTarget {
+  // Both forms are /<type>/d/<id>/..., so the id is always the third segment.
+  let id = parsed.pathname.split("/")[3];
+  if (parsed.pathname.startsWith("/document/d/")) {
+    if (!id) throw new Error("Invalid Google Docs URL: no document ID found");
+    return { kind: "doc", documentId: id };
+  }
+  if (parsed.pathname.startsWith("/spreadsheets/d/")) {
+    if (!id) throw new Error("Invalid Google Sheets URL: no spreadsheet ID found");
+    return { kind: "sheets", spreadsheetId: id };
+  }
+  throw new Error(`Unsupported Google Docs resource URL: ${parsed.href}`);
+}
+
+function parseCalendarUrl(parsed: URL): ResourceTarget {
+  if (!parsed.pathname.startsWith("/calendar/")) {
+    throw new Error(`Unsupported Google Calendar resource URL: ${parsed.href}`);
+  }
+  let calendarId = decodeURIComponent(parsed.pathname.split("/")[2] ?? "");
+  if (!calendarId) {
+    throw new Error("Invalid Google Calendar URL: no calendar ID found");
+  }
+  if (calendarId === "primary") {
+    throw new Error(
+      "Google Calendar bindings must use a stable calendar ID, not the account-relative " +
+      "\"primary\" alias.");
+  }
+  // Least privilege unless the URL explicitly opts into all calendars.
+  let availabilityMode: CalendarAvailabilityMode =
+      parsed.searchParams.get("availability") === "allVisible" ? "allVisible" : "thisCalendar";
+  return { kind: "calendar", calendarId, availabilityMode };
+}
+
+function parseBigQueryUrl(parsed: URL): ResourceTarget {
+  if (parsed.search || parsed.hash) {
+    throw new Error("BigQuery resource URLs must not include query strings or fragments.");
+  }
+
+  // Synthetic path: /<projectId>/<datasetId>/<tableId> (each segment optional after the first).
+  let segments = parsed.pathname.split("/").filter(Boolean).map(s => decodeURIComponent(s));
+  if (segments.length > 3) {
+    throw new Error(
+        "BigQuery resource URLs must be /<projectId>, /<projectId>/<datasetId>, " +
+        "or /<projectId>/<datasetId>/<tableId>.");
+  }
+  let [projectId, datasetId, tableId] = segments;
+  if (!projectId) {
+    throw new Error("BigQuery resource URLs must include a project ID.");
+  }
+  if (tableId && !datasetId) {
+    throw new Error("Cannot scope to a table without specifying a dataset.");
+  }
+  return { kind: "bigquery", projectId, datasetId, tableId };
+}

--- a/packages/gatekeeper-google/src/resources.ts
+++ b/packages/gatekeeper-google/src/resources.ts
@@ -199,10 +199,11 @@ export function parseResourceUrl(url: string): ResourceTarget {
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`Not a valid resource URL: ${url}`);
+    // Nothing of an unparseable string is safe to quote back.
+    throw new Error("Not a valid resource URL.");
   }
   if (parsed.protocol !== "https:") {
-    throw new Error(`Google resource URLs must use https: ${url}`);
+    throw new Error(`Google resource URLs must use https, not ${parsed.protocol}`);
   }
 
   switch (parsed.hostname) {
@@ -211,7 +212,20 @@ export function parseResourceUrl(url: string): ResourceTarget {
     case "calendar.google.com": return parseCalendarUrl(parsed);
     case BIGQUERY_HOST: return parseBigQueryUrl(parsed);
   }
-  throw new Error(`Unsupported Google resource URL: ${url}`);
+  throw new Error(`Unsupported Google resource URL host: ${parsed.hostname}`);
+}
+
+/**
+ * How much of a resource URL is safe to name in an error.
+ *
+ * A resource URL is caller-supplied and its tail is the sensitive part: a Gmail hash carries a
+ * search query, and `href` retains any embedded credentials. These errors reach the Workshop UI and
+ * are logged by their catchers, so only the host and path travel. The path still names a document
+ * id, which is what makes the error worth reading at all -- but an id the caller just supplied and
+ * the recorded binding will hold anyway, not a secret this adds to the trail.
+ */
+function describeUrl(parsed: URL): string {
+  return `${parsed.hostname}${parsed.pathname}`;
 }
 
 /**
@@ -251,12 +265,12 @@ function parseDocsUrl(parsed: URL): ResourceTarget {
     if (!id) throw new Error("Invalid Google Sheets URL: no spreadsheet ID found");
     return { kind: "sheets", spreadsheetId: id };
   }
-  throw new Error(`Unsupported Google Docs resource URL: ${parsed.href}`);
+  throw new Error(`Unsupported Google Docs resource URL: ${describeUrl(parsed)}`);
 }
 
 function parseCalendarUrl(parsed: URL): ResourceTarget {
   if (!parsed.pathname.startsWith("/calendar/")) {
-    throw new Error(`Unsupported Google Calendar resource URL: ${parsed.href}`);
+    throw new Error(`Unsupported Google Calendar resource URL: ${describeUrl(parsed)}`);
   }
   let calendarId = decodeURIComponent(parsed.pathname.split("/")[2] ?? "");
   if (!calendarId) {

--- a/packages/gatekeeper-google/tsconfig.json
+++ b/packages/gatekeeper-google/tsconfig.json
@@ -13,6 +13,6 @@
       "@gadgets/workshop-shared/*": ["../workshop-shared/src/*"]
     }
   },
-  "include": ["src"],
-  "exclude": ["dist", "node_modules"]
+  "include": ["src", "__tests__"],
+  "exclude": ["dist", "node_modules", ".wrangler"]
 }

--- a/packages/gatekeeper-google/vite.config.ts
+++ b/packages/gatekeeper-google/vite.config.ts
@@ -1,3 +1,3 @@
-// Vite+ per-package settings. The build:configurator task definition is shared by all gatekeepers
-// with a configurator UI and lives beside the builder it runs.
-export { default } from '../../scripts/gatekeeper-configurator-vite-config.js'
+// Vite+ per-package settings. Shared by all gatekeepers with a configurator UI and living beside the
+// builder it runs; `withTests` is that config plus the shared vitest `test` task.
+export { withTests as default } from '../../scripts/gatekeeper-configurator-vite-config.js'

--- a/packages/gatekeeper-google/vitest.config.ts
+++ b/packages/gatekeeper-google/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["__tests__/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
         version: 4.120.0(@cloudflare/workers-types@5.20260808.1)


### PR DESCRIPTION
Groundwork for a Drive gatekeeper, in two commits, with no new resource type yet.

The first gives `gatekeeper-google` a vitest project — it had none — and moves the Gmail validators and the five resource declarations into `gmail-validate.ts` and `resources.ts`, so adding a resource type stops meaning five edits scattered through a 3,800-line file. `getGatekeeperClassFor` becomes a switch over `parseResourceUrl`, fixing an unrecognised resource URL that fell through to Gmail rather than throwing.

The second extracts three engines: `observers.ts`, the strategy C tracker BigQuery and Calendar each kept a near-identical copy of, now shared with persisted key encodings unchanged and two faults fixed (an unbounded `Promise.all` over observers × tracked sets, and no cap on tracked sets at all — now 1,000, failing closed without disturbing existing observers); `cursor.ts`, Gmail's thread paging, generalised so a page emptied by a scope filter is walked past rather than mistaken for the end of the results; and `drive-api.ts`, which moves the configurator's Drive search off a raw `fetch` onto `fetchWithAuthRetry` so a stale token refreshes instead of 401ing.