### PR TITLE
fix gatekeeper connection modal on mobile

### DIFF
--- a/packages/workshop-frontend/src/components/ConnectConnectorModal.tsx
+++ b/packages/workshop-frontend/src/components/ConnectConnectorModal.tsx
@@ -204,7 +204,7 @@ export default function ConnectConnectorModal({
       }}
     >
       <Dialog
-        className="responsive-dialog !z-[1000] !top-[clamp(28px,8vh,80px)] !flex !max-h-[calc(100vh-clamp(28px,8vh,80px)-28px)] !w-[min(640px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0"
+        className="responsive-dialog connect-connector-dialog !z-[1000] !top-[clamp(28px,8vh,80px)] !flex !max-h-[calc(100vh-clamp(28px,8vh,80px)-28px)] !w-[min(640px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0"
         size="lg"
       >
         <div className="shrink-0 flex items-start justify-between gap-4 border-b border-kumo-line px-5 py-4">

--- a/packages/workshop-frontend/src/styles.css
+++ b/packages/workshop-frontend/src/styles.css
@@ -266,18 +266,30 @@ body {
       top: auto !important;
       right: env(safe-area-inset-right) !important;
       bottom: calc(var(--app-bottom) + env(safe-area-inset-bottom)) !important;
-      left: env(safe-area-inset-left) !important;
+      left: 50% !important;
       width: calc(100vw - env(safe-area-inset-left) - env(safe-area-inset-right)) !important;
       max-width: none !important;
       max-height: calc(var(--app-height) - 8px - env(safe-area-inset-top)) !important;
       border-bottom-right-radius: 0 !important;
       border-bottom-left-radius: 0 !important;
-      translate: 0 0 !important;
+      translate: -50% 0 !important;
       transform: none !important;
     }
 
     body .responsive-dialog :is(input, textarea, select) {
       font-size: 16px;
+    }
+
+    body .connect-connector-dialog {
+      top: 50% !important;
+      bottom: auto !important;
+      right: auto !important;
+      left: 50% !important;
+      width: calc(100vw - 32px) !important;
+      max-height: calc(var(--app-height) - 32px) !important;
+      border-bottom-right-radius: var(--radius-xl) !important;
+      border-bottom-left-radius: var(--radius-xl) !important;
+      translate: -50% -50% !important;
     }
   }
 }


### PR DESCRIPTION
The gatekeeper connection modal is currently broken on mobile:

<img width="1168" height="1648" alt="image" src="https://github.com/user-attachments/assets/7988d018-30e2-4351-9b41-8f5def7d9128" />

This PR fixes that:

<img width="1173" height="1588" alt="image" src="https://github.com/user-attachments/assets/29ecb5c1-0131-4f9d-b3ba-a033880bdf70" />
