### PR TITLE
Preserve Cloudflare OAuth token exchange errors

### DIFF
--- a/packages/gatekeeper-cloudflare/__tests__/oauth.test.ts
+++ b/packages/gatekeeper-cloudflare/__tests__/oauth.test.ts
@@ -85,10 +85,15 @@ describe("Cloudflare OAuth", () => {
     });
   });
 
-  it("returns null rather than a token on a rejected redemption", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response("nope", { status: 401 })));
+  it("surfaces the provider error when redemption is rejected", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      error: "invalid_client",
+      error_description: "Client authentication failed.",
+    }, { status: 401 })));
 
-    expect(await exchangeCode(config, "code", "verifier")).toBeNull();
+    await expect(exchangeCode(config, "code", "verifier")).rejects.toThrow(
+      "Cloudflare OAuth token exchange failed (401 invalid_client): Client authentication failed.",
+    );
   });
 
   it("returns null when a successful response carries no access token", async () => {

--- a/packages/gatekeeper-cloudflare/src/oauth.ts
+++ b/packages/gatekeeper-cloudflare/src/oauth.ts
@@ -138,8 +138,18 @@ async function redeem(config: CloudflareOAuthConfig, body: URLSearchParams): Pro
     body,
   });
   if (!resp.ok) {
-    resp.body?.cancel();
-    return null;
+    const providerError: unknown = await resp.json().catch(() => null);
+    const errorCode = providerError !== null && typeof providerError === "object" &&
+        "error" in providerError && typeof providerError.error === "string"
+      ? ` ${providerError.error}`
+      : "";
+    const errorDescription = providerError !== null && typeof providerError === "object" &&
+        "error_description" in providerError && typeof providerError.error_description === "string"
+      ? `: ${providerError.error_description}`
+      : "";
+    throw new Error(
+      `Cloudflare OAuth token exchange failed (${resp.status}${errorCode})${errorDescription}`,
+    );
   }
   const data = await resp.json() as RawTokenResponse;
   if (!data.access_token) return null;


### PR DESCRIPTION
Closes #323

## What does this change?

Cloudflare OAuth token redemption currently collapses every non-2xx response to `null`. That makes invalid client credentials indistinguishable from a successful response that omitted an access token. This patch throws an error containing only the HTTP status and standard OAuth `error` and `error_description` fields, and adds a focused rejection-path test.

## Why is this obviously correct and trivially verifiable?

The change affects one non-2xx branch in the token exchange helper. The test supplies a 401 `invalid_client` response and asserts the exact sanitized error. Credentials and token values are never read into the message. Successful response handling is unchanged.

## Verification

- `pnpm --filter @gadgets/cloudflare-gatekeeper test:run`

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.