### PR TITLE
Add Kimi K3 and refresh the quick model

### DIFF
--- a/packages/workshop-backend/__tests__/ai-gateway.test.ts
+++ b/packages/workshop-backend/__tests__/ai-gateway.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  AiGatewayConfig,
   AiGatewayLogRetryableError,
   getAiGatewayLogCost,
 } from "../src/ai-gateway.js";
@@ -7,11 +8,38 @@ import {
 function env(overrides: Partial<Cloudflare.Env> = {}): Cloudflare.Env {
   return {
     CF_AI_GATEWAY: "platform-gateway",
+    CF_AI_GATEWAY_ACCOUNT_ID: "gateway-account-id",
+    CF_AI_GATEWAY_API_TOKEN: "read-run-token",
     CF_AI_GATEWAY_PROVIDERS: "anthropic,openai,google",
     WORKERS_AI: {} as Ai,
     ...overrides,
   } as Cloudflare.Env;
 }
+
+describe("AiGatewayConfig", () => {
+  it("offers the deployment-funded Kimi and Claude catalog globally", () => {
+    const config = new AiGatewayConfig(env({
+      CF_AI_GATEWAY_PROVIDERS: "cloudflare,anthropic",
+    }));
+
+    expect(config.getModelList()).toEqual(expect.arrayContaining([
+      { type: "agent", id: "moonshotai/kimi-k3", name: "Kimi K3" },
+      { type: "agent", id: "claude-opus-5", name: "Claude Opus 5" },
+      { type: "agent", id: "claude-sonnet-5", name: "Claude Sonnet 5" },
+      { type: "agent", id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+    ]));
+  });
+
+  it("uses GLM 4.7 Flash for quick tasks", () => {
+    const config = new AiGatewayConfig(env());
+
+    expect(config.getQuickModelConfig()).toEqual({
+      provider: "cloudflare",
+      model: "@cf/zai-org/glm-4.7-flash",
+      apiToken: "",
+    });
+  });
+});
 
 describe("getAiGatewayLogCost", () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/packages/workshop-backend/src/ai-gateway.ts
+++ b/packages/workshop-backend/src/ai-gateway.ts
@@ -3,9 +3,9 @@ import { UserAiModelRecord } from "./user.js";
 
 // The model used for quick tasks like title generation when AI Gateway mode is active.
 //
-// This 70B model is quite fast and cheap and produces pretty good titles. The cost is insignificant
-// compared to the actual coding model so there's not much reason to use a smaller model.
-const QUICK_MODEL_ID = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
+// Optimized for low latency and instruction following, with enough context for naming and title
+// tasks at a small fraction of frontier-model cost.
+const QUICK_MODEL_ID = "@cf/zai-org/glm-4.7-flash";
 
 export class AiGatewayConfig {
   readonly gateway: string;

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -960,6 +960,9 @@ export const SUGGESTED_MODELS: Record<
   Record<string, {name: string, contextWindow: number, outputLimit?: number}>
 > = {
   "cloudflare": {
+    "moonshotai/kimi-k3": {
+      name: "Kimi K3", contextWindow: 1048576, outputLimit: WORKERS_AI_OUTPUT_LIMIT,
+    },
     "@cf/moonshotai/kimi-k2.7-code": {
       name: "Kimi K2.7 Code (Workers AI)", contextWindow: 262144,
       outputLimit: WORKERS_AI_OUTPUT_LIMIT,


### PR DESCRIPTION
## Summary
- add Kimi K3 to the deployment-funded Cloudflare model catalog
- replace the retired Llama 3.3 quick model with GLM 4.7 Flash
- verify Kimi, Claude Opus, Sonnet, and Haiku are exposed by the global catalog

## Testing
- `pnpm --filter @gadgets/workshop-backend exec vitest run __tests__/ai-gateway.test.ts`
- full starter `pnpm check` build and dry-run against this submodule commit