### PR TITLE
Clean up loose ends in git-storage, improving crash recovery

### DIFF
--- a/packages/workshop-backend/__tests__/chat-changes.test.ts
+++ b/packages/workshop-backend/__tests__/chat-changes.test.ts
@@ -1048,66 +1048,188 @@ describe("updateChatFromMainline", () => {
   }));
 });
 
-describe("agent change appends", () => {
-  it("appendAgentCodeChange pins at the current head and mirrors the pin at append time",
+describe("agent step barrier", () => {
+  // The step's chat messages as the turn_end barrier would hand them over.
+  function stepMsgs(text: string): { type: "message", message: string }[] {
+    return [{ type: "message", message: text }];
+  }
+  const NO_EXTRAS = { createdGadgets: [], addedBindings: [] };
+
+  it("persists the step message, appends rows in order, and materializes -- one transaction",
       () => withImpl(async impl => {
     let c1 = await commitFiles(impl, { "a.txt": "one\n" });
     addGadget(impl, 1, "APP", c1);
     addChat(impl, 1);
 
-    let ack = await impl.appendAgentCodeChange(1, AGENT,
-        { 1: [["a.txt", { set: "one\nagent\n" }]] }, { gadgetId: 1, baseCommit: c1 });
-    expect(ack).toEqual({ generation: 0, revision: 1 });
+    expect(await impl.commitAgentStep(1, AGENT, stepMsgs("wrote files"), {
+      ...NO_EXTRAS,
+      changes: [
+        { change: { 1: [["a.txt", { set: "one\nagent\n" }]] },
+          pin: { gadgetId: 1, baseCommit: c1 } },
+        { change: { 1: [["b.txt", { set: "bee\n" }]] } },
+      ],
+    })).toBe(true);
+
+    // Ordering: the tool-call message precedes the step's single "changes" message, so a
+    // suffix revert can never erase the call while keeping its edits.
+    let msgs = chatMessages(impl, 1);
+    expect(msgs.map(msg => msg.type)).toEqual(["message", "changes"]);
+    expect(msgs[1].author).toEqual(AGENT);
+    expect(msgs[1].pins).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
+    expect(msgs[1].watermark).toEqual({ changesGeneration: 0, throughRevision: 2 });
+
+    // One row per buffered change, in call order, born retired (live only inside the barrier);
+    // the pin was validated and mirrored with its row.
+    let rows = [...impl.storage.chatChanges.list({ prefix: `${keyString(1)}.` })];
+    expect(rows.map((row: any) => [row.revision, row.source, row.retired]))
+        .toEqual([[1, "agent", true], [2, "agent", true]]);
     expect(impl.storage.chatMeta.get(1)!.codeBase!.pins).toEqual(
         [{ gadgetId: 1, baseCommit: c1, mergedCommit: c1 }]);
-    expect(await gadgetContent(impl, 1, 1)).toEqual({ "a.txt": "one\nagent\n" });
-    expect(impl.listUnmaterializedChatChanges(1)).toHaveLength(1);
-    expect(impl.undeclaredChatPins(1)).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
-
-    // The turn flush materializes the rows and declares the pin.
-    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(true);
-    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(false);  // nothing left
-    let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
-    expect(changes).toHaveLength(1);
-    expect(changes[0].author).toEqual(AGENT);
-    expect(changes[0].pins).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
     expect(impl.undeclaredChatPins(1)).toEqual([]);
+    expect(await gadgetContent(impl, 1, 1)).toEqual(
+        { "a.txt": "one\nagent\n", "b.txt": "bee\n" });
 
-    // A pin whose base is no longer the head fails the append (mid-turn head movement).
-    let c2 = await commitFiles(impl, { "a.txt": "two\n" }, [c1]);
-    addGadget(impl, 2, "OTHER", c2);
-    setHead(impl, 2, c1);
-    await expect(impl.appendAgentCodeChange(1, AGENT,
-        { 2: [["a.txt", { set: "x" }]] }, { gadgetId: 2, baseCommit: c2 }))
-        .rejects.toThrow(/no longer the gadget's head/);
+    // A changeless step persists its message but writes no "changes" message (the agent's
+    // change-ID numbering counts messages, so the false return keeps the counter in step).
+    expect(await impl.commitAgentStep(1, AGENT, stepMsgs("just talk"),
+        { ...NO_EXTRAS, changes: [] })).toBe(false);
+    expect(chatMessages(impl, 1).map(msg => msg.type))
+        .toEqual(["message", "changes", "message"]);
   }));
 
-  it("the turn flush writes exactly one message even past the byte budget",
+  it("writes the step's buffer as one message even past the message byte budget",
       () => withImpl(async impl => {
     let c1 = await commitFiles(impl, { "a.txt": "one\n" });
     addGadget(impl, 1, "APP", c1);
     addChat(impl, 1);
 
-    // Two rows whose composition (~1.2MB by the serialized-size estimate) exceeds the 1MB
-    // budget. The old chunker would have split them across two "changes" messages,
-    // desynchronizing the agent's message-counting change-ID numbering (one flush, one counter
-    // bump -- see flushPendingChanges in agent.ts); a flush now writes exactly one message,
-    // always. (In production the agent's own append-time trigger flushes before a window grows
-    // this big; this exercises the materialize side alone.)
+    // Two buffered changes composing to ~1.2MB by the serialized-size estimate: past
+    // CHAT_CHANGE_MESSAGE_BUDGET (the *user* path's accumulation bound) but within the step
+    // budget the write calls enforce. The barrier still writes exactly one message -- the
+    // no-chunking policy; the step's bound is what keeps this storable.
     let text = "文".repeat(300_000);
-    await impl.appendAgentCodeChange(1, AGENT,
-        { 1: [["a.txt", { set: text }]] }, { gadgetId: 1, baseCommit: c1 });
-    await impl.appendAgentCodeChange(1, AGENT, { 1: [["b.txt", { set: text }]] });
+    expect(await impl.commitAgentStep(1, AGENT, stepMsgs("big step"), {
+      ...NO_EXTRAS,
+      changes: [
+        { change: { 1: [["a.txt", { set: text }]] }, pin: { gadgetId: 1, baseCommit: c1 } },
+        { change: { 1: [["b.txt", { set: text }]] } },
+      ],
+    })).toBe(true);
 
-    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(true);
     let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
     expect(changes).toHaveLength(1);
     expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 2 });
-    expect(changes[0].pins).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
     expect(liveRows(impl, 1)).toHaveLength(0);
 
     let folded = await impl.buildChatContent(1);
     expect(["a.txt", "b.txt"].map(file => folded.get(1)!.get(file))).toEqual([text, text]);
+  }));
+
+  it("a mid-barrier failure leaves no partial durable state and the chat stays usable",
+      () => withImpl(async impl => {
+    let c1 = await commitFiles(impl, { "a.txt": "one\n" });
+    addGadget(impl, 1, "APP", c1);
+    addChat(impl, 1);
+
+    // The second buffered change fails content validation after the first already appended its
+    // row (and broadcast it): the transaction must roll back the row, the pin mirror, and the
+    // step's messages together -- a partial step is exactly the state this barrier exists to
+    // make impossible.
+    await expect(impl.commitAgentStep(1, AGENT, stepMsgs("doomed"), {
+      ...NO_EXTRAS,
+      changes: [
+        { change: { 1: [["a.txt", { set: "one\nagent\n" }]] },
+          pin: { gadgetId: 1, baseCommit: c1 } },
+        { change: { 1: [["a.txt", { edit: [2, [2, "x"], 96] }]] } },  // expects a 100-unit file
+      ],
+    })).rejects.toThrow(/length mismatch/);
+
+    expect(chatMessages(impl, 1)).toEqual([]);
+    expect([...impl.storage.chatChanges.list({ prefix: `${keyString(1)}.` })]).toEqual([]);
+    expect(impl.storage.chatMeta.get(1)!.codeBase?.pins ?? []).toEqual([]);
+    expect(await gadgetContent(impl, 1, 1)).toEqual({});
+
+    // The in-memory content/byte caches were dropped with the rollback: a subsequent barrier
+    // starts from revision 0 as if the failed one never happened.
+    expect(await impl.commitAgentStep(1, AGENT, stepMsgs("retried"), {
+      ...NO_EXTRAS,
+      changes: [{ change: { 1: [["a.txt", { set: "one\nagent\n" }]] },
+                  pin: { gadgetId: 1, baseCommit: c1 } }],
+    })).toBe(true);
+    expect(chatMessages(impl, 1).find(msg => msg.type === "changes")!.watermark)
+        .toEqual({ changesGeneration: 0, throughRevision: 1 });
+    expect(await gadgetContent(impl, 1, 1)).toEqual({ "a.txt": "one\nagent\n" });
+  }));
+
+  it("a pin whose base is no longer the head fails the barrier with no durable trace",
+      () => withImpl(async impl => {
+    let c1 = await commitFiles(impl, { "a.txt": "one\n" });
+    let c2 = await commitFiles(impl, { "a.txt": "two\n" }, [c1]);
+    addGadget(impl, 1, "APP", c2);
+    addChat(impl, 1);
+
+    // Mainline moved between the tool call (which anchored at c2) and the barrier.
+    setHead(impl, 1, c1);
+    await expect(impl.commitAgentStep(1, AGENT, stepMsgs("stale pin"), {
+      ...NO_EXTRAS,
+      changes: [{ change: { 1: [["a.txt", { set: "x" }]] },
+                  pin: { gadgetId: 1, baseCommit: c2 } }],
+    })).rejects.toThrow(/no longer the gadget's head/);
+    expect(chatMessages(impl, 1)).toEqual([]);
+    expect([...impl.storage.chatChanges.list({ prefix: `${keyString(1)}.` })]).toEqual([]);
+  }));
+
+  it("stamps a pending gadget creation with the step's changes message",
+      () => withImpl(async impl => {
+    addChat(impl, 1);
+    let created = impl.createGadget("My Gadget", "MY_GADGET", 1);
+    // The record is created (and its name reserved) mid-step, unstamped until the barrier.
+    expect(impl.storage.gadgets.get(created.id)!.pending).toEqual({ chatId: 1 });
+
+    expect(await impl.commitAgentStep(1, AGENT, stepMsgs("created a gadget"), {
+      changes: [{ change: { [created.id]: [["main.js", { set: "code\n" }]] } }],
+      createdGadgets: [
+        { gadgetId: created.id, title: created.title, bindingName: "MY_GADGET" }],
+      addedBindings: [],
+    })).toBe(true);
+
+    // The stamp is the changes message's sequence: the durable record merge/revert compare
+    // against, written in the same transaction as the message itself.
+    let changes = chatMessages(impl, 1).find(msg => msg.type === "changes")!;
+    expect(changes.createdGadgets).toEqual(
+        [{ gadgetId: created.id, title: created.title, bindingName: "MY_GADGET" }]);
+    expect(impl.storage.gadgets.get(created.id)!.pending)
+        .toEqual({ chatId: 1, sequence: changes.sequence });
+  }));
+
+  it("flushAgentChanges (transitional) covers rows a crashed pre-barrier turn left live",
+      () => withImpl(async impl => {
+    let c1 = await commitFiles(impl, { "a.txt": "one\n" });
+    addGadget(impl, 1, "APP", c1);
+    addChat(impl, 1);
+
+    // Hand-craft the stranded state (the per-tool append path that produced it is gone): a
+    // live agent row whose pin was mirrored into the code base but never declared in the log.
+    let meta = impl.storage.chatMeta.get(1)!;
+    meta.codeBase = {
+      pins: [{ gadgetId: 1, baseCommit: c1, mergedCommit: c1 }], generation: 0, revision: 1,
+    };
+    impl.storage.chatMeta.put(meta);
+    impl.storage.chatChanges.put({
+      chatId: 1, generation: 0, revision: 1, timestamp: impl.getChatTimestamp(), author: AGENT,
+      change: { 1: [["a.txt", { set: "one\nagent\n" }]] }, source: "agent",
+    });
+    expect(impl.listUnmaterializedChatChanges(1)).toHaveLength(1);
+    expect(impl.undeclaredChatPins(1)).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
+
+    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(true);
+    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(false);  // nothing left
+    let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
+    expect(changes).toHaveLength(1);
+    expect(changes[0].pins).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
+    expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 1 });
+    expect(impl.undeclaredChatPins(1)).toEqual([]);
+    expect(await gadgetContent(impl, 1, 1)).toEqual({ "a.txt": "one\nagent\n" });
   }));
 });
 

--- a/packages/workshop-backend/__tests__/chat-changes.test.ts
+++ b/packages/workshop-backend/__tests__/chat-changes.test.ts
@@ -1081,11 +1081,11 @@ describe("agent step barrier", () => {
     // One row per buffered change, in call order, born retired (live only inside the barrier);
     // the pin was validated and mirrored with its row.
     let rows = [...impl.storage.chatChanges.list({ prefix: `${keyString(1)}.` })];
-    expect(rows.map((row: any) => [row.revision, row.source, row.retired]))
+    expect(rows.map((row: any) => [row.revision, row.author.type, row.retired]))
         .toEqual([[1, "agent", true], [2, "agent", true]]);
     expect(impl.storage.chatMeta.get(1)!.codeBase!.pins).toEqual(
         [{ gadgetId: 1, baseCommit: c1, mergedCommit: c1 }]);
-    expect(impl.undeclaredChatPins(1)).toEqual([]);
+    expect(impl.undeclaredMetaPins(1, impl.storage.chatMeta.get(1)!)).toEqual([]);
     expect(await gadgetContent(impl, 1, 1)).toEqual(
         { "a.txt": "one\nagent\n", "b.txt": "bee\n" });
 
@@ -1202,34 +1202,70 @@ describe("agent step barrier", () => {
         .toEqual({ chatId: 1, sequence: changes.sequence });
   }));
 
-  it("flushAgentChanges (transitional) covers rows a crashed pre-barrier turn left live",
+});
+
+describe("reconcilePendingGadgets", () => {
+  it("reaps unstamped records and edges regardless of what the log holds (no vouching)",
       () => withImpl(async impl => {
     let c1 = await commitFiles(impl, { "a.txt": "one\n" });
     addGadget(impl, 1, "APP", c1);
     addChat(impl, 1);
 
-    // Hand-craft the stranded state (the per-tool append path that produced it is gone): a
-    // live agent row whose pin was mirrored into the code base but never declared in the log.
-    let meta = impl.storage.chatMeta.get(1)!;
-    meta.codeBase = {
-      pins: [{ gadgetId: 1, baseCommit: c1, mergedCommit: c1 }], generation: 0, revision: 1,
-    };
-    impl.storage.chatMeta.put(meta);
-    impl.storage.chatChanges.put({
-      chatId: 1, generation: 0, revision: 1, timestamp: impl.getChatTimestamp(), author: AGENT,
-      change: { 1: [["a.txt", { set: "one\nagent\n" }]] }, source: "agent",
-    });
-    expect(impl.listUnmaterializedChatChanges(1)).toHaveLength(1);
-    expect(impl.undeclaredChatPins(1)).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
+    // Simulate a mid-step crash: the createGadget/setGadgetBinding tools ran (registry record
+    // created and name reserved, edge added) but the step never reached its barrier, so both
+    // are unstamped.
+    let created = impl.createGadget("Doomed", "DOOMED", 1);
+    let gadget1 = impl.storage.gadgets.get(1)!;
+    gadget1.bindings["FOO"] = { target: 99, pending: { chatId: 1 } };
+    impl.storage.gadgets.put(gadget1);
 
-    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(true);
-    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(false);  // nothing left
-    let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
-    expect(changes).toHaveLength(1);
-    expect(changes[0].pins).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
-    expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 1 });
-    expect(impl.undeclaredChatPins(1)).toEqual([]);
-    expect(await gadgetContent(impl, 1, 1)).toEqual({ "a.txt": "one\nagent\n" });
+    // The old recovery scanned the log for persisted tool calls that "vouch" for an orphan,
+    // sparing it for replay to re-adopt. Barrier atomicity inverted that: a persisted call
+    // implies a persisted stamp, so an unstamped record is a mid-step crash orphan no matter
+    // what the log holds -- even a message referencing it (which, post-barrier, can only be
+    // corrupt or pre-barrier history) must not resurrect it.
+    impl.addChatMessages(1, AGENT, [{
+      type: "message", message: "creating",
+      toolCalls: [
+        { toolCallId: "t1", toolName: "createGadget",
+          input: { title: "Doomed", bindingName: "DOOMED" },
+          output: { gadgetId: created.id, changeId: 1 } },
+        { toolCallId: "t2", toolName: "setGadgetBinding",
+          input: { gadget: "APP", source: "FOO" },
+          output: { gadgetId: 1, name: "FOO", target: 99, changeId: 1 } },
+      ],
+    }]);
+
+    await impl.reconcilePendingGadgets(1);
+    expect(impl.storage.gadgets.get(created.id)).toBeUndefined();
+    expect(impl.storage.gadgets.get(1)!.bindings).toEqual({});
+  }));
+
+  it("removes a stamped record once the log marks its creation reverted",
+      () => withImpl(async impl => {
+    addChat(impl, 1);
+    let created = impl.createGadget("My Gadget", "MY_GADGET", 1);
+    await impl.commitAgentStep(1, AGENT, [{ type: "message", message: "created a gadget" }], {
+      changes: [{ change: { [created.id]: [["main.js", { set: "code\n" }]] } }],
+      createdGadgets: [
+        { gadgetId: created.id, title: created.title, bindingName: "MY_GADGET" }],
+      addedBindings: [],
+    });
+    let stamp = impl.storage.gadgets.get(created.id)!.pending!.sequence!;
+
+    // A stamped record is untouched while its creation stands...
+    await impl.reconcilePendingGadgets(1);
+    expect(impl.storage.gadgets.get(created.id)).toBeDefined();
+
+    // ...but once a revert message covers the stamp, reconciliation removes it. (Simulates a
+    // revert that recorded its message and then crashed before the awaited record deletions --
+    // reverts record first, see #revertChanges -- making reconciliation the recovery.)
+    impl.storage.chats.put({
+      chatId: 1, sequence: impl.nextChatSequence(1), timestamp: impl.getChatTimestamp(),
+      author: USER, type: "revert", revertFrom: stamp,
+    });
+    await impl.reconcilePendingGadgets(1);
+    expect(impl.storage.gadgets.get(created.id)).toBeUndefined();
   }));
 });
 

--- a/packages/workshop-backend/__tests__/chat-changes.test.ts
+++ b/packages/workshop-backend/__tests__/chat-changes.test.ts
@@ -1081,6 +1081,34 @@ describe("agent change appends", () => {
         { 2: [["a.txt", { set: "x" }]] }, { gadgetId: 2, baseCommit: c2 }))
         .rejects.toThrow(/no longer the gadget's head/);
   }));
+
+  it("the turn flush writes exactly one message even past the byte budget",
+      () => withImpl(async impl => {
+    let c1 = await commitFiles(impl, { "a.txt": "one\n" });
+    addGadget(impl, 1, "APP", c1);
+    addChat(impl, 1);
+
+    // Two rows whose composition (~1.2MB by the serialized-size estimate) exceeds the 1MB
+    // budget. The old chunker would have split them across two "changes" messages,
+    // desynchronizing the agent's message-counting change-ID numbering (one flush, one counter
+    // bump -- see flushPendingChanges in agent.ts); a flush now writes exactly one message,
+    // always. (In production the agent's own append-time trigger flushes before a window grows
+    // this big; this exercises the materialize side alone.)
+    let text = "文".repeat(300_000);
+    await impl.appendAgentCodeChange(1, AGENT,
+        { 1: [["a.txt", { set: text }]] }, { gadgetId: 1, baseCommit: c1 });
+    await impl.appendAgentCodeChange(1, AGENT, { 1: [["b.txt", { set: text }]] });
+
+    expect(impl.flushAgentChanges(1, AGENT, {})).toBe(true);
+    let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
+    expect(changes).toHaveLength(1);
+    expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 2 });
+    expect(changes[0].pins).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
+    expect(liveRows(impl, 1)).toHaveLength(0);
+
+    let folded = await impl.buildChatContent(1);
+    expect(["a.txt", "b.txt"].map(file => folded.get(1)!.get(file))).toEqual([text, text]);
+  }));
 });
 
 describe("chat content reconstruction", () => {
@@ -1115,7 +1143,7 @@ describe("chat content reconstruction", () => {
     addChat(impl, 1);
 
     let text = "0\n";
-    for (let i = 1; i <= 129; i++) {
+    for (let i = 1; i <= 1001; i++) {
       let next = `${i}\n${text}`;
       await submit(impl, 1, {
         generation: 0, revision: i - 1, clientId: "cli", seq: i,
@@ -1125,53 +1153,85 @@ describe("chat content reconstruction", () => {
       text = next;
     }
 
-    // The 128-row window was materialized into a "changes" message; the stream keeps counting.
+    // The 1000-row window was materialized into a single "changes" message; the stream keeps
+    // counting.
     let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
     expect(changes).toHaveLength(1);
-    expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 128 });
+    expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 1000 });
     expect(liveRows(impl, 1)).toHaveLength(1);
-    expect(impl.storage.chatMeta.get(1)!.codeBase!.revision).toBe(129);
+    expect(impl.storage.chatMeta.get(1)!.codeBase!.revision).toBe(1001);
     expect((await gadgetContent(impl, 1, 1))["a.txt"]).toBe(text);
   }));
 
-  it("splits an oversized batch across consecutive watermarked messages",
+  it("materializes the pending window before a submission would breach the byte budget",
       () => withImpl(async impl => {
     let c1 = await commitFiles(impl, { "a.txt": "one\n" });
     addGadget(impl, 1, "APP", c1);
     addChat(impl, 1);
 
-    // Three rows setting *distinct* files (so their composition genuinely accumulates payload
-    // rather than collapsing), each ~200K CJK characters = ~600KB of UTF-8 (hand-built `set`
-    // changes: diffing dissimilar strings this large is quadratic). Any two rows compose past the
-    // 1MB byte budget -- though a code-unit measure would put all three at ~600K "characters"
-    // and pack them into one oversized message -- so materialization must cut per row.
-    let files = ["a.txt", "b.txt", "c.txt"];
-    let text = "文".repeat(200_000);
-    for (let [i, file] of files.entries()) {
-      await submit(impl, 1, {
-        generation: 0, revision: i, clientId: "cli", seq: i + 1,
-        ...(i === 0 ? { pins: [{ gadgetId: 1, baseCommit: c1 }] } : {}),
-        change: { 1: [[file, { set: text }]] },
-      });
-    }
+    // Two rows setting *distinct* files (so their composition genuinely accumulates payload
+    // rather than collapsing), each 300K two-byte characters = ~600KB by the serialized-size
+    // estimate (hand-built `set` changes: diffing dissimilar strings this large is quadratic).
+    // Together they compose past the 1MB byte budget, so the second submission must materialize
+    // the first row into its own message before appending.
+    let text = "文".repeat(300_000);
+    await submit(impl, 1, {
+      generation: 0, revision: 0, clientId: "cli", seq: 1,
+      pins: [{ gadgetId: 1, baseCommit: c1 }],
+      change: { 1: [["a.txt", { set: text }]] },
+    });
+    expect(chatMessages(impl, 1).filter(msg => msg.type === "changes")).toHaveLength(0);
 
-    impl.materializeChatChanges(1);
+    await submit(impl, 1, {
+      generation: 0, revision: 1, clientId: "cli", seq: 2,
+      change: { 1: [["b.txt", { set: text }]] },
+    });
     let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
-    expect(changes).toHaveLength(3);
-    // The pin declaration rides the first message only; each message's watermark names the
-    // rows it absorbed.
+    expect(changes).toHaveLength(1);
     expect(changes[0].pins).toEqual([{ gadgetId: 1, baseCommit: c1 }]);
-    expect(changes.map(msg => msg.watermark)).toEqual([
-      { changesGeneration: 0, throughRevision: 1 },
-      { changesGeneration: 0, throughRevision: 2 },
-      { changesGeneration: 0, throughRevision: 3 },
-    ]);
+    expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 1 });
+    expect(liveRows(impl, 1)).toHaveLength(1);
+
+    // A materialize call writes exactly one message covering the remaining row.
+    impl.materializeChatChanges(1);
+    changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
+    expect(changes).toHaveLength(2);
+    expect(changes[1].watermark).toEqual({ changesGeneration: 0, throughRevision: 2 });
     expect(changes[1].pins).toBeUndefined();
     expect(liveRows(impl, 1)).toHaveLength(0);
 
-    // The chunked log folds to the same content a single message would have.
+    // The split log folds to the same content a single message would have.
     let folded = await impl.buildChatContent(1);
-    expect(files.map(file => folded.get(1)!.get(file))).toEqual([text, text, text]);
+    expect(["a.txt", "b.txt"].map(file => folded.get(1)!.get(file))).toEqual([text, text]);
+  }));
+
+  it("a change bigger than the whole budget travels alone in one oversized message",
+      () => withImpl(async impl => {
+    let c1 = await commitFiles(impl, { "a.txt": "one\n" });
+    addGadget(impl, 1, "APP", c1);
+    addChat(impl, 1);
+
+    // One row -- a single multi-file change of two 300K-two-byte-character files, ~1.2MB by the
+    // serialized-size estimate -- exceeds the 1MB budget on its own while staying inside the
+    // per-file and per-change caps. It appends into an empty window; the next submission's byte
+    // trigger then materializes it alone, in one message.
+    let big = "文".repeat(300_000);
+    await submit(impl, 1, {
+      generation: 0, revision: 0, clientId: "cli", seq: 1,
+      pins: [{ gadgetId: 1, baseCommit: c1 }],
+      change: { 1: [["a.txt", { set: big }], ["b.txt", { set: big }]] },
+    });
+    await submit(impl, 1, {
+      generation: 0, revision: 1, clientId: "cli", seq: 2,
+      change: { 1: [["c.txt", { set: "small\n" }]] },
+    });
+
+    let changes = chatMessages(impl, 1).filter(msg => msg.type === "changes");
+    expect(changes).toHaveLength(1);
+    expect(changes[0].watermark).toEqual({ changesGeneration: 0, throughRevision: 1 });
+    expect(liveRows(impl, 1)).toHaveLength(1);
+    expect((await gadgetContent(impl, 1, 1))["a.txt"]).toBe(big);
+    expect((await gadgetContent(impl, 1, 1))["b.txt"]).toBe(big);
   }));
 
   it("splits batches by author when a different author resumes after idle",

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -378,34 +378,6 @@ export interface AgentHooks {
       estimatedCost?: number): Promise<boolean>;
 
   /**
-   * Transitional, called only by the compaction early-return (and deleted with the
-   * replay-discharge machinery): materialize live change rows re-adopted from a crashed
-   * pre-barrier turn into one "changes" message carrying the given re-adopted creations and
-   * binding additions, before compaction removes the log tail replay re-adopts them from.
-   * Barrier-committed turns leave no live agent rows for this to find. Returns whether a
-   * message was written (change-ID numbering counts messages).
-   */
-  flushAgentChanges(chatId: number, author: AiChatAuthorInfo, extras: {
-    createdGadgets?: {gadgetId: WorkpieceId, title: string, bindingName: string}[],
-    addedBindings?: {gadgetId: WorkpieceId, name: string, target: WorkpieceId}[],
-  }): boolean;
-
-  /**
-   * The chat's live (unmaterialized) change rows, oldest first. Nonempty at turn start only when a
-   * previous turn crashed after appending rows but before its flush; replay applies them on top
-   * of the messages' changes -- they are already durable chat content.
-   */
-  listUnmaterializedChatChanges(chatId: number): {change: CodeChange, generation: number,
-                                                  revision: number}[];
-
-  /**
-   * Pins present in the chat's code base whose establishment no surviving "changes" message
-   * records yet (see the flush above). At turn start these identify a crashed predecessor's
-   * pins, whose base trees replay must establish before applying the unmaterialized rows.
-   */
-  undeclaredChatPins(chatId: number): ChatGadgetPin[];
-
-  /**
    * The gadget's current head commit (WorkpieceSummary.commitId), or undefined if it has none:
    * still pending in a chat, created outside chats and never accepted, or deleted. An unpinned
    * gadget with a head is read at that head; one without a head lives only in the session doc.
@@ -1081,18 +1053,14 @@ export async function runAgent(
     }
     return cached;
   };
-  // Gadgets created this turn, awaiting attachment to the next flushed "changes" message (see
-  // flushCapturedYdocChanges and the createGadget tool) -- which is what durably records, and
-  // sequence-stamps, each creation. Like captured edits, buffered creations from a turn that
-  // crashed before flushing are recovered during history replay: replayed createGadget calls not
-  // listed in any "changes" message's `createdGadgets` are re-added here (see
-  // replayedCreations/recordedCreations below).
+  // Gadgets created this step (see the createGadget tool), awaiting the step's persistence
+  // barrier: its "changes" message is what durably records, and sequence-stamps, each creation.
+  // A step that dies before its barrier leaves only the unstamped registry record, which
+  // reconciliation reaps (see reconcilePendingGadgets in overseer.ts).
   let pendingCreatedGadgets: {gadgetId: WorkpieceId, title: string, bindingName: string}[] = [];
 
-  // Binding edges added this turn (via the setGadgetBinding tool), likewise awaiting attachment
-  // to the next flushed "changes" message (see `addedBindings`), which sequence-stamps the
-  // pending edge. Crash recovery mirrors creations: replayed additions not listed in any
-  // "changes" message are re-added here (see replayedBindingAdditions/recordedBindingAdditions).
+  // Binding edges added this step (via the setGadgetBinding tool), likewise awaiting the
+  // barrier's "changes" message (see `addedBindings`), which sequence-stamps the pending edge.
   let pendingAddedBindings: {gadgetId: WorkpieceId, name: string, target: WorkpieceId}[] = [];
 
   // The chat's binding map: what each name in the agent's executeCode `env` resolves to. Starts
@@ -1168,31 +1136,10 @@ export async function runAgent(
   // As we replay the chat history, when we see tool calls that make edits, we add them to this
   // array, and when we see "changes" messages that represent those edits being flushed, we
   // clear this array. Thus, it continuously contains the list of edits for which we haven't seen
-  // a "changes" message yet. This is needed for a few tricky cases.
+  // a "changes" message yet: within a step, reads that follow an edit replay against these (the
+  // step's "changes" message, which advances the session content, comes after the whole
+  // tool-call message).
   let pendingReplayEdits: ReplayPendingEdit[] = [];
-
-  // Same idea for gadget creations, but exact and order-immune: a creation is durably recorded
-  // iff some "changes" message lists it in `createdGadgets` -- possibly even *before* the tool
-  // call's own message (an executeCode barrier flush in the same step) -- so rather than
-  // clearing a pending list incrementally, collect the tool calls and the recorded ids
-  // separately and re-adopt the difference after replay. Whatever isn't recorded is a crashed
-  // turn's tail. (The registry records already exist -- created durably at tool time, awaiting
-  // their stamp -- which is why replay of createGadget itself never re-creates anything.)
-  let replayedCreations: {gadgetId: WorkpieceId, title: string, bindingName: string}[] = [];
-  let recordedCreations = new Set<WorkpieceId>();
-
-  // And the same again for binding additions (setGadgetBinding), recorded by `addedBindings`.
-  // Unlike creations, additions have no unique id: (gadgetId, name) can legitimately recur when
-  // an earlier addition is removed or reverted and the same name is added again. So instead of a
-  // set difference, count per key -- recordings consume the *earliest* replayed additions (an
-  // addition is recorded no later than any subsequent same-name addition, which requires the
-  // earlier edge to be gone first) and the excess tail is re-adopted. Only agent-flushed
-  // recordings count: a user-authored "changes" message records a UI-initiated bind
-  // (GadgetClient.bind), which has no tool call, and counting it would mask an agent addition of
-  // the same name.
-  let replayedBindingAdditions: {gadgetId: WorkpieceId, name: string, target: WorkpieceId}[] = [];
-  let recordedBindingAdditions = new Map<string, number>();
-  let bindingAdditionKey = (gadgetId: WorkpieceId, name: string) => `${gadgetId}:${name}`;
 
   // Track which files have been read in this session, per workpiece by filename. Edits
   // aren't allowed before reading. The value is the commit an unpinned read observed
@@ -1310,23 +1257,23 @@ export async function runAgent(
   };
 
   // Ensures the session content holds a base for a replayed write's target gadget. The pin
-  // declaration itself rides the write's *flush* -- a "changes" message recorded after the tool
+  // declaration itself rides the write's step's "changes" message -- recorded after the tool
   // step's own message -- but replayed reads between the two need the pinned base in the
   // content. Establishing early from the upcoming declaration is safe because establishment is
-  // idempotent (above). Four cases by what the log holds after `sequence`:
+  // idempotent (above). Cases by what the log holds after `sequence` (a persisted write implies
+  // its step's "changes" message -- they share the barrier's transaction -- so one of these
+  // always follows):
   // - an upcoming surviving declaration: establish from it now;
   // - a *reverted* declaration: do nothing -- the range's reads are elided and its pending
-  //   edits are discharged by the (reverted) flush message, so the base is never needed;
-  // - a flush (any change- or watermark-carrying "changes" message, which is what discharges
+  //   edits are discharged by the (reverted) "changes" message, so the base is never needed;
+  // - a "changes" message (any change- or watermark-carrying one, which is what discharges
   //   pending edits and what a live write's pin would have ridden) with *no* declaration: the
   //   write was made while the gadget had no committed code -- it was still pending in this
   //   chat, its content built up from its own changes -- and the head seen now is its later
-  //   promotion. Nothing to establish;
-  // - nothing at all: the turn crashed before flushing. The pin was still mirrored into the
-  //   chat's code base when the write's row was appended (the pre-barrier per-tool append
-  //   path, whose stranded rows this recovery still tolerates), so
-  //   establish from the meta pin; the trailing unmaterialized rows applied after replay carry
-  //   the edits themselves, and the next flush declares the pin (see undeclaredChatPins).
+  //   promotion. Nothing to establish.
+  // (Nothing at all would mean a log from before the barrier existed, whose turn crashed
+  // between the write and its flush; that stranded-tail tolerance is gone, so the write's
+  // effects are simply absent and reads of them surface as replayed errors.)
   let ensureReplayContentForWrite = async (workpieceId: WorkpieceId, sequence: number) => {
     if (pinnedGadgets.has(workpieceId)) return;
     if (hooks.getGadgetHead(workpieceId) === undefined) return;  // no committed code
@@ -1347,26 +1294,22 @@ export async function runAgent(
       }
     }
 
-    if (upcoming === "reverted" || upcoming === "flushed-unpinned") return;
-    if (upcoming === undefined) {
-      upcoming = hooks.undeclaredChatPins(chatId).find(p => p.gadgetId === workpieceId);
-      // No meta pin either: the crashed tail's rows were since erased (e.g. a draft discard).
-      // The write's effects are gone; reads of the missing content surface as replayed errors.
-      if (upcoming === undefined) return;
+    if (upcoming === undefined || upcoming === "reverted" || upcoming === "flushed-unpinned") {
+      return;
     }
     await applyReplayedPin(upcoming);
   };
 
   // The base commit-anchored knowledge from before `afterSequence` must match to still be
   // current: the base of the gadget's next surviving pin declaration after that point, else
-  // (never pinned since) the pin of the chat's live code base -- established by unmaterialized
-  // rows, so declared nowhere yet -- else the live head. The next *pin* rather than the final
-  // head because a pin is where the model's belief chain re-roots: from the pin on, the file's
-  // evolution is in the model's own context (its edits, user-change diffs, revert notes), so
-  // knowledge that matches the pin base stays current through it (and across an epoch boundary,
-  // where resetSessionEpoch re-anchors it to the merge's commit). Between the knowledge and that
-  // pin the gadget was unpinned -- tracking head, with nothing chat-local in between -- so a
-  // plain per-file comparison is exactly the freshness question.
+  // (never pinned since) the pin of the chat's live code base -- established by
+  // not-yet-materialized user rows, so declared nowhere yet -- else the live head. The next
+  // *pin* rather than the final head because a pin is where the model's belief chain re-roots:
+  // from the pin on, the file's evolution is in the model's own context (its edits, user-change
+  // diffs, revert notes), so knowledge that matches the pin base stays current through it (and
+  // across an epoch boundary, where resetSessionEpoch re-anchors it to the merge's commit).
+  // Between the knowledge and that pin the gadget was unpinned -- tracking head, with nothing
+  // chat-local in between -- so a plain per-file comparison is exactly the freshness question.
   let stampedReadBase = (workpieceId: WorkpieceId, afterSequence: number): string | undefined => {
     for (let msg of chatMessages) {
       if (msg.sequence <= afterSequence || msg.type !== "changes") continue;
@@ -1636,11 +1579,11 @@ export async function runAgent(
                     let {workpieceId} =
                         hooks.resolveWorkpieceRoot(resolveToolWorkpieceId(toolCall.input.workpiece));
 
-                    // The read was served from the session content. Pending (not-yet-flushed)
-                    // edits from earlier in the same turn are applied to the file's text here:
-                    // the content map advances only when the covering "changes" message's change
-                    // applies, so reads between an edit and its flush replay the edits against
-                    // the string.
+                    // The read was served from the session content. Pending edits from earlier
+                    // in the same step are applied to the file's text here: the content map
+                    // advances only when the step's "changes" message's change applies, so
+                    // reads between an edit and that message replay the edits against the
+                    // string.
                     let value: string | null =
                         sessionContent.get(workpieceId)?.get(toolCall.input.filename) ?? null;
                     for (let edit of pendingReplayEdits) {
@@ -1704,17 +1647,11 @@ export async function runAgent(
                   toolOutput = {text: jsonToolResultText({success: true})};
                   break;
                 case "setGadgetBinding":
-                  // The addition is provisional and the recorded output identifies the edge so a
-                  // crashed turn's unrecorded addition can be re-adopted, exactly like
-                  // createGadget.
+                  // The recorded edge (registry state) already exists, stamped by the step's
+                  // "changes" message, so replay just reproduces the recorded result.
                   if (toolCall.output === undefined) {
                     throw new Error("setGadgetBinding tool call in log is missing its result");
                   }
-                  replayedBindingAdditions.push({
-                    gadgetId: toolCall.output.gadgetId,
-                    name: toolCall.output.name,
-                    target: toolCall.output.target,
-                  });
                   toolOutput = {
                     text: jsonToolResultText({success: true, changeId: toolCall.output.changeId}),
                   };
@@ -1725,16 +1662,11 @@ export async function runAgent(
                   // (The recorded changeId needs no counter bookkeeping here: it names the
                   // "changes" message that recorded the creation, which is numbered by the
                   // normal "changes" replay below. Likewise a blueprint instantiation needs no
-                  // re-fetch: its files ride that same "changes" message, which the live tool
-                  // flushes before its own step's message can land in the log.)
+                  // re-fetch: its files ride that same "changes" message, recorded by the
+                  // call's own step barrier.)
                   if (toolCall.output === undefined) {
                     throw new Error("createGadget tool call in log is missing its result");
                   }
-                  replayedCreations.push({
-                    gadgetId: toolCall.output.gadgetId,
-                    title: toolCall.input.title,
-                    bindingName: toolCall.input.bindingName,
-                  });
                   chatBindings.set(toolCall.input.bindingName,
                       {type: "workpiece", id: toolCall.output.gadgetId});
                   toolOutput = {text: jsonToolResultText(toolCall.output)};
@@ -1888,15 +1820,6 @@ export async function runAgent(
         // discharge any.
         if (msg.change !== undefined || msg.watermark !== undefined) {
           pendingReplayEdits = [];
-        }
-        for (let {gadgetId} of msg.createdGadgets ?? []) {
-          recordedCreations.add(gadgetId);
-        }
-        if (msg.author.type !== "user") {
-          for (let {gadgetId, name} of msg.addedBindings ?? []) {
-            let key = bindingAdditionKey(gadgetId, name);
-            recordedBindingAdditions.set(key, (recordedBindingAdditions.get(key) ?? 0) + 1);
-          }
         }
         changeIdMap.set(msg.sequence, nextChangeId);
         ++nextChangeId;
@@ -2054,43 +1977,11 @@ export async function runAgent(
   // at each write call.
   let stepBuffer = {changes: [] as AgentStepChange[], bytes: 0};
 
-  // If the previous agent turn was aborted by a server restart, its edits are already durable,
-  // broadcast change rows that no "changes" message covers yet: establish their pins' bases (the
-  // pins were mirrored into the chat's code base when the rows were appended, but their log
-  // declarations ride the next flush) and apply the rows to the session content. The pending
-  // replay edits are the same edits in tool-call form, so they are discharged rather than
-  // applied -- the rows are the authoritative record. (If the rows were since erased -- e.g.
-  // the user discarded the draft -- there is simply nothing to apply, and the erased edits stay
-  // erased.)
-  for (let pin of hooks.undeclaredChatPins(chatId)) {
-    if (!pinnedGadgets.has(pin.gadgetId)) {
-      await applyReplayedPin(pin);
-    }
-  }
-  for (let row of hooks.listUnmaterializedChatChanges(chatId)) {
-    sessionContent = applyCodeChange(sessionContent, row.change);
-  }
-  pendingReplayEdits = [];
-
-  // Likewise, re-adopt gadget creations and binding additions from a crashed turn that were
-  // never recorded in a "changes" message, so this turn's next flush records (and thereby
-  // sequence-stamps) them. The registry rows/edges already exist, unstamped; reconciliation
-  // spares them because their tool calls appear in the log (see reconcilePendingGadgets in
-  // overseer.ts).
-  for (let creation of replayedCreations) {
-    if (!recordedCreations.has(creation.gadgetId)) {
-      pendingCreatedGadgets.push(creation);
-    }
-  }
-  let seenAdditionCounts = new Map<string, number>();
-  for (let addition of replayedBindingAdditions) {
-    let key = bindingAdditionKey(addition.gadgetId, addition.name);
-    let occurrence = (seenAdditionCounts.get(key) ?? 0) + 1;
-    seenAdditionCounts.set(key, occurrence);
-    if (occurrence > (recordedBindingAdditions.get(key) ?? 0)) {
-      pendingAddedBindings.push(addition);
-    }
-  }
+  // (A crashed predecessor leaves no stranded state to recover here: each step's rows, pins,
+  // creation/binding stamps and messages are committed in one barrier transaction, so replay of
+  // the surviving log accounts for everything durable, and a mid-step crash durably kept
+  // nothing but unstamped registry records -- reaped by reconcilePendingGadgets before this
+  // turn started.)
 
   // Error-path notes for tool calls, merged into the persisted tool-call log at the turn_end
   // barrier. A tool that fails throws (so the model sees an error result), but pi's conversion
@@ -2115,20 +2006,6 @@ export async function runAgent(
   // Latched by the turn_end barrier when this step submitted an awaitDecision action.
   // shouldStopAfterTurn reads it afterwards to end the turn until approval resumes it.
   let awaitingActionDecision = false;
-
-  // Transitional, for the compaction early-return only (see AgentHooks.flushAgentChanges): a
-  // crashed pre-barrier turn's re-adopted rows, creations and binding additions must be covered
-  // by a "changes" message before compaction removes the log tail they were re-adopted from.
-  // Change-ID numbering counts messages, so the counter advances exactly when one was written.
-  let flushReadoptedChanges = () => {
-    let createdGadgets = pendingCreatedGadgets;
-    pendingCreatedGadgets = [];
-    let addedBindings = pendingAddedBindings;
-    pendingAddedBindings = [];
-    if (hooks.flushAgentChanges(chatId, author, {createdGadgets, addedBindings})) {
-      ++nextChangeId;
-    }
-  };
 
   // Buffer one file edit into the step and apply it to the session content; it becomes durable
   // (row + broadcast) only at the step's persistence barrier. The first write to an unpinned
@@ -2346,13 +2223,6 @@ export async function runAgent(
 
   let compactionTurn = isCompactionTurn(chatMessages);
   if (compactionTurn || shouldCompactChat(contextTokens, inputBudget)) {
-    // Returning below runs no step (and thus no barrier), so cover re-adopted state here:
-    // replay may have re-adopted a crashed pre-barrier turn's unmaterialized rows, creations
-    // and binding additions, and they must be covered by a message before compaction removes
-    // the log tail they were re-adopted from. The message lands above any boundary chosen
-    // here, so the checkpoint is unaffected.
-    flushReadoptedChanges();
-
     let compactedTo = findCompactionBoundary(
         projection, inputBudget, contextTokens,
         checkpoint?.compactedTo, findProtectedFromSequence(chatMessages));
@@ -2720,9 +2590,9 @@ export async function runAgent(
           pendingAddedBindings.push(
               {gadgetId: gadgetEntry.id, name: bindingName, target: sourceEntry.id});
 
-          // Record the resolved edge as the tool's output so a crashed turn's replay can re-adopt
-          // the addition (see replayedBindingAdditions); the model-visible result is just
-          // success + the batch's change ID.
+          // Record the resolved edge as the tool's output -- the durable record of what the
+          // call did, which replay reproduces instead of re-running the tool; the model-visible
+          // result is just success + the batch's change ID.
           let output = {gadgetId: gadgetEntry.id, name: bindingName, target: sourceEntry.id,
                         changeId: nextChangeId};
           return toolResult(
@@ -2814,7 +2684,8 @@ export async function runAgent(
             // the barrier: the blueprint's contents aren't reconstructible from the call's
             // input the way writeFile edits are, so either both survive a crash or neither
             // does. (Old logs may hold the pre-barrier order -- the "changes" message *before*
-            // its creating call -- which replay still tolerates; see recordedCreations.)
+            // its creating call -- which replay handles fine: the message's replay applies the
+            // files, and the call's replay just returns its recorded output.)
 
             output.blueprintNotes = blueprint.notes;
           }
@@ -3254,8 +3125,7 @@ export async function runAgent(
   // (No end-of-turn flush: every completed step's effects were barrier-committed with its
   // message, and an abort simply drops the in-flight step's buffer -- nothing durable exists
   // for it. Cancellation stops the agent, it does not revert the turn; completed steps' work
-  // stays, and the user reverts explicitly if they want it gone. Re-adopted crashed-turn state
-  // that never met a barrier stays live for the next turn to re-adopt.)
+  // stays, and the user reverts explicitly if they want it gone.)
 
   // Cancellation surfaces as the abort reason, matching the old thrown-abort behavior. (Checked
   // outside turnFailure because an abort during tool execution stops the loop after a persisted,

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -1,6 +1,6 @@
 import { AiChatMessage, AiChatAuthorInfo, AiToolCall, AiChatMessageBody, AgentSpawnerConfig, AiChatStreamEvent, BlueprintOutput, ChatGadgetPin, ChatCodeBase, WorkpieceId, type AiModelConfig, isTextLikeAttachmentMimeType, validateBindingName } from '@gadgets/workshop-shared/api';
-import { applyCodeChange, replaceSpanChange, type CodeContent, type CodeChange }
-  from '@gadgets/workshop-shared/code-change';
+import { applyCodeChange, codeChangeSerializedSize, replaceSpanChange, type CodeContent,
+  type CodeChange } from '@gadgets/workshop-shared/code-change';
 import { PDF_MIME_TYPE, modelApiSupportsPdfAttachments } from './chat-attachment-pdf';
 import { AgentCatalog, ObservationDescription } from '@gadgets/workshop-shared/gatekeeper';
 import { createWorkshopLogger } from "./observability";
@@ -27,6 +27,25 @@ import {
 } from "./agent-compaction";
 
 const logger = createWorkshopLogger("workshop.agent");
+
+/**
+ * Byte bound on one "changes" message's composed change, shared by every producer of chat
+ * change rows. Materialization writes exactly one message per call (see materializeChatChanges
+ * in overseer.ts), so the composition is kept storable by bounding what *accumulates* rather
+ * than by splitting the output: each producer materializes the pending live rows before
+ * appending a row that would push their summed size past the budget (submitCodeChange for user
+ * edits; appendAgentEdit's flush trigger for tool edits). Rows are individually bounded
+ * (MAX_CODE_CHANGE_SIZE) but a composition of several is not, and an unstorable message would
+ * wedge materialization permanently (rows only retire on success, so accept and turn start
+ * would retry the same oversized compose forever). A single row may legally exceed the budget:
+ * the append-time triggers then guarantee it lands in an empty window and travels alone in one
+ * oversized message, which storage already proved it can hold when the row itself was written.
+ * Measured with codeChangeSerializedSize (composition never exceeds the sum of its inputs'
+ * sizes, so summing rows bounds their composed change) and sized well clear of the 2MB storage
+ * record cap the estimate upper-bounds against. (Declared here rather than in overseer.ts
+ * because agent.ts must not import overseer.ts -- the dependency runs the other way.)
+ */
+export const CHAT_CHANGE_MESSAGE_BUDGET = 1024 * 1024;
 
 /** Additional per-chat-thread info needed by the AI agent but not by the client. */
 export type AiChatAgentContext = {
@@ -1981,6 +2000,12 @@ export async function runAgent(
     }
   }
 
+  // The summed size of the turn's pending (unflushed) change rows: appendAgentEdit flushes
+  // before a row would push it past what one "changes" message may compose, since a flush
+  // writes exactly one message (see CHAT_CHANGE_MESSAGE_BUDGET). Seeded below with any
+  // re-adopted crashed-turn rows, which join this turn's next flush.
+  let pendingChangeBytes = 0;
+
   // If the previous agent turn was aborted by a server restart, its edits are already durable,
   // broadcast change rows that no "changes" message covers yet: establish their pins' bases (the
   // pins were mirrored into the chat's code base when the rows were appended, but their log
@@ -1996,6 +2021,7 @@ export async function runAgent(
   }
   for (let row of hooks.listUnmaterializedChatChanges(chatId)) {
     sessionContent = applyCodeChange(sessionContent, row.change);
+    pendingChangeBytes += codeChangeSerializedSize(row.change);
   }
   pendingReplayEdits = [];
 
@@ -2053,6 +2079,7 @@ export async function runAgent(
     pendingCreatedGadgets = [];
     let addedBindings = pendingAddedBindings;
     pendingAddedBindings = [];
+    pendingChangeBytes = 0;  // the flush materializes every pending row
     if (hooks.flushAgentChanges(chatId, author, {createdGadgets, addedBindings})) {
       ++nextChangeId;
     }
@@ -2067,8 +2094,19 @@ export async function runAgent(
   let appendAgentEdit = async (
       workpieceId: WorkpieceId, change: CodeChange,
       pin?: {baseCommit: string, baseFiles: Map<string, string>}) => {
+    // Keep the pending composition storable: a flush writes exactly one "changes" message, so
+    // materialize the rows appended so far before this one would push their summed size past
+    // the message budget. Flushing through flushPendingChanges (not an overseer-side trigger)
+    // keeps nextChangeId counting messages -- an overseer-written message would sit behind the
+    // agent's counter. A lone change bigger than the whole budget lands in an empty window and
+    // travels alone.
+    let size = codeChangeSerializedSize(change);
+    if (pendingChangeBytes > 0 && pendingChangeBytes + size > CHAT_CHANGE_MESSAGE_BUDGET) {
+      flushPendingChanges();
+    }
     await hooks.appendAgentCodeChange(chatId, author, change,
         pin !== undefined ? {gadgetId: workpieceId, baseCommit: pin.baseCommit} : undefined);
+    pendingChangeBytes += size;
     if (pin !== undefined) {
       sessionContent = new Map(sessionContent);
       sessionContent.set(workpieceId, pin.baseFiles);

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -29,23 +29,57 @@ import {
 const logger = createWorkshopLogger("workshop.agent");
 
 /**
- * Byte bound on one "changes" message's composed change, shared by every producer of chat
- * change rows. Materialization writes exactly one message per call (see materializeChatChanges
- * in overseer.ts), so the composition is kept storable by bounding what *accumulates* rather
- * than by splitting the output: each producer materializes the pending live rows before
- * appending a row that would push their summed size past the budget (submitCodeChange for user
- * edits; appendAgentEdit's flush trigger for tool edits). Rows are individually bounded
+ * Byte bound on one "changes" message's composed change for the *user* edit path.
+ * Materialization writes exactly one message per call (see materializeChatChanges in
+ * overseer.ts), so the composition is kept storable by bounding what *accumulates* rather than
+ * by splitting the output: submitCodeChange materializes the pending live rows before appending
+ * a row that would push their summed size past the budget. Rows are individually bounded
  * (MAX_CODE_CHANGE_SIZE) but a composition of several is not, and an unstorable message would
  * wedge materialization permanently (rows only retire on success, so accept and turn start
  * would retry the same oversized compose forever). A single row may legally exceed the budget:
- * the append-time triggers then guarantee it lands in an empty window and travels alone in one
+ * the append-time trigger then guarantees it lands in an empty window and travels alone in one
  * oversized message, which storage already proved it can hold when the row itself was written.
- * Measured with codeChangeSerializedSize (composition never exceeds the sum of its inputs'
- * sizes, so summing rows bounds their composed change) and sized well clear of the 2MB storage
- * record cap the estimate upper-bounds against. (Declared here rather than in overseer.ts
- * because agent.ts must not import overseer.ts -- the dependency runs the other way.)
+ * Agent tool edits don't accumulate as live rows at all: they buffer in the step and land at
+ * the barrier in one message, bounded by STEP_CHANGE_BUDGET at the write call. Measured with
+ * codeChangeSerializedSize (composition never exceeds the sum of its inputs' sizes, so summing
+ * rows bounds their composed change) and sized well clear of the 2MB storage record cap the
+ * estimate upper-bounds against. (Declared here rather than in overseer.ts because agent.ts
+ * must not import overseer.ts -- the dependency runs the other way.)
  */
 export const CHAT_CHANGE_MESSAGE_BUDGET = 1024 * 1024;
+
+/**
+ * Byte bound on one agent step's buffered changes (their summed codeChangeSerializedSize),
+ * enforced at the write call: the file-tool call that would exceed it fails with an
+ * agent-visible error, everything buffered before it persists normally at the barrier, and the
+ * model adapts mid-turn. The bound exists for correctness -- the barrier writes the step's
+ * buffer as *one* "changes" message, which must fit in a 2MB storage record, envelope included
+ * -- with bounded buffer memory falling out as a side effect. Sized to admit any single valid
+ * file write with margin: a maximal whole-file `set` (MAX_FILE_TEXT_LENGTH, 512K UTF-16 units)
+ * measures at most ~1MB under the at-most-two-bytes-per-unit estimate. (Known, accepted gap:
+ * createGadget's blueprint copy is a single multi-file change that may legally measure past
+ * the budget, but no shipped blueprint comes close.)
+ */
+export const STEP_CHANGE_BUDGET = 1536 * 1024;
+
+/**
+ * One buffered agent tool edit: an entry of the step buffer, which the step's persistence
+ * barrier appends as one chat change row (see AgentHooks.commitAgentStep). One row per tool
+ * call, in call order, never pre-composed: the client resolves streaming edit previews by
+ * matching each broadcast row to the oldest pending preview of the same file, so the barrier's
+ * burst must preserve the per-call row correspondence.
+ */
+export interface AgentStepChange {
+  /** The tool call's edit, exactly as it will be recorded (and broadcast) as a row. */
+  change: CodeChange;
+
+  /**
+   * Present on the step's first write to an unpinned gadget with committed code: the head the
+   * edit is anchored to. The barrier validates it against the gadget's *current* head and
+   * mirrors it into the chat's code base in the same transaction that records the row.
+   */
+  pin?: {gadgetId: WorkpieceId, baseCommit: string};
+}
 
 /** Additional per-chat-thread info needed by the AI agent but not by the client. */
 export type AiChatAgentContext = {
@@ -270,9 +304,9 @@ export type StoredAssistantMessage = Omit<AssistantMessage, "content"> & {
 };
 
 /**
- * A chat message body as the agent loop hands it to AgentHooks.addChatMessages: the client-visible
- * body, plus (for agent steps) the model-facing snapshot to persist alongside it. The overseer
- * strips `modelData` into separate storage; it must never reach clients.
+ * A chat message body as the agent loop hands it to AgentHooks.commitAgentStep: the
+ * client-visible body, plus (for agent steps) the model-facing snapshot to persist alongside it.
+ * The overseer strips `modelData` into separate storage; it must never reach clients.
  */
 export type AiChatMessageBodyWithModelData = AiChatMessageBody & {
   modelData?: StoredAssistantMessage;
@@ -312,22 +346,44 @@ export interface AgentHooks {
   getChatCodeBase(chatId: number): ChatCodeBase | undefined;
 
   /**
-   * Append one agent tool edit to the chat's change stream: durable and broadcast immediately (the
-   * row doubles as the streaming preview). `pin`, on the first write to an unpinned gadget,
-   * names the head the edit is anchored to; it is validated against the gadget's *current* head
-   * and mirrored into the chat's code base in the same synchronous step that records the row
-   * (a moved head fails the append, surfacing as a tool error). The pin's durable log
-   * declaration rides the next turn flush (see flushAgentChanges).
+   * The step's persistence barrier: in one storage transaction, persist the step's chat
+   * messages (`msgs`, the tool-call record among them), validate and append each buffered
+   * change as a chat change row -- one row per tool call, in call order, with the same
+   * pin/codeBase bookkeeping the appends always had -- materialize the rows into the step's
+   * single "changes" message carrying the step's gadget creations and binding additions
+   * (which stamps their pending registry records), and retire the rows. The step's effects
+   * are thus durable iff its transcript record is; a crash mid-step loses both, and the
+   * resumed model re-runs the step against unmodified content. Returns whether a "changes"
+   * message was written (change-ID numbering counts messages).
+   *
+   * Rows and messages broadcast from inside the transaction, as every append always has: the
+   * transaction protects server-side storage, not what subscribers saw before a rollback (a
+   * mid-barrier exception is itself a bug; see the design note on materializeChatChanges'
+   * caller in overseer.ts). The rows' `changeApplied` broadcasts supersede the tool calls'
+   * streamed edit previews.
+   *
+   * The accounting parameters match the overseer's addChatMessages: when both `aiGatewayLogId`
+   * and `aiGatewayLogRoute` are present, the authoritative cost is fetched asynchronously from
+   * the AI Gateway log, with `estimatedCost` (pi's catalog-priced estimate from the turn's
+   * token usage, in dollars) as the fallback; otherwise the estimate is applied directly.
    */
-  appendAgentCodeChange(chatId: number, author: AiChatAuthorInfo, change: CodeChange,
-                        pin?: {gadgetId: WorkpieceId, baseCommit: string})
-      : Promise<{generation: number, revision: number}>;
+  commitAgentStep(chatId: number, author: AiChatAuthorInfo,
+      msgs: AiChatMessageBodyWithModelData[],
+      step: {
+        changes: AgentStepChange[],
+        createdGadgets: {gadgetId: WorkpieceId, title: string, bindingName: string}[],
+        addedBindings: {gadgetId: WorkpieceId, name: string, target: WorkpieceId}[],
+      },
+      totalTokens?: number, aiGatewayLogId?: string, aiGatewayLogRoute?: AiGatewayLogRoute,
+      estimatedCost?: number): Promise<boolean>;
 
   /**
-   * The turn flush: materialize the chat's unmaterialized change rows (this turn's appends, plus
-   * any crashed predecessor's re-adopted tail) into one durable "changes" message, carrying the
-   * still-undeclared pin establishments and the given buffered gadget creations and binding
-   * additions. Returns whether a message was written (change-ID numbering counts messages).
+   * Transitional, called only by the compaction early-return (and deleted with the
+   * replay-discharge machinery): materialize live change rows re-adopted from a crashed
+   * pre-barrier turn into one "changes" message carrying the given re-adopted creations and
+   * binding additions, before compaction removes the log tail replay re-adopts them from.
+   * Barrier-committed turns leave no live agent rows for this to find. Returns whether a
+   * message was written (change-ID numbering counts messages).
    */
   flushAgentChanges(chatId: number, author: AiChatAuthorInfo, extras: {
     createdGadgets?: {gadgetId: WorkpieceId, title: string, bindingName: string}[],
@@ -430,18 +486,6 @@ export interface AgentHooks {
   rejectAllAgentCallbacks(chatId: number, error: string): void;
   consumeCapturedActions(chatId: number)
       : {actions: number[], accessedGadget: boolean, awaitDecision: boolean} | undefined;
-  /**
-   * Appends messages to the chat log and updates cost/token accounting. When both
-   * `aiGatewayLogId` and `aiGatewayLogRoute` are present, the authoritative cost is fetched
-   * asynchronously from the AI Gateway log, with `estimatedCost` (pi's catalog-priced estimate
-   * from the turn's token usage, in dollars) as the fallback if the gateway can't produce a
-   * cost; otherwise the estimate is applied directly, so direct-provider routes still get cost
-   * accounting.
-   */
-  addChatMessages(chatId: number, author: AiChatAuthorInfo,
-      msgs: AiChatMessageBodyWithModelData[],
-      totalTokens?: number, aiGatewayLogId?: string, aiGatewayLogRoute?: AiGatewayLogRoute,
-      estimatedCost?: number): void;
   emitChatStreamEvent(chatId: number, event: AiChatStreamEvent): void;
 
   /**
@@ -1279,7 +1323,8 @@ export async function runAgent(
   //   chat, its content built up from its own changes -- and the head seen now is its later
   //   promotion. Nothing to establish;
   // - nothing at all: the turn crashed before flushing. The pin was still mirrored into the
-  //   chat's code base when the write's row was appended (see AgentHooks.appendAgentCodeChange), so
+  //   chat's code base when the write's row was appended (the pre-barrier per-tool append
+  //   path, whose stranded rows this recovery still tolerates), so
   //   establish from the meta pin; the trailing unmaterialized rows applied after replay carry
   //   the edits themselves, and the next flush declares the pin (see undeclaredChatPins).
   let ensureReplayContentForWrite = async (workpieceId: WorkpieceId, sequence: number) => {
@@ -2000,11 +2045,14 @@ export async function runAgent(
     }
   }
 
-  // The summed size of the turn's pending (unflushed) change rows: appendAgentEdit flushes
-  // before a row would push it past what one "changes" message may compose, since a flush
-  // writes exactly one message (see CHAT_CHANGE_MESSAGE_BUDGET). Seeded below with any
-  // re-adopted crashed-turn rows, which join this turn's next flush.
-  let pendingChangeBytes = 0;
+  // The step buffer: the current step's tool edits, applied to the session content as they
+  // buffer but durable (and broadcast) only at the step's persistence barrier
+  // (AgentHooks.commitAgentStep), so a crash loses the whole step -- transcript and effects
+  // together -- and the resumed model re-runs it cleanly. Turn-owned and passed explicitly
+  // where needed (the barrier now; executeCodeMode once worktree writes join it). `bytes` is
+  // the buffered changes' summed codeChangeSerializedSize, checked against STEP_CHANGE_BUDGET
+  // at each write call.
+  let stepBuffer = {changes: [] as AgentStepChange[], bytes: 0};
 
   // If the previous agent turn was aborted by a server restart, its edits are already durable,
   // broadcast change rows that no "changes" message covers yet: establish their pins' bases (the
@@ -2021,7 +2069,6 @@ export async function runAgent(
   }
   for (let row of hooks.listUnmaterializedChatChanges(chatId)) {
     sessionContent = applyCodeChange(sessionContent, row.change);
-    pendingChangeBytes += codeChangeSerializedSize(row.change);
   }
   pendingReplayEdits = [];
 
@@ -2069,50 +2116,53 @@ export async function runAgent(
   // shouldStopAfterTurn reads it afterwards to end the turn until approval resumes it.
   let awaitingActionDecision = false;
 
-  // Flush the turn's pending structure and durable rows into a "changes" message: the message
-  // is the durable record that stamps pending registry rows/edges (see addChatMessages in
-  // overseer.ts) and declares the pins this turn's writes established; its change re-records the
-  // rows appended since the last flush (see AgentHooks.flushAgentChanges). Change-ID numbering
-  // counts messages, so the counter advances exactly when a message was written.
-  let flushPendingChanges = () => {
+  // Transitional, for the compaction early-return only (see AgentHooks.flushAgentChanges): a
+  // crashed pre-barrier turn's re-adopted rows, creations and binding additions must be covered
+  // by a "changes" message before compaction removes the log tail they were re-adopted from.
+  // Change-ID numbering counts messages, so the counter advances exactly when one was written.
+  let flushReadoptedChanges = () => {
     let createdGadgets = pendingCreatedGadgets;
     pendingCreatedGadgets = [];
     let addedBindings = pendingAddedBindings;
     pendingAddedBindings = [];
-    pendingChangeBytes = 0;  // the flush materializes every pending row
     if (hooks.flushAgentChanges(chatId, author, {createdGadgets, addedBindings})) {
       ++nextChangeId;
     }
   };
 
-  // Append one file edit to the chat's change stream, durable and broadcast immediately, and apply
-  // it to the session content. The first write to an unpinned gadget with committed code pins
-  // it at the given head -- always the current head, never an older observed commit: a read
-  // that observed an older head is (or will be) elided, and a previously-elided read must not
-  // spring back to life as the anchor of a later write. The pin is validated and mirrored into
-  // the chat's code base at append time; its log declaration rides the next flush.
-  let appendAgentEdit = async (
+  // Buffer one file edit into the step and apply it to the session content; it becomes durable
+  // (row + broadcast) only at the step's persistence barrier. The first write to an unpinned
+  // gadget with committed code pins it at the given head -- always the current head, never an
+  // older observed commit: a read that observed an older head is (or will be) elided, and a
+  // previously-elided read must not spring back to life as the anchor of a later write. The
+  // pin is validated and mirrored into the chat's code base when the barrier appends the row;
+  // within the step, later tools read the edit through the session content.
+  let appendAgentEdit = (
       workpieceId: WorkpieceId, change: CodeChange,
       pin?: {baseCommit: string, baseFiles: Map<string, string>}) => {
-    // Keep the pending composition storable: a flush writes exactly one "changes" message, so
-    // materialize the rows appended so far before this one would push their summed size past
-    // the message budget. Flushing through flushPendingChanges (not an overseer-side trigger)
-    // keeps nextChangeId counting messages -- an overseer-written message would sit behind the
-    // agent's counter. A lone change bigger than the whole budget lands in an empty window and
-    // travels alone.
+    // Bound the step's total: the barrier writes the buffer as exactly one "changes" message,
+    // which must fit in one storage record. The failed call buffers nothing -- everything
+    // buffered before it persists normally at the barrier -- and the error tells the model how
+    // to adapt.
     let size = codeChangeSerializedSize(change);
-    if (pendingChangeBytes > 0 && pendingChangeBytes + size > CHAT_CHANGE_MESSAGE_BUDGET) {
-      flushPendingChanges();
+    if (stepBuffer.bytes + size > STEP_CHANGE_BUDGET) {
+      throw new Error("Too many code changes in one step. End this response; the changes made " +
+          "so far are being saved, and you can continue the work in your next step.");
     }
-    await hooks.appendAgentCodeChange(chatId, author, change,
-        pin !== undefined ? {gadgetId: workpieceId, baseCommit: pin.baseCommit} : undefined);
-    pendingChangeBytes += size;
+    // Apply first: an inapplicable change must throw before anything buffers.
+    let newContent = sessionContent;
     if (pin !== undefined) {
-      sessionContent = new Map(sessionContent);
-      sessionContent.set(workpieceId, pin.baseFiles);
-      pinnedGadgets.add(workpieceId);
+      newContent = new Map(newContent);
+      newContent.set(workpieceId, pin.baseFiles);
     }
-    sessionContent = applyCodeChange(sessionContent, change);
+    newContent = applyCodeChange(newContent, change);
+    stepBuffer.changes.push({
+      change,
+      ...(pin !== undefined ? {pin: {gadgetId: workpieceId, baseCommit: pin.baseCommit}} : {}),
+    });
+    stepBuffer.bytes += size;
+    if (pin !== undefined) pinnedGadgets.add(workpieceId);
+    sessionContent = newContent;
   };
 
   let agentContext = hooks.getChatAgentContext(chatId);
@@ -2296,11 +2346,12 @@ export async function runAgent(
 
   let compactionTurn = isCompactionTurn(chatMessages);
   if (compactionTurn || shouldCompactChat(contextTokens, inputBudget)) {
-    // Returning below skips the flush that ends a normal turn, so do it here: replay may have
-    // re-adopted a crashed turn's unmaterialized rows, creations and binding additions, and they
-    // must be covered by a message before this turn stops carrying them. The message lands above
-    // any boundary chosen here, so the checkpoint is unaffected.
-    flushPendingChanges();
+    // Returning below runs no step (and thus no barrier), so cover re-adopted state here:
+    // replay may have re-adopted a crashed pre-barrier turn's unmaterialized rows, creations
+    // and binding additions, and they must be covered by a message before compaction removes
+    // the log tail they were re-adopted from. The message lands above any boundary chosen
+    // here, so the checkpoint is unaffected.
+    flushReadoptedChanges();
 
     let compactedTo = findCompactionBoundary(
         projection, inputBudget, contextTokens,
@@ -2454,7 +2505,7 @@ export async function runAgent(
 
           // A whole-file write is a `set`: valid against any state, so replay and concurrent
           // transforms can never mis-anchor it.
-          await appendAgentEdit(resolved.workpieceId,
+          appendAgentEdit(resolved.workpieceId,
               {[resolved.workpieceId]: [[filename, {set: newContent}]]}, pin);
 
           // The agent knows exactly what's in the file, so add it to the `filesRead` set so
@@ -2531,7 +2582,7 @@ export async function runAgent(
           let pos = findEditPos(before, textToReplace);
           if (replacement !== textToReplace) {
             let edit = replaceSpanChange(before.length, pos, textToReplace, replacement);
-            await appendAgentEdit(
+            appendAgentEdit(
                 resolved.workpieceId, {[resolved.workpieceId]: [[filename, {edit}]]}, pin);
             // Like writeFile: the agent knows the file's exact resulting content, so the entry
             // becomes session knowledge (the gadget is pinned now, so a commit stamp -- which
@@ -2661,11 +2712,10 @@ export async function runAgent(
           }
           let bindingName = name ?? source;
 
-          // Like createGadget, flush edits made so far into their own "changes" message
-          // first, so a revert at the addition never drags along earlier edits; the addition
-          // then rides the *next* flush, whose "changes" message durably records and
-          // sequence-stamps the pending edge (see addChatMessages in overseer.ts).
-          flushPendingChanges();
+          // The addition rides the step's "changes" message (via the barrier's
+          // `addedBindings`), which durably records and sequence-stamps the pending edge (see
+          // addChatMessages in overseer.ts). Same-step edits share that message, so a revert
+          // keeps or discards the step's work as one unit.
           hooks.addGadgetBinding(gadgetEntry.id, bindingName, sourceEntry.id, chatId);
           pendingAddedBindings.push(
               {gadgetId: gadgetEntry.id, name: bindingName, target: sourceEntry.id});
@@ -2721,20 +2771,14 @@ export async function runAgent(
           let blueprint = blueprintId !== undefined
               ? await hooks.fetchBlueprint(blueprintId) : undefined;
 
-          // Flush edits made so far into their own "changes" message before creating the
-          // gadget, so the creation cleanly separates change batches: a revert from this creation
-          // onward must not drag along a batch that also holds earlier edits. (Same barrier
-          // pattern as executeCode, including its known single-step-mixing caveat there.)
-          flushPendingChanges();
-
           // The gadget is created provisional to this chat: it becomes permanent only when the
-          // user accepts the chat's changes. The creation is attached to the next flushed
-          // "changes" message, which is the durable record that sequence-stamps the pending
-          // registry row (see addChatMessages in overseer.ts). Until then it behaves like a
-          // pending write/edit: if the turn dies first, either this tool call was persisted (the
-          // resumed turn re-adopts the creation from the log tail -- see replayedCreations) or
-          // it wasn't (the registry row is reaped as an orphan -- see reconcilePendingGadgets --
-          // and the resumed turn just creates a fresh gadget).
+          // user accepts the chat's changes. The registry record (and its name reservation) is
+          // created immediately -- deferring it to the barrier would surface name conflicts
+          // after the model already saw this call succeed -- but it is *stamped* by the step's
+          // "changes" message, which the barrier records the creation on (see addChatMessages
+          // in overseer.ts). If the step dies before its barrier, the record is reaped as an
+          // unstamped orphan (see reconcilePendingGadgets) and the resumed turn just creates a
+          // fresh gadget.
 
           // Let the transcript name the format while the call runs, as writes do with their target
           // file.
@@ -2761,21 +2805,16 @@ export async function runAgent(
             let fileChanges = Object.entries(blueprint.files)
                 .map(([filename, text]): [string, {set: string}] => [filename, {set: text}]);
             if (fileChanges.length > 0) {
-              await appendAgentEdit(created.id, {[created.id]: fileChanges});
+              appendAgentEdit(created.id, {[created.id]: fileChanges});
             }
             // (The files are deliberately NOT added to filesRead: unlike a writeFile, the agent
             // hasn't seen their contents, so it must read before editing.)
 
-            // Flush the creation + files immediately rather than waiting for the next barrier.
-            // The blueprint's contents aren't reconstructible from this tool call's input the way
-            // writeFile edits are, so they must be durable before the step's message lands: the
-            // "changes" message then precedes the tool call in the log, which replay already
-            // tolerates (see recordedCreations) -- and which makes replay of a later readFile of
-            // a blueprint file work with no special cases. The residual crash window (changes
-            // persisted, step's message lost) leaves a stamped pending gadget the resumed model
-            // doesn't remember; it is visible in the chat's proposed changes and reverts
-            // normally.
-            flushPendingChanges();
+            // The copies ride the step buffer and persist atomically with this call's record at
+            // the barrier: the blueprint's contents aren't reconstructible from the call's
+            // input the way writeFile edits are, so either both survive a crash or neither
+            // does. (Old logs may hold the pre-barrier order -- the "changes" message *before*
+            // its creating call -- which replay still tolerates; see recordedCreations.)
 
             output.blueprintNotes = blueprint.notes;
           }
@@ -2833,12 +2872,16 @@ export async function runAgent(
       }),
       execute: async (toolCallId, {code}) => {
         try {
-          // Flush before running code so the "changes" message covering earlier edits lands
-          // first. (Edits are durable rows the moment they apply, so the gadget preview sees
-          // them either way; the flush keeps the batch boundaries clean. The known caveat that a
-          // same-step edit's message lands before the step's own message is unchanged; replay
-          // tolerates it -- see recordedCreations.)
-          flushPendingChanges();
+          // Step-transactionality guard: buffered edits are durable only at the step's
+          // barrier, so code must not run against content the persisted history doesn't yet
+          // hold -- a crash would lose the edits the execution observed. Editing code and then
+          // executing it in one step never worked; the error is retryable and tells the model
+          // to split them. (Deliberately coarse: no per-gadget touched-set -- worktrees keep
+          // the same rule.)
+          if (stepBuffer.changes.length > 0) {
+            throw new Error("This step already made code changes, which take effect when the " +
+                "step ends. End this response and call executeCode again in your next step.");
+          }
 
           let output = await hooks.executeCodeMode(
               chatId, code, initiator, author.id, Object.fromEntries(chatBindings),
@@ -3055,11 +3098,12 @@ export async function runAgent(
           break;
         }
         // Note: a turn the model completed is persisted even if the user cancelled while its
-        // tools were executing -- their durable side effects (Y.Doc changes, captured actions,
-        // connection requests) have already happened, and dropping the record would leave those
-        // changes without history and the captured actions/requests orphaned for the next turn
-        // to mis-consume. Tool calls the abort kept from running are recorded as errors below,
-        // and shouldStopAfterTurn ends the loop right after this barrier.
+        // tools were executing -- the completed calls' buffered edits and captured
+        // actions/connection requests land with their records here (effects iff record, the
+        // invariant this barrier exists for), rather than evaporating out from under side
+        // effects the next turn would mis-consume. Tool calls the abort kept from running are
+        // recorded as errors below, and shouldStopAfterTurn ends the loop right after this
+        // barrier.
 
         let msgs: AiChatMessageBodyWithModelData[] = [];
 
@@ -3138,9 +3182,24 @@ export async function runAgent(
           msgs.push(cr);
         }
 
-        hooks.addChatMessages(chatId, author, msgs, message.usage.totalTokens,
-            handle.lastResponse?.aiGatewayLogId, handle.aiGatewayLogRoute,
-            message.usage.cost.total);
+        // The barrier itself: one transaction persists the step's messages and its buffered
+        // effects -- rows, the step's single "changes" message, retirement, registry stamps --
+        // so the effects are durable iff the transcript that explains them is. The buffer is
+        // drained before the call: if the barrier throws, the turn dies with it (rethrown out
+        // of the loop), and re-delivering the step's changes anywhere would be wrong.
+        let stepChanges = stepBuffer.changes;
+        stepBuffer.changes = [];
+        stepBuffer.bytes = 0;
+        let createdGadgets = pendingCreatedGadgets;
+        pendingCreatedGadgets = [];
+        let addedBindings = pendingAddedBindings;
+        pendingAddedBindings = [];
+        if (await hooks.commitAgentStep(chatId, author, msgs,
+            {changes: stepChanges, createdGadgets, addedBindings},
+            message.usage.totalTokens, handle.lastResponse?.aiGatewayLogId,
+            handle.aiGatewayLogRoute, message.usage.cost.total)) {
+          ++nextChangeId;
+        }
 
         // Reset per-step streaming state.
         toolCallNotes.clear();
@@ -3150,57 +3209,53 @@ export async function runAgent(
     }
   };
 
-  try {
-    if (modelMessages.length === 0 ||
-        modelMessages[modelMessages.length - 1].role === "assistant") {
-      // The log tail ends with a completed assistant response and nothing new has arrived for
-      // the model to answer (e.g. the previous turn crashed between persisting its final message
-      // and finishing), so there is nothing to run. pi's loop requires the context to end with a
-      // user or toolResult message, which replay otherwise guarantees.
-      logger.warn("agent turn skipped: history ends with a completed assistant message", {
-        event: "agent.turn.skipped", chatId,
-      });
-      return undefined;
-    }
-
-    let context: AgentContext = {
-      systemPrompt,
-      messages: modelMessages,
-      tools: toolList,
-    };
-
-    await runAgentLoopContinue(context, {
-      model: handle.model,
-      // Replay already produces LLM-shaped messages; no custom message types exist.
-      convertToLlm: (messages) => messages as Message[],
-      toolExecution: "sequential",
-      maxTokens: maxOutputTokens,
-      shouldStopAfterTurn: () =>
-          // Cancelled during tool execution: the completed turn was persisted by the turn_end
-          // barrier just above; don't start another (doomed) model request.
-          abortSignal.aborted ||
-          // Hard cap on turns, as before.
-          ++turnCount >= 30 ||
-          // End the turn once the agent has successfully requested a connection: it must wait
-          // for the user to respond, not keep reasoning in the meantime. (Accept resumes it on a
-          // fresh turn; deny just leaves the turn ended.) A rejected requestConnection (e.g.
-          // unresolvable resource) leaves this false so the agent can fix the request and retry
-          // in the same turn.
-          connectionRequested ||
-          // Wait for approval before continuing against state that may not reflect the action.
-          awaitingActionDecision ||
-          // Auto-terminate when callback-initiated and all callbacks have been resolved/rejected.
-          (callbackInitiated && hooks.activeAgentCallbackCount(chatId) === 0),
-    }, emit, abortSignal, handle.stream);
-  } finally {
-    // Flush any remaining rows appended during this turn (including a crashed predecessor's
-    // re-adopted tail) into a "changes" message. Deliberately unconditional: a user cancel
-    // keeps the completed tool calls' edits, exactly as the Y.Doc flush before it did --
-    // cancellation stops the agent, it does not revert the turn. (A turn that must *discard*
-    // its edits would need the revert-shaped path: remove its contiguous tail of
-    // unmaterialized rows and bump the generation. No such path exists today.)
-    flushPendingChanges();
+  if (modelMessages.length === 0 ||
+      modelMessages[modelMessages.length - 1].role === "assistant") {
+    // The log tail ends with a completed assistant response and nothing new has arrived for
+    // the model to answer (e.g. the previous turn crashed between persisting its final message
+    // and finishing), so there is nothing to run. pi's loop requires the context to end with a
+    // user or toolResult message, which replay otherwise guarantees.
+    logger.warn("agent turn skipped: history ends with a completed assistant message", {
+      event: "agent.turn.skipped", chatId,
+    });
+    return undefined;
   }
+
+  let context: AgentContext = {
+    systemPrompt,
+    messages: modelMessages,
+    tools: toolList,
+  };
+
+  await runAgentLoopContinue(context, {
+    model: handle.model,
+    // Replay already produces LLM-shaped messages; no custom message types exist.
+    convertToLlm: (messages) => messages as Message[],
+    toolExecution: "sequential",
+    maxTokens: maxOutputTokens,
+    shouldStopAfterTurn: () =>
+        // Cancelled during tool execution: the completed turn was persisted by the turn_end
+        // barrier just above; don't start another (doomed) model request.
+        abortSignal.aborted ||
+        // Hard cap on turns, as before.
+        ++turnCount >= 30 ||
+        // End the turn once the agent has successfully requested a connection: it must wait
+        // for the user to respond, not keep reasoning in the meantime. (Accept resumes it on a
+        // fresh turn; deny just leaves the turn ended.) A rejected requestConnection (e.g.
+        // unresolvable resource) leaves this false so the agent can fix the request and retry
+        // in the same turn.
+        connectionRequested ||
+        // Wait for approval before continuing against state that may not reflect the action.
+        awaitingActionDecision ||
+        // Auto-terminate when callback-initiated and all callbacks have been resolved/rejected.
+        (callbackInitiated && hooks.activeAgentCallbackCount(chatId) === 0),
+  }, emit, abortSignal, handle.stream);
+
+  // (No end-of-turn flush: every completed step's effects were barrier-committed with its
+  // message, and an abort simply drops the in-flight step's buffer -- nothing durable exists
+  // for it. Cancellation stops the agent, it does not revert the turn; completed steps' work
+  // stays, and the user reverts explicitly if they want it gone. Re-adopted crashed-turn state
+  // that never met a barrier stays live for the next turn to re-adopt.)
 
   // Cancellation surfaces as the abort reason, matching the old thrown-abort behavior. (Checked
   // outside turnFailure because an abort during tool execution stops the loop after a persisted,

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -1,8 +1,8 @@
 import { RpcCompatible, RpcStub, RpcTarget } from "capnweb";
 import { validateRpc } from "capnweb-validate";
 import { Overseer, GadgetMetadata, UiBundle, WorkpieceId, WorkpieceSummary, WorkpiecesSubscriber, GadgetClient, GadgetBindingInfo, GatekeeperClient, ActionState, ActionLogEntry, ActionsSubscriber, ActionHistoryFilter, ActionHistoryPage, ChatGadgetPin, ChatCodeBase, ChatGadgetPinState, CodeChangeSubmission, CommitIdentity, CommitInfo, MergeChangesResult, AiChatMetadata, AiChatMessage, AiChatHistoryPage, AiChatSubscriber, AiChatAuthorInfo, AiModelConfig, AiChatMessageBody, AgentSpawnerConfig, ConsoleLogSubscriber, ConsoleLogEvent, CapsuleSpecifier, CollaboratorInfo, CollaboratorRole, AffectedCollaborator, ShareLinkInfo, GatekeeperCreationSpec, ObserverConfigCallback, ObserverBindingNeed, ObserverBindingFailure, BlueprintBindingAnnotation, BlueprintBinding, BlueprintMetadata, BlueprintOutput, MessageFormatRef, isOutputIcon, SpawnerEnvTarget, BlueprintGadgetSummary, AiChatStreamEvent, BlueprintScreenshotUpload, BLUEPRINT_SCREENSHOT_R2_PREFIX, blueprintScreenshotUrl, ChatAttachmentUpload, ChatAttachmentHandle, ChatAttachmentRef, BoundHookInfo, PreApprovableAction, PresenceParticipant, PresenceSubscriber, SlashCommandChoice, SlashCommandRequest, validateBindingName, createOpenGadgetError, OPEN_GADGET_ERROR_CODES, resolveSiteName, actionChangeTime } from '@gadgets/workshop-shared/api';
-import { applyCodeChange, changedGadgets, composeCodeChange, diffFiles, transformCodeChange,
-  validateCodeChangeContent, validateCodeChangeSchema,
+import { applyCodeChange, changedGadgets, codeChangeSerializedSize, composeCodeChange, diffFiles,
+  transformCodeChange, validateCodeChangeContent, validateCodeChangeSchema,
   type CodeContent, type CodeChange } from "@gadgets/workshop-shared/code-change";
 import { Gatekeeper, HookInitiator, ResourceDescription, ApprovalQueue, ActionDescription, ObservationAuthorizer, ObservationDescription, VendorDescription, SupportedResource, resolveRequestedResource, HookController, HookDescription, ActionKind } from "@gadgets/workshop-shared/gatekeeper";
 import {
@@ -27,7 +27,7 @@ import {
   getAiGatewayLogCost,
   type AiGatewayLogRoute,
 } from "./ai-gateway";
-import { AgentGadgetInfo, AgentHooks, AiChatAgentContext, ChatBindingEntry, SeedBindingInfo, runAgent, makeStorableArgs, summarizeArgs, type AiChatMessageBodyWithModelData, type CompactionCheckpoint, type StoredAssistantMessage } from "./agent";
+import { AgentGadgetInfo, AgentHooks, AiChatAgentContext, CHAT_CHANGE_MESSAGE_BUDGET, ChatBindingEntry, SeedBindingInfo, runAgent, makeStorableArgs, summarizeArgs, type AiChatMessageBodyWithModelData, type CompactionCheckpoint, type StoredAssistantMessage } from "./agent";
 import { deploymentOutputForBlueprint, FormatOffer, listFormatOffers, readAdminConfig } from "./admin-config";
 import { chatChangeStatuses, foldProposedChanges, isCompactionTurn,
   type ChangeBatch } from "./agent-compaction";
@@ -822,21 +822,12 @@ const CHAT_CHANGE_AUTHOR_SPLIT_MS = 60_000;
 
 // Materialize the live row window into a "changes" message once it grows past this many rows,
 // so a long editing session can't grow the window (and its subscribe-replay cost) without bound.
-// Thanks to the retired-row grace window this stales nobody: a submission based inside the
-// materialized range still transforms over the retired rows.
-const CHAT_CHANGE_MATERIALIZE_THRESHOLD = 128;
-
-// Materialization splits a batch of rows across consecutive "changes" messages so that no one
-// message's composed change exceeds this size: rows are individually bounded
-// (MAX_CODE_CHANGE_SIZE) but a composition of several is not, and an unstorable message would
-// wedge materialization permanently (rows only retire on success, so accept and turn start would
-// retry the same oversized compose forever). Composition never exceeds the sum of its inputs'
-// sizes, so cutting chunks by that sum keeps every multi-row message under the budget; a single
-// row larger than the budget travels alone, which storage already proved it can hold when the row
-// itself was written. Sizes are the UTF-8 byte length of the change's JSON -- never less than
-// the storage serialization's string payload (which stores at most two bytes per UTF-16 unit), so
-// the budget can't be undershot by multi-byte-heavy content.
-const CHAT_CHANGE_MESSAGE_BUDGET = 1024 * 1024;
+// The job is compacting keystroke-granularity ops into few large composed ops -- rows arrive
+// per edit burst, so this is sized in "a screenful of typing", not lines. Byte growth is
+// bounded separately (CHAT_CHANGE_MESSAGE_BUDGET, enforced at row-append time). Thanks to the
+// retired-row grace window this stales nobody: a submission based inside the materialized range
+// still transforms over the retired rows.
+const CHAT_CHANGE_MATERIALIZE_THRESHOLD = 1000;
 
 // How long retired rows are kept as a transform window before lazy expiry. Late submissions are
 // in-flight-RTT scale, so a minute is generous; a submission whose base has aged out is rejected
@@ -2530,6 +2521,31 @@ class OverseerImpl implements AgentHooks {
     this.#chatContentCache.delete(chatId);
   }
 
+  // Cache of the live (unretired) window's summed serialized-size estimate, keyed by the
+  // (generation, revision) it reflects. The byte trigger in submitCodeChange consults it per
+  // keystroke, and recomputing means re-reading every live row from storage -- O(window) per
+  // keystroke, quadratic over an editing session. Row appends update it incrementally (see
+  // #appendChatChangeRow) and retirement drops it (see #retireChatChanges); anything else that
+  // changes the window (revert, epoch reset, draft discard) bumps the generation or revision,
+  // which invalidates the entry. A miss (also after a DO restart) recomputes from the rows the
+  // caller listed anyway.
+  #liveChangeBytesCache = new Map<number, {generation: number, revision: number,
+                                           bytes: number}>();
+
+  // The summed codeChangeSerializedSize of the given live rows (the caller already listed them),
+  // served from #liveChangeBytesCache when it is current for (generation, revision).
+  #liveChangeBytes(chatId: number, codeBase: ChatCodeBase, liveRows: ChatChangeRecord[]): number {
+    let cached = this.#liveChangeBytesCache.get(chatId);
+    if (cached !== undefined && cached.generation === codeBase.generation &&
+        cached.revision === codeBase.revision) {
+      return cached.bytes;
+    }
+    let bytes = liveRows.reduce((sum, row) => sum + codeChangeSerializedSize(row.change), 0);
+    this.#liveChangeBytesCache.set(chatId,
+        {generation: codeBase.generation, revision: codeBase.revision, bytes});
+    return bytes;
+  }
+
   // The chat's current content: what the next change row will apply to. Cached; treat the result as
   // immutable (it is shared with the cache and with code-change's structure sharing).
   async getCurrentChatContent(chatId: number, meta: AiChatMetadata): Promise<CodeContent> {
@@ -2643,6 +2659,17 @@ class OverseerImpl implements AgentHooks {
       this.#chatContentCache.delete(chatId);
     }
 
+    // Advance the byte cache incrementally when it was current for the window this row joins;
+    // otherwise drop it and let the next read recompute.
+    let cachedBytes = this.#liveChangeBytesCache.get(chatId);
+    if (cachedBytes !== undefined && cachedBytes.generation === codeBase.generation &&
+        cachedBytes.revision === revision - 1) {
+      this.#liveChangeBytesCache.set(chatId, {generation: codeBase.generation, revision,
+                                              bytes: cachedBytes.bytes + codeChangeSerializedSize(change)});
+    } else {
+      this.#liveChangeBytesCache.delete(chatId);
+    }
+
     meta.lastActive = row.timestamp;
     meta.hasProposedChanges = true;
     this.storage.chatMeta.put(meta);
@@ -2657,6 +2684,12 @@ class OverseerImpl implements AgentHooks {
     for (let row of rows) {
       row.retired = true;
       this.storage.chatChanges.put(row);
+    }
+    // Retirement always covers the generation's entire live window (materialization and epoch
+    // close both list-then-retire), so the byte cache no longer describes it; drop the entry
+    // and let the next read recompute -- over a window that is empty at that point.
+    if (rows.length > 0) {
+      this.#liveChangeBytesCache.delete(rows[0].chatId);
     }
   }
 
@@ -2681,6 +2714,7 @@ class OverseerImpl implements AgentHooks {
     }
     this.storage.chatChangeBoundaries.delete(chatId);
     this.#chatContentCache.delete(chatId);
+    this.#liveChangeBytesCache.delete(chatId);
   }
 
   // Gadgets whose pin establishment is recorded by a surviving (non-reverted) "changes" message
@@ -2852,15 +2886,19 @@ class OverseerImpl implements AgentHooks {
     return meta;
   }
 
-  // Materialize the chat's live change rows into durable "changes" messages -- one, unless the
-  // batch's composed change would exceed CHAT_CHANGE_MESSAGE_BUDGET, in which case consecutive
-  // messages each take a slice of the rows. Each message's `change` is its rows' composition and
-  // its `watermark` names the rows it absorbed; the first message additionally stamps `pins`
-  // for any meta pins not yet declared in the log (closing the meta/log loop: submitCodeChange and
-  // the agent's appends establish pins in codeBase atomically with the row that needed them,
-  // and this is where the establishment becomes durable log history). The rows are then
-  // retired -- kept briefly as a transform window, not deleted -- so late submissions based
-  // inside the materialized range still rebase cleanly.
+  // Materialize the chat's live change rows into exactly one durable "changes" message. The
+  // message's `change` is the rows' composition and its `watermark` names the rows it absorbed;
+  // it additionally stamps `pins` for any meta pins not yet declared in the log (closing the
+  // meta/log loop: submitCodeChange and the agent's appends establish pins in codeBase
+  // atomically with the row that needed them, and this is where the establishment becomes
+  // durable log history). The rows are then retired -- kept briefly as a transform window, not
+  // deleted -- so late submissions based inside the materialized range still rebase cleanly.
+  //
+  // One message, always: the composition is kept storable by bounding what accumulates (each
+  // row producer materializes the pending window before a row would push its summed size past
+  // CHAT_CHANGE_MESSAGE_BUDGET, declared in agent.ts), never by splitting the output --
+  // splitting would scatter one batch's extras and edits across messages a suffix revert could
+  // divide, and would break the agent's message-counting change-ID numbering.
   //
   // `options.extras` lets the agent's turn flush attach its buffered creations/binding
   // additions, and updateChatFromMainline attaches its `mainlineMerge` record; a message is
@@ -2901,51 +2939,31 @@ class OverseerImpl implements AgentHooks {
       return;
     }
 
-    // Chunk the batch so no message's composed change exceeds the byte budget (see
-    // CHAT_CHANGE_MESSAGE_BUDGET). No rows means one message with no change of its own, carrying
-    // the pins/extras.
-    let chunks: ChatChangeRecord[][] = rows.length > 0 ? [] : [[]];
-    let chunkSize = 0;
+    // No rows means one message with no change of its own, carrying the pins/extras. Pins-first
+    // is correct for the same reason getCurrentChatContent establishes them up front: within a
+    // message pins apply before changes (see buildChatContent), and every batch row touching a
+    // pinned gadget was appended after that pin established.
+    let change: CodeChange | undefined;
     for (let row of rows) {
-      let size = new TextEncoder().encode(JSON.stringify(row.change)).byteLength;
-      let current = chunks[chunks.length - 1];
-      if (current === undefined || (chunkSize > 0 && chunkSize + size >
-          CHAT_CHANGE_MESSAGE_BUDGET)) {
-        chunks.push([row]);
-        chunkSize = size;
-      } else {
-        current.push(row);
-        chunkSize += size;
-      }
+      change = change === undefined ? row.change : composeCodeChange(change, row.change);
     }
 
     let sequence = this.nextChatSequencePeek(chatId);
-    for (let [index, chunk] of chunks.entries()) {
-      let change: CodeChange | undefined;
-      for (let row of chunk) {
-        change = change === undefined ? row.change : composeCodeChange(change, row.change);
-      }
-      // The pins and extras all ride the first message. Pins-first is correct for the same
-      // reason getCurrentChatContent establishes them up front: within a message pins apply
-      // before changes (see buildChatContent), and every batch row touching a pinned gadget was
-      // appended after that pin established, so no earlier chunk's change needs a later pin.
-      let first = index === 0;
-      this.addChatMessages(chatId, author!, [{
-        type: "changes",
-        ...(change !== undefined ? {change} : {}),
-        ...(chunk.length > 0
-            ? {watermark: {changesGeneration: codeBase.generation,
-                           throughRevision: chunk[chunk.length - 1].revision}}
-            : {}),
-        ...(first && pins.length > 0 ? {pins} : {}),
-        ...(first && options?.createdGadgets?.length
-            ? {createdGadgets: options.createdGadgets} : {}),
-        ...(first && options?.addedBindings?.length
-            ? {addedBindings: options.addedBindings} : {}),
-        ...(first && options?.mainlineMerge !== undefined
-            ? {mainlineMerge: options.mainlineMerge} : {}),
-      }]);
-    }
+    this.addChatMessages(chatId, author!, [{
+      type: "changes",
+      ...(change !== undefined ? {change} : {}),
+      ...(rows.length > 0
+          ? {watermark: {changesGeneration: codeBase.generation,
+                         throughRevision: rows[rows.length - 1].revision}}
+          : {}),
+      ...(pins.length > 0 ? {pins} : {}),
+      ...(options?.createdGadgets?.length
+          ? {createdGadgets: options.createdGadgets} : {}),
+      ...(options?.addedBindings?.length
+          ? {addedBindings: options.addedBindings} : {}),
+      ...(options?.mainlineMerge !== undefined
+          ? {mainlineMerge: options.mainlineMerge} : {}),
+    }]);
 
     this.#retireChatChanges(rows);
     this.#pruneRetiredChatChanges(chatId);
@@ -3320,14 +3338,22 @@ class OverseerImpl implements AgentHooks {
     // Content validation, against exactly what the change will apply to.
     validateCodeChangeContent(transformed, validationContent);
 
-    // Attribution: if the newest live rows belong to a different author who has gone idle,
-    // materialize their batch into its own message first, so one message never blends two
-    // authors' sessions. (Two authors typing *concurrently* still share a batch, attributed to
-    // "Multiple Authors".)
+    // Materialize the pending window first when this row must not join it:
+    //  - Attribution: the newest live rows belong to a different author who has gone idle, and
+    //    one message must never blend two authors' sessions. (Two authors typing *concurrently*
+    //    still share a batch, attributed to "Multiple Authors".)
+    //  - Byte budget: this row would push the window's summed change size past what one
+    //    "changes" message may compose (materialization writes exactly one message, so the
+    //    bound is enforced here, where rows accumulate). A row bigger than the whole budget
+    //    thus always lands in an empty window and later travels alone in one oversized message.
     let liveRows = this.listLiveChatChanges(chatId, codeBase.generation);
     let latest = liveRows[liveRows.length - 1];
-    if (latest !== undefined && !this.sameChatAuthor(latest.author, author) &&
-        Date.now() - latest.timestamp.getTime() > CHAT_CHANGE_AUTHOR_SPLIT_MS) {
+    let authorSplit = latest !== undefined && !this.sameChatAuthor(latest.author, author) &&
+        Date.now() - latest.timestamp.getTime() > CHAT_CHANGE_AUTHOR_SPLIT_MS;
+    let byteSplit = liveRows.length > 0 &&
+        this.#liveChangeBytes(chatId, codeBase, liveRows) + codeChangeSerializedSize(transformed) >
+            CHAT_CHANGE_MESSAGE_BUDGET;
+    if (authorSplit || byteSplit) {
       this.materializeChatChanges(chatId, meta);
       meta = this.getChatMetaOrThrow(chatId);
       codeBase = this.chatCodeBase(meta);

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -27,7 +27,7 @@ import {
   getAiGatewayLogCost,
   type AiGatewayLogRoute,
 } from "./ai-gateway";
-import { AgentGadgetInfo, AgentHooks, AiChatAgentContext, CHAT_CHANGE_MESSAGE_BUDGET, ChatBindingEntry, SeedBindingInfo, runAgent, makeStorableArgs, summarizeArgs, type AiChatMessageBodyWithModelData, type CompactionCheckpoint, type StoredAssistantMessage } from "./agent";
+import { AgentGadgetInfo, AgentHooks, AiChatAgentContext, CHAT_CHANGE_MESSAGE_BUDGET, ChatBindingEntry, SeedBindingInfo, runAgent, makeStorableArgs, summarizeArgs, type AgentStepChange, type AiChatMessageBodyWithModelData, type CompactionCheckpoint, type StoredAssistantMessage } from "./agent";
 import { deploymentOutputForBlueprint, FormatOffer, listFormatOffers, readAdminConfig } from "./admin-config";
 import { chatChangeStatuses, foldProposedChanges, isCompactionTurn,
   type ChangeBatch } from "./agent-compaction";
@@ -2894,17 +2894,18 @@ class OverseerImpl implements AgentHooks {
   // durable log history). The rows are then retired -- kept briefly as a transform window, not
   // deleted -- so late submissions based inside the materialized range still rebase cleanly.
   //
-  // One message, always: the composition is kept storable by bounding what accumulates (each
-  // row producer materializes the pending window before a row would push its summed size past
-  // CHAT_CHANGE_MESSAGE_BUDGET, declared in agent.ts), never by splitting the output --
+  // One message, always: the composition is kept storable by bounding what accumulates
+  // (submitCodeChange materializes the pending window before a row would push its summed size
+  // past CHAT_CHANGE_MESSAGE_BUDGET; the agent's step buffer is bounded by STEP_CHANGE_BUDGET
+  // at the write call -- both declared in agent.ts), never by splitting the output --
   // splitting would scatter one batch's extras and edits across messages a suffix revert could
   // divide, and would break the agent's message-counting change-ID numbering.
   //
-  // `options.extras` lets the agent's turn flush attach its buffered creations/binding
-  // additions, and updateChatFromMainline attaches its `mainlineMerge` record; a message is
-  // written when there is anything at all to record (rows, undeclared pins, or extras).
-  // `options.author` overrides the row-derived author (required when there are no rows).
-  // The returned `sequence` is the first written message's.
+  // `options.extras` lets the agent's step barrier attach its creations/binding additions, and
+  // updateChatFromMainline attaches its `mainlineMerge` record; a message is written when
+  // there is anything at all to record (rows, undeclared pins, or extras). `options.author`
+  // overrides the row-derived author (required when there are no rows). The returned
+  // `sequence` is the first written message's.
   materializeChatChanges(chatId: number, meta?: AiChatMetadata, options?: {
     author?: AiChatAuthorInfo,
     allowDuringTurn?: boolean,
@@ -2919,7 +2920,8 @@ class OverseerImpl implements AgentHooks {
       }
     }
 
-    // Defensive: only the agent's own turn flush may materialize while a turn runs.
+    // Defensive: while a turn runs, only the agent-run machinery itself may materialize (the
+    // step barrier, turn-start sweep, and the transitional pre-compaction flush).
     if (meta.activeAgent && !options?.allowDuringTurn) {
       throw new Error(AGENT_RUNNING_ERROR_MESSAGE);
     }
@@ -2970,8 +2972,10 @@ class OverseerImpl implements AgentHooks {
     return {sequence, meta: this.getChatMetaOrThrow(chatId)};
   }
 
-  // AgentHooks implementation: the agent's turn flush. Returns whether a message was written
-  // (the agent's change-ID numbering counts messages).
+  // AgentHooks implementation, transitional (see the interface doc): materialize rows a crashed
+  // pre-barrier turn left live, before compaction removes the log tail they were re-adopted
+  // from. Returns whether a message was written (the agent's change-ID numbering counts
+  // messages).
   flushAgentChanges(chatId: number, author: AiChatAuthorInfo, extras: {
     createdGadgets?: {gadgetId: WorkpieceId, title: string, bindingName: string}[],
     addedBindings?: {gadgetId: WorkpieceId, name: string, target: WorkpieceId}[],
@@ -2997,59 +3001,108 @@ class OverseerImpl implements AgentHooks {
         .map(row => ({change: row.change, generation: row.generation, revision: row.revision}));
   }
 
-  // AgentHooks implementation: append one agent tool edit to the chat's change stream, durable
-  // and broadcast immediately (superseding the provisional editPreview* stream of the call's
-  // in-progress content; see AiChatSubscriber.changeApplied).
-  // `pin`, on the first write to an unpinned gadget, is validated against the gadget's *current*
-  // head and mirrored into the chat's code base in the same synchronous step that records the
-  // row -- head movement after the append merely leaves the chat stale for the accept gate to
-  // catch, never retroactively fails the turn.
-  async appendAgentCodeChange(chatId: number, author: AiChatAuthorInfo, change: CodeChange,
-                              pin?: {gadgetId: WorkpieceId, baseCommit: string})
-      : Promise<{generation: number, revision: number}> {
-    let meta = this.getChatMetaOrThrow(chatId);
-    validateCodeChangeSchema(change);
+  // AgentHooks implementation: the agent step's persistence barrier (see the interface doc for
+  // the contract). One storage transaction persists the step's messages (tool-call record
+  // first), appends each buffered change as a row -- broadcast immediately, superseding the
+  // calls' provisional editPreview* streams (see AiChatSubscriber.changeApplied) -- and
+  // materializes them into the step's single "changes" message (tool message first, so a
+  // suffix revert can never erase a call while keeping its edits). Each change's `pin` is
+  // validated against the gadget's *current* head and mirrored into the chat's code base with
+  // its row -- head movement after the barrier merely leaves the chat stale for the accept
+  // gate to catch, never retroactively fails the turn.
+  //
+  // The transaction protects server-side storage only: broadcasts fire on write and ignore
+  // rollback (deliberate -- rerouting the subscription path through commit is out of scope),
+  // so a mid-barrier exception, itself a bug, can leak broadcasts for rolled-back rows. The
+  // in-memory content/byte caches *are* restored on rollback (dropped, to rebuild from
+  // storage), or they would serve content the rows no longer back.
+  async commitAgentStep(chatId: number, author: AiChatAuthorInfo,
+      msgs: AiChatMessageBodyWithModelData[],
+      step: {
+        changes: AgentStepChange[],
+        createdGadgets: {gadgetId: WorkpieceId, title: string, bindingName: string}[],
+        addedBindings: {gadgetId: WorkpieceId, name: string, target: WorkpieceId}[],
+      },
+      totalTokens?: number, aiGatewayLogId?: string, aiGatewayLogRoute?: AiGatewayLogRoute,
+      estimatedCost?: number): Promise<boolean> {
+    let meta = this.storage.chatMeta.get(chatId);
+    if (!meta) return false;  // chat deleted mid-turn
 
-    // Prefetch (awaits) before the synchronous tail.
-    let content = await this.getCurrentChatContent(chatId, meta);
-    let baseFiles = pin !== undefined
-        ? await this.gitStore.readCommitFiles(pin.baseCommit) : undefined;
-
-    // ---- synchronous tail ----
-    let fresh = this.getChatMetaOrThrow(chatId);
-    let codeBase = this.chatCodeBase(fresh);
-    let cached = this.#chatContentCache.get(chatId);
-    if (cached === undefined || cached.generation !== codeBase.generation ||
-        cached.revision !== codeBase.revision) {
-      // Nothing should move the stream mid-turn (submissions are rejected and the sibling
-      // operations assert no active turn), so a stale cache indicates a bug.
-      throw new Error("Chat content changed during an agent edit.");
+    for (let {change} of step.changes) {
+      validateCodeChangeSchema(change);
     }
-    content = cached.content;
 
-    let newPins: ChatGadgetPinState[] = [];
-    if (pin !== undefined) {
-      let existing = codeBase.pins.find(p => p.gadgetId === pin.gadgetId);
-      if (existing !== undefined) {
-        if (existing.baseCommit !== pin.baseCommit) {
-          throw new Error("Gadget was concurrently pinned at a different commit.");
+    // Prefetch (awaits) before the synchronous transaction: current content (warming the cache
+    // the tail below requires to be current) and each new pin's base tree.
+    let baseFilesByCommit = new Map<string, Map<string, string>>();
+    if (step.changes.length > 0) {
+      await this.getCurrentChatContent(chatId, meta);
+      for (let {pin} of step.changes) {
+        if (pin !== undefined && !baseFilesByCommit.has(pin.baseCommit)) {
+          baseFilesByCommit.set(pin.baseCommit,
+                                await this.gitStore.readCommitFiles(pin.baseCommit));
         }
-      } else {
-        if (this.storage.gadgets.get(pin.gadgetId)?.commitId !== pin.baseCommit) {
-          throw new Error("Pinned commit is no longer the gadget's head; mainline moved while " +
-              "the changes were being made.");
-        }
-        newPins.push({gadgetId: pin.gadgetId, baseCommit: pin.baseCommit,
-                      mergedCommit: pin.baseCommit});
-        content = new Map(content);
-        content.set(pin.gadgetId, baseFiles!);
       }
     }
 
-    validateCodeChangeContent(change, content);
-    let row = this.#appendChatChangeRow(chatId, fresh, author, change, "agent", newPins,
-                                        applyCodeChange(content, change));
-    return {generation: row.generation, revision: row.revision};
+    try {
+      return this.storage.transaction(() => {
+        let fresh = this.storage.chatMeta.get(chatId);
+        if (!fresh) return false;  // chat deleted during the prefetches
+
+        if (step.changes.length > 0) {
+          let codeBase = this.chatCodeBase(fresh);
+          let cached = this.#chatContentCache.get(chatId);
+          if (cached === undefined || cached.generation !== codeBase.generation ||
+              cached.revision !== codeBase.revision) {
+            // Nothing should move the stream mid-turn (submissions are rejected and the
+            // sibling operations assert no active turn), so a stale cache indicates a bug.
+            throw new Error("Chat content changed during an agent step.");
+          }
+          let content = cached.content;
+
+          for (let {change, pin} of step.changes) {
+            let newPins: ChatGadgetPinState[] = [];
+            if (pin !== undefined) {
+              let pins = this.chatCodeBase(fresh).pins;
+              let existing = pins.find(p => p.gadgetId === pin.gadgetId);
+              if (existing !== undefined) {
+                if (existing.baseCommit !== pin.baseCommit) {
+                  throw new Error("Gadget was concurrently pinned at a different commit.");
+                }
+              } else {
+                if (this.storage.gadgets.get(pin.gadgetId)?.commitId !== pin.baseCommit) {
+                  throw new Error("Pinned commit is no longer the gadget's head; mainline " +
+                      "moved while the changes were being made.");
+                }
+                newPins.push({gadgetId: pin.gadgetId, baseCommit: pin.baseCommit,
+                              mergedCommit: pin.baseCommit});
+                content = new Map(content);
+                content.set(pin.gadgetId, baseFilesByCommit.get(pin.baseCommit)!);
+              }
+            }
+            validateCodeChangeContent(change, content);
+            content = applyCodeChange(content, change);
+            this.#appendChatChangeRow(chatId, fresh, author, change, "agent", newPins, content);
+          }
+        }
+
+        this.addChatMessages(chatId, author, msgs, totalTokens, aiGatewayLogId,
+                             aiGatewayLogRoute, estimatedCost);
+        return this.materializeChatChanges(chatId, undefined, {
+          author,
+          allowDuringTurn: true,
+          createdGadgets: step.createdGadgets,
+          addedBindings: step.addedBindings,
+        }) !== undefined;
+      });
+    } catch (err) {
+      // The transaction rolled the rows back, but the append path already advanced the
+      // in-memory caches to reflect them; drop both so later reads rebuild from storage.
+      this.#chatContentCache.delete(chatId);
+      this.#liveChangeBytesCache.delete(chatId);
+      throw err;
+    }
   }
 
   // The (user, clientId, seq) dedupe step of submitCodeChange: returns the recorded landing spot
@@ -7128,7 +7181,7 @@ class OverseerImpl implements AgentHooks {
       if (msg.type === "changes") {
         // (A message's `pins` need no validation or mirroring here: pins are validated and
         // mirrored into the chat's code base when the establishing row is *appended* -- see
-        // submitCodeChange / appendAgentCodeChange -- and the message merely makes the
+        // submitCodeChange / commitAgentStep -- and the message merely makes the
         // establishment durable log history.)
         meta.hasProposedChanges = true;
         this.proposedChangesChanged(chatId);

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -2466,29 +2466,50 @@ class OverseerImpl implements AgentHooks {
     this.#chatContentCache.delete(chatId);
   }
 
-  // Cache of the live (unretired) window's summed serialized-size estimate, keyed by the
-  // (generation, revision) it reflects. The byte trigger in submitCodeChange consults it per
-  // keystroke, and recomputing means re-reading every live row from storage -- O(window) per
-  // keystroke, quadratic over an editing session. Row appends update it incrementally (see
+  // Cache summarizing the live (unretired) window -- its summed serialized-size estimate and its
+  // row count -- keyed by the (generation, revision) it reflects. submitCodeChange consults both
+  // per keystroke (the byte trigger before appending, the row-count trigger after), and
+  // recomputing either means re-reading every live row from storage -- O(window) per keystroke,
+  // quadratic over an editing session. Row appends update the entry incrementally (see
   // #appendChatChangeRow) and retirement drops it (see #retireChatChanges); anything else that
   // changes the window (revert, epoch reset, draft discard) bumps the generation or revision,
-  // which invalidates the entry. A miss (also after a DO restart) recomputes from the rows the
-  // caller listed anyway.
-  #liveChangeBytesCache = new Map<number, {generation: number, revision: number,
-                                           bytes: number}>();
+  // which invalidates the entry. A miss (also after a DO restart) recomputes with one full
+  // listing (see #liveWindowSummary).
+  #liveWindowCache = new Map<number, {generation: number, revision: number, bytes: number,
+                                      count: number}>();
 
-  // The summed codeChangeSerializedSize of the given live rows (the caller already listed them),
-  // served from #liveChangeBytesCache when it is current for (generation, revision).
-  #liveChangeBytes(chatId: number, codeBase: ChatCodeBase, liveRows: ChatChangeRecord[]): number {
-    let cached = this.#liveChangeBytesCache.get(chatId);
+  // The live window's summary at the given (generation, revision) -- the caller's current code
+  // base position -- served from #liveWindowCache when it is current for that position and
+  // recomputed from one listing of the live rows otherwise.
+  #liveWindowSummary(chatId: number, codeBase: {generation: number, revision: number})
+      : {bytes: number, count: number} {
+    let cached = this.#liveWindowCache.get(chatId);
     if (cached !== undefined && cached.generation === codeBase.generation &&
         cached.revision === codeBase.revision) {
-      return cached.bytes;
+      return cached;
     }
-    let bytes = liveRows.reduce((sum, row) => sum + codeChangeSerializedSize(row.change), 0);
-    this.#liveChangeBytesCache.set(chatId,
-        {generation: codeBase.generation, revision: codeBase.revision, bytes});
-    return bytes;
+    let liveRows = this.listLiveChatChanges(chatId, codeBase.generation);
+    let entry = {
+      generation: codeBase.generation, revision: codeBase.revision,
+      bytes: liveRows.reduce((sum, row) => sum + codeChangeSerializedSize(row.change), 0),
+      count: liveRows.length,
+    };
+    this.#liveWindowCache.set(chatId, entry);
+    return entry;
+  }
+
+  // The live window's newest row, or undefined if the window is empty. One indexed read: the
+  // generation's rows sort by revision, and retirement always covers the generation's entire
+  // window at once (see #retireChatChanges), so the live rows are a contiguous suffix -- a
+  // retired (or absent) newest row means the window is empty. Read from storage rather than
+  // cached so out-of-band row updates can't serve stale attribution data.
+  #newestLiveChatChange(chatId: number, generation: number): ChatChangeRecord | undefined {
+    for (let row of this.storage.chatChanges.list({
+      prefix: `${keyString(chatId)}.${keyString(generation)}.`, reverse: true, limit: 1,
+    })) {
+      return row.retired ? undefined : row;
+    }
+    return undefined;
   }
 
   // The chat's current content: what the next change row will apply to. Cached; treat the result as
@@ -2603,15 +2624,18 @@ class OverseerImpl implements AgentHooks {
       this.#chatContentCache.delete(chatId);
     }
 
-    // Advance the byte cache incrementally when it was current for the window this row joins;
-    // otherwise drop it and let the next read recompute.
-    let cachedBytes = this.#liveChangeBytesCache.get(chatId);
-    if (cachedBytes !== undefined && cachedBytes.generation === codeBase.generation &&
-        cachedBytes.revision === revision - 1) {
-      this.#liveChangeBytesCache.set(chatId, {generation: codeBase.generation, revision,
-                                              bytes: cachedBytes.bytes + codeChangeSerializedSize(change)});
+    // Advance the window summary incrementally when it was current for the window this row
+    // joins; otherwise drop it and let the next read recompute.
+    let cachedWindow = this.#liveWindowCache.get(chatId);
+    if (cachedWindow !== undefined && cachedWindow.generation === codeBase.generation &&
+        cachedWindow.revision === revision - 1) {
+      this.#liveWindowCache.set(chatId, {
+        generation: codeBase.generation, revision,
+        bytes: cachedWindow.bytes + codeChangeSerializedSize(change),
+        count: cachedWindow.count + 1,
+      });
     } else {
-      this.#liveChangeBytesCache.delete(chatId);
+      this.#liveWindowCache.delete(chatId);
     }
 
     meta.lastActive = row.timestamp;
@@ -2630,10 +2654,10 @@ class OverseerImpl implements AgentHooks {
       this.storage.chatChanges.put(row);
     }
     // Retirement always covers the generation's entire live window (materialization and epoch
-    // close both list-then-retire), so the byte cache no longer describes it; drop the entry
+    // close both list-then-retire), so the window summary no longer describes it; drop the entry
     // and let the next read recompute -- over a window that is empty at that point.
     if (rows.length > 0) {
-      this.#liveChangeBytesCache.delete(rows[0].chatId);
+      this.#liveWindowCache.delete(rows[0].chatId);
     }
   }
 
@@ -2658,7 +2682,7 @@ class OverseerImpl implements AgentHooks {
     }
     this.storage.chatChangeBoundaries.delete(chatId);
     this.#chatContentCache.delete(chatId);
-    this.#liveChangeBytesCache.delete(chatId);
+    this.#liveWindowCache.delete(chatId);
   }
 
   // Gadgets whose pin establishment is recorded by a surviving (non-reverted) "changes" message
@@ -3007,7 +3031,7 @@ class OverseerImpl implements AgentHooks {
       // The transaction rolled the rows back, but the append path already advanced the
       // in-memory caches to reflect them; drop both so later reads rebuild from storage.
       this.#chatContentCache.delete(chatId);
-      this.#liveChangeBytesCache.delete(chatId);
+      this.#liveWindowCache.delete(chatId);
       throw err;
     }
   }
@@ -3166,8 +3190,9 @@ class OverseerImpl implements AgentHooks {
       // different author who has gone idle, their batch was already materialized just before
       // the append (see below); here, cap the live window's size so a long editing session
       // can't grow subscribe-replay without bound. Thanks to the retired-row grace window this
-      // stales nobody.
-      if (this.listLiveChatChanges(chatId, result.generation).length >=
+      // stales nobody. (The append just advanced the window summary to `result`, so this is an
+      // O(1) cache read, not a window scan.)
+      if (this.#liveWindowSummary(chatId, result).count >=
           CHAT_CHANGE_MATERIALIZE_THRESHOLD) {
         this.materializeChatChanges(chatId);
       }
@@ -3306,13 +3331,12 @@ class OverseerImpl implements AgentHooks {
     //    "changes" message may compose (materialization writes exactly one message, so the
     //    bound is enforced here, where rows accumulate). A row bigger than the whole budget
     //    thus always lands in an empty window and later travels alone in one oversized message.
-    let liveRows = this.listLiveChatChanges(chatId, codeBase.generation);
-    let latest = liveRows[liveRows.length - 1];
+    let latest = this.#newestLiveChatChange(chatId, codeBase.generation);
     let authorSplit = latest !== undefined && !this.sameChatAuthor(latest.author, author) &&
         Date.now() - latest.timestamp.getTime() > CHAT_CHANGE_AUTHOR_SPLIT_MS;
-    let byteSplit = liveRows.length > 0 &&
-        this.#liveChangeBytes(chatId, codeBase, liveRows) + codeChangeSerializedSize(transformed) >
-            CHAT_CHANGE_MESSAGE_BUDGET;
+    let window = this.#liveWindowSummary(chatId, codeBase);
+    let byteSplit = window.count > 0 &&
+        window.bytes + codeChangeSerializedSize(transformed) > CHAT_CHANGE_MESSAGE_BUDGET;
     if (authorSplit || byteSplit) {
       this.materializeChatChanges(chatId, meta);
       meta = this.getChatMetaOrThrow(chatId);

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -363,14 +363,13 @@ type GadgetRecord = {
   // Present while the gadget is provisional: it was created within the given chat and follows
   // that chat's accept/reject lifecycle exactly like code changes (see mergeChanges() /
   // revertChanges()). `sequence` is the chat-log sequence of the "changes" message whose
-  // `createdGadgets` records the creation; it is stamped in the same synchronous step that
-  // persists the message, so the log and the registry can never disagree. An unstamped record
-  // means the creation's "changes" message hasn't flushed yet: normally the creating turn is
-  // still running, but after a crash the record may linger -- backed by a persisted createGadget
-  // tool call, from which the resumed turn recovers it, or by nothing, in which case it is
-  // reaped (both cases: see reconcilePendingGadgets()). The chat log is the source of truth;
-  // this record materializes it so the gadget is fully functional (bindings, facet, env) before
-  // acceptance.
+  // `createdGadgets` records the creation; it is stamped in the same transaction that persists
+  // the message (the step's barrier), so the log and the registry can never disagree. An
+  // unstamped record means the creating step hasn't reached its barrier yet: normally that step
+  // is still running, but after a mid-step crash the record may linger -- backed by nothing,
+  // since the step's message is by construction lost -- and is reaped (see
+  // reconcilePendingGadgets()). The chat log is the source of truth; this record materializes
+  // it so the gadget is fully functional (bindings, facet, env) before acceptance.
   pending?: {chatId: number, sequence?: number};
 };
 
@@ -646,9 +645,6 @@ export type ChatChangeRecord = {
 
   /** The submission echo for user rows (see AiChatSubscriber.changeApplied); absent otherwise. */
   submission?: {clientId: string, seq: number};
-
-  /** What produced the row. Turn abort keys on "agent"; nothing else dispatches on this yet. */
-  source: "user" | "agent" | "mainlineMerge";
 
   /**
    * Set when the row is no longer live: a "changes" message has materialized it (its change is part
@@ -2088,41 +2084,24 @@ class OverseerImpl implements AgentHooks {
   }
 
   // Reap crash-orphaned provisional gadgets and binding edges for the given chat. A pending
-  // record/edge with no stamped sequence means it hasn't yet been recorded by a flushed
-  // "changes" message; whether it ever will be is decided by the chat log, the source of truth:
-  //   - If a persisted createGadget (resp. setGadgetBinding) tool call references it, it is
-  //     a crashed turn's tail, exactly like an edit whose "changes" message never flushed: the
-  //     resumed turn re-adopts it during history replay (see replayedCreations /
-  //     replayedBindingAdditions in agent.ts) and stamps it with its next flush. Spare it.
-  //   - Otherwise nothing backs it (the worker died before the step persisted), so it must go;
-  //     the resumed turn then simply re-creates it (for a gadget, wasting only an ID, which is
+  // record/edge is sequence-stamped in the same transaction that persists the "changes" message
+  // recording it (the step's barrier; see addChatMessages), so with no turn running:
+  //   - An *unstamped* record/edge is a mid-step crash orphan: its step's message is by
+  //     construction lost, so nothing in the log backs it. Reap it; the resumed turn simply
+  //     re-creates it if the model still wants it (for a gadget, wasting only an ID, which is
   //     fine -- workpiece IDs are never reused anyway).
-  // For edges, "references it" must be counted, not merely tested: (gadgetId, name) can recur
-  // when an earlier addition was removed or reverted and the name added again, so an old,
-  // already-recorded tool call must not vouch for a new unstamped edge that replay will never
-  // re-adopt. An unstamped edge is a re-adoptable tail iff persisted tool calls for its key
-  // outnumber agent-flushed `addedBindings` recordings -- exactly the condition under which the
-  // resumed turn's replay re-adopts (and thereby flushes and stamps) it.
-  // A *stamped* record is reaped when the log marks its creation reverted: reverts record their
-  // message before the awaited record deletions (see #revertChanges), so this is both the tail
-  // of every revert and the recovery from one that crashed partway.
+  //   - A *stamped* record is reaped when the log marks its creation reverted: reverts record
+  //     their message before the awaited record deletions (see #revertChanges), so this is both
+  //     the tail of every revert and the recovery from one that crashed partway.
   // Called at agent turn start (before history replay) and turn end, plus from merge and revert
-  // (which assert the chat has no active turn). The log scans run only when a pending record
-  // actually exists, so the common case costs one registry listing.
+  // (which assert the chat has no active turn) -- never mid-step, when an unstamped record
+  // awaiting its barrier legitimately exists.
   // Best-effort per gadget: a failure (e.g. a hook controller that can't be reached) leaves the
   // record for the next reconciliation attempt.
   async reconcilePendingGadgets(chatId: number): Promise<void> {
     let pending = this.listPendingGadgets(chatId);
     let unstamped = pending.filter(gadget => gadget.pending!.sequence === undefined);
     let stamped = pending.filter(gadget => gadget.pending!.sequence !== undefined);
-    let unstampedEdges: {gadget: GadgetRecord, name: string}[] = [];
-    for (let gadget of this.storage.gadgets.list()) {
-      for (let [name, edge] of Object.entries(gadget.bindings)) {
-        if (edge.pending?.chatId === chatId && edge.pending.sequence === undefined) {
-          unstampedEdges.push({gadget, name});
-        }
-      }
-    }
 
     // A marking message only affects messages recorded before it, so statuses for the stamped
     // creations need only the log tail from the earliest one on.
@@ -2134,60 +2113,26 @@ class OverseerImpl implements AgentHooks {
       }));
       reverted = stamped.filter(g => statuses.get(g.pending!.sequence!) === "reverted");
     }
-    for (let gadget of reverted) {
+    for (let gadget of [...reverted, ...unstamped]) {
       try {
         await this.removeGadget(gadget.id);
       } catch (err) {
-        this.logger.warn("failed to reap reverted pending gadget", {
+        this.logger.warn("failed to reap pending gadget", {
           event: "gadget.pending.reconcile.failed", chatId, error: err,
         });
       }
     }
 
-    if (unstamped.length === 0 && unstampedEdges.length === 0) return;
-
-    let referenced = new Set<WorkpieceId>();
-    // Per (gadgetId, name): persisted setGadgetBinding tool calls minus agent-flushed
-    // `addedBindings` recordings (user-authored "changes" messages record UI-initiated binds,
-    // which have no tool call and are stamped synchronously, so they don't participate).
-    let additionBalance = new Map<string, number>();
-    let bump = (key: string, delta: number) =>
-        additionBalance.set(key, (additionBalance.get(key) ?? 0) + delta);
-    for (let msg of this.storage.chats.list({prefix: `${keyString(chatId)}.`})) {
-      if (msg.type === "message") {
-        for (let call of msg.toolCalls ?? []) {
-          if (call.toolName === "createGadget" && call.output) {
-            referenced.add(call.output.gadgetId);
-          } else if (call.toolName === "setGadgetBinding" && call.output) {
-            bump(`${call.output.gadgetId}:${call.output.name}`, 1);
-          }
-        }
-      } else if (msg.type === "changes" && msg.author.type !== "user") {
-        for (let {gadgetId, name} of msg.addedBindings ?? []) {
-          bump(`${gadgetId}:${name}`, -1);
-        }
-      }
-    }
-
-    for (let gadget of unstamped) {
-      if (referenced.has(gadget.id)) continue;
-      try {
-        await this.removeGadget(gadget.id);
-      } catch (err) {
-        this.logger.warn("failed to reap orphaned pending gadget", {
-          event: "gadget.pending.reconcile.failed", chatId, error: err,
-        });
-      }
-    }
-
-    for (let {gadget, name} of unstampedEdges) {
-      if ((additionBalance.get(`${gadget.id}:${name}`) ?? 0) > 0) continue;
-      // Re-read: the gadget may have been reaped just above (taking its edges with it).
-      let fresh = this.storage.gadgets.get(gadget.id);
-      if (!fresh || !fresh.bindings[name]) continue;
-      delete fresh.bindings[name];
-      this.storage.gadgets.put(fresh);
-      this.bumpVersion([fresh.id]);
+    // (Listed after the reaps above, which may have removed a gadget along with its edges.)
+    for (let gadget of Array.from(this.storage.gadgets.list())) {
+      let orphanNames = Object.entries(gadget.bindings)
+          .filter(([, edge]) => edge.pending?.chatId === chatId &&
+                                edge.pending.sequence === undefined)
+          .map(([name]) => name);
+      if (orphanNames.length === 0) continue;
+      for (let name of orphanNames) delete gadget.bindings[name];
+      this.storage.gadgets.put(gadget);
+      this.bumpVersion([gadget.id]);
     }
   }
 
@@ -2484,7 +2429,7 @@ class OverseerImpl implements AgentHooks {
   //
   // Live (unmaterialized) change rows are deliberately NOT included: callers that need them either
   // materialize first (accept, update-from-mainline, UI bundle loads) or apply them on top
-  // themselves (getCurrentChatContent, agent replay).
+  // themselves (getCurrentChatContent).
   async buildChatContent(chatId: number, through?: number): Promise<CodeContent> {
     let messages = [...this.storage.chats.list({prefix: `${keyString(chatId)}.`})];
     if (through !== undefined) {
@@ -2631,7 +2576,7 @@ class OverseerImpl implements AgentHooks {
   // `newPins` are pins this row establishes (already validated), and `contentAfter` is the
   // chat content with the row applied (the caller computed it while validating).
   #appendChatChangeRow(chatId: number, meta: AiChatMetadata, author: AiChatAuthorInfo,
-                       change: CodeChange, source: ChatChangeRecord["source"],
+                       change: CodeChange,
                        newPins: ChatGadgetPinState[], contentAfter: CodeContent | undefined,
                        submission?: {clientId: string, seq: number}): ChatChangeRecord {
     let codeBase = this.chatCodeBase(meta);
@@ -2648,7 +2593,6 @@ class OverseerImpl implements AgentHooks {
       author,
       change,
       ...(submission !== undefined ? {submission} : {}),
-      source,
     };
     this.storage.chatChanges.put(row);
 
@@ -2739,21 +2683,13 @@ class OverseerImpl implements AgentHooks {
   // Pins in the chat's live state (see ChatGadgetPinState) whose establishment no surviving
   // current-epoch "changes" message records yet, stripped back to what the log stores. A pin
   // lands in `codeBase` atomically with the row that needed it; its durable log declaration
-  // lands when the rows materialize. Also the AgentHooks implementation of the same name (a
-  // resumed turn re-adopts these so its next flush declares them).
+  // lands when the rows materialize.
   undeclaredMetaPins(chatId: number, meta: AiChatMetadata): ChatGadgetPin[] {
     let pins = meta.codeBase?.pins ?? [];
     if (pins.length === 0) return [];
     let declared = this.declaredPinGadgets(chatId);
     return pins.filter(pin => !declared.has(pin.gadgetId))
         .map(pin => ({gadgetId: pin.gadgetId, baseCommit: pin.baseCommit}));
-  }
-
-  // AgentHooks implementation: undeclaredMetaPins against the chat's current metadata.
-  undeclaredChatPins(chatId: number): ChatGadgetPin[] {
-    let meta = this.storage.chatMeta.get(chatId);
-    if (!meta) return [];
-    return this.undeclaredMetaPins(chatId, meta);
   }
 
   makeBindingLoopback(target: BindingLoopbackTarget, caller: GatekeeperCaller) {
@@ -2921,7 +2857,7 @@ class OverseerImpl implements AgentHooks {
     }
 
     // Defensive: while a turn runs, only the agent-run machinery itself may materialize (the
-    // step barrier, turn-start sweep, and the transitional pre-compaction flush).
+    // step barrier and the turn-start sweep).
     if (meta.activeAgent && !options?.allowDuringTurn) {
       throw new Error(AGENT_RUNNING_ERROR_MESSAGE);
     }
@@ -2970,35 +2906,6 @@ class OverseerImpl implements AgentHooks {
     this.#retireChatChanges(rows);
     this.#pruneRetiredChatChanges(chatId);
     return {sequence, meta: this.getChatMetaOrThrow(chatId)};
-  }
-
-  // AgentHooks implementation, transitional (see the interface doc): materialize rows a crashed
-  // pre-barrier turn left live, before compaction removes the log tail they were re-adopted
-  // from. Returns whether a message was written (the agent's change-ID numbering counts
-  // messages).
-  flushAgentChanges(chatId: number, author: AiChatAuthorInfo, extras: {
-    createdGadgets?: {gadgetId: WorkpieceId, title: string, bindingName: string}[],
-    addedBindings?: {gadgetId: WorkpieceId, name: string, target: WorkpieceId}[],
-  }): boolean {
-    let meta = this.storage.chatMeta.get(chatId);
-    if (!meta) return false;  // chat deleted mid-turn
-    return this.materializeChatChanges(chatId, meta, {
-      author,
-      allowDuringTurn: true,
-      createdGadgets: extras.createdGadgets,
-      addedBindings: extras.addedBindings,
-    }) !== undefined;
-  }
-
-  // AgentHooks implementation: the chat's live (unmaterialized) rows, oldest first. Replay
-  // applies these on top of the messages' changes -- a crashed turn's edits are durable rows even
-  // though no "changes" message covers them yet.
-  listUnmaterializedChatChanges(chatId: number): {change: CodeChange, generation: number,
-                                                  revision: number}[] {
-    let meta = this.storage.chatMeta.get(chatId);
-    if (!meta) return [];
-    return this.listLiveChatChanges(chatId, this.chatCodeBase(meta).generation)
-        .map(row => ({change: row.change, generation: row.generation, revision: row.revision}));
   }
 
   // AgentHooks implementation: the agent step's persistence barrier (see the interface doc for
@@ -3083,7 +2990,7 @@ class OverseerImpl implements AgentHooks {
             }
             validateCodeChangeContent(change, content);
             content = applyCodeChange(content, change);
-            this.#appendChatChangeRow(chatId, fresh, author, change, "agent", newPins, content);
+            this.#appendChatChangeRow(chatId, fresh, author, change, newPins, content);
           }
         }
 
@@ -3413,7 +3320,7 @@ class OverseerImpl implements AgentHooks {
     }
 
     let row = this.#appendChatChangeRow(
-        chatId, meta, author, transformed, "user", newPins,
+        chatId, meta, author, transformed, newPins,
         applyCodeChange(validationContent, transformed),
         {clientId: submission.clientId, seq: submission.seq});
     return {generation: row.generation, revision: row.revision};
@@ -3547,7 +3454,7 @@ class OverseerImpl implements AgentHooks {
     // the revert guard (revertChanges) depends on. Without it, reverting the chat's earlier
     // proposals could silently regress content the advanced pins claim as merged.
     if (changedGadgets(change).length > 0) {
-      this.#appendChatChangeRow(chatId, freshMeta, author, change, "mainlineMerge", [], merged);
+      this.#appendChatChangeRow(chatId, freshMeta, author, change, [], merged);
     }
     this.materializeChatChanges(chatId, undefined, {author, mainlineMerge: {conflictPaths}});
 
@@ -3568,9 +3475,9 @@ class OverseerImpl implements AgentHooks {
     let result = this.materializeChatChanges(chatId, meta);
     if (result) meta = result.meta;
 
-    // Reap crash-orphaned provisional records first: an unstamped record that survives
-    // reconciliation -- a crashed turn's not-yet-resumed tail -- has no sequence and is simply
-    // not covered by this merge.
+    // Reap crash-orphaned provisional records first. (Reconciliation is best-effort, so an
+    // unstamped record can still survive a failed reap; it has no sequence and is simply not
+    // covered by this merge.)
     await this.reconcilePendingGadgets(chatId);
 
     // Everything read from here through the commit writes must still describe the chat when the
@@ -3842,10 +3749,10 @@ class OverseerImpl implements AgentHooks {
       : Promise<void> {
     this.assertChatNotActive(chatId);
 
-    // Reap crash orphans first: an unstamped record that survives reconciliation -- a crashed
-    // turn's not-yet-resumed tail -- has no sequence and is not covered by this revert. This is
-    // the only await before the revert lands; reconciliation is an idempotent repair, safe to
-    // run whether or not the revert below proceeds.
+    // Reap crash orphans first. (Reconciliation is best-effort, so an unstamped record can
+    // still survive a failed reap; it has no sequence and is not covered by this revert.) This
+    // is the only await before the revert lands; reconciliation is an idempotent repair, safe
+    // to run whether or not the revert below proceeds.
     await this.reconcilePendingGadgets(chatId);
 
     // Everything from the meta re-read (which rechecks the agent after the await above) through
@@ -5801,10 +5708,10 @@ class OverseerImpl implements AgentHooks {
     });
 
     try {
-      // Reap any provisional gadgets orphaned by a crashed prior turn before snapshotting history:
-      // replay must not see registry records the chat log doesn't back (see
-      // reconcilePendingGadgets; records backed by a persisted createGadget tool call are spared
-      // for replay to re-adopt). The model then simply re-creates a reaped gadget if it still
+      // Reap any provisional gadgets orphaned by a crashed prior turn before snapshotting
+      // history: replay must not see registry records the chat log doesn't back (an unstamped
+      // record's creating step never reached its barrier, so the log holds no trace of it; see
+      // reconcilePendingGadgets). The model then simply re-creates a reaped gadget if it still
       // wants it.
       await this.reconcilePendingGadgets(chatId);
 
@@ -5975,11 +5882,10 @@ class OverseerImpl implements AgentHooks {
         this.ctx.waitUntil(refreshCachedBalance(this.env, byokOwnerStub));
       }
 
-      // Belt-and-suspenders: reap any provisional gadget this turn created whose creation ended
-      // up backed by nothing in the log. (Normally the turn's final flush -- which runs even on
-      // error, in runAgent's own finally -- records every buffered creation, so this only
-      // matters when that flush couldn't write, e.g. the chat was deleted mid-turn.) Never
-      // throws, so it can't mask an error propagating out of the turn.
+      // Reap any provisional gadget this turn created whose creating step never reached its
+      // barrier (the turn erred or was aborted mid-step): the record is unstamped and the
+      // step's message is by construction lost, so nothing in the log backs it. Never throws,
+      // so it can't mask an error propagating out of the turn.
       await this.reconcilePendingGadgets(chatId);
 
       // Note: We no longer emit a stream "clear" event here. The client performs a full clear of

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -2984,10 +2984,10 @@ export type AiToolCall = {
   };
 
   /**
-   * The added binding edge as resolved when the tool ran, recorded so crash recovery can re-adopt
-   * an addition whose "changes" message never flushed (see `addedBindings`), mirroring
-   * createGadget's recorded output. `changeId` is the change number of the batch that records the
-   * addition. Absent only when the call failed (`error` is set).
+   * The added binding edge as resolved when the tool ran -- the durable record of what the call
+   * did, which history replay reproduces instead of re-running the tool, mirroring createGadget's
+   * recorded output. `changeId` is the change number of the batch that records the addition (see
+   * `addedBindings`). Absent only when the call failed (`error` is set).
    */
   output?: {gadgetId: WorkpieceId, name: string, target: WorkpieceId, changeId: number};
 } | {

--- a/packages/workshop-shared/src/code-change.ts
+++ b/packages/workshop-shared/src/code-change.ts
@@ -150,6 +150,45 @@ export const MAX_CODE_CHANGE_SIZE = 2 * 1024 * 1024;
 const FILE_ENTRY_SIZE_OVERHEAD = 16;
 const EDIT_SECTION_SIZE_WEIGHT = 4;
 
+// Structure overhead granted per file entry and per edit section by codeChangeSerializedSize:
+// V8 writes a handful of header/varint bytes per object, array, and string, so a generous
+// fixed share per node keeps the estimate an upper bound without measuring anything.
+const SERIALIZED_ENTRY_OVERHEAD = 32;
+const SERIALIZED_SECTION_OVERHEAD = 16;
+
+/**
+ * Upper bound on the bytes a `CodeChange` contributes to a V8-serialized storage record --
+ * the form Durable Object storage actually holds change rows and "changes" messages in,
+ * subject to its 2MB value cap. V8 writes each string raw (Latin-1 at one byte per UTF-16
+ * code unit, or UTF-16 at two) plus small structure headers, so two bytes per code unit plus
+ * a fixed per-entry/per-section overhead never undercounts; the estimate reads only string
+ * lengths, costing O(entries), and is immune to the escape-sequence and multi-byte inflation
+ * a JSON-text measure would suffer. Callers use it to keep *compositions* of changes inside
+ * one storable record; `MAX_CODE_CHANGE_SIZE` separately bounds a single change with its own
+ * unit-weighted measure at validation time.
+ */
+export function codeChangeSerializedSize(change: CodeChange): number {
+  let bytes = 0;
+  for (let entries of Object.values(change)) {
+    for (let [path, fileChange] of entries) {
+      bytes += SERIALIZED_ENTRY_OVERHEAD + 2 * path.length;
+      if ("set" in fileChange) {
+        bytes += 2 * fileChange.set.length;
+      } else if ("edit" in fileChange) {
+        for (let section of fileChange.edit) {
+          bytes += SERIALIZED_SECTION_OVERHEAD;
+          if (typeof section !== "number") {
+            for (let part of section) {
+              if (typeof part === "string") bytes += 2 * part.length;
+            }
+          }
+        }
+      }
+    }
+  }
+  return bytes;
+}
+
 // =======================================================================================
 // Internal helpers
 

--- a/packages/workshop-shared/src/code-change.ts
+++ b/packages/workshop-shared/src/code-change.ts
@@ -31,7 +31,7 @@
 // Both stages take a `CodeChange`, and that parameter type is a precondition rather than a
 // hope: the declared shape is established before they run, by capnweb-validate's generated
 // validator at the RPC edge (Overseer.submitCodeChange) and by the compiler for the one
-// in-process producer (the agent's AgentHooks.appendAgentCodeChange, whose changes this module
+// in-process producer (the agent's AgentHooks.commitAgentStep, whose changes this module
 // itself builds). So neither stage re-checks that a value is an object, an array, a pair, or a
 // string; they check the invariants a TypeScript type cannot express -- canonical gadget keys,
 // path rules, size caps, integer section lengths, and the one variant rule the wire validator's

--- a/packages/workshop-shared/src/code-change.ts
+++ b/packages/workshop-shared/src/code-change.ts
@@ -150,26 +150,29 @@ export const MAX_CODE_CHANGE_SIZE = 2 * 1024 * 1024;
 const FILE_ENTRY_SIZE_OVERHEAD = 16;
 const EDIT_SECTION_SIZE_WEIGHT = 4;
 
-// Structure overhead granted per file entry and per edit section by codeChangeSerializedSize:
-// V8 writes a handful of header/varint bytes per object, array, and string, so a generous
-// fixed share per node keeps the estimate an upper bound without measuring anything.
+// Structure overhead granted per node by codeChangeSerializedSize: V8 writes a handful of
+// header/varint bytes per object, array, and string, so a generous fixed share per node keeps
+// the estimate an upper bound without measuring anything.
 const SERIALIZED_ENTRY_OVERHEAD = 32;
 const SERIALIZED_SECTION_OVERHEAD = 16;
+const SERIALIZED_LINE_OVERHEAD = 8;
 
 /**
  * Upper bound on the bytes a `CodeChange` contributes to a V8-serialized storage record --
  * the form Durable Object storage actually holds change rows and "changes" messages in,
  * subject to its 2MB value cap. V8 writes each string raw (Latin-1 at one byte per UTF-16
- * code unit, or UTF-16 at two) plus small structure headers, so two bytes per code unit plus
- * a fixed per-entry/per-section overhead never undercounts; the estimate reads only string
- * lengths, costing O(entries), and is immune to the escape-sequence and multi-byte inflation
- * a JSON-text measure would suffer. Callers use it to keep *compositions* of changes inside
+ * code unit, or UTF-16 at two) plus small structure headers, so two bytes per code unit of
+ * every string -- gadget keys, paths, `set` text, inserted lines -- plus a fixed share per
+ * structural node never undercounts; the estimate reads only string lengths, costing O(nodes)
+ * independent of text size, and is immune to the escape-sequence and multi-byte inflation a
+ * JSON-text measure would suffer. Callers use it to keep *compositions* of changes inside
  * one storable record; `MAX_CODE_CHANGE_SIZE` separately bounds a single change with its own
  * unit-weighted measure at validation time.
  */
 export function codeChangeSerializedSize(change: CodeChange): number {
-  let bytes = 0;
-  for (let entries of Object.values(change)) {
+  let bytes = SERIALIZED_ENTRY_OVERHEAD;  // the change object's own framing
+  for (let [gadgetKey, entries] of Object.entries(change)) {
+    bytes += SERIALIZED_ENTRY_OVERHEAD + 2 * gadgetKey.length;
     for (let [path, fileChange] of entries) {
       bytes += SERIALIZED_ENTRY_OVERHEAD + 2 * path.length;
       if ("set" in fileChange) {
@@ -179,7 +182,7 @@ export function codeChangeSerializedSize(change: CodeChange): number {
           bytes += SERIALIZED_SECTION_OVERHEAD;
           if (typeof section !== "number") {
             for (let part of section) {
-              if (typeof part === "string") bytes += 2 * part.length;
+              if (typeof part === "string") bytes += SERIALIZED_LINE_OVERHEAD + 2 * part.length;
             }
           }
         }

--- a/plans/step-transactionality.md
+++ b/plans/step-transactionality.md
@@ -60,12 +60,17 @@ first).
   broadcast supersedes previews at step end instead of per call. The stale "the row
   doubles as the streaming preview" comment (agent.ts:297) gets fixed —
   overseer.ts:2904-2906 already states the correct supersedes relationship.
-- **Mid-step gadget access with buffered edits throws.** executeCode reaching a
-  gadget whose code has buffered, not-yet-persisted edits gets a retryable,
-  agent-visible error ("changes land next step — retry") instead of running
-  provisional code. This replaces what the mid-tool flushes guaranteed, and closes
-  by construction the historical corruption where a mid-turn flush materialized a
-  `"changes"` message containing a not-yet-persisted step's changes.
+- **executeCode after any buffered edits throws.** Once the step buffer holds
+  any change, executeCode fails with a retryable, agent-visible error ("changes
+  land next step — retry") instead of running provisional code. Deliberately
+  coarse — no per-gadget touched-set, no machinery in the gadget-loading path:
+  editing code and then executing it in one step never worked (and agents don't
+  try it), and worktrees keep the same rule (their writes happen *inside*
+  executeCode, and a second executeCode in one step is never sensible — the
+  agent writes one script that does both things). This replaces what the
+  mid-tool flushes guaranteed, and closes by construction the historical
+  corruption where a mid-turn flush materialized a `"changes"` message
+  containing a not-yet-persisted step's changes.
 - **User submissions stay rejected during agent turns** (reject + client-side
   buffering and retry: overseer.ts:3013-3017, otClient.ts:125-136). Restoring
   durable server-side drafts mid-turn — which the pre-git-storage
@@ -127,9 +132,22 @@ first).
    tool. `appendAgentEdit` becomes: compute the change (same prefetches), push to
    the buffer, update session content. The created-gadget/binding recordings that
    already accumulate turn-side (`pendingCreatedGadgets` etc.) keep working as
-   they do — only the rows move to the barrier.
+   they do — only the rows move to the barrier. The buffer is a small turn-owned
+   object (created in `runAgent` beside the other per-step state, cleared at
+   each barrier), **passed explicitly** wherever it's needed — to the barrier
+   hook now, and into `executeCodeMode` when worktrees land so the worktree
+   binding loopbacks can read/write it by reference (agent↔overseer is a
+   same-isolate direct call; there is no marshalling boundary). No ambient
+   buffer state on the overseer's live chat context.
+   **Row granularity is one row per buffered tool change, in call order —
+   never a pre-composed row.** The client resolves streaming previews by
+   shifting the oldest pending preview per file as each `changeApplied` row
+   arrives (GadgetCodeInterface.tsx:296-305), so the barrier's burst must
+   preserve the per-call row↔preview correspondence.
 2. **Barrier extension.** The `turn_end` handler passes the buffer to the overseer
-   (a new hook, or an extended `addChatMessages`) which, inside one
+   via a **new dedicated hook, `commitAgentStep`** (not an extended
+   `addChatMessages`, which has six non-agent callers that would all be touched
+   by a widened signature) which, inside one
    `transactionSync()` (typed-storage's `TypedStorage.transaction`; established
    overseer precedent, e.g. overseer.ts:1602): persists the step's tool-call
    message, validates and appends each buffered change as a `chatChanges` row
@@ -182,23 +200,39 @@ first).
      large ops (128 rows is only a line or two of typing) — and add a **byte
      trigger** beside it: materialize the pending rows *before* appending a row
      that would push the pending composition estimate past **1MB** (staying
-     well clear of the 2MB record cap; the estimate is the same summed-row-size
-     proxy the chunker uses today). Carve-out unchanged from today's
+     well clear of the 2MB record cap; the estimate is `codeChangeSerializedSize`
+     — an O(entries) upper bound on the rows' V8-serialized storage footprint,
+     2 bytes per UTF-16 code unit plus fixed structure overhead. DO storage
+     V8-serializes records, so a JSON-text measure would overcount escapes and
+     multi-byte text and cost a serialization per row; summing rows bounds
+     their composition). Carve-out unchanged from today's
      lone-oversized-row chunk: a single change may reach `MAX_CODE_CHANGE_SIZE`
      (2MB, code-change.ts:144) and then travels alone in one oversized message
-     — storage already held it as a row.
-   - **Step buffer**: a `STEP_CHANGE_BUDGET` (~1MB) on the buffer's total
+     — storage already held it as a row. Accepted, no migration: a live window
+     whose rows predate this change and already sum past what one message
+     record can hold would fail to materialize — but the deployment is in
+     early testing and users almost never hand-edit code, so a multi-megabyte
+     unmaterialized window does not plausibly exist.
+   - **Step buffer**: a `STEP_CHANGE_BUDGET` (**~1.5MB**) on the buffer's total
      change size, enforced **at the write call** — the file-tool call or
      worktree `writeFile` RPC that would exceed it fails with an actionable,
      agent-visible error ("too many changes in one step; split the work across
      steps"), everything buffered before it persists normally, and the model
-     can adapt mid-turn. Sizing constraint: the budget must admit at least one
-     maximal single change (a whole-file `set` of a max-size file — worktrees'
-     `MAX_WORKTREE_FILE_SIZE` is ~1MB — must not be unwritable), and stay under
-     what one message can hold with envelope headroom below the 2MB record cap;
-     tune the two constants together. File tools can't realistically hit it (their content
-     is model output); script-driven worktree writes can. A barrier-time
-     transaction failure remains the backstop if anything slips through.
+     can adapt mid-turn. Sizing rationale: the budget must admit one maximal
+     single change, and the proxy is `codeChangeSerializedSize` (≤ 2 bytes per
+     UTF-16 code unit plus fixed overhead), so a maximal whole-file `set`
+     (`MAX_FILE_TEXT_LENGTH` is 512K units; worktrees'
+     `MAX_WORKTREE_FILE_SIZE` respects the same cap) measures ≤ ~1MB — 1.5MB
+     admits any valid single file write with margin, while keeping the step's
+     single message, envelope included, below the 2MB record cap the estimate
+     upper-bounds against. File tools can't realistically hit the budget
+     (their content is model output); script-driven worktree writes can. A
+     barrier-time transaction failure remains the backstop if anything slips
+     through. Known, accepted gap: `createGadget`'s blueprint copy is a single
+     multi-file change that may legally reach `MAX_CODE_CHANGE_SIZE` (2MB) —
+     past the budget. **No carve-out**: no existing blueprint exceeds 1MB, and
+     the planned Yjs→git blueprint format rework resolves this class of problem
+     outright.
    The changeId drift dies by deletion (one message per flush — live and
    replay counting trivially agree), and a revert can never split a step's
    effects: extras and edits share the step's single message. This also
@@ -209,9 +243,9 @@ first).
    persist with their `createGadget` call — the 2731-2739 crash window closes. The
    end-of-turn flush in the `finally` (agent.ts:3164) can no longer find agent
    rows to materialize; keep it as a cheap invariant assertion or delete it.
-5. **Gadget-access guard.** The gadget-loading path executeCode uses consults the
-   step buffer's touched-workpiece set and throws the retryable error. One
-   chokepoint check.
+5. **executeCode guard.** The executeCode tool checks the step buffer before
+   running: non-empty ⇒ throw the retryable error. One `if` in the tool, no
+   changes to the gadget-loading path (see the locked decision).
 6. **Machinery deletion.** With no live agent rows possible outside the barrier:
    delete the replay-discharge path and `listUnmaterializedChatChanges`; delete
    the vouched re-adoption scan (agent.ts:2002-2020); shrink
@@ -284,7 +318,7 @@ first).
   creation, and call atomically.
 - **Abort mid-step**: buffer dropped, prior steps' messages intact, nothing
   reverted.
-- **Gadget-access guard**: executeCode touching a buffer-edited gadget throws the
+- **executeCode guard**: executeCode after any buffered edit throws the
   retryable error; the next step succeeds.
 - **User submission mid-turn** still rejected; post-turn resubmission transforms
   against the turn's retired rows (window intact across multiple per-step
@@ -314,7 +348,7 @@ first).
 2. **Buffer + barrier**: step buffer, barrier extension (transactional, tool
    message first), `STEP_CHANGE_BUDGET` enforced at the write call — which
    supersedes commit 1's transitional agent-side flush trigger (removed along
-   with the per-tool append path) — mid-tool flush removal, gadget-access
+   with the per-tool append path) — mid-tool flush removal, executeCode
    guard, materialize hardening, and the remaining behavior tests. One
    reviewable commit — these pieces are not independently shippable.
 3. **Deletions + comment fixes**: replay-discharge path,

--- a/plans/step-transactionality.md
+++ b/plans/step-transactionality.md
@@ -1,0 +1,343 @@
+# Plan: Step-transactional agent effects
+
+## Goal
+
+Make an agent tool call's chat-content side effects durable **iff** the tool call's
+transcript record is durable — one transaction per model step.
+
+Terminology: a **step** here is one model request plus its tool batch (pi calls this a
+"turn"; agent.ts's `turn_end` is the per-step event). The chat-level *turn* is the
+whole agent run, which may span many steps.
+
+Today an agent edit becomes a durable, broadcast `chatChanges` row the moment the
+tool executes (`#appendChatChangeRow`, overseer.ts:2539), while the `AiToolCall`
+record that explains it persists only at the step's `turn_end` barrier, after the
+rest of the tool batch (agent.ts:3008-3111). A crash in between leaves content the
+transcript cannot account for; on resume the model re-runs the step against content
+that already contains its edits — `writeFile` survives by idempotence, `editFile`
+double-applies or fails on a missing find-string. This is a live bug. (The *other*
+crash window — rows and step message durable, end-of-turn flush lost — is the one
+today's replay-discharge machinery handles; this plan makes both windows impossible
+and deletes that machinery.)
+
+The fix is also the foundation the worktrees plan builds on: with effects buffered
+until the barrier, worktree binding writes inherit transactional crash semantics for
+free, and worktree `commit()` head advancements need no staging collection and no
+vouching (see plans/worktrees.md, whose backend commits require this plan to land
+first).
+
+## Locked decisions
+
+- **All agent-authored code changes buffer in memory until the step's persistence
+  barrier.** That covers the writeFile/editFile tools (whatever workpiece they
+  target — identical file-tool semantics across gadgets and worktrees is a core
+  worktrees goal), blueprint file copies inside `createGadget`, and (once worktrees
+  land) worktree binding writes and `commit()` head advancements. Within a step,
+  later tools read through the buffer (session content already works this way);
+  nothing is durable or broadcast mid-step.
+- **The barrier is one `transactionSync()` block.** At `turn_end`, in one storage
+  transaction: persist the step's tool-call message, append the buffered changes
+  as rows, materialize them into the step's single `"changes"` message, retire
+  the rows, and stamp pending gadget/binding records. Agent rows are thus **born and retired in
+  the same transaction** — the *live* rows in `chatChanges` become user-authored
+  only, and no crash or mid-barrier exception can strand an agent row without its
+  transcript record or vice versa. (A DO's synchronous writes are already
+  implicitly atomic against crashes; the explicit transaction adds rollback when
+  an application exception escapes mid-block, which implicit atomicity does not.)
+- **The wire protocol is unchanged.** Rows still go out as `changeApplied` (now in
+  a burst at the barrier) and the message's watermark still covers them; zero
+  frontend changes. Message-borne-only delivery was considered and rejected:
+  caught-up clients ignore the message's `change` payload entirely (they prune by
+  watermark — otClient.ts:378-396), client-side transform against a composed
+  message change doesn't exist (a watermark gap triggers rebuild, discarding
+  unacked local edits after 5s — otClient.ts:295-348), and rows must remain in the
+  protocol regardless for user edits (multi-tab) and the server's resubmission
+  transform window — so message-only delivery would *add* a client ingestion path
+  while removing nothing.
+- **Streaming is unaffected.** The live preview is the `editPreview*` stream fed
+  from the model's raw tool-call input fragments as it generates
+  (code-preview.ts:53-133, api.ts:3237-3286), not OT rows; the barrier's row
+  broadcast supersedes previews at step end instead of per call. The stale "the row
+  doubles as the streaming preview" comment (agent.ts:297) gets fixed —
+  overseer.ts:2904-2906 already states the correct supersedes relationship.
+- **Mid-step gadget access with buffered edits throws.** executeCode reaching a
+  gadget whose code has buffered, not-yet-persisted edits gets a retryable,
+  agent-visible error ("changes land next step — retry") instead of running
+  provisional code. This replaces what the mid-tool flushes guaranteed, and closes
+  by construction the historical corruption where a mid-turn flush materialized a
+  `"changes"` message containing a not-yet-persisted step's changes.
+- **User submissions stay rejected during agent turns** (reject + client-side
+  buffering and retry: overseer.ts:3013-3017, otClient.ts:125-136). Restoring
+  durable server-side drafts mid-turn — which the pre-git-storage
+  `chatDraftUpdates` mechanism had, and which survives tab close — is a severable
+  follow-up: it requires transforming live user rows against barrier messages,
+  machinery that doesn't exist and isn't needed here.
+- **Abort semantics stay: stop, don't revert.** Abort drops the in-flight step's
+  buffer (nothing durable exists yet); completed steps' effects are ordinary
+  message-recorded state that abort keeps, exactly like today's documented
+  behavior (agent.ts:3157-3165). The user reverts explicitly if they want the
+  turn's work gone.
+- **Crash-mid-step loses the whole step, by design.** Even the effects of tools
+  that completed earlier in the batch evaporate — correct, because the step's
+  message is lost and the resumed model re-runs the whole step from the top.
+
+## Current-state anchors (for orientation)
+
+- Turn loop: pi's `runAgentLoopContinue` (agent.ts:3134) with
+  `toolExecution: "sequential"` (agent.ts:3138); per step: stream assistant
+  response → execute tool batch → `turn_end` emit.
+- Persistence barrier: the `turn_end` case (agent.ts:3008-3111) — "one durable
+  chat-log step per completed model turn" — calling `hooks.addChatMessages`
+  (agent.ts:3103), which is synchronous end-to-end and already stamps pending
+  gadget/binding records in the same step (overseer.ts:7013-7091, stamping at
+  7035-7056). Errored/aborted model steps persist nothing (agent.ts:3013-3018); a
+  step cancelled mid-batch persists, with pre-empted calls recorded as errors
+  (agent.ts:3019-3024, 3050-3057).
+- Agent edit path today: writeFile/editFile tools → `appendAgentEdit`
+  (agent.ts:2067-2078) → `appendAgentCodeChange` (overseer.ts:2911-2957; prefetch,
+  then a synchronous tail that throws if content moved) → `#appendChatChangeRow`
+  (overseer.ts:2539-2573; durable row + `changeApplied` broadcast, per tool,
+  mid-step).
+- Flush: end-of-turn `flushPendingChanges` in the loop's `finally` (agent.ts:3164)
+  → `flushAgentChanges` → `materializeChatChanges` (overseer.ts:2792-2875), which
+  already guards against non-agent materialization during a turn
+  (overseer.ts:2806-2809). Mid-tool flush call sites: setGadgetBinding
+  (agent.ts:2630), createGadget (agent.ts:2690), blueprint copy (agent.ts:2740 —
+  deliberately *before* the step message, with its residual crash window
+  documented at 2731-2739), executeCode (agent.ts:2803), compaction early-return
+  (agent.ts:2265).
+- Crash recovery today: the rows-and-message-durable-but-flush-lost window is
+  handled by replay discharge (`listUnmaterializedChatChanges`,
+  agent.ts:1984-2000, overseer.ts:2893-2902) and by vouched re-adoption of
+  creations/bindings (agent.ts:2002-2020; `reconcilePendingGadgets`,
+  overseer.ts:2040-2118). The rows-durable-but-message-lost window is the bug.
+- Agent reads: immutable turn-start `sessionContent` (agent.ts:989-993); unpinned
+  gadgets read at a head fixed at first observation (`observeHead`,
+  agent.ts:1000-1008). User submissions cannot interleave (rejected mid-turn),
+  which is what makes `appendAgentCodeChange`'s staleness check a bug detector
+  (overseer.ts:2922-2932).
+- `ChatChangeRecord.source` is written but read by nothing; its "turn abort keys
+  on 'agent'" comment (overseer.ts:642-643) is aspirational — today's abort keys
+  on nothing and discards nothing.
+
+## Design
+
+1. **Step buffer.** The agent session accumulates the step's `CodeChange`s
+   (ordered, keyed by workpiece) instead of calling `appendAgentCodeChange` per
+   tool. `appendAgentEdit` becomes: compute the change (same prefetches), push to
+   the buffer, update session content. The created-gadget/binding recordings that
+   already accumulate turn-side (`pendingCreatedGadgets` etc.) keep working as
+   they do — only the rows move to the barrier.
+2. **Barrier extension.** The `turn_end` handler passes the buffer to the overseer
+   (a new hook, or an extended `addChatMessages`) which, inside one
+   `transactionSync()` (typed-storage's `TypedStorage.transaction`; established
+   overseer precedent, e.g. overseer.ts:1602): persists the step's tool-call
+   message, validates and appends each buffered change as a `chatChanges` row
+   (the same pin/codeBase bookkeeping as `appendAgentCodeChange`'s synchronous
+   tail, with the prefetches hoisted before the block), materializes the rows
+   into the step's single `"changes"` message carrying
+   `createdGadgets`/`addedBindings` (exactly one message — see the no-chunking
+   policy below), retires the rows, and stamps pending records. Broadcasts
+   (`changeApplied`, message delivery) fire immediately from inside the block,
+   as they always have. **This is an explicit, deliberate decision — do not
+   "fix" it in passing**: the underlying collection subscription callbacks fire
+   on write and ignore transactions, so deferring broadcasts to commit would
+   mean rerouting the whole subscription path — convoluted, and out of scope.
+   The trade, stated honestly: the transaction protects **server-side** storage
+   only. If a bug throws mid-barrier, clients may receive broadcasts for
+   rolled-back rows, and because rollback un-bumps the revision counter while
+   the client dedupes rows first-seen-wins by `(generation, revision)`
+   (otClient.ts:360-371), a later real row can be silently shadowed until the
+   client refreshes or rebuilds — not merely transient flicker. We accept this
+   because a mid-barrier exception is itself a bug (the transaction exists as a
+   safeguard, not an expected path), and server-side consistency is what must
+   survive it. If it ever bites in practice, the cheap hardening is a
+   rollback-path resync signal (force-resubscribe or a generation bump) rather
+   than transactional broadcasts — noted in future work.
+   **Ordering within the step: the tool-call message first, then its changes
+   message.** Reverts are suffix-only (`revertFrom` through end,
+   overseer.ts:3684ff, api.ts:2664-2672), so this order makes it impossible for
+   a revert to erase a call while keeping its edits — content can be reverted
+   out from under a surviving call (today's turn-grouped revert, handled by the
+   revert observation, agent.ts:1856-1879, and replay elision), but never the
+   reverse, which would recreate exactly the content-without-transcript state
+   this plan exists to kill. (The blueprint flush's changes-first precedent was
+   motivated by crash ordering, which barrier atomicity dissolves.)
+3. **Chunking removed: bound the input, don't split the output.** Today
+   `materializeChatChanges` splits an over-budget composition into multiple
+   `"changes"` messages (`CHAT_CHANGE_MESSAGE_BUDGET`, overseer.ts:821-842 — an
+   anti-wedge valve: rows retire only on success, so an unstorable message
+   would retry forever). Multi-message flushes have two soft spots: replay
+   numbers each message as its own changeId while the live counter bumps once
+   per flush (agent.ts:1837-1838 vs. agent.ts:2051-2059 — a pre-existing
+   live/replay numbering drift), and the extras
+   (`pins`/`createdGadgets`/`addedBindings`, overseer.ts:2854-2868) ride the
+   first message only, so a suffix revert landing mid-flush would keep
+   creations and earlier edits while discarding later ones. Rather than
+   patching those with grouping metadata, delete the chunking loop — **one
+   message per materialize call, always** — and make every composition fit by
+   bounding what accumulates:
+   - **User rows**: raise `CHAT_CHANGE_MATERIALIZE_THRESHOLD` from 128 to
+     **1000** — its real job is compacting keystroke-granularity ops into few
+     large ops (128 rows is only a line or two of typing) — and add a **byte
+     trigger** beside it: materialize the pending rows *before* appending a row
+     that would push the pending composition estimate past **1MB** (staying
+     well clear of the 2MB record cap; the estimate is the same summed-row-size
+     proxy the chunker uses today). Carve-out unchanged from today's
+     lone-oversized-row chunk: a single change may reach `MAX_CODE_CHANGE_SIZE`
+     (2MB, code-change.ts:144) and then travels alone in one oversized message
+     — storage already held it as a row.
+   - **Step buffer**: a `STEP_CHANGE_BUDGET` (~1MB) on the buffer's total
+     change size, enforced **at the write call** — the file-tool call or
+     worktree `writeFile` RPC that would exceed it fails with an actionable,
+     agent-visible error ("too many changes in one step; split the work across
+     steps"), everything buffered before it persists normally, and the model
+     can adapt mid-turn. Sizing constraint: the budget must admit at least one
+     maximal single change (a whole-file `set` of a max-size file — worktrees'
+     `MAX_WORKTREE_FILE_SIZE` is ~1MB — must not be unwritable), and stay under
+     what one message can hold with envelope headroom below the 2MB record cap;
+     tune the two constants together. File tools can't realistically hit it (their content
+     is model output); script-driven worktree writes can. A barrier-time
+     transaction failure remains the backstop if anything slips through.
+   The changeId drift dies by deletion (one message per flush — live and
+   replay counting trivially agree), and a revert can never split a step's
+   effects: extras and edits share the step's single message. This also
+   resolves what an aggregate step-buffer bound is *for*: correctness (the one
+   message must fit a record), with bounded memory as a side effect.
+4. **Mid-tool flushes removed** (agent.ts:2630, 2690, 2740, 2803; the compaction
+   call at 2265 becomes redundant too). The blueprint's copies ride the buffer and
+   persist with their `createGadget` call — the 2731-2739 crash window closes. The
+   end-of-turn flush in the `finally` (agent.ts:3164) can no longer find agent
+   rows to materialize; keep it as a cheap invariant assertion or delete it.
+5. **Gadget-access guard.** The gadget-loading path executeCode uses consults the
+   step buffer's touched-workpiece set and throws the retryable error. One
+   chokepoint check.
+6. **Machinery deletion.** With no live agent rows possible outside the barrier:
+   delete the replay-discharge path and `listUnmaterializedChatChanges`; delete
+   the vouched re-adoption scan (agent.ts:2002-2020); shrink
+   `reconcilePendingGadgets` to "unstamped ⇒ reap (only a mid-step crash can
+   produce one, and its step message is by construction lost),
+   stamped-but-reverted ⇒ remove". Fix the stale comments (agent.ts:296-305
+   preview claim; overseer.ts:642-643 abort claim).
+7. **Hardening.** `materializeChatChanges` throws whenever a turn is active unless
+   invoked by the barrier (tighten the existing guard at overseer.ts:2806-2809).
+   Between turns it sweeps user rows exactly as today.
+
+## Edge cases / watch-fors
+
+- **`createGadget` record creation stays immediate.** The registry record (and its
+  name reservation via the unique `byBindingName` index) is created mid-step as
+  today, `pending` and unstamped; only its *stamping* is barrier-bound. Deferring
+  creation to the barrier would surface name conflicts after the model already saw
+  the tool succeed. The stamped⇔persisted-call equivalence is what lets the
+  vouching scan die: an unstamped record now *always* means a mid-step crash.
+- **Step-buffer size**: per-file and per-change caps bound each buffered item
+  (`MAX_CODE_CHANGE_SIZE`, the file-size caps), and `STEP_CHANGE_BUDGET` bounds
+  the step's total at write time (Design §3) — needed for correctness (the
+  step's single message must fit a storage record), with bounded buffer memory
+  falling out as a side effect rather than a goal.
+- **Preview supersession timing**: `editPreview*` previews for completed calls now
+  live until the barrier's row broadcast (or the step's failure withdraws them).
+  Verify the client clears a preview on row arrival rather than on tool
+  completion, and that `tool_execution_end` withdrawal (agent.ts:2994-3002) still
+  covers failed calls.
+- **Cancel mid-batch**: completed calls' buffered effects persist with the step
+  message (pre-empted calls record errors) — effects land iff their call's record
+  lands, which is the invariant this plan exists to establish. Today's rationale
+  comment ("the durable side effects already happened", agent.ts:3019-3024)
+  inverts but the observable behavior is unchanged.
+- **Read-your-writes**: session content already layers the buffer's effects;
+  unpinned-gadget reads (`readCommitFiles(head)`) and the read-before-edit gate
+  are unaffected.
+- **Client compatibility**: subscribers see per-step `changeApplied` bursts
+  followed by the watermark-bearing message — the same sequence as today's
+  per-turn pattern, compressed in time and repeated per step. Revisions stay
+  gapless; the retired-row transform window for post-turn user resubmissions is
+  intact.
+
+## Tests
+
+(workshop-backend workerd suite)
+
+- **Double-edit regression**: crash between a tool's execution and the barrier →
+  no durable trace of the edit (no rows, no message); the resumed turn re-runs the
+  step cleanly against unmodified content.
+- **Barrier atomicity**: a persisted step message implies its changes message,
+  row retirement, and stamps are persisted — assert the public invariant that
+  every persisted writeFile/editFile/executeCode call's edits are message-covered,
+  and that an unstamped pending record never coexists with its persisted creating
+  call.
+- **Barrier exception rollback**: an exception thrown mid-barrier (injected after
+  the tool-call message put) leaves no partial durable state — no message, no
+  rows, no stamps. (Broadcasts may have escaped; only server-side consistency is
+  asserted.)
+- **No chunking / input bounds**: a write that would push the step buffer past
+  `STEP_CHANGE_BUDGET` fails with the actionable error while earlier buffered
+  writes persist normally at the barrier; user typing past the 1000-row
+  threshold materializes; a user submission that would push the pending
+  composition past 1MB materializes the pending rows first; a single
+  `MAX_CODE_CHANGE_SIZE` change still lands (alone, in one oversized message);
+  every materialize call writes exactly one message, and live vs. replay
+  changeId numbering agree across a flush that would previously have chunked.
+- **Blueprint createGadget**: crash before the barrier leaves no copied content
+  and an unstamped record that reconciliation reaps; success persists copies,
+  creation, and call atomically.
+- **Abort mid-step**: buffer dropped, prior steps' messages intact, nothing
+  reverted.
+- **Gadget-access guard**: executeCode touching a buffer-edited gadget throws the
+  retryable error; the next step succeeds.
+- **User submission mid-turn** still rejected; post-turn resubmission transforms
+  against the turn's retired rows (window intact across multiple per-step
+  flushes).
+- **`reconcilePendingGadgets`**: an unstamped record (simulated mid-step crash) is
+  reaped with no vouching scan; a stamped record whose message a revert covers is
+  removed.
+
+## Commit sequence
+
+1. **Chunking removal + materialization bounds** — standalone; depends on
+   nothing else here and fixes the changeId numbering drift on its own. Delete
+   the chunking loop (one message per materialize call), raise the materialize
+   threshold 128 → 1000, and add the 1MB byte trigger at row-append time on
+   user submissions. The agent path gets a *transitional* equivalent — until
+   commit 2, agent rows still append per-tool and compose over a whole turn
+   (many steps), so a turn-spanning composition must be kept storable — but it
+   lives **agent-side, not in the overseer**: `appendAgentEdit` tracks the
+   turn's pending composed size and calls the agent's own
+   `flushPendingChanges()` when an append would push it past 1MB. That reuses
+   the existing mid-turn flush path (same one executeCode/createGadget already
+   call), so `nextChangeId` increments with the flush as it always does and
+   live/replay numbering stay in step — an overseer-side trigger would write a
+   message behind the agent's counter. Live and replay changeId numbering agree
+   from here on. Tests: the no-chunking/input-bounds bullets minus
+   `STEP_CHANGE_BUDGET`.
+2. **Buffer + barrier**: step buffer, barrier extension (transactional, tool
+   message first), `STEP_CHANGE_BUDGET` enforced at the write call — which
+   supersedes commit 1's transitional agent-side flush trigger (removed along
+   with the per-tool append path) — mid-tool flush removal, gadget-access
+   guard, materialize hardening, and the remaining behavior tests. One
+   reviewable commit — these pieces are not independently shippable.
+3. **Deletions + comment fixes**: replay-discharge path,
+   `listUnmaterializedChatChanges`, vouched re-adoption,
+   `reconcilePendingGadgets` simplification, stale comments. Green on its own;
+   separated so the kernel reviewer sees the semantic change and the cleanup
+   apart (AGENTS.md kernel bar).
+
+## Punted / future work (deliberately kept open)
+
+- Durable server-side user drafts during agent turns (restores the tab-close
+  survival the Yjs-era `chatDraftUpdates` had; needs live-row-vs-barrier-message
+  transform machinery).
+- Delivery-time elision of the `"changes"` message's `change` payload for
+  caught-up subscribers — they ignore it today, so eliding it removes the
+  redundant second copy of each turn's edits on the wire without touching the OT
+  model (rebuild and late-subscribe paths still fetch it).
+- Message-borne-only agent change delivery (rejected above; recorded for
+  context).
+- A rollback-path client resync signal (force-resubscribe or generation bump
+  after a rolled-back barrier), if the accepted
+  broadcasts-before-commit-can-shadow-a-revision trade (Design §2) ever bites
+  in practice.
+- Extending step rollback to gatekeeper effects: a gatekeeper must not apply
+  side effects before approval, so actions queued by an unpersisted step could in
+  principle be revoked at reconciliation. Out of scope here.

--- a/plans/step-transactionality.md
+++ b/plans/step-transactionality.md
@@ -148,8 +148,10 @@ first).
    via a **new dedicated hook, `commitAgentStep`** (not an extended
    `addChatMessages`, which has six non-agent callers that would all be touched
    by a widened signature) which, inside one
-   `transactionSync()` (typed-storage's `TypedStorage.transaction`; established
-   overseer precedent, e.g. overseer.ts:1602): persists the step's tool-call
+   `transactionSync()` block (via typed-storage's `TypedStorage.transaction`,
+   today a bare delegate to `transactionSync` but the natural place to later
+   grow transaction-aware behavior, e.g. delaying subscription callbacks until
+   commit): persists the step's tool-call
    message, validates and appends each buffered change as a `chatChanges` row
    (the same pin/codeBase bookkeeping as `appendAgentCodeChange`'s synchronous
    tail, with the prefetches hoisted before the block), materializes the rows
@@ -238,11 +240,17 @@ first).
    effects: extras and edits share the step's single message. This also
    resolves what an aggregate step-buffer bound is *for*: correctness (the one
    message must fit a record), with bounded memory as a side effect.
-4. **Mid-tool flushes removed** (agent.ts:2630, 2690, 2740, 2803; the compaction
-   call at 2265 becomes redundant too). The blueprint's copies ride the buffer and
-   persist with their `createGadget` call — the 2731-2739 crash window closes. The
-   end-of-turn flush in the `finally` (agent.ts:3164) can no longer find agent
-   rows to materialize; keep it as a cheap invariant assertion or delete it.
+4. **Mid-tool flushes removed** (agent.ts:2630, 2690, 2740, 2803). The blueprint's
+   copies ride the buffer and persist with their `createGadget` call — the
+   2731-2739 crash window closes. The end-of-turn flush in the `finally`
+   (agent.ts:3164) is deleted: every completed step barrier-commits its own
+   effects, and an abort's in-flight buffer is memory only. **Exception, until
+   the machinery deletion lands (commit 3): the compaction early-return keeps a
+   flush** (`flushReadoptedChanges`, backed by the transitional
+   `flushAgentChanges` hook) — a crashed *pre-barrier* turn's re-adopted
+   rows/creations/bindings must be covered by a message before compaction
+   removes the log tail replay re-adopts them from. It dies with the
+   re-adoption machinery itself.
 5. **executeCode guard.** The executeCode tool checks the step buffer before
    running: non-empty ⇒ throw the retryable error. One `if` in the tool, no
    changes to the gadget-loading path (see the locked decision).


### PR DESCRIPTION
Last week's changes to transition to git storage had some obscure issues.

When an agent message contained a write/edit tool call, the resulting edits would be persisted to `chatChanges` (which contains the OT change log) at the time the tool executed, but the overall agent message was not persisted to the actual chat history until the end of the step. A poorly-timed crash could leave the edit in `chatChanges` while the agent message was never persisted. When the DO started back up, the agent would run again, and very likely try to make the same changes again, resulting in the changes either being double-applied or confusingly failing.

We now instead buffer changes to an in-memory buffer, which gets persisted as part of the same transaction that persists the chat log message. Either everything gets persisted together, or nothing does.

Moreover, this means that the `chatChanges` contains ONLY user-authored edits, which is closer to how things worked back in the Yjs days. Agent-authored changes go into the in-memory buffer, and then are persisted directly to a "changes" message in the chat log.

These changes fell out of my upcoming work to enable agents to create git worktrees. In that work, the agent will gain the ability to edit files programmatically within executeCode. Such edits will also need to land in the in-memory buffer so that they can be persisted transactionally.

`plans/step-transactionality.md` contains a more complete description of this change.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->