### PR TITLE
Fix app sidebar height

### DIFF
--- a/packages/workshop-frontend/src/components/AppShell/AppShell.test.tsx
+++ b/packages/workshop-frontend/src/components/AppShell/AppShell.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+/* eslint-disable react/react-in-jsx-scope */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', () => ({ useRouterState: () => '/' }))
+
+vi.mock('../../RpcContext', () => ({ useConnectionLost: () => false }))
+vi.mock('../../TopBarNotice', () => ({ default: () => null }))
+vi.mock('./CommandPalette', () => ({ default: () => null }))
+vi.mock('./Sidebar', () => ({
+  default: () => <aside data-testid="sidebar" />,
+}))
+
+import AppShell from './AppShell'
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('AppShell', () => {
+  let root: Root | undefined
+  let container: HTMLDivElement | undefined
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    container?.remove()
+  })
+
+  it('gives the percentage-height desktop sidebar a definite-height container', () => {
+    container = document.createElement('div')
+    root = createRoot(container)
+    act(() => root!.render(<AppShell><div /></AppShell>))
+
+    const sidebarContainer = container.querySelector('[data-testid="sidebar"]')?.parentElement
+    expect(sidebarContainer?.classList.contains('h-full')).toBe(true)
+  })
+})

--- a/packages/workshop-frontend/src/components/AppShell/AppShell.tsx
+++ b/packages/workshop-frontend/src/components/AppShell/AppShell.tsx
@@ -109,7 +109,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full min-h-0 w-full overflow-hidden bg-kumo-base">
       {/* Desktop sidebar — hidden on mobile in favor of the drawer. */}
-      <div className="hidden md:flex">
+      <div className="hidden h-full md:flex">
         <Sidebar collapsed={collapsed} onToggleCollapsed={toggleCollapsed} />
       </div>
 


### PR DESCRIPTION
The responsive shell changed the sidebar from viewport height to percentage height, but its desktop wrapper did not establish a definite containing height. This makes the shared rail reach the viewport bottom on Outputs and every other AppShell route, with a regression test for the layout contract.

Verified with the full workshop frontend test suite, frontend production build, and lint.