### PR TITLE
Don't gate previews or Bonk on author_association

### DIFF
--- a/.github/workflows/bonk-pr.yml
+++ b/.github/workflows/bonk-pr.yml
@@ -17,13 +17,18 @@ jobs:
   # - The `bonk` job reads that label live, so re-runs honour it as well.
   # - Removing the label re-triggers a real review via `unlabeled`.
   # - Authorized users may bypass Bonk even for changes to this workflow.
+  #
+  # Authorization is the permission lookup in the step below, not this `if:`. Do not add
+  # `author_association` back to it: GitHub computes that field with no viewer, so it cannot see
+  # private organization membership, and a maintainer whose Cloudflare membership is private and
+  # who reaches this repository through a team rather than a direct collaborator grant arrives as
+  # `CONTRIBUTOR`. The exact-match body check keeps this from starting on ordinary comments.
   break-glass:
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.sender.type != 'Bot' &&
-      github.event.comment.body == 'bonk break glass' &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      github.event.comment.body == 'bonk break glass'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -9,10 +9,19 @@ on:
   #   types: [created]
 
 jobs:
+  # This `if:` is a prefilter, not the authorization: it only keeps the job from starting a runner
+  # on every comment in the repository. Authorization is the permission lookup in the first step.
+  #
+  # Do not put `author_association` back here. GitHub computes that field with no viewer, so it
+  # cannot see private organization membership, and a maintainer whose Cloudflare membership is
+  # private and who reaches this repository through a team rather than a direct collaborator grant
+  # arrives as `CONTRIBUTOR` — which silently ignored them. The mention terms below mirror the
+  # `mentions:` input, so the job starts on the same comments the action would act on.
   bonk:
     if: >-
       github.event.sender.type != 'Bot' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      (contains(github.event.comment.body, '/bonk') ||
+       contains(github.event.comment.body, '@ask-bonk'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
@@ -24,6 +33,22 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # First, before checkout and before any step can reference a secret. `issue_comment` and
+      # `pull_request_review_comment` both run privileged with the AI gateway secrets available,
+      # and anyone can comment on a public repository, so this is the whole gate.
+      - name: Verify the commenter is a maintainer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          permission=$(gh api "repos/$GH_REPO/collaborators/$COMMENTER/permission" \
+            --jq '.permission')
+          if [[ ! "$permission" =~ ^(admin|maintain|write)$ ]]; then
+            echo "$COMMENTER has '$permission' on $GH_REPO; Bonk requires write access."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,14 @@ name: Preview
 # that a future edit which weakens the trigger still does not leak the token. They are not what
 # makes this safe today.
 #
+# Deliberately absent from those conditions: `author_association`. GitHub computes that field for
+# the payload with no viewer, so it cannot see private organization membership — a Cloudflare
+# member whose membership is private, and who reaches this repository through a team rather than a
+# direct collaborator grant, arrives as `CONTRIBUTOR` and had every preview silently skipped. Do
+# not add it back. `head.repo.id == base.repo.id` is the stronger statement in any case, since
+# pushing a branch into this repository already requires write access, and the first step of each
+# job re-checks the author's permission against the API and fails closed.
+#
 # The setup-vp `cache: true` below is deliberate and is not a poisoning path: a fork PR's Actions
 # cache is scoped to `refs/pull/<n>/merge` and cannot be read from another PR or from `main`.
 
@@ -45,7 +53,6 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
       github.event.pull_request.user.type != 'Bot' &&
       github.head_ref != 'main' &&
       github.repository_owner == 'cloudflare'
@@ -169,7 +176,6 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
       github.event.pull_request.user.type != 'Bot' &&
       github.head_ref != 'main' &&
       github.repository_owner == 'cloudflare'


### PR DESCRIPTION
`author_association` is computed for the webhook payload with no viewer, so it can't see private org membership. Maintainers whose Cloudflare membership is private and who reach the repo through a team rather than a direct collaborator grant arrive as `CONTRIBUTOR`, and had every preview silently skipped.

The remaining conditions plus the in-job check already cover this: pushing a branch into the repo requires write access, and the first step of each job verifies `admin|maintain|write` against the API and fails closed.