### PR TITLE
fix modal presentation for embedded gatekeeper UI

### DIFF
--- a/packages/workshop-frontend/src/SandboxedGatekeeperApp.test.tsx
+++ b/packages/workshop-frontend/src/SandboxedGatekeeperApp.test.tsx
@@ -46,6 +46,10 @@ vi.mock("./AuthContext", () => ({
 
 interface TestHost extends RpcTarget {
   subscribeTheme(receiver: GatekeeperAppThemeReceiver): Promise<GatekeeperAppTheme>;
+  setPresenting(active: boolean): Promise<{
+    rect: { left: number; top: number; width: number; height: number } | null;
+    willResize: boolean;
+  }>;
   openWorkspace(workspaceId: string, gadgetId?: number): Promise<void>;
   resolveWorkspaceTitles(ids: string[]): Promise<(string | null)[]>;
   openPrompt(prompt: string): Promise<void>;
@@ -115,6 +119,26 @@ describe("SandboxedGatekeeperApp navigation", () => {
       mode: "light",
       accentColor: "#7c3aed",
     });
+
+    await act(async () => {
+      await host!.setPresenting(true);
+    });
+    expect(iframe.style.position).toBe("fixed");
+    expect(iframe.style.top).toBe("calc(var(--app-top) + env(safe-area-inset-top))");
+    expect(iframe.style.bottom).toBe("calc(var(--app-bottom) + env(safe-area-inset-bottom))");
+    expect(iframe.style.width).toBe(
+      "calc(100vw - (env(safe-area-inset-left) + env(safe-area-inset-right)))",
+    );
+    expect(iframe.style.height).toBe(
+      "calc(100vh - var(--app-top) - var(--app-bottom) - env(safe-area-inset-top) - env(safe-area-inset-bottom))",
+    );
+
+    await act(async () => {
+      await host!.setPresenting(false);
+    });
+    expect(iframe.style.position).toBe("");
+    expect(iframe.style.width).toBe("100%");
+    expect(iframe.style.height).toBe("100%");
 
     await act(async () => {
       await host!.openWorkspace(WORKSPACE_ID, 2);

--- a/packages/workshop-frontend/src/SandboxedGatekeeperApp.tsx
+++ b/packages/workshop-frontend/src/SandboxedGatekeeperApp.tsx
@@ -62,8 +62,8 @@ function iframeStyleForOverlay(overlay: OverlayState): CSSProperties {
       right: 'env(safe-area-inset-right)',
       bottom: 'calc(var(--app-bottom) + env(safe-area-inset-bottom))',
       left: 'env(safe-area-inset-left)',
-      width: 'auto',
-      height: 'auto',
+      width: 'calc(100vw - env(safe-area-inset-left) - env(safe-area-inset-right))',
+      height: 'calc(100vh - var(--app-top) - var(--app-bottom) - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
       zIndex: overlayZIndex,
     }
   }


### PR DESCRIPTION
https://github.com/cloudflare/cloudflare-os/pull/284 introduced a modal styling regression for embedded gatekeeper UI pages (e.g. context and skills):

<img width="645" height="652" alt="image" src="https://github.com/user-attachments/assets/7f12dc27-1ed4-433c-8d6c-c6b86fbcfa7e" />

This PR fixes it so modals appear normally:

<img width="2992" height="1015" alt="image" src="https://github.com/user-attachments/assets/45169d97-bb28-4602-84c9-232077dd22a1" />

