### PR TITLE
add preview support to google oauth flow

### DIFF
--- a/packages/gatekeeper-google/README.md
+++ b/packages/gatekeeper-google/README.md
@@ -145,6 +145,26 @@ User — see Step 4.)
 
 You can also see your connected accounts and add and remove them in the settings (accessed through the account menu in the upper-right).
 
+## Worker Preview OAuth callbacks
+
+Deployments using Worker Preview hostnames can register one stable Google callback and relay the
+result to the preview that initiated authorization. Configure the stable Worker and its previews
+with the same `OAUTH_STATE_SIGNING_SECRET` and `OAUTH_ALLOW_PREVIEW_REDIRECTS=true`. Set the fixed
+redirect only on previews:
+
+```text
+OAUTH_REDIRECT_URI=https://gatekeeper-google.example.workers.dev/oauth
+```
+
+Register `OAUTH_REDIRECT_URI` as the authorized redirect URI in Google. The preview sends that fixed
+URI to Google and carries its own callback in signed, short-lived OAuth state. The stable Worker
+accepts return URLs only on its `<preview>-<worker>.<workers.dev>` hosts and forwards only the OAuth
+result and state. Normal deployments should omit these settings and continue using
+`${BASE_URL}/oauth` directly.
+
+Deploy the relay-capable stable Worker before enabling the fixed redirect on previews. Wrangler
+stores baseline and Preview secrets separately, so provision the same signing value in both places.
+
 ## Troubleshooting
 
 ### "redirect_uri_mismatch" error

--- a/packages/gatekeeper-google/__tests__/oauth.test.ts
+++ b/packages/gatekeeper-google/__tests__/oauth.test.ts
@@ -1,0 +1,142 @@
+import { SignJWT } from "jose";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { exchangeAuthCode } from "../src/google-api";
+import {
+  decodeGoogleOAuthState,
+  decodeLegacyGoogleOAuthState,
+  encodeGoogleOAuthState,
+  encodeLegacyGoogleOAuthState,
+  getDynamicGoogleOAuthReturnUrl,
+  getRegisteredGoogleOAuthRedirectUri,
+  isCurrentGoogleOAuthCallback,
+  redirectToGoogleOAuthReturnUrl,
+  validateGoogleOAuthReturnUrl,
+  type GoogleOAuthState,
+} from "../src/oauth";
+
+const STATE_SECRET = "test-state-secret";
+const STATE_KEY = new TextEncoder().encode(STATE_SECRET);
+const PREVIEW_RETURN_URL =
+  "https://preview-gatekeeper-google.gadgets-staging.workers.dev/oauth";
+const DOT_PREVIEW_RETURN_URL =
+  "https://preview.gatekeeper-google.gadgets-staging.workers.dev/oauth";
+const STATE: GoogleOAuthState = {
+  userObjectId: "0".repeat(64),
+  oauthNonce: "1".repeat(64),
+  returnUrl: PREVIEW_RETURN_URL,
+};
+const STABLE_ENV = {
+  BASE_URL: "https://gatekeeper-google.gadgets-staging.workers.dev",
+  OAUTH_ALLOW_PREVIEW_REDIRECTS: true,
+};
+const PREVIEW_ENV = {
+  ...STABLE_ENV,
+  BASE_URL: "https://preview-gatekeeper-google.gadgets-staging.workers.dev",
+  OAUTH_REDIRECT_URI: "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Google OAuth callback relay", () => {
+  it("round-trips signed and legacy OAuth state", async () => {
+    const signed = await encodeGoogleOAuthState(STATE, STATE_SECRET);
+    await expect(decodeGoogleOAuthState(signed, STATE_SECRET)).resolves.toEqual(STATE);
+
+    const directState = { userObjectId: STATE.userObjectId, oauthNonce: STATE.oauthNonce };
+    expect(decodeLegacyGoogleOAuthState(encodeLegacyGoogleOAuthState(directState)))
+      .toEqual(directState);
+  });
+
+  it("rejects tampered, expired, and malformed OAuth state", async () => {
+    const encoded = await encodeGoogleOAuthState(STATE, STATE_SECRET);
+    const segments = encoded.split(".");
+    if (segments.length !== 3 || !segments[1]) throw new Error("Expected a three-segment JWT");
+    segments[1] = `${segments[1].startsWith("A") ? "B" : "A"}${segments[1].slice(1)}`;
+    await expect(decodeGoogleOAuthState(segments.join("."), STATE_SECRET)).rejects.toThrow();
+
+    const now = Math.floor(Date.now() / 1000);
+    const expired = await new SignJWT(STATE)
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt(now - 120)
+      .setExpirationTime(now - 60)
+      .sign(STATE_KEY);
+    await expect(decodeGoogleOAuthState(expired, STATE_SECRET)).rejects.toThrow();
+    expect(() => decodeLegacyGoogleOAuthState("not-valid-state")).toThrow(/invalid/i);
+  });
+
+  it("uses a direct callback unless a preview has a registered stable redirect", () => {
+    expect(getRegisteredGoogleOAuthRedirectUri(STABLE_ENV)).toBe(
+      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
+    );
+    expect(getDynamicGoogleOAuthReturnUrl(STABLE_ENV)).toBeUndefined();
+    expect(getRegisteredGoogleOAuthRedirectUri(PREVIEW_ENV)).toBe(
+      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
+    );
+    expect(getDynamicGoogleOAuthReturnUrl(PREVIEW_ENV)).toBe(STATE.returnUrl);
+    expect(() => getDynamicGoogleOAuthReturnUrl({
+      ...PREVIEW_ENV,
+      OAUTH_ALLOW_PREVIEW_REDIRECTS: false,
+    })).toThrow(/OAUTH_ALLOW_PREVIEW_REDIRECTS/);
+  });
+
+  it("accepts only the stable callback and its Worker Preview hosts", () => {
+    expect(validateGoogleOAuthReturnUrl(
+      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
+      STABLE_ENV,
+    ).hostname).toBe("gatekeeper-google.gadgets-staging.workers.dev");
+    expect(validateGoogleOAuthReturnUrl(PREVIEW_RETURN_URL, STABLE_ENV).hostname)
+      .toBe("preview-gatekeeper-google.gadgets-staging.workers.dev");
+    expect(validateGoogleOAuthReturnUrl(DOT_PREVIEW_RETURN_URL, STABLE_ENV).hostname)
+      .toBe("preview.gatekeeper-google.gadgets-staging.workers.dev");
+    expect(() => validateGoogleOAuthReturnUrl("https://attacker.example/oauth", STABLE_ENV))
+      .toThrow(/host/);
+    expect(() => validateGoogleOAuthReturnUrl(
+      "https://preview-gatekeeper-google.gadgets-staging.workers.dev/not-oauth",
+      STABLE_ENV,
+    )).toThrow(/path/);
+    expect(() => validateGoogleOAuthReturnUrl(`${PREVIEW_RETURN_URL}?next=bad`, STABLE_ENV))
+      .toThrow(/path/);
+  });
+
+  it("relays only the provider result and unchanged signed state", () => {
+    const target = validateGoogleOAuthReturnUrl(PREVIEW_RETURN_URL, STABLE_ENV);
+    const callback = new URL(
+      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth" +
+      "?error=access_denied&error_description=provider-secret",
+    );
+    const response = redirectToGoogleOAuthReturnUrl(target, callback, "signed-state");
+    const location = new URL(response.headers.get("location") ?? "");
+
+    expect(response.status).toBe(302);
+    expect(location.origin + location.pathname).toBe(STATE.returnUrl);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("state")).toBe("signed-state");
+    expect(location.searchParams.has("error_description")).toBe(false);
+    expect(isCurrentGoogleOAuthCallback(location, STABLE_ENV)).toBe(false);
+    expect(isCurrentGoogleOAuthCallback(location, PREVIEW_ENV)).toBe(true);
+  });
+
+  it("sends the selected redirect URI unchanged during code exchange", async () => {
+    const calls: RequestInit[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(init ?? {});
+      return Response.json({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+        scope: "openid",
+      });
+    }));
+
+    await exchangeAuthCode(
+      "code",
+      "client-id",
+      "client-secret",
+      PREVIEW_ENV.OAUTH_REDIRECT_URI,
+    );
+
+    const body = calls[0]?.body;
+    expect(body).toBeInstanceOf(URLSearchParams);
+    expect((body as URLSearchParams).get("redirect_uri")).toBe(PREVIEW_ENV.OAUTH_REDIRECT_URI);
+  });
+});

--- a/packages/gatekeeper-google/__tests__/oauth.test.ts
+++ b/packages/gatekeeper-google/__tests__/oauth.test.ts
@@ -9,6 +9,7 @@ import {
   getDynamicGoogleOAuthReturnUrl,
   getRegisteredGoogleOAuthRedirectUri,
   isCurrentGoogleOAuthCallback,
+  isGoogleOAuthPreviewRedirectEnabled,
   redirectToGoogleOAuthReturnUrl,
   validateGoogleOAuthReturnUrl,
   type GoogleOAuthState,
@@ -27,7 +28,7 @@ const STATE: GoogleOAuthState = {
 };
 const STABLE_ENV = {
   BASE_URL: "https://gatekeeper-google.gadgets-staging.workers.dev",
-  OAUTH_ALLOW_PREVIEW_REDIRECTS: true,
+  OAUTH_ALLOW_PREVIEW_REDIRECTS: "true",
 };
 const PREVIEW_ENV = {
   ...STABLE_ENV,
@@ -65,6 +66,19 @@ describe("Google OAuth callback relay", () => {
   });
 
   it("uses a direct callback unless a preview has a registered stable redirect", () => {
+    expect(isGoogleOAuthPreviewRedirectEnabled(STABLE_ENV)).toBe(true);
+    expect(isGoogleOAuthPreviewRedirectEnabled({
+      ...STABLE_ENV,
+      OAUTH_ALLOW_PREVIEW_REDIRECTS: true,
+    })).toBe(true);
+    expect(isGoogleOAuthPreviewRedirectEnabled({
+      ...STABLE_ENV,
+      OAUTH_ALLOW_PREVIEW_REDIRECTS: "false",
+    })).toBe(false);
+    expect(isGoogleOAuthPreviewRedirectEnabled({
+      ...STABLE_ENV,
+      OAUTH_ALLOW_PREVIEW_REDIRECTS: "TRUE",
+    })).toBe(false);
     expect(getRegisteredGoogleOAuthRedirectUri(STABLE_ENV)).toBe(
       "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
     );
@@ -75,7 +89,7 @@ describe("Google OAuth callback relay", () => {
     expect(getDynamicGoogleOAuthReturnUrl(PREVIEW_ENV)).toBe(STATE.returnUrl);
     expect(() => getDynamicGoogleOAuthReturnUrl({
       ...PREVIEW_ENV,
-      OAUTH_ALLOW_PREVIEW_REDIRECTS: false,
+      OAUTH_ALLOW_PREVIEW_REDIRECTS: "false",
     })).toThrow(/OAUTH_ALLOW_PREVIEW_REDIRECTS/);
   });
 
@@ -88,6 +102,10 @@ describe("Google OAuth callback relay", () => {
       .toBe("preview-gatekeeper-google.gadgets-staging.workers.dev");
     expect(validateGoogleOAuthReturnUrl(DOT_PREVIEW_RETURN_URL, STABLE_ENV).hostname)
       .toBe("preview.gatekeeper-google.gadgets-staging.workers.dev");
+    expect(() => validateGoogleOAuthReturnUrl(PREVIEW_RETURN_URL, {
+      ...STABLE_ENV,
+      OAUTH_ALLOW_PREVIEW_REDIRECTS: "false",
+    })).toThrow(/host/);
     expect(() => validateGoogleOAuthReturnUrl("https://attacker.example/oauth", STABLE_ENV))
       .toThrow(/host/);
     expect(() => validateGoogleOAuthReturnUrl(

--- a/packages/gatekeeper-google/package.json
+++ b/packages/gatekeeper-google/package.json
@@ -15,6 +15,7 @@
     "@gadgets/workshop-shared": "workspace:*",
     "capnweb": "catalog:",
     "capnweb-validate": "catalog:",
+    "jose": "^6.2.8",
     "mimetext": "^3.0.28",
     "postal-mime": "^2.7.6"
   },

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -1,6 +1,6 @@
 import { WorkerEntrypoint, DurableObject, RpcTarget, RpcStub } from "cloudflare:workers";
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
-import { GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor as GatekeeperVendorIface, Gatekeeper, ResourceDescription, ApprovalQueue, ObservationDescription, VendorDescription, GatekeeperConnectCallback, GatekeeperConnectOptions, AccountDescription, SupportedResource, ResourceConfiguratorFrame, Cursor, ActionKind, stripTrailingSlashes } from '@gadgets/workshop-shared/gatekeeper';
+import { GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor as GatekeeperVendorIface, Gatekeeper, ResourceDescription, ApprovalQueue, ObservationDescription, VendorDescription, GatekeeperConnectCallback, GatekeeperConnectOptions, AccountDescription, SupportedResource, ResourceConfiguratorFrame, Cursor, ActionKind } from '@gadgets/workshop-shared/gatekeeper';
 import { exchangeAuthCode, getAccessToken, getGoogleAccountDescription, getGoogleVerifiedEmail, GmailApi, GmailMessageRaw, GmailOutboundMessage, GoogleAccessToken, normalizeEmailRecipients, revokeGoogleToken } from "./google-api";
 import {
   GmailSession, GmailThread, GmailMessage,
@@ -59,6 +59,23 @@ import {
 } from "./resources";
 import { ObserverCheck, ObserverTracker } from "./observers";
 import { CursorPager, Pager } from "./cursor";
+import {
+  decodeGoogleOAuthState,
+  decodeLegacyGoogleOAuthState,
+  encodeGoogleOAuthState,
+  encodeLegacyGoogleOAuthState,
+  getBasePath,
+  getBaseUrl,
+  getDynamicGoogleOAuthReturnUrl,
+  getGoogleOAuthCallbackUri,
+  getRegisteredGoogleOAuthRedirectUri,
+  isCurrentGoogleOAuthCallback,
+  isSignedGoogleOAuthState,
+  redirectToGoogleOAuthReturnUrl,
+  validateGoogleOAuthReturnUrl,
+  type GoogleOAuthEnv,
+  type GoogleOAuthState,
+} from "./oauth";
 
 // Vendor id = GATEKEEPER_<NAME> binding suffix (lowercased).
 const VENDOR_ID = "google";
@@ -72,6 +89,8 @@ type StoredNonce = {
   value: string;
   expiresAt: number;
   stage: "initiation" | "oauth";
+  // Bound to the OAuth-stage nonce so authorization and code exchange use the exact same URI.
+  oauthRedirectUri?: string;
 };
 
 const NONCE_BYTES = 32;
@@ -108,10 +127,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 // Declare optional environment variables here since they may be omitted from wrangler.jsonc.
-type Env = Cloudflare.Env & {
-  // Base URL (protocol+host+optional path) at which the default fetch handler is served. Should
-  // NOT include a trailing slash. Omit for localhost dev server.
-  BASE_URL?: string;
+type Env = Cloudflare.Env & GoogleOAuthEnv & {
   // OAuth app credentials (wrangler secrets / .dev.vars); not in wrangler.jsonc.
   CLIENT_ID?: string;
   CLIENT_SECRET?: string;
@@ -138,15 +154,6 @@ function toLabelObjects(labelIds: string[], labelMap: Map<string, string>): Gmai
     let name = labelMap.get(id) || id;
     return { id, name, type: "custom" as const };
   });
-}
-
-function getBaseUrl(env: Env) {
-  return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/google");
-}
-
-function getBasePath(env: Env) {
-  const path = new URL(getBaseUrl(env)).pathname;
-  return path === "/" ? "" : path;
 }
 
 // =======================================================================================
@@ -215,7 +222,21 @@ export default {
       let doId = path[0];
       let initiationNonce = path[1];
       let stub = ctx.exports.UserAccount.get(ctx.exports.UserAccount.idFromString(doId));
-      let begun = await stub.beginOAuthFlow(initiationNonce);
+      let oauthRedirectUri: string;
+      let returnUrl: string | undefined;
+      try {
+        oauthRedirectUri = getRegisteredGoogleOAuthRedirectUri(env);
+        returnUrl = getDynamicGoogleOAuthReturnUrl(env);
+        if (returnUrl && !env.OAUTH_STATE_SIGNING_SECRET) {
+          throw new Error("Google OAuth state signing secret is not configured.");
+        }
+      } catch (error) {
+        return new Response(
+          error instanceof Error ? error.message : "Google OAuth callback is not configured.",
+          { status: 503 },
+        );
+      }
+      let begun = await stub.beginOAuthFlow(initiationNonce, oauthRedirectUri);
       if (begun === null) {
         return new Response(INVALID_LINK_HTML, {
           headers: { "Content-Type": "text/html; charset=utf-8" }
@@ -224,37 +245,89 @@ export default {
 
       let newUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
       newUrl.searchParams.set("client_id", env.CLIENT_ID);
-      newUrl.searchParams.set("redirect_uri", getBaseUrl(env) + "/oauth");
+      newUrl.searchParams.set("redirect_uri", begun.oauthRedirectUri);
       newUrl.searchParams.set("response_type", "code");
       newUrl.searchParams.set("scope", begun.scopes.join(" "));
       newUrl.searchParams.set("access_type", "offline");
       newUrl.searchParams.set("prompt", "consent");
       // Add newly-requested scopes to any the user already granted, rather than replacing them.
       newUrl.searchParams.set("include_granted_scopes", "true");
-      newUrl.searchParams.set("state", `${doId}:${begun.oauthNonce}`);
+      let oauthState: GoogleOAuthState = {
+        userObjectId: doId,
+        oauthNonce: begun.oauthNonce,
+        ...(returnUrl ? { returnUrl } : {}),
+      };
+      let encodedState = encodeLegacyGoogleOAuthState(oauthState);
+      if (returnUrl) {
+        let signingSecret = env.OAUTH_STATE_SIGNING_SECRET;
+        if (!signingSecret) throw new Error("Google OAuth state signing secret is not configured.");
+        encodedState = await encodeGoogleOAuthState(oauthState, signingSecret);
+      }
+      newUrl.searchParams.set("state", encodedState);
 
       return Response.redirect(newUrl.toString(), 302);
     } else if (relPath === "/oauth") {
       // Completion redirect.
 
-      let error = url.searchParams.get("error");
-      if (error) {
-        return new Response(`${error}: ${url.searchParams.get("error_description")}`);
+      let state = url.searchParams.get("state");
+      if (!state) return new Response("Error: no 'state' provided", { status: 400 });
+
+      let oauthState: GoogleOAuthState;
+      try {
+        if (isSignedGoogleOAuthState(state)) {
+          if (!env.OAUTH_STATE_SIGNING_SECRET) {
+            return new Response("Google OAuth state signing secret is not configured.", { status: 500 });
+          }
+          oauthState = await decodeGoogleOAuthState(state, env.OAUTH_STATE_SIGNING_SECRET);
+        } else {
+          oauthState = decodeLegacyGoogleOAuthState(state);
+        }
+      } catch (error) {
+        return new Response(error instanceof Error ? error.message : "Invalid Google OAuth state", {
+          status: 400,
+        });
       }
 
-      let state = url.searchParams.get("state");
-      if (!state) return new Response("Error: no 'state' provided");
-      let colonIdx = state.indexOf(":");
-      if (colonIdx < 0) return new Response("Error: malformed state");
-      let doId = state.slice(0, colonIdx);
-      let oauthNonce = state.slice(colonIdx + 1);
+      if (oauthState.returnUrl) {
+        if (!env.OAUTH_ALLOW_PREVIEW_REDIRECTS) {
+          return new Response("Google OAuth return URLs are not allowed.", { status: 400 });
+        }
+        let returnUrl: URL;
+        try {
+          returnUrl = validateGoogleOAuthReturnUrl(oauthState.returnUrl, env);
+        } catch (error) {
+          return new Response(
+            error instanceof Error ? error.message : "Invalid Google OAuth return URL",
+            { status: 400 },
+          );
+        }
+        if (!isCurrentGoogleOAuthCallback(returnUrl, env)) {
+          return redirectToGoogleOAuthReturnUrl(returnUrl, url, state);
+        }
+      }
+
+      let userObjectId;
+      try {
+        userObjectId = ctx.exports.UserAccount.idFromString(oauthState.userObjectId);
+      } catch {
+        return new Response("Error: malformed state", { status: 400 });
+      }
+      let stub: DurableObjectStub<UserAccount> = ctx.exports.UserAccount.get(userObjectId);
+
+      let error = url.searchParams.get("error");
+      if (error) {
+        if (!await stub.consumeOAuthNonce(oauthState.oauthNonce)) {
+          return new Response(INVALID_LINK_HTML, {
+            headers: { "Content-Type": "text/html; charset=utf-8" }
+          });
+        }
+        return new Response("Google authorization was not completed.", { status: 400 });
+      }
 
       let code = url.searchParams.get("code");
-      if (!code) return new Response("Error: no 'code' provided");
+      if (!code) return new Response("Error: no 'code' provided", { status: 400 });
 
-      let userObjectId = ctx.exports.UserAccount.idFromString(doId);
-      let stub: DurableObjectStub<UserAccount> = ctx.exports.UserAccount.get(userObjectId);
-      if (!await stub.acceptAuthCode(code, oauthNonce)) {
+      if (!await stub.acceptAuthCode(code, oauthState.oauthNonce)) {
         return new Response(INVALID_LINK_HTML, {
           headers: { "Content-Type": "text/html; charset=utf-8" }
         });
@@ -413,7 +486,11 @@ export class UserAccount extends DurableObject<Env> {
    * nonce, consumes it, and returns a fresh OAuth nonce plus the scopes to request. Returns null if
    * the nonce is invalid or expired.
    */
-  async beginOAuthFlow(initiationNonce: string): Promise<{oauthNonce: string, scopes: string[]} | null> {
+  async beginOAuthFlow(initiationNonce: string, oauthRedirectUri: string): Promise<{
+    oauthNonce: string,
+    oauthRedirectUri: string,
+    scopes: string[],
+  } | null> {
     let stored = this.ctx.storage.kv.get<StoredNonce>("nonce");
     if (!stored || stored.stage !== "initiation" ||
         Date.now() >= stored.expiresAt || !constantTimeEqual(stored.value, initiationNonce)) {
@@ -426,22 +503,33 @@ export class UserAccount extends DurableObject<Env> {
       value: oauthNonce,
       expiresAt: Date.now() + OAUTH_NONCE_LIFETIME_MS,
       stage: "oauth",
+      oauthRedirectUri,
     });
     // Fall back to all scopes for legacy flows that didn't record a requested set.
     let scopes = this.ctx.storage.kv.get<string[]>("requestedScopes")
         ?? resourceUrlPatternsToOAuthScopes();
-    return {oauthNonce, scopes};
+    return {oauthNonce, oauthRedirectUri, scopes};
+  }
+
+  #consumeOAuthNonce(oauthNonce: string): string | null {
+    let stored = this.ctx.storage.kv.get<StoredNonce>("nonce");
+    if (!stored || stored.stage !== "oauth" ||
+        Date.now() >= stored.expiresAt || !constantTimeEqual(stored.value, oauthNonce)) {
+      return null;
+    }
+    this.ctx.storage.kv.delete("nonce");
+    // Existing in-flight flows did not persist this field and used the direct callback URI.
+    return stored.oauthRedirectUri ?? getGoogleOAuthCallbackUri(this.env);
+  }
+
+  consumeOAuthNonce(oauthNonce: string): boolean {
+    return this.#consumeOAuthNonce(oauthNonce) !== null;
   }
 
   /** Returns false if the OAuth nonce is invalid or expired. */
   async acceptAuthCode(code: string, oauthNonce: string): Promise<boolean> {
-    // Verify and consume the OAuth nonce.
-    let stored = this.ctx.storage.kv.get<StoredNonce>("nonce");
-    if (!stored || stored.stage !== "oauth" ||
-        Date.now() >= stored.expiresAt || !constantTimeEqual(stored.value, oauthNonce)) {
-      return false;
-    }
-    this.ctx.storage.kv.delete("nonce");
+    let oauthRedirectUri = this.#consumeOAuthNonce(oauthNonce);
+    if (!oauthRedirectUri) return false;
 
     let { CLIENT_ID: clientId, CLIENT_SECRET: clientSecret } = this.env;
     if (!clientId || !clientSecret) {
@@ -460,7 +548,7 @@ export class UserAccount extends DurableObject<Env> {
       }
 
       let response = await exchangeAuthCode(
-          code, clientId, clientSecret, getBaseUrl(this.env) + "/oauth",
+          code, clientId, clientSecret, oauthRedirectUri,
           AbortSignal.timeout(AUTH_CODE_EXCHANGE_TIMEOUT_MS));
 
       if (!response.refreshToken) {

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -237,7 +237,7 @@ export default {
           { status: 503 },
         );
       }
-      let begun = await stub.beginOAuthFlow(initiationNonce, oauthRedirectUri);
+      const begun = await stub.beginOAuthFlow(initiationNonce, oauthRedirectUri);
       if (begun === null) {
         return new Response(INVALID_LINK_HTML, {
           headers: { "Content-Type": "text/html; charset=utf-8" }
@@ -246,7 +246,7 @@ export default {
 
       let newUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
       newUrl.searchParams.set("client_id", env.CLIENT_ID);
-      newUrl.searchParams.set("redirect_uri", begun.oauthRedirectUri);
+      newUrl.searchParams.set("redirect_uri", oauthRedirectUri);
       newUrl.searchParams.set("response_type", "code");
       newUrl.searchParams.set("scope", begun.scopes.join(" "));
       newUrl.searchParams.set("access_type", "offline");
@@ -489,7 +489,6 @@ export class UserAccount extends DurableObject<Env> {
    */
   async beginOAuthFlow(initiationNonce: string, oauthRedirectUri: string): Promise<{
     oauthNonce: string,
-    oauthRedirectUri: string,
     scopes: string[],
   } | null> {
     let stored = this.ctx.storage.kv.get<StoredNonce>("nonce");
@@ -509,7 +508,7 @@ export class UserAccount extends DurableObject<Env> {
     // Fall back to all scopes for legacy flows that didn't record a requested set.
     let scopes = this.ctx.storage.kv.get<string[]>("requestedScopes")
         ?? resourceUrlPatternsToOAuthScopes();
-    return {oauthNonce, oauthRedirectUri, scopes};
+    return {oauthNonce, scopes};
   }
 
   #consumeOAuthNonce(oauthNonce: string): string | null {

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -70,6 +70,7 @@ import {
   getGoogleOAuthCallbackUri,
   getRegisteredGoogleOAuthRedirectUri,
   isCurrentGoogleOAuthCallback,
+  isGoogleOAuthPreviewRedirectEnabled,
   isSignedGoogleOAuthState,
   redirectToGoogleOAuthReturnUrl,
   validateGoogleOAuthReturnUrl,
@@ -289,7 +290,7 @@ export default {
       }
 
       if (oauthState.returnUrl) {
-        if (!env.OAUTH_ALLOW_PREVIEW_REDIRECTS) {
+        if (!isGoogleOAuthPreviewRedirectEnabled(env)) {
           return new Response("Google OAuth return URLs are not allowed.", { status: 400 });
         }
         let returnUrl: URL;

--- a/packages/gatekeeper-google/src/oauth.ts
+++ b/packages/gatekeeper-google/src/oauth.ts
@@ -7,7 +7,7 @@ const HEX_64 = /^[0-9a-f]{64}$/i;
 
 export type GoogleOAuthEnv = {
   BASE_URL?: string;
-  OAUTH_ALLOW_PREVIEW_REDIRECTS?: boolean;
+  OAUTH_ALLOW_PREVIEW_REDIRECTS?: boolean | string;
   OAUTH_REDIRECT_URI?: string;
   OAUTH_STATE_SIGNING_SECRET?: string;
 };
@@ -35,11 +35,16 @@ export function getRegisteredGoogleOAuthRedirectUri(env: GoogleOAuthEnv): string
   return env.OAUTH_REDIRECT_URI || getGoogleOAuthCallbackUri(env);
 }
 
+export function isGoogleOAuthPreviewRedirectEnabled(env: GoogleOAuthEnv): boolean {
+  const value = env.OAUTH_ALLOW_PREVIEW_REDIRECTS;
+  return value === true || value === "true";
+}
+
 export function getDynamicGoogleOAuthReturnUrl(env: GoogleOAuthEnv): string | undefined {
   if (!env.OAUTH_REDIRECT_URI) return undefined;
   const callback = getGoogleOAuthCallbackUri(env);
   if (new URL(callback).href === new URL(env.OAUTH_REDIRECT_URI).href) return undefined;
-  if (!env.OAUTH_ALLOW_PREVIEW_REDIRECTS) {
+  if (!isGoogleOAuthPreviewRedirectEnabled(env)) {
     throw new Error(
       "OAUTH_ALLOW_PREVIEW_REDIRECTS must be enabled when OAUTH_REDIRECT_URI differs from BASE_URL",
     );
@@ -112,7 +117,7 @@ export function validateGoogleOAuthReturnUrl(returnUrl: string, env: GoogleOAuth
   // Worker Preview hosts use either <preview-slug>-<deployed-host> or
   // <preview-slug>.<deployed-host>.
   const allowed = url.origin === callback.origin || Boolean(
-    env.OAUTH_ALLOW_PREVIEW_REDIRECTS &&
+    isGoogleOAuthPreviewRedirectEnabled(env) &&
     url.protocol === callback.protocol &&
     url.port === callback.port &&
     (url.hostname.endsWith(`-${callback.hostname}`) ||

--- a/packages/gatekeeper-google/src/oauth.ts
+++ b/packages/gatekeeper-google/src/oauth.ts
@@ -1,0 +1,138 @@
+import { SignJWT, jwtVerify, type JWTPayload } from "jose";
+import { stripTrailingSlashes } from "@gadgets/workshop-shared/gatekeeper";
+
+const OAUTH_CALLBACK_PATH = "/oauth";
+const OAUTH_STATE_MAX_AGE = "10m";
+const HEX_64 = /^[0-9a-f]{64}$/i;
+
+export type GoogleOAuthEnv = {
+  BASE_URL?: string;
+  OAUTH_ALLOW_PREVIEW_REDIRECTS?: boolean;
+  OAUTH_REDIRECT_URI?: string;
+  OAUTH_STATE_SIGNING_SECRET?: string;
+};
+
+export type GoogleOAuthState = {
+  userObjectId: string;
+  oauthNonce: string;
+  returnUrl?: string;
+};
+
+export function getBaseUrl(env: GoogleOAuthEnv): string {
+  return stripTrailingSlashes(env.BASE_URL || "http://localhost:8787/gatekeeper/google");
+}
+
+export function getBasePath(env: GoogleOAuthEnv): string {
+  const path = new URL(getBaseUrl(env)).pathname;
+  return path === "/" ? "" : path;
+}
+
+export function getGoogleOAuthCallbackUri(env: GoogleOAuthEnv): string {
+  return `${getBaseUrl(env)}${OAUTH_CALLBACK_PATH}`;
+}
+
+export function getRegisteredGoogleOAuthRedirectUri(env: GoogleOAuthEnv): string {
+  return env.OAUTH_REDIRECT_URI || getGoogleOAuthCallbackUri(env);
+}
+
+export function getDynamicGoogleOAuthReturnUrl(env: GoogleOAuthEnv): string | undefined {
+  if (!env.OAUTH_REDIRECT_URI) return undefined;
+  const callback = getGoogleOAuthCallbackUri(env);
+  if (new URL(callback).href === new URL(env.OAUTH_REDIRECT_URI).href) return undefined;
+  if (!env.OAUTH_ALLOW_PREVIEW_REDIRECTS) {
+    throw new Error(
+      "OAUTH_ALLOW_PREVIEW_REDIRECTS must be enabled when OAUTH_REDIRECT_URI differs from BASE_URL",
+    );
+  }
+  return callback;
+}
+
+function oauthStateKey(secret: string): Uint8Array {
+  return new TextEncoder().encode(secret);
+}
+
+function parseGoogleOAuthState(payload: JWTPayload): GoogleOAuthState {
+  const allowedKeys = new Set(["userObjectId", "oauthNonce", "returnUrl", "iat", "exp"]);
+  if (Object.keys(payload).some((key) => !allowedKeys.has(key)) ||
+      typeof payload.userObjectId !== "string" || !HEX_64.test(payload.userObjectId) ||
+      typeof payload.oauthNonce !== "string" || !HEX_64.test(payload.oauthNonce) ||
+      (payload.returnUrl !== undefined && typeof payload.returnUrl !== "string")) {
+    throw new Error("Invalid Google OAuth state");
+  }
+  return {
+    userObjectId: payload.userObjectId,
+    oauthNonce: payload.oauthNonce,
+    ...(payload.returnUrl === undefined ? {} : { returnUrl: payload.returnUrl }),
+  };
+}
+
+export async function encodeGoogleOAuthState(
+    state: GoogleOAuthState, secret: string): Promise<string> {
+  const payload = parseGoogleOAuthState(state);
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt()
+    .setExpirationTime(OAUTH_STATE_MAX_AGE)
+    .sign(oauthStateKey(secret));
+}
+
+export async function decodeGoogleOAuthState(
+    state: string, secret: string): Promise<GoogleOAuthState> {
+  const { payload } = await jwtVerify(state, oauthStateKey(secret), {
+    algorithms: ["HS256"],
+    requiredClaims: ["iat", "exp"],
+  });
+  return parseGoogleOAuthState(payload);
+}
+
+export function encodeLegacyGoogleOAuthState(state: GoogleOAuthState): string {
+  return `${state.userObjectId}:${state.oauthNonce}`;
+}
+
+export function decodeLegacyGoogleOAuthState(state: string): GoogleOAuthState {
+  const match = /^([0-9a-f]{64}):([0-9a-f]{64})$/i.exec(state);
+  if (!match?.[1] || !match[2]) throw new Error("Invalid Google OAuth state");
+  return { userObjectId: match[1], oauthNonce: match[2] };
+}
+
+export function isSignedGoogleOAuthState(state: string): boolean {
+  return state.split(".").length === 3;
+}
+
+export function validateGoogleOAuthReturnUrl(returnUrl: string, env: GoogleOAuthEnv): URL {
+  const url = new URL(returnUrl);
+  const callback = new URL(getGoogleOAuthCallbackUri(env));
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && url.hostname === "localhost")) {
+    throw new Error("Invalid Google OAuth return URL protocol");
+  }
+  if (url.pathname !== callback.pathname || url.search || url.hash || url.username || url.password) {
+    throw new Error("Invalid Google OAuth return URL path");
+  }
+
+  // Worker Preview hosts use either <preview-slug>-<deployed-host> or
+  // <preview-slug>.<deployed-host>.
+  const allowed = url.origin === callback.origin || Boolean(
+    env.OAUTH_ALLOW_PREVIEW_REDIRECTS &&
+    url.protocol === callback.protocol &&
+    url.port === callback.port &&
+    (url.hostname.endsWith(`-${callback.hostname}`) ||
+      url.hostname.endsWith(`.${callback.hostname}`)),
+  );
+  if (!allowed) throw new Error("Invalid Google OAuth return URL host");
+  return url;
+}
+
+export function isCurrentGoogleOAuthCallback(url: URL, env: GoogleOAuthEnv): boolean {
+  const callback = new URL(getGoogleOAuthCallbackUri(env));
+  return url.origin === callback.origin && url.pathname === callback.pathname;
+}
+
+export function redirectToGoogleOAuthReturnUrl(
+    target: URL, callbackUrl: URL, state: string): Response {
+  for (const key of ["code", "error"]) {
+    const value = callbackUrl.searchParams.get(key);
+    if (value) target.searchParams.set(key, value);
+  }
+  target.searchParams.set("state", state);
+  return Response.redirect(target.toString(), 302);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
       capnweb-validate:
         specifier: 'catalog:'
         version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+      jose:
+        specifier: ^6.2.8
+        version: 6.2.8
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -3771,9 +3774,6 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@6.2.5:
-    resolution: {integrity: sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==}
-
   jose@6.2.8:
     resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
@@ -6097,7 +6097,7 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      jose: 6.2.5
+      jose: 6.2.8
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
@@ -7682,8 +7682,6 @@ snapshots:
   isomorphic.js@0.2.5: {}
 
   jiti@2.7.0: {}
-
-  jose@6.2.5: {}
 
   jose@6.2.8: {}
 

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -123,7 +123,7 @@ interface FetchedPullRequest {
 const USAGE = "Usage: preview.ts <config|deploy|delete|sweep> [--dry-run]";
 const OUTPUT_DIR = join(ROOT, "output");
 const PREVIEW_COMMENT = join(OUTPUT_DIR, "preview-comment.md");
-const GATEKEEPER_CONCURRENCY = 8;
+const GATEKEEPER_CONCURRENCY = 4;
 // How many of the sweep's read-only API requests — one preview list per worker, one pull request per
 // number — are in flight at once.
 const API_CONCURRENCY = 8;

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -123,7 +123,7 @@ interface FetchedPullRequest {
 const USAGE = "Usage: preview.ts <config|deploy|delete|sweep> [--dry-run]";
 const OUTPUT_DIR = join(ROOT, "output");
 const PREVIEW_COMMENT = join(OUTPUT_DIR, "preview-comment.md");
-const GATEKEEPER_CONCURRENCY = 4;
+const GATEKEEPER_CONCURRENCY = 8;
 // How many of the sweep's read-only API requests — one preview list per worker, one pull request per
 // number — are in flight at once.
 const API_CONCURRENCY = 8;


### PR DESCRIPTION
Upgrade the OAuth state parameter into a signed JWT that can optionally carry a preview callback URL for completing the flow. Dynamic redirection is only allowed when the `OAUTH_ALLOW_PREVIEW_REDIRECTS` variable is set, and preview redirect URLs must be suffixed by the main deployment URL.

This allows a single callback URL to be registered with the OAuth application that covers all preview deployments.