### PR TITLE
Migration fidelity tests: YJS-seeded workspace -> git storage

### DIFF
--- a/packages/workshop-backend/__tests__/git-migration-do.test.ts
+++ b/packages/workshop-backend/__tests__/git-migration-do.test.ts
@@ -1,0 +1,165 @@
+// Exercises the git-storage migration through its *real* trigger: the OverseerImpl constructor
+// noticing `version` 1 and running #migrateToGitStorage under blockConcurrencyWhile, over real
+// SQLite DO storage -- complementing git-migration.test.ts's direct migrateCodeLogToGit calls on
+// mock storage. Each test seeds a legacy (version-1) workspace into a fresh DO, aborts every DO
+// so the next touch re-runs the constructor, then asserts the migrated snapshots against an
+// independent replay of the seeded Yjs update log.
+//
+// This lives in __tests__/ (the unit workerd config), not __integration__/: the TEST_OVERSEER
+// DO binding exists only in vitest.config.ts, and no public API path can create a legacy
+// workspace anymore (new workspaces are born at version 2), so seeding must reach into
+// impl.storage -- the same pattern as chat-changes.test.ts. The public DO surface (open() etc.)
+// is deliberately never called: #initializeNewWorkspace would stamp version 2 and shadow the
+// scenario.
+
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { abortAllDurableObjects, runInDurableObject } from "cloudflare:test";
+import type { OverseerDurableObject } from "../src/overseer.js";
+import { HISTORY_COMMIT_GAP_MS } from "../src/git-migration";
+import {
+  LegacyWorkspace, MINUTE, T0, USER, expectHeadsMatchDoc, readDocFiles, setFile,
+} from "./legacy-workspace";
+
+declare module "cloudflare:workers" {
+  interface ProvidedEnv {
+    TEST_OVERSEER: DurableObjectNamespace<OverseerDurableObject>;
+  }
+}
+
+// With no ownerId seeded, #ownerCommitIdentity() resolves to this documented fallback without
+// contacting any user DO.
+const FALLBACK_OWNER = { name: "Workspace owner", email: "owner@localhost" };
+
+// Mints a fresh stub per call: after abortAllDurableObjects() the previous stub is permanently
+// poisoned, and only a fresh stub re-constructs the object.
+async function inOverseer(name: string, fn: (impl: any) => Promise<void>): Promise<void> {
+  let stub = env.TEST_OVERSEER.getByName(name);
+  await runInDurableObject(stub, async (instance: OverseerDurableObject) => {
+    await fn((instance as unknown as { impl: any }).impl);
+  });
+}
+
+// Seeds a legacy workspace into the named DO's real storage and arms the constructor trigger.
+// The returned LegacyWorkspace lives in test scope, so its in-memory update log (docAt) survives
+// the DO abort and serves as the post-migration oracle.
+async function seedLegacyWorkspace(
+    name: string, build: (ws: LegacyWorkspace, impl: any) => void): Promise<LegacyWorkspace> {
+  let ws!: LegacyWorkspace;
+  await inOverseer(name, async impl => {
+    // Pins the seeding recipe's precondition: a fresh TEST_OVERSEER DO writes *nothing* at
+    // construction (#migrateStorage returns immediately at version 0 with no ownerId). If a
+    // future constructor change starts initializing fresh DOs, this fails loudly and the
+    // recipe needs rethinking.
+    expect(impl.storage.version.get()).toBe(0);
+    ws = new LegacyWorkspace(impl.storage);
+    build(ws, impl);
+    // ownerId is deliberately never seeded: it keeps #migrateStorage inert on re-entry and
+    // makes #ownerCommitIdentity() return its fallback instead of calling a user DO.
+    //
+    // Last write: arm the constructor's version-1 git-storage migration trigger.
+    impl.storage.version.put(1);
+  });
+  return ws;
+}
+
+describe("git-storage migration via the Overseer constructor", () => {
+  it("migrates a single-gadget workspace, preserving content across the batching gap",
+      async () => {
+    let ws = await seedLegacyWorkspace("git-migration-single", (ws, impl) => {
+      ws.addGadget(1, "APP");
+      impl.storage.defaultGadgetId.put(1);  // the default gadget's legacy files root is ""
+
+      // A burst of edits (within a minute of the constructor's empty v1, so that v1 doesn't
+      // become its own commit point), then non-code versions, then an edit across the one-hour
+      // batching boundary.
+      ws.edit(T0 + 1 * MINUTE, doc => setFile(doc, "", "app.js", "hello\n"));            // v2
+      ws.edit(T0 + 2 * MINUTE, doc => setFile(doc, "", "util.js", "util one\n"));        // v3
+      ws.skipVersions(2);                                                                // v4-v5
+      ws.edit(T0 + 2 * MINUTE + HISTORY_COMMIT_GAP_MS, doc => {
+        setFile(doc, "", "app.js", "hello\nworld\n");
+        setFile(doc, "", "util.js", "util two\n");
+      });                                                                                // v6
+    });
+
+    await abortAllDurableObjects();
+
+    await inOverseer("git-migration-single", async impl => {
+      // The constructor's blockConcurrencyWhile completed before this event was delivered.
+      expect(impl.storage.version.get()).toBe(2);
+
+      await expectHeadsMatchDoc(impl.storage, impl.gitStore, ws.docAt("current"), 1);
+
+      // Chain sanity: an empty parentless root, the pre-gap batch (v1-v3), and the final
+      // version, linearly chained and authored as the ownerless fallback identity.
+      let head = impl.storage.gadgets.get(1)!.commitId!;
+      let log = await impl.gitStore.readCommitLog(head);
+      expect(log.length).toBe(3);
+      expect(log[0].parents).toEqual([log[1].oid]);
+      expect(log[1].parents).toEqual([log[2].oid]);
+      expect(log[2].parents).toEqual([]);
+      expect(await impl.gitStore.readCommitFiles(log[2].oid)).toEqual(new Map());
+      expect(await impl.gitStore.readCommitFiles(log[1].oid)).toEqual(new Map([
+        ["app.js", "hello\n"],
+        ["util.js", "util one\n"],
+      ]));
+      for (let entry of log) {
+        expect(entry.author).toEqual(FALLBACK_OWNER);
+      }
+    });
+  });
+
+  it("migrates a multi-gadget workspace with per-gadget heads and unpolluted chains",
+      async () => {
+    let ws = await seedLegacyWorkspace("git-migration-multi", (ws, impl) => {
+      ws.addGadget(1, "APP");   // default gadget: legacy files root ""
+      ws.addGadget(2, "LEFT");  // root "2"
+      ws.addGadget(3, "RIGHT"); // root "3"
+      impl.storage.defaultGadgetId.put(1);
+      ws.addChat(1);
+
+      ws.edit(T0 + 1 * MINUTE, doc => setFile(doc, "", "app.js", "a one\n"));            // v2
+      ws.addMessage(1, USER, { type: "merge", mergeThrough: 0, version: 2 });
+      // One version touching two gadgets' roots at once.
+      ws.edit(T0 + 2 * MINUTE, doc => {
+        setFile(doc, "", "app.js", "a two\n");
+        setFile(doc, "2", "left.js", "l one\n");
+      });                                                                                // v3
+      ws.addMessage(1, USER, { type: "merge", mergeThrough: 1, version: 3 });
+      // A gap-spanning burst on gadget 3 alone: v4-v6 batch to one commit, v7 is its own.
+      ws.edit(T0 + 3 * MINUTE, doc => setFile(doc, "3", "right.js", "r one\n"));         // v4
+      ws.edit(T0 + 4 * MINUTE, doc => setFile(doc, "3", "extra.js", "r extra\n"));       // v5
+      ws.edit(T0 + 5 * MINUTE, doc => setFile(doc, "3", "right.js", "r two\n"));         // v6
+      ws.edit(T0 + 5 * MINUTE + HISTORY_COMMIT_GAP_MS,
+          doc => setFile(doc, "3", "right.js", "r three\n"));                            // v7
+    });
+
+    await abortAllDurableObjects();
+
+    await inOverseer("git-migration-multi", async impl => {
+      expect(impl.storage.version.get()).toBe(2);
+
+      // Every gadget's head equals its own root's content in an independent replay of the log.
+      await expectHeadsMatchDoc(impl.storage, impl.gitStore, ws.docAt("current"), 1);
+
+      // Non-pollution: each chain is the empty root plus that gadget's own commit points,
+      // regardless of the others' activity, and carries only its own filenames.
+      let logOf = async (gadgetId: number) =>
+          await impl.gitStore.readCommitLog(impl.storage.gadgets.get(gadgetId)!.commitId!);
+      let appLog = await logOf(1);
+      let leftLog = await logOf(2);
+      let rightLog = await logOf(3);
+      expect(appLog.length).toBe(3);    // empty root + merge points v2 and v3
+      expect(leftLog.length).toBe(2);   // empty root + merge point v3
+      expect(rightLog.length).toBe(3);  // empty root + pre-gap batch (v6) + final (v7)
+
+      expect(await impl.gitStore.readCommitFiles(appLog[1].oid))
+          .toEqual(new Map([["app.js", "a one\n"]]));
+      expect(await impl.gitStore.readCommitFiles(leftLog[0].oid))
+          .toEqual(new Map([["left.js", "l one\n"]]));
+      // Gadget 3's intermediate commit is the batch's end state, checked against the replay.
+      expect(await impl.gitStore.readCommitFiles(rightLog[1].oid))
+          .toEqual(readDocFiles(ws.docAt(6), "3"));
+    });
+  });
+});

--- a/packages/workshop-backend/__tests__/git-migration.test.ts
+++ b/packages/workshop-backend/__tests__/git-migration.test.ts
@@ -1,174 +1,11 @@
 import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { keyString } from "@gadgets/typed-storage";
-import type {
-  AiChatAuthorInfo, AiChatMessage, BlueprintMetadata, ChatCodeBase,
-} from "@gadgets/workshop-shared/api";
-import { applyCodeChange, type CodeContent } from "@gadgets/workshop-shared/code-change";
-import { makeMockStorage } from "./mock-storage";
-import { makeOverseerStorage } from "../src/overseer";
-import { GitStore } from "../src/git-store";
-import {
-  HISTORY_COMMIT_GAP_MS, migrateCodeLogToGit, type GitMigrationHost,
-} from "../src/git-migration";
+import type { AiChatMessage, BlueprintMetadata } from "@gadgets/workshop-shared/api";
+import { HISTORY_COMMIT_GAP_MS, migrateCodeLogToGit } from "../src/git-migration";
 import { foldProposedChanges, legacyChatBaseVersion } from "../src/agent-compaction";
-
-const USER: AiChatAuthorInfo = { type: "user", id: "alice@example.com", name: "Alice" };
-const AGENT: AiChatAuthorInfo = { type: "agent", id: "some-model", name: "Agent" };
-const OWNER = { name: "Alice", email: "alice@example.com" };
-
-const T0 = Date.UTC(2024, 0, 1);
-const MINUTE = 60_000;
-
-/**
- * Builds a synthetic pre-git-storage workspace on mock storage: a legacy code log written the
- * way the old updateCode() wrote it (incremental V2 updates against one workspace-wide doc,
- * versions drawn from the shared change counter -- so `skipVersions` models the gaps that
- * non-code changes left), plus gadget records, chats (with legacy Yjs-update messages and
- * drafts), and blueprint records.
- */
-class LegacyWorkspace {
-  storage = makeOverseerStorage(makeMockStorage());
-  gitStore = new GitStore(this.storage.gitObjects);
-
-  #doc = new Y.Doc();
-  #version = 0;
-  #updates: Uint8Array[] = [];
-  #timestamp = 0;
-
-  constructor() {
-    // Legacy workspaces always wrote an (often empty) version 1 at initialization.
-    this.edit(T0, () => {});
-  }
-
-  /** Applies `fn` to the mainline doc and records the resulting update as the next version. */
-  edit(timestampMs: number, fn: (doc: Y.Doc) => void): number {
-    let captured: Uint8Array[] = [];
-    let handler = (update: Uint8Array) => captured.push(update);
-    this.#doc.on("updateV2", handler);
-    this.#doc.transact(() => fn(this.#doc));
-    this.#doc.off("updateV2", handler);
-    let update = captured.length > 0
-        ? Y.mergeUpdatesV2(captured) : Y.encodeStateAsUpdateV2(new Y.Doc());
-    this.#updates.push(update);
-    let version = ++this.#version;
-    this.storage.code.put({ version, timestamp: new Date(timestampMs), update });
-    return version;
-  }
-
-  /** Models non-code changes consuming versions from the shared counter (binding edits etc.). */
-  skipVersions(count: number): void {
-    this.#version += count;
-  }
-
-  /** A fresh doc replaying the recorded log through `version` ("current" = all of it). */
-  docAt(version: number | "current"): Y.Doc {
-    let doc = new Y.Doc();
-    let count = version === "current" ? this.#updates.length : version;
-    for (let update of this.#updates.slice(0, count)) {
-      Y.applyUpdateV2(doc, update);
-    }
-    return doc;
-  }
-
-  addGadget(id: number, bindingName: string,
-            pending?: { chatId: number, sequence?: number }): void {
-    this.storage.gadgets.put({
-      id, title: bindingName, created: new Date(T0), bindingName, bindings: {},
-      ...(pending !== undefined ? { pending } : {}),
-    });
-  }
-
-  addChat(id: number): void {
-    this.storage.chatMeta.put(
-        { id, title: "Chat", started: new Date(T0), lastActive: new Date(T0 + id) });
-  }
-
-  addMessage(chatId: number, author: AiChatAuthorInfo, body: object): number {
-    // Sequences come from the real counter collection, exactly as the legacy system allocated
-    // them (the migration's conversion message continues the same counter).
-    let sequence = this.storage.nextChatSequences.get(chatId)?.nextSequence ?? 0;
-    this.storage.nextChatSequences.put({ chatId, nextSequence: sequence + 1 });
-    // Legacy bodies (e.g. merge messages without `commits`, changes messages carrying a retired
-    // Yjs `update`) are exactly what the migration consumes, so this deliberately bypasses the
-    // current wire type.
-    this.storage.chats.put({
-      chatId, sequence, timestamp: new Date(T0 + ++this.#timestamp), author, ...body,
-    } as AiChatMessage);
-    return sequence;
-  }
-
-  /** Records a legacy live draft (see ChatDraftUpdateRecord in overseer.ts). */
-  addDraft(chatId: number, update: Uint8Array): void {
-    this.storage.chatDraftUpdates.put({
-      chatId, timestamp: new Date(T0 + ++this.#timestamp), author: USER, update,
-    });
-  }
-
-  host(defaultGadgetId?: number): GitMigrationHost {
-    return {
-      storage: this.storage,
-      gitStore: this.gitStore,
-      ownerIdentity: OWNER,
-      defaultGadgetId,
-      gadgetRootName: (id) => id === defaultGadgetId ? "" : `${id}`,
-      getActiveChatCompaction: (chatId) => {
-        let compactedTo = this.storage.chatMeta.get(chatId)?.compactedTo;
-        return compactedTo === undefined ? undefined
-            : this.storage.chatCompactions.get(
-                `${keyString(chatId)}.${keyString(compactedTo)}`);
-      },
-      // The shared counter keeps conversion timestamps unique against every message's (the
-      // chats collection's byTimestamp index is unique), like the real getChatTimestamp().
-      getChatTimestamp: () => new Date(T0 + ++this.#timestamp),
-    };
-  }
-
-  mergeMessages(chatId: number): Extract<AiChatMessage, { type: "merge" }>[] {
-    return [...this.storage.chats.list({ prefix: `${keyString(chatId)}.` })]
-        .filter(msg => msg.type === "merge");
-  }
-
-  messages(chatId: number): AiChatMessage[] {
-    return [...this.storage.chats.list({ prefix: `${keyString(chatId)}.` })];
-  }
-
-  conversionMessage(chatId: number): Extract<AiChatMessage, { type: "changes" }> {
-    let found = this.messages(chatId).filter(
-        msg => msg.type === "changes" && msg.conversionBoundary);
-    expect(found).toHaveLength(1);
-    return found[0] as Extract<AiChatMessage, { type: "changes" }>;
-  }
-
-  codeBase(chatId: number): ChatCodeBase | undefined {
-    return this.storage.chatMeta.get(chatId)?.codeBase;
-  }
-
-  /** The chat's converted content: the pin bases with the conversion change applied on top. */
-  async convertedContent(chatId: number): Promise<CodeContent> {
-    let conversion = this.conversionMessage(chatId);
-    let content: CodeContent = new Map();
-    for (let pin of conversion.pins ?? []) {
-      content.set(pin.gadgetId, await this.gitStore.readCommitFiles(pin.baseCommit));
-    }
-    return conversion.change !== undefined ? applyCodeChange(content, conversion.change) : content;
-  }
-}
-
-function setFile(doc: Y.Doc, root: string, name: string, text: string): void {
-  doc.getMap<Y.Text>(root).set(name, new Y.Text(text));
-}
-
-// Captures the update of one edit made against `doc` (a chat-local edit, never applied to the
-// mainline log).
-function captureEdit(doc: Y.Doc, fn: (doc: Y.Doc) => void): Uint8Array {
-  let captured: Uint8Array[] = [];
-  let handler = (update: Uint8Array) => captured.push(update);
-  doc.on("updateV2", handler);
-  doc.transact(() => fn(doc));
-  doc.off("updateV2", handler);
-  return Y.mergeUpdatesV2(captured);
-}
+import {
+  AGENT, LegacyWorkspace, MINUTE, OWNER, T0, USER, captureEdit, expectHeadsMatchDoc, setFile,
+} from "./legacy-workspace";
 
 describe("migrateCodeLogToGit", () => {
   it("synthesizes commits at merge points and backfills merge messages", async () => {
@@ -188,6 +25,9 @@ describe("migrateCodeLogToGit", () => {
 
     let { commits } = await migrateCodeLogToGit(ws.host());
     expect(commits).toBe(3);
+
+    // Every head tree must equal an independent replay of the recorded update log.
+    await expectHeadsMatchDoc(ws.storage, ws.gitStore, ws.docAt("current"));
 
     // The head is the merge-point chain's tip: v3 was neither a merge point nor a gap, so it
     // folded into the v4 commit. The chain is rooted at the synthesized version-0 empty-tree
@@ -266,6 +106,9 @@ describe("migrateCodeLogToGit", () => {
 
     let { commits } = await migrateCodeLogToGit(ws.host());
     expect(commits).toBe(4);  // two empty roots, two content commits
+
+    // Every head tree must equal an independent replay of the recorded update log.
+    await expectHeadsMatchDoc(ws.storage, ws.gitStore, ws.docAt("current"));
 
     // Each gadget's chain has exactly its empty root plus the commit where its own files
     // changed.
@@ -482,6 +325,10 @@ describe("migrateCodeLogToGit", () => {
     ws.storage.blueprints.put({ id: "bp-deleted", metadata, gadgetId: 70, codeVersion: 2 });
 
     await migrateCodeLogToGit(ws.host(60));
+
+    // Every head tree must equal an independent replay of the recorded update log (the default
+    // gadget's root is "").
+    await expectHeadsMatchDoc(ws.storage, ws.gitStore, ws.docAt("current"), 60);
 
     // Each blueprint points at the commit whose tree is exactly the exported snapshot, even
     // though mainline moved on (bp-default) or the gadget is gone (bp-deleted).

--- a/packages/workshop-backend/__tests__/legacy-workspace.ts
+++ b/packages/workshop-backend/__tests__/legacy-workspace.ts
@@ -1,0 +1,212 @@
+// Shared fixture for the git-migration test suites: a synthetic pre-git-storage workspace whose
+// code log is written the way the legacy system wrote it, plus a content-fidelity oracle
+// (`expectHeadsMatchDoc`) that checks migrated gadget heads against an independent replay of the
+// recorded Yjs update log. Used both by the unit suite (git-migration.test.ts, over mock
+// storage) and by the DO-level integration tests (git-migration-do.test.ts, over a real
+// Durable Object's storage).
+
+import { expect } from "vitest";
+import * as Y from "yjs";
+import { keyString } from "@gadgets/typed-storage";
+import type {
+  AiChatAuthorInfo, AiChatMessage, ChatCodeBase, WorkpieceId,
+} from "@gadgets/workshop-shared/api";
+import { applyCodeChange, type CodeContent } from "@gadgets/workshop-shared/code-change";
+import { makeMockStorage } from "./mock-storage";
+import { makeOverseerStorage, type OverseerStorage } from "../src/overseer";
+import { GitStore } from "../src/git-store";
+import type { GitMigrationHost } from "../src/git-migration";
+
+export const USER: AiChatAuthorInfo = { type: "user", id: "alice@example.com", name: "Alice" };
+export const AGENT: AiChatAuthorInfo = { type: "agent", id: "some-model", name: "Agent" };
+export const OWNER = { name: "Alice", email: "alice@example.com" };
+
+export const T0 = Date.UTC(2024, 0, 1);
+export const MINUTE = 60_000;
+
+/**
+ * Builds a synthetic pre-git-storage workspace: a legacy code log written the way the old
+ * updateCode() wrote it (incremental V2 updates against one workspace-wide doc, versions drawn
+ * from the shared change counter -- so `skipVersions` models the gaps that non-code changes
+ * left), plus gadget records, chats (with legacy Yjs-update messages and drafts), and blueprint
+ * records. Defaults to mock storage; pass a real DO's storage to seed the workspace in place.
+ */
+export class LegacyWorkspace {
+  readonly storage: OverseerStorage;
+  readonly gitStore: GitStore;
+
+  #doc = new Y.Doc();
+  #version = 0;
+  #updates: Uint8Array[] = [];
+  #timestamp = 0;
+
+  constructor(storage: OverseerStorage = makeOverseerStorage(makeMockStorage())) {
+    this.storage = storage;
+    this.gitStore = new GitStore(storage.gitObjects);
+    // Legacy workspaces always wrote an (often empty) version 1 at initialization.
+    this.edit(T0, () => {});
+  }
+
+  /** Applies `fn` to the mainline doc and records the resulting update as the next version. */
+  edit(timestampMs: number, fn: (doc: Y.Doc) => void): number {
+    let captured: Uint8Array[] = [];
+    let handler = (update: Uint8Array) => captured.push(update);
+    this.#doc.on("updateV2", handler);
+    this.#doc.transact(() => fn(this.#doc));
+    this.#doc.off("updateV2", handler);
+    let update = captured.length > 0
+        ? Y.mergeUpdatesV2(captured) : Y.encodeStateAsUpdateV2(new Y.Doc());
+    this.#updates.push(update);
+    let version = ++this.#version;
+    this.storage.code.put({ version, timestamp: new Date(timestampMs), update });
+    return version;
+  }
+
+  /** Models non-code changes consuming versions from the shared counter (binding edits etc.). */
+  skipVersions(count: number): void {
+    this.#version += count;
+  }
+
+  /** A fresh doc replaying the recorded log through `version` ("current" = all of it). */
+  docAt(version: number | "current"): Y.Doc {
+    let doc = new Y.Doc();
+    let count = version === "current" ? this.#updates.length : version;
+    for (let update of this.#updates.slice(0, count)) {
+      Y.applyUpdateV2(doc, update);
+    }
+    return doc;
+  }
+
+  addGadget(id: number, bindingName: string,
+            pending?: { chatId: number, sequence?: number }): void {
+    this.storage.gadgets.put({
+      id, title: bindingName, created: new Date(T0), bindingName, bindings: {},
+      ...(pending !== undefined ? { pending } : {}),
+    });
+  }
+
+  addChat(id: number): void {
+    this.storage.chatMeta.put(
+        { id, title: "Chat", started: new Date(T0), lastActive: new Date(T0 + id) });
+  }
+
+  addMessage(chatId: number, author: AiChatAuthorInfo, body: object): number {
+    // Sequences come from the real counter collection, exactly as the legacy system allocated
+    // them (the migration's conversion message continues the same counter).
+    let sequence = this.storage.nextChatSequences.get(chatId)?.nextSequence ?? 0;
+    this.storage.nextChatSequences.put({ chatId, nextSequence: sequence + 1 });
+    // Legacy bodies (e.g. merge messages without `commits`, changes messages carrying a retired
+    // Yjs `update`) are exactly what the migration consumes, so this deliberately bypasses the
+    // current wire type.
+    this.storage.chats.put({
+      chatId, sequence, timestamp: new Date(T0 + ++this.#timestamp), author, ...body,
+    } as AiChatMessage);
+    return sequence;
+  }
+
+  /** Records a legacy live draft (see ChatDraftUpdateRecord in overseer.ts). */
+  addDraft(chatId: number, update: Uint8Array): void {
+    this.storage.chatDraftUpdates.put({
+      chatId, timestamp: new Date(T0 + ++this.#timestamp), author: USER, update,
+    });
+  }
+
+  host(defaultGadgetId?: number): GitMigrationHost {
+    return {
+      storage: this.storage,
+      gitStore: this.gitStore,
+      ownerIdentity: OWNER,
+      defaultGadgetId,
+      gadgetRootName: (id) => id === defaultGadgetId ? "" : `${id}`,
+      getActiveChatCompaction: (chatId) => {
+        let compactedTo = this.storage.chatMeta.get(chatId)?.compactedTo;
+        return compactedTo === undefined ? undefined
+            : this.storage.chatCompactions.get(
+                `${keyString(chatId)}.${keyString(compactedTo)}`);
+      },
+      // The shared counter keeps conversion timestamps unique against every message's (the
+      // chats collection's byTimestamp index is unique), like the real getChatTimestamp().
+      getChatTimestamp: () => new Date(T0 + ++this.#timestamp),
+    };
+  }
+
+  mergeMessages(chatId: number): Extract<AiChatMessage, { type: "merge" }>[] {
+    return [...this.storage.chats.list({ prefix: `${keyString(chatId)}.` })]
+        .filter(msg => msg.type === "merge");
+  }
+
+  messages(chatId: number): AiChatMessage[] {
+    return [...this.storage.chats.list({ prefix: `${keyString(chatId)}.` })];
+  }
+
+  conversionMessage(chatId: number): Extract<AiChatMessage, { type: "changes" }> {
+    let found = this.messages(chatId).filter(
+        msg => msg.type === "changes" && msg.conversionBoundary);
+    expect(found).toHaveLength(1);
+    return found[0] as Extract<AiChatMessage, { type: "changes" }>;
+  }
+
+  codeBase(chatId: number): ChatCodeBase | undefined {
+    return this.storage.chatMeta.get(chatId)?.codeBase;
+  }
+
+  /** The chat's converted content: the pin bases with the conversion change applied on top. */
+  async convertedContent(chatId: number): Promise<CodeContent> {
+    let conversion = this.conversionMessage(chatId);
+    let content: CodeContent = new Map();
+    for (let pin of conversion.pins ?? []) {
+      content.set(pin.gadgetId, await this.gitStore.readCommitFiles(pin.baseCommit));
+    }
+    return conversion.change !== undefined ? applyCodeChange(content, conversion.change) : content;
+  }
+}
+
+export function setFile(doc: Y.Doc, root: string, name: string, text: string): void {
+  doc.getMap<Y.Text>(root).set(name, new Y.Text(text));
+}
+
+/**
+ * Captures the update of one edit made against `doc` (a chat-local edit, never applied to the
+ * mainline log).
+ */
+export function captureEdit(doc: Y.Doc, fn: (doc: Y.Doc) => void): Uint8Array {
+  let captured: Uint8Array[] = [];
+  let handler = (update: Uint8Array) => captured.push(update);
+  doc.on("updateV2", handler);
+  doc.transact(() => fn(doc));
+  doc.off("updateV2", handler);
+  return Y.mergeUpdatesV2(captured);
+}
+
+/**
+ * `name -> text` snapshot of one root map of a legacy code doc, mirroring git-migration.ts's
+ * private reader of the same name.
+ */
+export function readDocFiles(doc: Y.Doc, rootName: string): Map<string, string> {
+  let files = new Map<string, string>();
+  for (let [name, text] of doc.getMap<Y.Text>(rootName)) {
+    files.set(name, text.toString());
+  }
+  return files;
+}
+
+/**
+ * The content-fidelity oracle: asserts every non-pending gadget's migrated head tree equals the
+ * legacy doc's content for that gadget's root ("" for the default gadget), and that pending
+ * gadgets got no head. Callers pass an independently replayed doc (e.g. `ws.docAt("current")`),
+ * so this checks the full log-replay -> commit-point -> tree-write pipeline against the recorded
+ * update log rather than against the migration's own doc.
+ */
+export async function expectHeadsMatchDoc(
+    storage: Pick<OverseerStorage, "gadgets">, gitStore: GitStore, doc: Y.Doc,
+    defaultGadgetId?: WorkpieceId): Promise<void> {
+  for (let gadget of storage.gadgets.list()) {
+    if (gadget.pending !== undefined) {
+      expect(gadget.commitId).toBeUndefined();
+      continue;
+    }
+    let root = gadget.id === defaultGadgetId ? "" : `${gadget.id}`;
+    expect(gadget.commitId).toBeDefined();
+    expect(await gitStore.readCommitFiles(gadget.commitId!)).toEqual(readDocFiles(doc, root));
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,7 +810,7 @@ importers:
         specifier: ^1.40.0
         version: 1.40.5
       jose:
-        specifier: ^6.2.5
+        specifier: ^6.2.8
         version: 6.2.8
       yjs:
         specifier: ^13.6.31


### PR DESCRIPTION
Adds a couple integration tests for migrating a single-gadget workspace and multi-gadget workspaces and asserts we're preserving content accordingly during migration