### PR TITLE
Keep chat subscribers alive after a rejected changeApplied callback

### DIFF
--- a/packages/workshop-backend/__tests__/chat-changes.test.ts
+++ b/packages/workshop-backend/__tests__/chat-changes.test.ts
@@ -1203,35 +1203,3 @@ describe("chat content reconstruction", () => {
     expect(liveRows(impl, 1)).toHaveLength(1);
   }));
 });
-
-describe("emitChatChangeApplied", () => {
-  it("keeps broadcasting to a subscriber after one rejected callback", () => withImpl(async impl => {
-    let c1 = await commitFiles(impl, { "a.txt": "one\n" });
-    addGadget(impl, 1, "APP", c1);
-    addChat(impl, 1);
-
-    let seen: number[] = [];
-    impl.addChatSubscriber({
-      changeApplied(_chatId: number, _generation: number, revision: number) {
-        seen.push(revision);
-        return revision === 1 ? Promise.reject(new Error("delivery failed")) : Promise.resolve();
-      },
-      [Symbol.dispose]() {},
-    });
-
-    await submit(impl, 1, {
-      generation: 0, revision: 0, clientId: "cli-a", seq: 1,
-      pins: [{ gadgetId: 1, baseCommit: c1 }],
-      change: editChange(1, { "a.txt": "one\n" }, { "a.txt": "one\ntwo\n" }),
-    });
-    await submit(impl, 1, {
-      generation: 0, revision: 1, clientId: "cli-a", seq: 2,
-      change: editChange(1, { "a.txt": "one\ntwo\n" }, { "a.txt": "one\ntwo\nthree\n" }),
-    });
-
-    // The revision-1 rejection must not have unsubscribed the client: a rejected callback
-    // doesn't mean the RPC connection is broken, and silently dropping the subscriber leaves
-    // the page connected but permanently stale (#305).
-    expect(seen).toEqual([1, 2]);
-  }));
-});

--- a/packages/workshop-backend/__tests__/chat-changes.test.ts
+++ b/packages/workshop-backend/__tests__/chat-changes.test.ts
@@ -1203,3 +1203,35 @@ describe("chat content reconstruction", () => {
     expect(liveRows(impl, 1)).toHaveLength(1);
   }));
 });
+
+describe("emitChatChangeApplied", () => {
+  it("keeps broadcasting to a subscriber after one rejected callback", () => withImpl(async impl => {
+    let c1 = await commitFiles(impl, { "a.txt": "one\n" });
+    addGadget(impl, 1, "APP", c1);
+    addChat(impl, 1);
+
+    let seen: number[] = [];
+    impl.addChatSubscriber({
+      changeApplied(_chatId: number, _generation: number, revision: number) {
+        seen.push(revision);
+        return revision === 1 ? Promise.reject(new Error("delivery failed")) : Promise.resolve();
+      },
+      [Symbol.dispose]() {},
+    });
+
+    await submit(impl, 1, {
+      generation: 0, revision: 0, clientId: "cli-a", seq: 1,
+      pins: [{ gadgetId: 1, baseCommit: c1 }],
+      change: editChange(1, { "a.txt": "one\n" }, { "a.txt": "one\ntwo\n" }),
+    });
+    await submit(impl, 1, {
+      generation: 0, revision: 1, clientId: "cli-a", seq: 2,
+      change: editChange(1, { "a.txt": "one\ntwo\n" }, { "a.txt": "one\ntwo\nthree\n" }),
+    });
+
+    // The revision-1 rejection must not have unsubscribed the client: a rejected callback
+    // doesn't mean the RPC connection is broken, and silently dropping the subscriber leaves
+    // the page connected but permanently stale (#305).
+    expect(seen).toEqual([1, 2]);
+  }));
+});

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -2524,9 +2524,12 @@ class OverseerImpl implements AgentHooks {
   emitChatChangeApplied(row: ChatChangeRecord): void {
     for (let subscriber of this.#chatSubscribers) {
       subscriber.changeApplied(row.chatId, row.generation, row.revision, row.author, row.change,
-                               row.submission).catch(() => {
-        subscriber[Symbol.dispose]();
-        this.#chatSubscribers.delete(subscriber);
+                               row.submission).catch(err => {
+        // One rejected callback doesn't mean the client is gone; dropping the subscriber here
+        // leaves a live page silently unsubscribed. Dead clients are removed by onRpcBroken.
+        this.logger.warn("chat changeApplied callback rejected", {
+          event: "chat.change.subscriber.rejected", chatId: row.chatId, error: err,
+        });
       });
     }
   }
@@ -9958,7 +9961,13 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     for (let row of this.impl.storage.chatChanges.list()) {
       if (row.retired) continue;
       subscriber.changeApplied(row.chatId, row.generation, row.revision, row.author, row.change,
-                               row.submission).catch(unsubscribe);
+                               row.submission).catch(err => {
+        // Keep the subscription on a rejected callback (see emitChatChangeApplied); dead clients
+        // are removed by the onRpcBroken handler above.
+        this.impl.logger.warn("chat changeApplied replay callback rejected", {
+          event: "chat.change.subscriber.rejected", chatId: row.chatId, error: err,
+        });
+      });
     }
 
     chatMeta.subscribe(metaSubscriber);


### PR DESCRIPTION
Fixes #305.

## What does this change?

Since #275, a rejected `changeApplied` callback removes the subscriber from `#chatSubscribers` (and the `subscribeToChat` replay path calls `unsubscribe` on rejection), even though one rejected callback does not mean the RPC connection is broken. The page stays connected but permanently unsubscribed, so the chat UI silently stops updating during an agent turn until a refresh re-subscribes it.

This patch makes both `changeApplied` rejection handlers (the live broadcast in `emitChatChangeApplied` and the retained-row replay in `subscribeToChat`) log the rejection and keep the subscription, matching the mitigation described in #305. Dead clients are still removed through the existing `subscriber.onRpcBroken(() => unsubscribe())` handler.

## Why is this obviously correct and trivially verifiable?

The patch only changes what happens after a `changeApplied` promise rejects: previously the subscriber was dropped (silently, with the error swallowed); now the error is logged with the existing logger convention and the subscriber is kept. No control flow before the `.catch` changes, and disconnect cleanup is unchanged (`onRpcBroken` → `unsubscribe`, visible a few lines above the replay site).

Verified locally: a regression test (a subscriber whose `changeApplied` rejects once must still receive the next row) fails on `main` and passes with this patch — kept out of this PR to stay within the line limit, available at [`hidcc:regression-test-305`](https://github.com/hidcc/cloudflare-os/compare/main...regression-test-305). The full `chat-changes.test.ts` suite passes, and `vp lint` / `tsc -p packages/workshop-backend` are clean.

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
