### PR TITLE
Keep pre-existing observer registrations when re-verification fails

### DIFF
--- a/packages/integration-tests/__tests__/observer-reverification.test.ts
+++ b/packages/integration-tests/__tests__/observer-reverification.test.ts
@@ -74,17 +74,34 @@ async function provisionAccount(api: RpcStub<AuthenticatedApi>): Promise<Connect
   });
 }
 
-/** Tell the gatekeeper what to do the next time it's asked to admit `label` as an observer. */
+/**
+ * Tell the gatekeeper what to do the next time it's asked to admit `label` as an observer --
+ * everywhere, or only at the binding `resourceUrl` names (a resource-specific outcome wins).
+ */
 async function setVerifyOutcome(
-    label: string, outcome: { allow: true } | { allow: false; reason: string }): Promise<void> {
+    label: string, outcome: { allow: true } | { allow: false; reason: string },
+    resourceUrl?: string): Promise<void> {
   const res = await harness.fetchWorker(
     TEST_GATEKEEPER_WORKER, "http://gatekeeper-test.test/control/verify-outcome",
-    { method: "POST", body: JSON.stringify({ label, ...outcome }) });
+    { method: "POST", body: JSON.stringify({ label, resourceUrl, ...outcome }) });
   if (res.status !== 204) {
     // The control route answers a rejected body with 400 and a reason, so surface it here rather
     // than leaving a bare status to be puzzled over.
     throw new Error(`Setting the verify outcome failed with ${res.status}: ${await res.text()}`);
   }
+}
+
+type ObserverEvent = { resourceUrl: string; type: "add" | "remove"; id: string };
+
+/** The addObserver()/removeObserver() calls one binding's gatekeeper has seen, in order. */
+async function observerEvents(resourceUrl: string): Promise<ObserverEvent[]> {
+  const res = await harness.fetchWorker(
+    TEST_GATEKEEPER_WORKER, "http://gatekeeper-test.test/control/observer-events",
+    { method: "POST", body: JSON.stringify({ resourceUrl }) });
+  if (res.status !== 200) {
+    throw new Error(`Reading observer events failed with ${res.status}: ${await res.text()}`);
+  }
+  return (await res.json() as { events: ObserverEvent[] }).events;
 }
 
 async function ambientVerificationCount(label: string): Promise<number> {
@@ -309,6 +326,42 @@ describe("observer re-verification", () => {
       expect(error!.message).toContain("Test Thing multi-a");
       expect(error!.message).toContain("Test Thing multi-b");
       expect(error!.message.split("\n").filter(l => l.includes(shared.bobLabel))).toHaveLength(2);
+    });
+  });
+
+  it.concurrent("keeps a repaired pre-existing registration when another binding fails terminally",
+      async () => {
+    await withSession(async publicApi => {
+      const shared = await shareGadgetWithBob(publicApi, ["keep-a", "keep-b"]);
+      // First open persists Bob's choices and registers him with both gatekeepers.
+      expect((await bobOpensAndCloses(shared)).callCount).toBe(1);
+
+      // Between opens, only binding a lapses; b still verifies.
+      await setVerifyOutcome(
+        shared.bobLabel, { allow: false, reason: EXPIRED_REASON }, thingUrl("keep-a"));
+
+      // Second open. Pass 1: a fails, b passes -> one re-prompt, about a alone. The responder --
+      // which runs exactly between the two passes -- repairs a just as b lapses, so pass 2 has a
+      // passing again and b failing terminally (the re-prompt budget is spent).
+      const second = new ObserverConfigRecorder().respondWith(async needs => {
+        await setVerifyOutcome(shared.bobLabel, { allow: true }, thingUrl("keep-a"));
+        await setVerifyOutcome(
+          shared.bobLabel, { allow: false, reason: EXPIRED_REASON }, thingUrl("keep-b"));
+        return needs.map(n => ({ gatekeeperId: n.gatekeeperId, accountId: shared.bobAccount.id }));
+      });
+      await expect(bobOpens(shared, second)).rejects.toThrow(/could not confirm/i);
+
+      expect(second.callCount).toBe(1);
+      expect(second.calls[0]).toHaveLength(1);
+      expect(second.needAt(0).failure?.reason).toContain(EXPIRED_REASON);
+
+      // The failed open rolls back only observers registered *this* call. a's registration
+      // predates the call and the persisted record still asserts it exists, so repairing it must
+      // not reclassify it as newly added. The buggy rollback emitted exactly one remove here.
+      const events = await observerEvents(thingUrl("keep-a"));
+      expect(events.filter(e => e.type === "remove")).toEqual([]);
+      // Both successful verifications registered it: the first open and the pass-2 repair.
+      expect(events.filter(e => e.type === "add")).toHaveLength(2);
     });
   });
 

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -56,14 +56,40 @@ const AVATAR = {
 
 type VerifyOutcome = { allow: true } | { allow: false; reason: string };
 
+/**
+ * One addObserver()/removeObserver() call, mirrored here as it happens: the gatekeeper is a facet
+ * under the gadget's Overseer, unreachable from this worker's routes, and a log (not a boolean)
+ * also pins the add/remove ordering.
+ */
+type ObserverEvent = { resourceUrl: string; type: "add" | "remove"; id: string };
+
+function outcomeKey(label: string, resourceUrl?: string): string {
+  return resourceUrl ? `outcome:${label}:${resourceUrl}` : `outcome:${label}`;
+}
+
 export class TestControl extends DurableObject<Cloudflare.Env> {
-  setVerifyOutcome(label: string, outcome: VerifyOutcome): void {
-    this.ctx.storage.kv.put(`outcome:${label}`, outcome);
+  setVerifyOutcome(label: string, outcome: VerifyOutcome, resourceUrl?: string): void {
+    this.ctx.storage.kv.put(outcomeKey(label, resourceUrl), outcome);
   }
 
-  getVerifyOutcome(label: string): VerifyOutcome {
-    // Default to admitting: a collaborator's first open has to be able to succeed.
-    return this.ctx.storage.kv.get<VerifyOutcome>(`outcome:${label}`) ?? { allow: true };
+  getVerifyOutcome(label: string, resourceUrl?: string): VerifyOutcome {
+    // A resource-specific outcome wins over a label-wide one. Default to admitting: a
+    // collaborator's first open has to be able to succeed.
+    return this.ctx.storage.kv.get<VerifyOutcome>(outcomeKey(label, resourceUrl))
+        ?? this.ctx.storage.kv.get<VerifyOutcome>(outcomeKey(label))
+        ?? { allow: true };
+  }
+
+  recordObserverEvent(event: ObserverEvent): void {
+    const events = this.ctx.storage.kv.get<ObserverEvent[]>("observer-events") ?? [];
+    events.push(event);
+    this.ctx.storage.kv.put("observer-events", events);
+  }
+
+  /** Filtered here rather than in the test: tests run concurrently against one shared log. */
+  getObserverEvents(resourceUrl: string): ObserverEvent[] {
+    return (this.ctx.storage.kv.get<ObserverEvent[]>("observer-events") ?? [])
+        .filter(e => e.resourceUrl === resourceUrl);
   }
 
   recordAmbientVerification(label: string): void {
@@ -264,18 +290,21 @@ export class TestGatekeeper
    */
   async addObserver(id: string, user: Fetcher<TestVerifierApi>): Promise<void> {
     const label = await user.identify();
+    const { resourceUrl } = this.ctx.props;
     if (this.ctx.props.ambient) {
       await control(this.ctx.exports).recordAmbientVerification(label);
-      this.ctx.storage.kv.put(`observer:${id}`, label);
-      return;
+    } else {
+      const outcome = await control(this.ctx.exports).getVerifyOutcome(label, resourceUrl);
+      if (!outcome.allow) throw new Error(outcome.reason);
     }
-    const outcome = await control(this.ctx.exports).getVerifyOutcome(label);
-    if (!outcome.allow) throw new Error(outcome.reason);
     this.ctx.storage.kv.put(`observer:${id}`, label);
+    await control(this.ctx.exports).recordObserverEvent({ resourceUrl, type: "add", id });
   }
 
   async removeObserver(id: string): Promise<void> {
     this.ctx.storage.kv.delete(`observer:${id}`);
+    await control(this.ctx.exports).recordObserverEvent(
+        { resourceUrl: this.ctx.props.resourceUrl, type: "remove", id });
   }
 
   async applyAction(_action: number): Promise<void> {
@@ -325,21 +354,36 @@ export default {
       }
     }
 
-    // Set what addObserver() should do for one account.
-    // Body: {"label": "...", "allow": false, "reason": "..."}
+    // Set what addObserver() should do for one account, either everywhere or (when `resourceUrl`
+    // is given) at one binding only.
+    // Body: {"label": "...", "allow": false, "reason": "...", "resourceUrl": "..."}
     if (url.pathname === "/control/verify-outcome" && req.method === "POST") {
-      const { label, allow, reason } = body as Record<string, unknown>;
+      const { label, allow, reason, resourceUrl } = body as Record<string, unknown>;
       if (!isNonEmptyString(label)) return badRequest("`label` must be a non-empty string");
       if (typeof allow !== "boolean") return badRequest("`allow` must be a boolean");
       if (reason !== undefined && typeof reason !== "string") {
         return badRequest("`reason` must be a string when present");
       }
+      if (resourceUrl !== undefined && !isNonEmptyString(resourceUrl)) {
+        return badRequest("`resourceUrl` must be a non-empty string when present");
+      }
 
       const outcome: VerifyOutcome = allow
         ? { allow: true }
         : { allow: false, reason: reason ?? "The test gatekeeper refused this account." };
-      await control(ctx.exports).setVerifyOutcome(label, outcome);
+      await control(ctx.exports).setVerifyOutcome(label, outcome, resourceUrl);
       return new Response(null, { status: 204 });
+    }
+
+    // Read back the addObserver()/removeObserver() calls one binding's gatekeeper has seen, in
+    // order.
+    // Body: {"resourceUrl": "..."} -> {"events": [{"resourceUrl", "type", "id"}, ...]}
+    if (url.pathname === "/control/observer-events" && req.method === "POST") {
+      const { resourceUrl } = body as Record<string, unknown>;
+      if (!isNonEmptyString(resourceUrl)) {
+        return badRequest("`resourceUrl` must be a non-empty string");
+      }
+      return Response.json({ events: await control(ctx.exports).getObserverEvents(resourceUrl) });
     }
 
     if (url.pathname === "/control/ambient-verification-count" && req.method === "POST") {

--- a/packages/integration-tests/src/rpc-client.ts
+++ b/packages/integration-tests/src/rpc-client.ts
@@ -138,10 +138,15 @@ export const MAX_OBSERVER_PROMPTS = 2;
  */
 export class ObserverConfigRecorder extends RpcTarget implements ObserverConfigCallback {
   readonly calls: ObserverBindingNeed[][] = [];
-  #responses: ((needs: ObserverBindingNeed[]) => ObserverAccountChoice[])[] = [];
+  #responses: ((needs: ObserverBindingNeed[]) =>
+      ObserverAccountChoice[] | Promise<ObserverAccountChoice[]>)[] = [];
 
-  /** Queue one response. The nth configure() call is answered by the nth queued responder. */
-  respondWith(responder: (needs: ObserverBindingNeed[]) => ObserverAccountChoice[]): this {
+  /**
+   * Queue one response. The nth configure() call is answered by the nth queued responder; a
+   * responder may be async (e.g. to flip gatekeeper control state between verification passes).
+   */
+  respondWith(responder: (needs: ObserverBindingNeed[]) =>
+      ObserverAccountChoice[] | Promise<ObserverAccountChoice[]>): this {
     this.#responses.push(responder);
     return this;
   }

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -7862,10 +7862,10 @@ class OverseerImpl implements AgentHooks {
     let record = this.storage.observers.get(profileId);
     let accountChoices: {[gatekeeperId: number]: number} = {...record?.accountChoices};
 
-    // Gatekeeper ids whose account choice came from the persisted record (vs. configured during
-    // this call). On a verification failure we only roll back observers we registered *this* call,
-    // leaving pre-existing registrations intact (rollback restores the pre-call state).
-    let preConfigured = new Set<number>(
+    // Gatekeeper ids registered before this call (their account choice came from the persisted
+    // record). An immutable snapshot: on a verification failure we roll back only observers we
+    // registered *this* call, leaving pre-existing registrations intact.
+    let registeredBeforeCall = new Set<number>(
         inScope.filter(gk => gk.id in accountChoices).map(gk => gk.id));
 
     let observerId = record?.observerId ?? crypto.randomUUID();
@@ -7976,7 +7976,7 @@ class OverseerImpl implements AgentHooks {
 
           try {
             await this.getGatekeeperFacet(gk.id).addObserver(observerId, verifier);
-            if (!preConfigured.has(gk.id)) newlyAdded.add(gk.id);
+            if (!registeredBeforeCall.has(gk.id)) newlyAdded.add(gk.id);
           } catch (err) {
             // Either a settled denial or an operational failure (expired credentials, upstream
             // outage). Treat every failure as repairable and let the user try again.
@@ -7985,13 +7985,13 @@ class OverseerImpl implements AgentHooks {
         }));
 
         if (failures.size > 0) {
-          // Drop the failed choices so the re-prompt asks about exactly these bindings, and forget
-          // that they were pre-configured so the `catch` below rolls back any registration a later
-          // pass makes -- otherwise a gatekeeper could be left admitting an observer on a choice we
-          // never persisted.
+          // Drop the failed choices so the re-prompt asks about exactly these bindings. Failed
+          // bindings stay in `registeredBeforeCall`: a registration repaired on the re-prompt must
+          // survive a later rollback -- removing it would break excludeObservers while the
+          // persisted record still asserts it exists. Its unpersisted account choice self-corrects
+          // on the next open (re-verification fails the stale persisted choice and re-prompts).
           for (let id of failures.keys()) {
             delete accountChoices[id];
-            preConfigured.delete(id);
           }
 
           // Offer the user a chance to repair (typically re-authenticate the expired account),


### PR DESCRIPTION
:bug: fix. It's actually just 1 line (the rest is supporting tests/comments)

`ensureObserver` mutated its snapshot of which gatekeepers were registered before the call.
a repaired pre-existing binding got misclassified as newly added, and if any other binding then failed terminally, the rollback deleted it
if e.g. your Slack token expired and you re-authed when the open re-prompted you, but some other connection also failed, the failed open would roll back and delete your Slack registration too, even though you'd had it for weeks.  
The bad part is nothing crashes, but the observer record and the gatekeeper now disagree, so the gatekeeper can't exclude you from data it read before your next good open.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->