### PR TITLE
log executeCode return values

### DIFF
--- a/packages/gatekeeper-scheduler/src/types.d.ts
+++ b/packages/gatekeeper-scheduler/src/types.d.ts
@@ -280,9 +280,9 @@ export interface ScheduledTaskHook {
  * runs through the restored Gadget and does not need the Scheduler binding.
  *
  * Every successful registration call creates a distinct hook; registration is not idempotent.
- * `executeCode` ignores the exported function's return value, so print the schedule ID with
- * `console.log()`. Empty console output is not evidence that registration failed, and the disabled
- * hook appearing in Connections confirms success. Do not retry solely because no ID was printed.
+ * Return or print the schedule ID so it appears in the `executeCode` output. Empty output is not
+ * evidence that registration failed, and the disabled hook appearing in Connections confirms
+ * success. Do not retry solely because no ID was printed.
  *
  * @example
  * // server.js
@@ -308,7 +308,7 @@ export interface ScheduledTaskHook {
  *   callback,
  *   { title: "Daily brief", description: "Prepare the morning activity summary." },
  * );
- * console.log("Schedule registered:", scheduleId);
+ * return scheduleId;
  */
 export interface ScheduleSession {
   /**

--- a/packages/gatekeeper-scheduler/src/types.d.ts
+++ b/packages/gatekeeper-scheduler/src/types.d.ts
@@ -305,7 +305,7 @@ export interface ScheduledTaskHook {
  *   callback,
  *   { title: "Daily brief", description: "Prepare the morning activity summary." },
  * );
- * return scheduleId;
+ * console.log("Schedule registered:", scheduleId);
  */
 export interface ScheduleSession {
   /**

--- a/packages/gatekeeper-scheduler/src/types.d.ts
+++ b/packages/gatekeeper-scheduler/src/types.d.ts
@@ -280,9 +280,6 @@ export interface ScheduledTaskHook {
  * runs through the restored Gadget and does not need the Scheduler binding.
  *
  * Every successful registration call creates a distinct hook; registration is not idempotent.
- * Return or print the schedule ID so it appears in the `executeCode` output. Empty output is not
- * evidence that registration failed, and the disabled hook appearing in Connections confirms
- * success. Do not retry solely because no ID was printed.
  *
  * @example
  * // server.js

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -831,8 +831,6 @@ Note that this differs from the \`env\` a Gadget's own code sees: a Gadget's ser
 When the user asks you to just do a task that can be done with these bindings, you should use executeCode to perform the task, instead of adding code to a gadget to do it.
 
 The function also receives a \`self\` parameter which is a magic object that points back to this chat thread. Calling any method on \`self\`, like \`self.foo(123)\`, delivers a callback message to this chat and activates you to respond. \`self\` can be passed over RPC (e.g. to a subscription method) and stored in a Durable Object's KV storage for long-term callbacks. When an agent callback is received, it appears in your env under a name like \`PARAMS_1\`, with \`.args\` (the callback arguments), \`.resolve(value)\` (to return a value to the caller), and \`.reject(error)\` (to reject with an error).
-
-A non-\`undefined\` value returned by the function is included as the final line of console output, so only return values that should be visible in this output.
 `.trim();
 
 let LIST_CONNECTABLE_RESOURCES_TOOL_DESCRIPTION = `

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -831,6 +831,8 @@ Note that this differs from the \`env\` a Gadget's own code sees: a Gadget's ser
 When the user asks you to just do a task that can be done with these bindings, you should use executeCode to perform the task, instead of adding code to a gadget to do it.
 
 The function also receives a \`self\` parameter which is a magic object that points back to this chat thread. Calling any method on \`self\`, like \`self.foo(123)\`, delivers a callback message to this chat and activates you to respond. \`self\` can be passed over RPC (e.g. to a subscription method) and stored in a Durable Object's KV storage for long-term callbacks. When an agent callback is received, it appears in your env under a name like \`PARAMS_1\`, with \`.args\` (the callback arguments), \`.resolve(value)\` (to return a value to the caller), and \`.reject(error)\` (to reject with an error).
+
+A non-\`undefined\` value returned by the function is included as the final line of console output, so only return values that should be visible in this output.
 `.trim();
 
 let LIST_CONNECTABLE_RESOURCES_TOOL_DESCRIPTION = `

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -100,7 +100,7 @@ export default class extends WorkerEntrypoint {
       }
     }
     let result = await agent(self, env, this.ctx);
-    if (result !== undefined) console.log(result);
+    if (result !== undefined) console.log("Return value:", result);
   }
 }
 `;

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -99,7 +99,8 @@ export default class extends WorkerEntrypoint {
         }
       }
     }
-    await agent(self, env, this.ctx);
+    let result = await agent(self, env, this.ctx);
+    if (result !== undefined) console.log(result);
   }
 }
 `;

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -7261,7 +7261,7 @@ class OverseerImpl implements AgentHooks {
         }).join(" ");
       }).join("\n");
 
-      if (error) {
+      if (error !== undefined) {
         log += `\n\nUncaught exception: ${error}`;
       } else if (log === "") {
         log = "(function succeeded with no output)";

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -7263,6 +7263,8 @@ class OverseerImpl implements AgentHooks {
 
       if (error) {
         log += `\n\nUncaught exception: ${error}`;
+      } else if (log === "") {
+        log = "(function succeeded with no output)";
       }
 
       return log;


### PR DESCRIPTION
Kimi likes to return values when using the `executeCode` tool instead of logging them. Return values are currently discarded, which causes confusion. We can automatically log them instead.

This is probably a better alternative to https://github.com/cloudflare/cloudflare-os/pull/299

Fixes #209
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->