### PR TITLE
Build "deploy" releases in parallel

### DIFF
--- a/scripts/kill-process-tree.test.ts
+++ b/scripts/kill-process-tree.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { describe, it } from "node:test";
-import { killProcessTree } from "./kill-process-tree.ts";
+import { killProcessTree, killProcessTreeEscalating } from "./kill-process-tree.ts";
 
 function isAlive(pid: number): boolean {
   try {
@@ -47,5 +47,125 @@ describe("killProcessTree", () => {
 
     // ESRCH is the expected outcome here, not a failure.
     await killProcessTree(pid);
+  });
+
+  it("reaches a grandchild the wrapper's own death would hide", async () => {
+    const { wrapperPid, grandchildPid, cleanUp } = await spawnWrapper(IDLE);
+    try {
+      await killProcessTree(wrapperPid);
+      assert.ok(await waitUntilGone(wrapperPid), "the wrapper outlived the kill");
+      assert.ok(await waitUntilGone(grandchildPid), "the grandchild outlived the kill");
+    } finally {
+      cleanUp();
+    }
+  });
+});
+
+// A process that ignores SIGTERM, as a `node -e` body. Whatever survives the first signal is what
+// escalation exists for.
+const IGNORES_SIGTERM = "process.on('SIGTERM', () => {}); setTimeout(() => {}, 60_000)";
+const IDLE = "setTimeout(() => {}, 60_000)";
+
+// A `pnpm exec`-shaped tree: a wrapper whose child does the real work. The grandchild's pid comes
+// back over the wrapper's stdout, since that is the only handle a caller would have on it.
+async function spawnWrapper(grandchildBody: string): Promise<{
+  wrapperPid: number;
+  grandchildPid: number;
+  cleanUp: () => void;
+}> {
+  const wrapper = spawn(process.execPath, ["-e",
+    `const { spawn } = require("node:child_process");
+     const child = spawn(process.execPath, ["-e", ${JSON.stringify(grandchildBody)}],
+         { stdio: "ignore" });
+     console.log(child.pid);
+     ${IDLE}`,
+  ], { stdio: ["ignore", "pipe", "ignore"] });
+
+  const wrapperPid = wrapper.pid;
+  assert.ok(wrapperPid, "the wrapper was not spawned");
+  let grandchildPid = 0;
+  // Unconditional, and by pid rather than through the wrapper: once the wrapper dies its children
+  // reparent away from it, so a leaked grandchild could not be found later. `node --test` stays
+  // alive as long as any spawned process does.
+  const cleanUp = () => {
+    for (const pid of [wrapperPid, grandchildPid]) {
+      if (pid) try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
+    }
+  };
+
+  try {
+    let output = "";
+    for await (const chunk of wrapper.stdout) {
+      output += String(chunk);
+      const printed = /\d+/.exec(output);
+      if (printed) {
+        grandchildPid = Number(printed[0]);
+        break;
+      }
+    }
+    assert.ok(grandchildPid, "the wrapper never reported a grandchild pid");
+  } catch (error) {
+    cleanUp();
+    throw error;
+  }
+  return { wrapperPid, grandchildPid, cleanUp };
+}
+
+describe("killProcessTreeEscalating", () => {
+  it("SIGKILLs a descendant that ignored the SIGTERM", async () => {
+    const { wrapperPid, grandchildPid, cleanUp } = await spawnWrapper(IGNORES_SIGTERM);
+    try {
+      // The regression this guards: the SIGTERM kills the wrapper, which reparents the grandchild
+      // to pid 1, so a second `killProcessTree(wrapperPid, "SIGKILL")` walk would find nothing and
+      // the grandchild would survive. Escalating over the pids captured by the first walk is what
+      // reaches it.
+      await killProcessTreeEscalating(wrapperPid, { graceMs: 250 });
+      assert.ok(await waitUntilGone(wrapperPid), "the wrapper outlived the escalation");
+      assert.ok(await waitUntilGone(grandchildPid), "the grandchild outlived the escalation");
+    } finally {
+      cleanUp();
+    }
+  });
+
+  it("reaps a tree that goes down on the SIGTERM without waiting out the grace", async () => {
+    const { wrapperPid, grandchildPid, cleanUp } = await spawnWrapper(IDLE);
+    try {
+      const startedAt = Date.now();
+      await killProcessTreeEscalating(wrapperPid, { graceMs: 10_000 });
+      // Returning promptly is the point: the grace period is a ceiling on the stubborn case, not a
+      // delay every caller pays.
+      assert.ok(Date.now() - startedAt < 5_000, "waited out the grace for a tree that was gone");
+      assert.ok(await waitUntilGone(wrapperPid), "the wrapper outlived the kill");
+      assert.ok(await waitUntilGone(grandchildPid), "the grandchild outlived the kill");
+    } finally {
+      cleanUp();
+    }
+  });
+
+  it("escalates immediately when forceSignal aborts, instead of waiting out the grace", async () => {
+    const { wrapperPid, grandchildPid, cleanUp } = await spawnWrapper(IGNORES_SIGTERM);
+    try {
+      // A caller about to call process.exit() cannot wait out a grace this long, and cannot deliver
+      // the SIGKILL itself either -- by now the wrapper is dead and the grandchild reparented, so
+      // only the pids captured in here can still reach it. Aborting is how it gets that SIGKILL
+      // delivered before it goes.
+      const force = new AbortController();
+      const startedAt = Date.now();
+      const escalation = killProcessTreeEscalating(
+          wrapperPid, { graceMs: 60_000, forceSignal: force.signal });
+      setTimeout(() => force.abort(), 100);
+      await escalation;
+      assert.ok(Date.now() - startedAt < 5_000, "waited out the grace despite the force signal");
+      assert.ok(await waitUntilGone(grandchildPid), "the grandchild outlived the forced escalation");
+    } finally {
+      cleanUp();
+    }
+  });
+
+  it("rejects pids that would address process groups", async () => {
+    for (const pid of [0, -123, 12.5]) {
+      await assert.rejects(
+          killProcessTreeEscalating(pid), /pid must be a positive integer/);
+    }
   });
 });

--- a/scripts/kill-process-tree.ts
+++ b/scripts/kill-process-tree.ts
@@ -61,6 +61,16 @@ function signalPid(pid: number, signal: NodeJS.Signals): void {
   }
 }
 
+// Whether `pid` still exists. Signal 0 delivers nothing and only checks for the process.
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
 /** Sends `signal` to `pid` and every descendant it has. */
 export async function killProcessTree(
   pid: number,
@@ -84,4 +94,48 @@ export async function killProcessTree(
   // returns nothing and the rest of the subtree can no longer be found. That is also why callers
   // must not kill the process themselves before calling this.
   for (const treePid of await collectTree(pid)) signalPid(treePid, signal);
+}
+
+/**
+ * Sends SIGTERM to `pid` and every descendant, then SIGKILLs whatever is still alive after
+ * `graceMs`. Resolves once the tree is gone or the escalation has been delivered.
+ *
+ * For callers that cannot afford to wait on a descendant which ignores SIGTERM -- one holding an
+ * inherited stdout pipe keeps the parent's `close` event from ever firing.
+ *
+ * An aborted `forceSignal` gives up the rest of the grace period and escalates now. It exists for
+ * the caller who is about to exit and needs the SIGKILL delivered first: this call holds the only
+ * usable list of the tree's pids (see the capture below), so abandoning it mid-grace leaks whatever
+ * it had left to kill.
+ */
+export async function killProcessTreeEscalating(
+  pid: number,
+  { graceMs = 5_000, forceSignal }: { graceMs?: number; forceSignal?: AbortSignal } = {},
+): Promise<void> {
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error("pid must be a positive integer");
+
+  // `taskkill /T /F` is already an unconditional tree kill, so there is nothing to escalate to.
+  if (process.platform === "win32") return killProcessTree(pid, "SIGKILL");
+
+  // Collected once, for the reason killProcessTree documents above -- and here the single walk is
+  // what makes escalation possible at all. Re-walking after the SIGTERM would find nothing: the
+  // wrapper dies first and reparents the very survivors we are escalating against, so the SIGKILL
+  // has to go to this captured list rather than to a fresh tree.
+  const tree = await collectTree(pid);
+  for (const treePid of tree) signalPid(treePid, "SIGTERM");
+
+  // Polled rather than a flat sleep so the ordinary case -- everything dies to the SIGTERM -- does
+  // not pay the grace period. A pid could in principle be recycled onto an unrelated process inside
+  // the window and be signalled below; the existing walk has the same exposure, and a window this
+  // short against pids that were this process's own descendants makes it not worth guarding.
+  const deadline = Date.now() + graceMs;
+  let survivors = tree.filter(isAlive);
+  while (survivors.length > 0 && Date.now() < deadline) {
+    // Checked here rather than in the condition above, where it reads as an unmodified loop
+    // variable: what changes is `.aborted`, not the signal.
+    if (forceSignal?.aborted) break;
+    await new Promise(resolve => setTimeout(resolve, 25));
+    survivors = survivors.filter(isAlive);
+  }
+  for (const treePid of survivors) signalPid(treePid, "SIGKILL");
 }

--- a/scripts/map-concurrent.test.ts
+++ b/scripts/map-concurrent.test.ts
@@ -69,6 +69,56 @@ describe("mapConcurrent", () => {
       });
   });
 
+  it("stops claiming items on abort, awaits the tasks in flight, rejects with the reason", async () => {
+    const controller = new AbortController();
+    const sentinel = new Error("doomed elsewhere");
+    const gates = [deferred<string>(), deferred<string>()];
+    const started: number[] = [];
+    let finished = 0;
+    const all = mapConcurrent([0, 1, 2, 3], 2, async i => {
+      started.push(i);
+      const value = await gates[i].promise;
+      finished++;
+      return value;
+    }, controller.signal);
+    controller.abort(sentinel);
+    gates[0].resolve("a");
+    gates[1].resolve("b");
+    await assert.rejects(all, (error: unknown) => error === sentinel);
+    assert.deepEqual(started, [0, 1]);
+    assert.equal(finished, 2);
+  });
+
+  it("rejects on an abort that cost it no items, with every task still succeeding", async () => {
+    const controller = new AbortController();
+    const sentinel = new Error("told to stop");
+    const gate = deferred<string>();
+    // Limit >= item count, so both are claimed before the abort and the loop's check never runs
+    // again: nothing is skipped, and the task below resolves regardless of the signal, the way a
+    // command already on its way out exits 0 after the kill.
+    const all = mapConcurrent([0, 1], 2, async () => gate.promise, controller.signal);
+    controller.abort(sentinel);
+    gate.resolve("done");
+    await assert.rejects(all, (error: unknown) => error === sentinel);
+  });
+
+  it("reports a task's own failure rather than the abort reason", async () => {
+    const controller = new AbortController();
+    const boom = new Error("boom");
+    const gate = deferred<number>();
+    const all = mapConcurrent([0, 1, 2], 2, async i => {
+      // Item 0 fails and aborts, the way build-release's failFast wrapper does; item 1 is already
+      // in flight and completes afterwards; item 2 is never claimed.
+      if (i === 0) {
+        controller.abort(new Error("abort reason, not the failure"));
+        throw boom;
+      }
+      return gate.promise;
+    }, controller.signal);
+    gate.resolve(1);
+    await assert.rejects(all, (error: unknown) => error === boom);
+  });
+
   it("accepts an empty list", async () => {
     assert.deepEqual(await mapConcurrent([], 4, async () => 1), []);
   });

--- a/scripts/map-concurrent.test.ts
+++ b/scripts/map-concurrent.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mapConcurrent } from "./map-concurrent.ts";
+
+// A deferred promise plus the resolve/reject handles, so a test can hold tasks open and observe
+// how many are in flight.
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+describe("mapConcurrent", () => {
+  it("returns results in the input's order, not completion order", async () => {
+    const gates = [deferred<string>(), deferred<string>(), deferred<string>()];
+    const all = mapConcurrent([0, 1, 2], 3, i => gates[i].promise);
+    // Resolve backwards: the slowest item is first in the input.
+    gates[2].resolve("c");
+    gates[1].resolve("b");
+    gates[0].resolve("a");
+    assert.deepEqual(await all, ["a", "b", "c"]);
+  });
+
+  it("runs no more than `limit` tasks at a time", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const results = await mapConcurrent(Array.from({ length: 20 }, (_, i) => i), 4, async i => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(resolve => setImmediate(resolve));
+      inFlight--;
+      return i * 2;
+    });
+    assert.equal(peak, 4);
+    assert.deepEqual(results, Array.from({ length: 20 }, (_, i) => i * 2));
+  });
+
+  it("runs every remaining task after one rejects", async () => {
+    const started: number[] = [];
+    await assert.rejects(
+      mapConcurrent([0, 1, 2, 3], 1, async i => {
+        started.push(i);
+        if (i === 0) throw new Error("first failed");
+        return i;
+      }),
+      /first failed/);
+    assert.deepEqual(started, [0, 1, 2, 3]);
+  });
+
+  it("rethrows a lone failure unwrapped", async () => {
+    const boom = new Error("boom");
+    await assert.rejects(
+      mapConcurrent([1, 2], 2, async i => { if (i === 1) throw boom; return i; }),
+      (error: unknown) => error === boom);
+  });
+
+  it("aggregates multiple failures", async () => {
+    await assert.rejects(
+      mapConcurrent([1, 2, 3], 2, async i => {
+        if (i !== 2) throw new Error(`failed ${i}`);
+        return i;
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof AggregateError);
+        assert.equal(error.errors.length, 2);
+        assert.match(error.message, /2 of 3 tasks failed/);
+        return true;
+      });
+  });
+
+  it("accepts an empty list", async () => {
+    assert.deepEqual(await mapConcurrent([], 4, async () => 1), []);
+  });
+
+  it("rejects a nonsensical limit", async () => {
+    await assert.rejects(mapConcurrent([1], 0, async i => i), RangeError);
+    await assert.rejects(mapConcurrent([1], 1.5, async i => i), RangeError);
+  });
+});

--- a/scripts/map-concurrent.ts
+++ b/scripts/map-concurrent.ts
@@ -10,6 +10,10 @@
 //    failure and leaves the rest writing to disk under a process that is already exiting; here
 //    every task is awaited, and all the failures are reported together -- in CI that names every
 //    broken package rather than whichever one lost the race.
+//
+// The optional signal is the fail-fast complement: when the caller learns elsewhere that the whole
+// run is doomed (the frontend build failed), aborting stops new tasks from being claimed while the
+// wait-for-all guarantee on the ones already running still holds.
 
 /**
  * Applies `task` to every item, with at most `limit` running at a time, and returns the results in
@@ -17,11 +21,16 @@
  *
  * Every task runs even if an earlier one rejects. If any did, this rejects once they have all
  * settled: with that error if there was exactly one, or an `AggregateError` over them otherwise.
+ *
+ * An aborted `signal` stops further items from starting; tasks already running are still awaited.
+ * If the signal aborted at any point and no task failed, this rejects with `signal.reason`; task
+ * failures take precedence over the abort reason.
  */
 export async function mapConcurrent<T, R>(
   items: readonly T[],
   limit: number,
   task: (item: T, index: number) => Promise<R>,
+  signal?: AbortSignal,
 ): Promise<R[]> {
   if (!Number.isInteger(limit) || limit < 1) {
     throw new RangeError(`concurrency limit must be a positive integer, got ${limit}`);
@@ -33,6 +42,7 @@ export async function mapConcurrent<T, R>(
   let next = 0;
   const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
     for (let i = next++; i < items.length; i = next++) {
+      if (signal?.aborted) break;
       try {
         results[i] = await task(items[i], i);
       } catch (error) {
@@ -45,5 +55,10 @@ export async function mapConcurrent<T, R>(
   if (failures.length > 1) {
     throw new AggregateError(failures, `${failures.length} of ${items.length} tasks failed`);
   }
+  // Aborted is aborted, whether or not it cost us an item. Keying this off "we skipped something"
+  // instead reports success for the case where the signal lands once every item is already claimed
+  // and each task then finishes on its own merits -- no holes in `results`, nothing rejected, and a
+  // caller that asked to stop handed a full set of results as if it had not.
+  if (signal?.aborted) throw signal.reason;
   return results;
 }

--- a/scripts/map-concurrent.ts
+++ b/scripts/map-concurrent.ts
@@ -1,0 +1,49 @@
+// Runs an async operation over a list with a bounded number of them in flight.
+//
+// Written for the release build, where each package's `wrangler deploy --dry-run` is independent
+// and saturates about one core. Two properties matter there, and they are why this is a shared,
+// tested helper rather than a `Promise.all` at the call site:
+//
+//  - Results keep the input's order, so a manifest built from them is byte-stable no matter which
+//    bundle happened to finish first.
+//  - A rejection does not abandon the tasks still running. `Promise.all` settles on the first
+//    failure and leaves the rest writing to disk under a process that is already exiting; here
+//    every task is awaited, and all the failures are reported together -- in CI that names every
+//    broken package rather than whichever one lost the race.
+
+/**
+ * Applies `task` to every item, with at most `limit` running at a time, and returns the results in
+ * the input's order.
+ *
+ * Every task runs even if an earlier one rejects. If any did, this rejects once they have all
+ * settled: with that error if there was exactly one, or an `AggregateError` over them otherwise.
+ */
+export async function mapConcurrent<T, R>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new RangeError(`concurrency limit must be a positive integer, got ${limit}`);
+  }
+  const results: R[] = Array.from({ length: items.length });
+  const failures: unknown[] = [];
+  // Each runner claims the next index and works until the list is exhausted. The claim is a bare
+  // `next++` because JS runs it to completion before any other runner resumes.
+  let next = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let i = next++; i < items.length; i = next++) {
+      try {
+        results[i] = await task(items[i], i);
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+  });
+  await Promise.all(runners);
+  if (failures.length === 1) throw failures[0];
+  if (failures.length > 1) {
+    throw new AggregateError(failures, `${failures.length} of ${items.length} tasks failed`);
+  }
+  return results;
+}

--- a/scripts/release/build-release.ts
+++ b/scripts/release/build-release.ts
@@ -16,12 +16,16 @@
 //
 // Usage: node scripts/release/build-release.ts --out <dir> [--release-id <id>] [--concurrency <n>]
 
-import { execFile, execFileSync, type ExecFileOptions } from "node:child_process";
+import {
+  execFile, execFileSync, type ChildProcess, type ExecFileOptions,
+} from "node:child_process";
+import { setMaxListeners } from "node:events";
 import { mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mkdtempSync } from "node:fs";
 import { availableParallelism, tmpdir } from "node:os";
+import { killProcessTree, killProcessTreeEscalating } from "../kill-process-tree.ts";
 import { mapConcurrent } from "../map-concurrent.ts";
 import {
   collectAssets, collectModules, stableStringify, type CollectedAssets,
@@ -37,7 +41,46 @@ const FRONTEND_DIR = join(PACKAGES_DIR, "workshop-frontend");
 
 // Captured rather than inherited (see `run`), so it has to be bounded. Wrangler's dry-run output is
 // a few KiB; this is a ceiling on a pathological build, not a budget.
+//
+// What overflowing it actually does, since the shape is easy to guess wrong: execFile destroys its
+// *own* read ends and then signals only the direct child. So it is not a hang -- a descendant still
+// holding the write end cannot keep the callback from settling, because nobody is reading that end
+// any more. What it can do is orphan descendants, and unlike the abort path that is not fixable
+// from here: killing the wrapper reparents them first, so by the time we are told, a tree walk can
+// no longer find them (kill-process-tree.ts explains the reparenting). In practice it is
+// self-limiting -- whatever produced 32 MiB is still writing, takes EPIPE on the destroyed pipe,
+// and takes the wrapper down with it. Left as an accepted limit rather than a `spawn` rewrite.
 const MAX_CAPTURED_OUTPUT = 32 * 1024 * 1024;
+
+// How long a shutdown signal waits for the in-flight trees to go down before it stops being polite.
+// Comfortably longer than killProcessTreeEscalating's own grace, so the escalation's SIGKILL is what
+// normally ends things and this is only the backstop for a tree that survives even that.
+const FORCE_KILL_GRACE_MS = 10_000;
+
+// The commands running right now, so a shutdown signal can reach their whole trees. Same reason
+// run-dev-server.ts keeps `preflightBuilds`: these are `pnpm exec` wrappers, so the ChildProcess
+// handle alone is not enough to stop the work.
+const running = new Set<ChildProcess>();
+
+// The escalations those commands' abort handlers started, and the switch that cuts their grace
+// period short. A second stop signal has to go through these rather than around them: each
+// escalation captured its tree's pids before anything was signalled, and once the first SIGTERM has
+// taken the wrapper down and reparented the survivors, that captured list is the only way left to
+// reach them (kill-process-tree.ts spells out why a fresh walk finds nothing). Exiting while one is
+// still in its grace period abandons exactly the processes the force path exists to kill.
+const escalations = new Set<Promise<void>>();
+const forceKill = new AbortController();
+
+/** The abort reason when a shutdown signal ended the run, rather than a build failing. */
+class CancelledBySignal extends Error {
+  signal: NodeJS.Signals;
+  exitCode: number;
+  constructor(signal: NodeJS.Signals, exitCode: number) {
+    super(`cancelled by ${signal}`);
+    this.signal = signal;
+    this.exitCode = exitCode;
+  }
+}
 
 /** A deployable package, with its `wrangler.jsonc` read once and carried alongside. */
 interface DeployablePackage {
@@ -81,19 +124,77 @@ function parseArgs(argv: string[]): {
 function run(
   label: string, command: string, argv: string[], options: ExecFileOptions = {},
 ): Promise<void> {
+  const signal = options.signal;
+  // Aborted before we spawn anything: nothing to cancel, and no reason to start a process just to
+  // kill it. mapConcurrent makes this check before claiming an item, but an asset-serving bundle
+  // sits in `await frontend` after that, so the abort can land in between.
+  if (signal?.aborted) return Promise.reject(signal.reason);
+
   console.log(`running: ${command} ${argv.join(" ")} ${options.cwd ? `(in ${options.cwd})` : ""}`);
   const startedAt = Date.now();
   return new Promise((resolveRun, rejectRun) => {
-    execFile(command, argv, { cwd: ROOT, maxBuffer: MAX_CAPTURED_OUTPUT, ...options },
+    // Whether the abort handler below signalled *this* command's tree. Local rather than read off
+    // the signal, because "the run was aborted" and "this command was cancelled" are different
+    // facts: a command that had already failed on its own merits when the abort arrived deserves to
+    // be reported as the failure it is (see the classification below).
+    let killedByUs = false;
+
+    // `signal` is deliberately *not* forwarded to execFile, and is cleared so a caller's cannot
+    // reach it through the spread. Node's own implementation is wrong for these commands twice
+    // over: it kills only the direct child -- here `pnpm`, a wrapper, leaving the `wrangler`/`vp`
+    // and esbuild descendants that do the actual work running and writing -- and it settles this
+    // promise the moment the signal fires rather than when the child exits, so awaiting it would
+    // return while the build is still live. Both are what the abort handler below fixes.
+    const child = execFile(command, argv,
+        { cwd: ROOT, maxBuffer: MAX_CAPTURED_OUTPUT, ...options, signal: undefined },
         (error, stdout, stderr) => {
+      signal?.removeEventListener("abort", onAbort);
+      running.delete(child);
       const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+      // A command we killed, which died to a signal, was cancelled rather than broken: its output
+      // is noise and its "failure" is the root cause's, so reject with that same object -- the
+      // caller dedupes failures by identity, which is what keeps a cancelled command out of the
+      // summary.
+      if (killedByUs && error?.signal) {
+        console.log(`cancelled: ${label} (${elapsed}s)`);
+        rejectRun(signal!.reason);
+        return;
+      }
       process.stdout.write(`\n----- ${label} (${elapsed}s) -----\n${stdout}${stderr}`);
       // Just the label and the status: the command's own diagnostics are in the block above, and
       // `error.message` repeats them, so carrying it would print the same failure twice more (a
       // third time when several are collected into an AggregateError).
-      if (error) rejectRun(new Error(`${label} failed (exit ${error.code ?? "signal"})`));
+      if (error) rejectRun(new Error(`${label} failed (exit ${error.signal ?? error.code})`));
       else resolveRun();
     });
+
+    running.add(child);
+
+    // Reaches the descendants execFile's own `signal` would leave behind, and escalates to SIGKILL
+    // because `pnpm` -- the direct child here -- ignores SIGTERM while a child of its own is still
+    // alive: signalled on its own it sits there with no exit code, and the callback above fires on
+    // `close`, so a polite signal alone would leave this promise pending indefinitely.
+    // Signalling the whole tree is also what makes `pnpm` itself go down promptly.
+    function onAbort() {
+      killedByUs = true;
+      // Undefined when the spawn itself failed; the callback is already on its way with the error.
+      if (child.pid === undefined) return;
+      // Deliberately not awaited *by this promise*: a straggler that outlives it is tolerated here
+      // (it only writes into its own scratch dir, and the release is already failing), and waiting
+      // for one was explicitly not wanted. The destroy/unref is what makes that safe -- the callback
+      // fires on `close`, so a descendant the tree snapshot missed still holding the pipe would
+      // otherwise keep this promise pending forever. It is still tracked, because a force exit does
+      // have to wait for it; see `escalations`.
+      const escalation = killProcessTreeEscalating(child.pid, { forceSignal: forceKill.signal })
+          .catch(() => {}).then(() => {
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+        child.unref();
+      });
+      escalations.add(escalation);
+      void escalation.then(() => escalations.delete(escalation));
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 
@@ -129,21 +230,127 @@ function pinnedWranglerVersion(): string {
 // Through vp rather than a package script: `build` is a task, so there is no script to run, and the
 // task declares VITE_* as fingerprinted env — a release built at a different flag value is a cache
 // miss rather than a stale replay.
-async function buildFrontend(): Promise<CollectedAssets> {
+async function buildFrontend(signal: AbortSignal): Promise<CollectedAssets> {
   const env = { ...process.env, VITE_CF_ACCESS_MODE: "true" };
   await run("frontend (access mode)", "pnpm",
-      ["exec", "vp", "run", "-F", "@gadgets/workshop-frontend", "build"], { env });
+      ["exec", "vp", "run", "-F", "@gadgets/workshop-frontend", "build"], { env, signal });
   return collectAssets(join(FRONTEND_DIR, "dist"));
 }
 
 // Bundles one package the way `wrangler deploy` would, without uploading. Run from the package dir
 // so custom build commands (capnweb-validate) resolve their bins, and into a directory of its own,
 // which is what makes these safe to overlap.
-async function bundleWorker(pkg: DeployablePackage, bundleDir: string) {
+async function bundleWorker(pkg: DeployablePackage, bundleDir: string, signal: AbortSignal) {
   const outDir = join(bundleDir, pkg.name);
   await run(pkg.name, "pnpm", ["exec", "wrangler", "deploy", "--dry-run", "--outdir", outDir],
-      { cwd: pkg.dir });
+      { cwd: pkg.dir, signal });
   return collectModules(outDir);
+}
+
+// Runs the frontend build and every worker bundle, and owns the scratch directory they bundle into
+// for exactly as long as they need it: `collectModules` has read each bundle's bytes into memory by
+// the time its task resolves, so nothing downstream reads the directory back.
+//
+// The frontend build and the worker bundles go all at once. Only a worker that serves static assets
+// reads workshop-frontend/dist (the router points its `assets.directory` there), so it alone waits
+// for the frontend; the rest start immediately. Read off the config rather than naming the router,
+// so a second asset-serving worker would be sequenced too.
+//
+// `frontend` is awaited by the allSettled as well as inside the task, so a frontend failure is
+// observed even when no bundle got as far as awaiting it.
+//
+// Fail-fast: the first failure anywhere aborts the controller *with itself as the reason*, which
+// stops mapConcurrent from claiming more bundles and kills the process trees of the commands
+// already running (see `run`). Every task is still awaited -- allSettled, and mapConcurrent waits
+// for its in-flight tasks -- so the run reports every real failure rather than whichever one lost
+// the race, and it always reaches the cleanup below. What it does not claim is that every
+// descendant is dead when a task settles; `run` says why that is tolerated. A cancelled command
+// rejects with the abort reason, i.e. the root cause itself, which is what lets the failure summary
+// below dedupe down to the real failures by identity.
+async function buildAll(packages: DeployablePackage[], concurrency: number): Promise<{
+  bundles: ReturnType<typeof collectModules>[];
+  assets: CollectedAssets;
+}> {
+  const controller = new AbortController();
+  // One abort listener per running command (`run`), removed as each finishes. The default cap of 10
+  // is below the concurrency this defaults to on a large runner, and the warning it emits would be
+  // pure noise.
+  setMaxListeners(0, controller.signal);
+  const failFast = <T>(p: Promise<T>): Promise<T> =>
+      p.catch((error: unknown) => { controller.abort(error); throw error; });
+
+  // Termination from outside runs the same cancellation path a build failure does, which is the only
+  // way the descendants get stopped and the scratch directory below gets removed. Installing these
+  // also disables Node's default exit-on-signal, and that default is the whole problem: a *targeted*
+  // signal (CI cancelling a job, an IDE stop button, `kill <pid>`) reaches only this process, so
+  // dying on the spot leaves every `pnpm exec wrangler` tree running and skips the `finally`. A
+  // terminal Ctrl-C is delivered to the process group and would have taken the descendants with it
+  // anyway; nothing else is that kind.
+  const bundleDir = mkdtempSync(join(tmpdir(), "gadgets-release-"));
+  let stopSignalsReceived = 0;
+  let forcing = false;
+  const onStopSignal = (signal: NodeJS.Signals) => {
+    const exitCode = signal === "SIGINT" ? 130 : 143;
+    // Impatience, or a tree that outlived even the escalation's SIGKILL. The escalations the first
+    // signal started are what actually reach a descendant it has already reparented, so this cuts
+    // their grace short and leaves with them rather than exiting out from under them -- bounded by
+    // one poll tick, not by the grace period the user just said they were done waiting for. The
+    // fresh walk alongside them adds whatever was spawned after they captured their trees.
+    if (++stopSignalsReceived > 1) {
+      if (forcing) return;
+      forcing = true;
+      forceKill.abort();
+      void Promise.all([...escalations, ...[...running].map((child) =>
+          child.pid === undefined ? null : killProcessTree(child.pid, "SIGKILL").catch(() => {}))])
+          .then(() => {
+            // process.exit() below skips the `finally`, so the scratch directory has to go here
+            // too. Ordered after the SIGKILLs, for the same reason the `finally` is ordered after
+            // the awaits: nothing may still be writing into what this removes.
+            rmSync(bundleDir, { recursive: true, force: true });
+            process.exit(exitCode);
+          });
+      return;
+    }
+    console.error(`\n${signal} received: cancelling in-flight builds`);
+    controller.abort(new CancelledBySignal(signal, exitCode));
+    // Unref'd so it is never the reason the process stays alive.
+    setTimeout(() => onStopSignal(signal), FORCE_KILL_GRACE_MS).unref();
+  };
+  const stopSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+  for (const signal of stopSignals) process.on(signal, onStopSignal);
+
+  try {
+    const frontend = failFast(buildFrontend(controller.signal));
+    const [bundlesResult, frontendResult] = await Promise.allSettled([
+      mapConcurrent(packages, concurrency, async (pkg) => {
+        if (pkg.config.assets) await frontend;
+        return failFast(bundleWorker(pkg, bundleDir, controller.signal));
+      }, controller.signal),
+      frontend,
+    ]);
+    if (bundlesResult.status === "rejected" || frontendResult.status === "rejected") {
+      const failures = new Set([bundlesResult, frontendResult]
+          .filter((r) => r.status === "rejected")
+          .flatMap((r) => r.reason instanceof AggregateError ? r.reason.errors : [r.reason]));
+      if (failures.size === 1) throw [...failures][0];
+      throw new AggregateError([...failures], `${failures.size} builds failed`);
+    }
+    // Everything succeeded -- but the run may still have been told to stop, with the signal landing
+    // late enough that every command had already finished and nothing rejected. Without this the
+    // manifest gets written and the process exits 0 for a build that was cancelled; and because the
+    // handlers above disable Node's default exit-on-signal, the signal is swallowed outright.
+    if (controller.signal.aborted) throw controller.signal.reason;
+    return { bundles: bundlesResult.value, assets: frontendResult.value };
+  } finally {
+    // Nothing is spawning any more, so hand the signals back to Node's default. Left installed they
+    // would swallow a Ctrl-C during the manifest write, which has nothing to cancel.
+    for (const signal of stopSignals) process.off(signal, onStopSignal);
+    // On the failure path too, which is why this is a `finally` rather than a line at the end: a
+    // failed build used to leave its scratch directory behind in the tmpdir. A straggler may still
+    // be writing in here (see `run`'s abort handler); harmless, as the release is already failing
+    // and on POSIX its open files survive the unlink.
+    rmSync(bundleDir, { recursive: true, force: true });
+  }
 }
 
 async function main() {
@@ -160,23 +367,9 @@ async function main() {
 
   const packages: DeployablePackage[] = findDeployablePackages(PACKAGES_DIR)
       .map((pkg) => ({ ...pkg, config: readWranglerConfig(pkg.dir) }));
-  const bundleDir = mkdtempSync(join(tmpdir(), "gadgets-release-"));
 
-  // 1. The frontend build and the worker bundles all at once. Only a worker that serves static
-  //    assets reads workshop-frontend/dist (the router points its `assets.directory` there), so it
-  //    alone waits for the frontend; the rest start immediately. Read off the config rather than
-  //    naming the router, so a second asset-serving worker would be sequenced too.
-  //
-  //    `frontend` is awaited by the Promise.all as well as inside the task, so a frontend failure
-  //    is observed even when no bundle got as far as awaiting it.
-  const frontend = buildFrontend();
-  const [bundles, assets] = await Promise.all([
-    mapConcurrent(packages, args.concurrency, async (pkg) => {
-      if (pkg.config.assets) await frontend;
-      return bundleWorker(pkg, bundleDir);
-    }),
-    frontend,
-  ]);
+  // 1. Every bundle, overlapping.
+  const { bundles, assets } = await buildAll(packages, args.concurrency);
 
   // 2. Everything below is ordered by package, so the release bytes do not depend on which build
   //    finished first.
@@ -213,7 +406,6 @@ async function main() {
   });
   writeFileSync(join(args.out, "manifest.json"), stableStringify(manifest) + "\n");
 
-  rmSync(bundleDir, { recursive: true, force: true });
   const moduleCount = workers.reduce((n, w) => n + w.modules.length, 0);
   console.log(`\nrelease ${releaseId}: ${workers.length} workers, ${moduleCount} modules, ` +
       `${Object.keys(manifest.assets).length} unique asset blobs -> ${args.out}`);
@@ -225,9 +417,21 @@ try {
   // A summary, not a stack: every failed command already printed its own diagnostics as a block,
   // and with the builds overlapping there can be more than one to name.
   const failures = error instanceof AggregateError ? error.errors : [error];
-  console.error("\nrelease build failed:");
-  for (const failure of failures) {
-    console.error(`  - ${failure instanceof Error ? failure.message : String(failure)}`);
+  // Cancelled from outside is not a broken build, and its exit code is the signal's. Checked over
+  // the flattened list rather than `error` alone: the dedupe in buildAll collapses the reason every
+  // cancelled command rejected with down to one, so the common case arrives bare -- but a real
+  // failure racing the signal arrives as an AggregateError holding both.
+  const cancelled = failures.find((f) => f instanceof CancelledBySignal);
+  if (cancelled) {
+    console.error(`\nrelease build ${cancelled.message}`);
+    process.exitCode = cancelled.exitCode;
+  } else {
+    console.error("\nrelease build failed:");
+    for (const failure of failures) {
+      console.error(`  - ${failure instanceof Error ? failure.message : String(failure)}`);
+    }
+    process.exitCode = 1;
   }
-  process.exit(1);
+  // Not process.exit(): every child has been awaited by now, so the event loop drains on its own
+  // and piped stdio gets flushed rather than truncated mid-diagnostic.
 }

--- a/scripts/release/build-release.ts
+++ b/scripts/release/build-release.ts
@@ -10,41 +10,91 @@
 //   <out>/modules/<sha256>                 worker module blobs, content-addressed
 //   <out>/assets/<cfHash>                  static asset blobs, content-addressed
 //
-// Usage: node scripts/release/build-release.ts --out <dir> [--release-id <id>]
+// The builds overlap: the frontend and every worker bundle run concurrently, up to --concurrency
+// at a time. Nothing about the output depends on that -- each bundle reads only its own package
+// and writes only its own directory, and results are reassembled in package order.
+//
+// Usage: node scripts/release/build-release.ts --out <dir> [--release-id <id>] [--concurrency <n>]
 
-import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+import { execFile, execFileSync, type ExecFileOptions } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { availableParallelism, tmpdir } from "node:os";
+import { mapConcurrent } from "../map-concurrent.ts";
 import {
   collectAssets, collectModules, stableStringify, type CollectedAssets,
 } from "./hash-lib.ts";
 import {
   findDeployablePackages, generateManifest, readDeployInputs, readWranglerConfig,
-  type WorkerBuild,
+  type WorkerBuild, type WranglerConfig,
 } from "./manifest-lib.ts";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const PACKAGES_DIR = join(ROOT, "packages");
 const FRONTEND_DIR = join(PACKAGES_DIR, "workshop-frontend");
 
-function parseArgs(argv: string[]): { out: string; releaseId: string | undefined } {
+// Captured rather than inherited (see `run`), so it has to be bounded. Wrangler's dry-run output is
+// a few KiB; this is a ceiling on a pathological build, not a budget.
+const MAX_CAPTURED_OUTPUT = 32 * 1024 * 1024;
+
+/** A deployable package, with its `wrangler.jsonc` read once and carried alongside. */
+interface DeployablePackage {
+  /** Package directory name, which is also the worker name. */
+  name: string;
+  /** Absolute path to the package directory. */
+  dir: string;
+  /** The package's parsed wrangler config. */
+  config: WranglerConfig;
+}
+
+function parseArgs(argv: string[]): {
+  out: string;
+  releaseId: string | undefined;
+  concurrency: number;
+} {
   let out: string | undefined;
   let releaseId: string | undefined;
+  // Each bundle is one mostly CPU-bound esbuild process. Lower it on a runner that cannot afford
+  // that many at once; raise it on one whose cores this undercounts.
+  let concurrency = availableParallelism();
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--out") out = resolve(argv[++i]);
     else if (argv[i] === "--release-id") releaseId = argv[++i];
-    else throw new Error(`unknown argument: ${argv[i]}`);
+    else if (argv[i] === "--concurrency") {
+      concurrency = Number(argv[++i]);
+      if (!Number.isInteger(concurrency) || concurrency < 1) {
+        throw new Error(`--concurrency must be a positive integer, got: ${argv[i]}`);
+      }
+    } else throw new Error(`unknown argument: ${argv[i]}`);
   }
   if (!out) throw new Error("--out <dir> is required");
-  return { out, releaseId };
+  return { out, releaseId, concurrency };
 }
 
-function run(command: string, argv: string[], options: ExecFileSyncOptions = {}) {
+// Runs a command to completion and prints its output as one block once it finishes.
+//
+// Captured rather than `stdio: "inherit"`: these run concurrently, and a dozen wrangler logs
+// interleaved line by line would be unreadable. A whole block per command carries the same
+// information; only the order the blocks appear in is no longer fixed.
+function run(
+  label: string, command: string, argv: string[], options: ExecFileOptions = {},
+): Promise<void> {
   console.log(`running: ${command} ${argv.join(" ")} ${options.cwd ? `(in ${options.cwd})` : ""}`);
-  execFileSync(command, argv, { stdio: "inherit", cwd: ROOT, ...options });
+  const startedAt = Date.now();
+  return new Promise((resolveRun, rejectRun) => {
+    execFile(command, argv, { cwd: ROOT, maxBuffer: MAX_CAPTURED_OUTPUT, ...options },
+        (error, stdout, stderr) => {
+      const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+      process.stdout.write(`\n----- ${label} (${elapsed}s) -----\n${stdout}${stderr}`);
+      // Just the label and the status: the command's own diagnostics are in the block above, and
+      // `error.message` repeats them, so carrying it would print the same failure twice more (a
+      // third time when several are collected into an AggregateError).
+      if (error) rejectRun(new Error(`${label} failed (exit ${error.code ?? "signal"})`));
+      else resolveRun();
+    });
+  });
 }
 
 function gitCommit(): string {
@@ -79,54 +129,77 @@ function pinnedWranglerVersion(): string {
 // Through vp rather than a package script: `build` is a task, so there is no script to run, and the
 // task declares VITE_* as fingerprinted env — a release built at a different flag value is a cache
 // miss rather than a stale replay.
-function buildFrontend(): CollectedAssets {
+async function buildFrontend(): Promise<CollectedAssets> {
   const env = { ...process.env, VITE_CF_ACCESS_MODE: "true" };
-  run("pnpm", ["exec", "vp", "run", "-F", "@gadgets/workshop-frontend", "build"], { env });
+  await run("frontend (access mode)", "pnpm",
+      ["exec", "vp", "run", "-F", "@gadgets/workshop-frontend", "build"], { env });
   return collectAssets(join(FRONTEND_DIR, "dist"));
 }
 
-function main() {
+// Bundles one package the way `wrangler deploy` would, without uploading. Run from the package dir
+// so custom build commands (capnweb-validate) resolve their bins, and into a directory of its own,
+// which is what makes these safe to overlap.
+async function bundleWorker(pkg: DeployablePackage, bundleDir: string) {
+  const outDir = join(bundleDir, pkg.name);
+  await run(pkg.name, "pnpm", ["exec", "wrangler", "deploy", "--dry-run", "--outdir", outDir],
+      { cwd: pkg.dir });
+  return collectModules(outDir);
+}
+
+async function main() {
   const args = parseArgs(process.argv.slice(2));
   const commit = gitCommit();
   const releaseId = args.releaseId ?? defaultReleaseId(commit);
   const wranglerVersion = pinnedWranglerVersion();
-  console.log(`building release ${releaseId} (commit ${commit}, wrangler ${wranglerVersion})`);
+  console.log(`building release ${releaseId} (commit ${commit}, wrangler ${wranglerVersion}, ` +
+      `${args.concurrency} bundles at a time)`);
 
   rmSync(args.out, { recursive: true, force: true });
   mkdirSync(join(args.out, "modules"), { recursive: true });
   mkdirSync(join(args.out, "assets"), { recursive: true });
 
-  // 1. Frontend first: the router's wrangler.jsonc points its assets directory at
-  //    workshop-frontend/dist, so it must exist before the router's dry-run.
-  const assetVariants = {
-    access: buildFrontend(),
-  };
+  const packages: DeployablePackage[] = findDeployablePackages(PACKAGES_DIR)
+      .map((pkg) => ({ ...pkg, config: readWranglerConfig(pkg.dir) }));
+  const bundleDir = mkdtempSync(join(tmpdir(), "gadgets-release-"));
+
+  // 1. The frontend build and the worker bundles all at once. Only a worker that serves static
+  //    assets reads workshop-frontend/dist (the router points its `assets.directory` there), so it
+  //    alone waits for the frontend; the rest start immediately. Read off the config rather than
+  //    naming the router, so a second asset-serving worker would be sequenced too.
+  //
+  //    `frontend` is awaited by the Promise.all as well as inside the task, so a frontend failure
+  //    is observed even when no bundle got as far as awaiting it.
+  const frontend = buildFrontend();
+  const [bundles, assets] = await Promise.all([
+    mapConcurrent(packages, args.concurrency, async (pkg) => {
+      if (pkg.config.assets) await frontend;
+      return bundleWorker(pkg, bundleDir);
+    }),
+    frontend,
+  ]);
+
+  // 2. Everything below is ordered by package, so the release bytes do not depend on which build
+  //    finished first.
+  const assetVariants = { access: assets };
   for (const { blobs } of Object.values(assetVariants)) {
     for (const [hash, blob] of blobs) {
       writeFileSync(join(args.out, "assets", hash), blob.bytes);
     }
   }
 
-  // 2. Bundle every deployable package the way `wrangler deploy` would, without uploading.
-  //    Run from each package dir so custom build commands (capnweb-validate) resolve their bins.
-  const bundleDir = mkdtempSync(join(tmpdir(), "gadgets-release-"));
-  const workers: WorkerBuild[] = [];
-  for (const pkg of findDeployablePackages(PACKAGES_DIR)) {
-    const outDir = join(bundleDir, pkg.name);
-    run("pnpm", ["exec", "wrangler", "deploy", "--dry-run", "--outdir", outDir],
-        { cwd: pkg.dir });
-    const { mainModule, modules } = collectModules(outDir);
+  const workers: WorkerBuild[] = packages.map((pkg, i) => {
+    const { mainModule, modules } = bundles[i];
     for (const mod of modules) {
       writeFileSync(join(args.out, "modules", mod.sha256), mod.bytes);
     }
-    workers.push({
+    return {
       pkgName: pkg.name,
-      config: readWranglerConfig(pkg.dir),
+      config: pkg.config,
       mainModule,
       modules,
       deployInputs: readDeployInputs(pkg.dir),
-    });
-  }
+    };
+  });
 
   // 3. The manifest ties it together. Written last locally too, mirroring the R2 upload order
   //    (manifest presence == release complete).
@@ -146,4 +219,15 @@ function main() {
       `${Object.keys(manifest.assets).length} unique asset blobs -> ${args.out}`);
 }
 
-main();
+try {
+  await main();
+} catch (error) {
+  // A summary, not a stack: every failed command already printed its own diagnostics as a block,
+  // and with the builds overlapping there can be more than one to name.
+  const failures = error instanceof AggregateError ? error.errors : [error];
+  console.error("\nrelease build failed:");
+  for (const failure of failures) {
+    console.error(`  - ${failure instanceof Error ? failure.message : String(failure)}`);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
Every worker bundle in a release is independent, they can be built in parallel which speeds up building the release manifest significantly.

`node scripts/release/build-release.ts`, on my machine (10 cores), medians of 4 runs:

| | main | this PR |
|---|---|---|
| wall clock | 61.3s | **18.9s** |
| range | 57.0–65.3s | 15.8–25.6s |

Both produce an identical release (18 workers, 87 modules, 29 unique asset blobs). The frontend `vp` build was a cache hit in every run
