### PR TITLE
Bound each agent turn with a watchdog

### DIFF
--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -1390,12 +1390,21 @@ class OverseerImpl implements AgentHooks {
   // when the running-agent count drops to zero.
   #allAgentsIdleWaiters: (() => void)[] = [];
 
+  // Per-turn watchdogs are armed when the turn starts, rather than by alarm(), because an
+  // external-message turn is itself held open with ctx.waitUntil(). In that case the already-live
+  // RPC invocation can keep the DO billable while the alarm remains queued and never runs.
+  #agentWatchdogTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
   // How long to set the keep-alive alarm into the future. Whenever the agent count goes from zero
   // to one, we schedule an alarm this far out; whenever it drops back to zero, we clear it. The
   // alarm guarantees the DO is restarted (and the agents resumed) after a server restart, even if
   // no client reconnects. While an agent is actively running and the DO is alive, the agent itself
   // keeps the DO alive, so the alarm typically never fires.
   static #AGENT_KEEPALIVE_ALARM_MS = 60_000;
+
+  // Agent turns normally finish in minutes. Bound every turn so a hung provider request or stream
+  // cannot keep an RPC invocation -- and Durable Object billing -- alive indefinitely.
+  static #AGENT_WATCHDOG_TIMEOUT_MS = 10 * 60_000;
 
   addChatSubscriber(subscriber: RpcStub<AiChatSubscriber>) {
     this.#chatSubscribers.add(subscriber);
@@ -1542,6 +1551,14 @@ class OverseerImpl implements AgentHooks {
   #registerRunningAgent(chatId: number) {
     let wasEmpty = this.#runningAgents.size === 0;
     this.#runningAgents.add(chatId);
+    this.#agentWatchdogTimers.set(chatId, setTimeout(() => {
+      if (!this.#runningAgents.has(chatId)) return;
+      this.logger.error("agent turn watchdog timeout; force-cancelling stuck agent", {
+        event: "agent.watchdog.timeout", chatId,
+        durationMs: OverseerImpl.#AGENT_WATCHDOG_TIMEOUT_MS,
+      });
+      this.cancelAgent(chatId, new Error("Agent stopped after exceeding the 10-minute time limit."));
+    }, OverseerImpl.#AGENT_WATCHDOG_TIMEOUT_MS));
     if (wasEmpty) {
       // Zero -> one running agents: schedule the keep-alive alarm.
       this.ctx.storage.setAlarm(Date.now() + OverseerImpl.#AGENT_KEEPALIVE_ALARM_MS);
@@ -1555,6 +1572,9 @@ class OverseerImpl implements AgentHooks {
   // otherwise interfere if the user immediately starts a new agent).
   #unregisterRunningAgent(chatId: number) {
     this.#runningAgents.delete(chatId);
+    let watchdogTimer = this.#agentWatchdogTimers.get(chatId);
+    if (watchdogTimer !== undefined) clearTimeout(watchdogTimer);
+    this.#agentWatchdogTimers.delete(chatId);
     this.storage.activeAgents.delete(chatId);
     if (this.#runningAgents.size === 0) {
       // One -> zero running agents: replace the keep-alive alarm with any response-target retry/sweep
@@ -5441,10 +5461,10 @@ class OverseerImpl implements AgentHooks {
     this.#updateExternalMessageResponseDeliveryAlarm();
   }
 
-  cancelAgent(chatId: number) {
+  cancelAgent(chatId: number, reason = new Error("User requested to stop agent.")) {
     let ctx = this.#liveChats.get(chatId);
     if (ctx) {
-      ctx.cancelController.abort(new Error("User requested to stop agent."));
+      ctx.cancelController.abort(reason);
     }
   }
 


### PR DESCRIPTION
## What does this change?

Fixes the agent-turn watchdog gap found while investigating #338.

The existing keep-alive alarm does not bound every expensive turn. External-message turns call `ctx.waitUntil(turn)`, so the turn is already keeping the RPC event live; an alarm queued for the same object may not run until that event ends.

This patch arms the existing 10-minute policy when each turn is registered, cancels through the existing abort-controller path when it expires, and clears the timer during normal teardown. It does not claim to address the ordinary long-lived workspace sessions described in #338.

## Why is this obviously correct and trivially verifiable?

There is one timer per entry in `#runningAgents`. Registration adds both together; the existing matching unregister path clears both together. The timeout only calls the same `cancelAgent()` path used by the Stop button, with a more specific reason. No public API, persistence schema, or successful-turn behavior changes.

Validation:

- `pnpm --filter @gadgets/workshop-backend test:run` (482 unit tests; integration suite passed)
- `pnpm exec vp run -F @gadgets/workshop-backend build`
- `pnpm lint:check` (warnings only; no errors)

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
