### PR TITLE
Bound the chat-change replay and expire retired rows

### DIFF
--- a/packages/workshop-backend/__tests__/chat-subscription.test.ts
+++ b/packages/workshop-backend/__tests__/chat-subscription.test.ts
@@ -7,6 +7,7 @@ import type { Collection } from "@gadgets/typed-storage";
 import type {
   AiChatMessage, AiChatMetadata, AiChatSubscriber,
 } from "@gadgets/workshop-shared/api";
+import { CHAT_REPLAY_PAGE_SIZE } from "../src/overseer.js";
 import type { ChatChangeRecord } from "../src/overseer.js";
 import { makeMockStorage } from "./mock-storage.js";
 import {
@@ -14,6 +15,8 @@ import {
 } from "./fixtures.js";
 
 vi.mock("capnweb-validate", () => ({ validateRpc: () => () => undefined }));
+
+const USER = { type: "user", id: "alice@example.com", name: "Alice" } as const;
 
 // Hand-rolled AiChatSubscriber stub. Collects delivered changes and messages; `changeApplied`
 // can be overridden to gate or fail deliveries.
@@ -50,12 +53,120 @@ function putChange(
   storage.chatChanges.put({
     chatId, generation, revision,
     timestamp: opts.timestamp ?? new Date(FIXTURE_EPOCH + revision),
-    author: { type: "user", id: "alice@example.com", name: "Alice" },
+    author: USER,
     change: {},
     source: "user",
     ...(opts.retired ? { retired: true as const } : {}),
   });
 }
+
+// chatMeta.byLastActive is unique, so lastActive must differ per chat.
+function putMeta(storage: ReturnType<typeof makeActionStorage>, id: number,
+                 opts: { hasProposedChanges?: boolean } = {}) {
+  storage.chatMeta.put({
+    id, title: `Chat ${id}`, started: new Date(FIXTURE_EPOCH),
+    lastActive: new Date(FIXTURE_EPOCH + id),
+    ...(opts.hasProposedChanges === false ? {} : { hasProposedChanges: true }),
+  });
+}
+
+describe("subscribeToChat replay", () => {
+  it("replays only live rows of flagged chats, in (generation, revision) order per chat",
+      async () => {
+    let storage = makeActionStorage();
+    putMeta(storage, 1);
+    putMeta(storage, 2);
+    putMeta(storage, 3, { hasProposedChanges: false });
+    putChange(storage, 1, 0, 1, { retired: true, timestamp: new Date() });
+    putChange(storage, 1, 0, 2, { retired: true, timestamp: new Date() });
+    putChange(storage, 1, 1, 1);
+    putChange(storage, 1, 1, 2);
+    putChange(storage, 2, 0, 1);
+    putChange(storage, 3, 0, 1);  // chat not flagged: skipped
+    let client = await openFakeOverseer(storage);
+    let { subscriber, changes } = makeChatSubscriber();
+
+    using _sub = await client.subscribeToChat(subscriber);
+    expect(changes).toEqual([
+      { chatId: 1, generation: 1, revision: 1 },
+      { chatId: 1, generation: 1, revision: 2 },
+      { chatId: 2, generation: 0, revision: 1 },
+    ]);
+  });
+
+  it("pages the replay, awaiting each page", async () => {
+    let storage = makeActionStorage();
+    putMeta(storage, 1);
+    let total = 2 * CHAT_REPLAY_PAGE_SIZE + 3;
+    for (let rev = 1; rev <= total; rev++) putChange(storage, 1, 0, rev);
+    let client = await openFakeOverseer(storage);
+    let release!: () => void;
+    let gate = new Promise<void>(resolve => { release = resolve; });
+    let inFlight = 0, maxInFlight = 0, delivered = 0;
+    let { subscriber } = makeChatSubscriber(async () => {
+      maxInFlight = Math.max(maxInFlight, ++inFlight);
+      await gate;
+      --inFlight;
+      ++delivered;
+    });
+
+    let pending = client.subscribeToChat(subscriber);
+    expect(maxInFlight).toBe(CHAT_REPLAY_PAGE_SIZE);  // only the first page is in flight
+    release();
+    using _sub = await pending;
+    expect(delivered).toBe(total);
+    expect(maxInFlight).toBe(CHAT_REPLAY_PAGE_SIZE);
+  });
+
+  it("swallows a mid-replay delivery failure and unsubscribes", async () => {
+    let storage = makeActionStorage();
+    putMeta(storage, 1);
+    putChange(storage, 1, 0, 1);
+    let client = await openFakeOverseer(storage);
+    let { subscriber, messages, disposeCount } = makeChatSubscriber(async () => {
+      throw new Error("delivery failed");
+    });
+
+    using _sub = await client.subscribeToChat(subscriber);  // resolves despite the failure
+    storage.chats.put({ chatId: 1, sequence: 1, timestamp: new Date(FIXTURE_EPOCH),
+                        author: USER, type: "message", message: "hi" });
+    expect(messages).toEqual([]);  // already unsubscribed: no live delivery
+    expect(disposeCount()).toBe(1);  // the failure tore down exactly once
+  });
+
+  it("delivers a materialization landing mid-replay via the early-attached subscription",
+      async () => {
+    let storage = makeActionStorage();
+    putMeta(storage, 1);
+    let total = CHAT_REPLAY_PAGE_SIZE + 2;  // two pages
+    for (let rev = 1; rev <= total; rev++) {
+      putChange(storage, 1, 0, rev, { timestamp: new Date() });
+    }
+    let client = await openFakeOverseer(storage);
+    let release!: () => void;
+    let gate = new Promise<void>(resolve => { release = resolve; });
+    let revisions: number[] = [];
+    let { subscriber, messages } = makeChatSubscriber(async (_chatId, _generation, revision) => {
+      revisions.push(revision);
+      await gate;
+    });
+
+    let pending = client.subscribeToChat(subscriber);
+    // Mimic a materialization while the first page is parked: retire every row and append the
+    // "changes" message that absorbed them.
+    for (let row of Array.from(storage.chatChanges.list())) {
+      row.retired = true;
+      storage.chatChanges.put(row);
+    }
+    storage.chats.put({ chatId: 1, sequence: 1, timestamp: new Date(FIXTURE_EPOCH), author: USER,
+        type: "changes", watermark: { changesGeneration: 0, throughRevision: total } });
+    release();
+    using _sub = await pending;
+
+    expect(messages.map(m => m.type)).toEqual(["changes"]);
+    expect(revisions.length).toBe(CHAT_REPLAY_PAGE_SIZE);  // the second page found nothing live
+  });
+});
 
 describe("retired-row sweep", () => {
   it("expires aged retired rows at subscribe entry, keeping fresh retired and live rows",

--- a/packages/workshop-backend/__tests__/chat-subscription.test.ts
+++ b/packages/workshop-backend/__tests__/chat-subscription.test.ts
@@ -1,0 +1,56 @@
+// subscribeToChat's change-row replay and the retired-row lifecycle, over the production
+// chatChanges collection (liveByChat / retiredByTimestamp indexes) on mock storage.
+
+import { describe, expect, it } from "vitest";
+import type { Collection } from "@gadgets/typed-storage";
+import type { ChatChangeRecord } from "../src/overseer.js";
+import { makeMockStorage } from "./mock-storage.js";
+import {
+  FIXTURE_EPOCH, makeActionStorage, makePreIndexChatChangeStorage,
+} from "./fixtures.js";
+
+// Puts one change row; timestamp defaults to FIXTURE_EPOCH + revision.
+function putChange(
+    storage: { chatChanges: Collection<ChatChangeRecord, string> },
+    chatId: number, generation: number, revision: number,
+    opts: { retired?: boolean, timestamp?: Date } = {}) {
+  storage.chatChanges.put({
+    chatId, generation, revision,
+    timestamp: opts.timestamp ?? new Date(FIXTURE_EPOCH + revision),
+    author: { type: "user", id: "alice@example.com", name: "Alice" },
+    change: {},
+    source: "user",
+    ...(opts.retired ? { retired: true as const } : {}),
+  });
+}
+
+describe("chat-change index migration", () => {
+  it("serves records written before the indexes existed once a rebuild backfills them", () => {
+    // Mirrors the version-4 migration: rows predate the index declarations, so each index
+    // starts empty until the migration's rebuild() runs.
+    let mock = makeMockStorage();
+    let legacy = makePreIndexChatChangeStorage(mock);
+    putChange(legacy, 1, 0, 1);
+    putChange(legacy, 1, 0, 2, { retired: true });
+    putChange(legacy, 2, 0, 1, { retired: true });
+    putChange(legacy, 2, 0, 2);
+
+    let storage = makeActionStorage(mock);
+    storage.chatChanges.liveByChat.rebuild();
+    storage.chatChanges.retiredByTimestamp.rebuild();
+
+    // The live index serves exactly the unretired rows, per chat; the retired index serves the
+    // retired rows in timestamp order.
+    expect([...storage.chatChanges.liveByChat.get(1)].map(r => r.revision)).toEqual([1]);
+    expect([...storage.chatChanges.liveByChat.get(2)].map(r => r.revision)).toEqual([2]);
+    expect([...storage.chatChanges.retiredByTimestamp.list()]
+        .map(r => [r.chatId, r.revision])).toEqual([[2, 1], [1, 2]]);
+
+    // Retiring a backfilled row must not throw on either index's update.
+    let row = [...storage.chatChanges.liveByChat.get(1)][0];
+    row.retired = true;
+    storage.chatChanges.put(row);
+    expect([...storage.chatChanges.liveByChat.get(1)]).toEqual([]);
+    expect([...storage.chatChanges.retiredByTimestamp.list()].length).toBe(3);
+  });
+});

--- a/packages/workshop-backend/__tests__/chat-subscription.test.ts
+++ b/packages/workshop-backend/__tests__/chat-subscription.test.ts
@@ -1,13 +1,46 @@
 // subscribeToChat's change-row replay and the retired-row lifecycle, over the production
 // chatChanges collection (liveByChat / retiredByTimestamp indexes) on mock storage.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { RpcStub } from "capnweb";
 import type { Collection } from "@gadgets/typed-storage";
+import type {
+  AiChatMessage, AiChatMetadata, AiChatSubscriber,
+} from "@gadgets/workshop-shared/api";
 import type { ChatChangeRecord } from "../src/overseer.js";
 import { makeMockStorage } from "./mock-storage.js";
 import {
-  FIXTURE_EPOCH, makeActionStorage, makePreIndexChatChangeStorage,
+  FIXTURE_EPOCH, makeActionStorage, makePreIndexChatChangeStorage, openFakeOverseer,
 } from "./fixtures.js";
+
+vi.mock("capnweb-validate", () => ({ validateRpc: () => () => undefined }));
+
+// Hand-rolled AiChatSubscriber stub. Collects delivered changes and messages; `changeApplied`
+// can be overridden to gate or fail deliveries.
+function makeChatSubscriber(
+    changeApplied?: (chatId: number, generation: number, revision: number) => Promise<void>) {
+  let changes: Array<{ chatId: number, generation: number, revision: number }> = [];
+  let messages: AiChatMessage[] = [];
+  let disposeCount = 0;
+  let subscriber = {
+    streamGeneration: async () => {},
+    metadata: async (_meta: AiChatMetadata) => {},
+    deleted: async () => {},
+    message: async (msg: AiChatMessage) => { messages.push(msg); },
+    changeApplied: changeApplied ?? (async (chatId: number, generation: number,
+                                            revision: number) => {
+      changes.push({ chatId, generation, revision });
+    }),
+    stream: async () => {},
+    dup: () => subscriber,
+    onRpcBroken: () => {},
+    [Symbol.dispose]: () => { ++disposeCount; },
+  };
+  return {
+    subscriber: subscriber as unknown as RpcStub<AiChatSubscriber>,
+    changes, messages, disposeCount: () => disposeCount,
+  };
+}
 
 // Puts one change row; timestamp defaults to FIXTURE_EPOCH + revision.
 function putChange(
@@ -23,6 +56,22 @@ function putChange(
     ...(opts.retired ? { retired: true as const } : {}),
   });
 }
+
+describe("retired-row sweep", () => {
+  it("expires aged retired rows at subscribe entry, keeping fresh retired and live rows",
+      async () => {
+    let storage = makeActionStorage();
+    let aged = new Date(Date.now() - 10 * 60_000);
+    putChange(storage, 1, 0, 1, { retired: true, timestamp: aged });
+    putChange(storage, 1, 0, 2, { retired: true, timestamp: new Date() });
+    putChange(storage, 1, 0, 3, { timestamp: aged });  // live rows never expire
+    let client = await openFakeOverseer(storage);
+    let { subscriber } = makeChatSubscriber();
+
+    using _sub = await client.subscribeToChat(subscriber);
+    expect([...storage.chatChanges.list()].map(r => r.revision)).toEqual([2, 3]);
+  });
+});
 
 describe("chat-change index migration", () => {
   it("serves records written before the indexes existed once a rebuild backfills them", () => {

--- a/packages/workshop-backend/__tests__/fixtures.ts
+++ b/packages/workshop-backend/__tests__/fixtures.ts
@@ -3,10 +3,10 @@
 // OverseerDurableObject.prototype.open.
 
 import { RpcStub as NativeRpcStub } from "cloudflare:workers";
-import { createTypedStorage, collection, keyString } from "@gadgets/typed-storage";
+import { createTypedStorage, collection } from "@gadgets/typed-storage";
 import type { Collection, Singleton } from "@gadgets/typed-storage";
 import type { Overseer } from "@gadgets/workshop-shared/api";
-import { OverseerDurableObject, makeOverseerStorage } from "../src/overseer.js";
+import { OverseerDurableObject, makeOverseerStorage, chatChangeKey } from "../src/overseer.js";
 import type { ActionRecord, ChatChangeRecord } from "../src/overseer.js";
 import { makeMockStorage } from "./mock-storage.js";
 
@@ -37,8 +37,7 @@ export function makePreIndexChatChangeStorage(mockStorage: DurableObjectStorage)
   return createTypedStorage(mockStorage, {
     collections: {
       chatChanges: collection<ChatChangeRecord>()({
-        primaryKey: (r: ChatChangeRecord) =>
-            `${keyString(r.chatId)}.${keyString(r.generation)}.${keyString(r.revision)}`,
+        primaryKey: (r: ChatChangeRecord) => chatChangeKey(r.chatId, r.generation, r.revision),
       }),
     },
   });

--- a/packages/workshop-backend/__tests__/fixtures.ts
+++ b/packages/workshop-backend/__tests__/fixtures.ts
@@ -92,6 +92,11 @@ export async function openFakeOverseer(
     open: OverseerDurableObject.prototype.open,
     impl: {
       ownerId,
+      streamGeneration: 1,
+      logger: { debug: () => {}, warn: () => {} },
+      addChatSubscriber: () => {},
+      removeChatSubscriber: () => {},
+      hydrateChatMessageForClient: (msg: unknown) => msg,
       ensureAmbientCapsules: async () => {},
       markOutputsDirty: () => {},
       joinPresence: () => () => {},

--- a/packages/workshop-backend/__tests__/fixtures.ts
+++ b/packages/workshop-backend/__tests__/fixtures.ts
@@ -3,11 +3,11 @@
 // OverseerDurableObject.prototype.open.
 
 import { RpcStub as NativeRpcStub } from "cloudflare:workers";
-import { createTypedStorage, collection } from "@gadgets/typed-storage";
+import { createTypedStorage, collection, keyString } from "@gadgets/typed-storage";
 import type { Collection, Singleton } from "@gadgets/typed-storage";
 import type { Overseer } from "@gadgets/workshop-shared/api";
 import { OverseerDurableObject, makeOverseerStorage } from "../src/overseer.js";
-import type { ActionRecord } from "../src/overseer.js";
+import type { ActionRecord, ChatChangeRecord } from "../src/overseer.js";
 import { makeMockStorage } from "./mock-storage.js";
 
 /**
@@ -29,6 +29,18 @@ export function makePreIndexActionStorage(mockStorage: DurableObjectStorage) {
   return createTypedStorage(mockStorage, {
     singletons: { nextActionId: 0 },
     collections: { actions: collection<ActionRecord>()({ primaryKey: "id" }) },
+  });
+}
+
+/** Same, for chatChanges records written before the version-4 indexes existed. */
+export function makePreIndexChatChangeStorage(mockStorage: DurableObjectStorage) {
+  return createTypedStorage(mockStorage, {
+    collections: {
+      chatChanges: collection<ChatChangeRecord>()({
+        primaryKey: (r: ChatChangeRecord) =>
+            `${keyString(r.chatId)}.${keyString(r.generation)}.${keyString(r.revision)}`,
+      }),
+    },
   });
 }
 

--- a/packages/workshop-backend/__tests__/git-migration-do.test.ts
+++ b/packages/workshop-backend/__tests__/git-migration-do.test.ts
@@ -95,8 +95,9 @@ describe("git-storage migration via the Overseer constructor", () => {
 
     await inOverseer("git-migration-single", async impl => {
       // The constructor's blockConcurrencyWhile completed before this event was delivered,
-      // running the whole migration ladder: git storage (2), then the action indexes (3).
-      expect(impl.storage.version.get()).toBe(3);
+      // running the whole migration ladder: git storage (2), the action indexes (3), then the
+      // chat-change indexes (4).
+      expect(impl.storage.version.get()).toBe(4);
       expect([...impl.storage.actions.pendingByGatekeeper.list()].map((r: any) => r.id))
           .toEqual([1]);
 
@@ -149,7 +150,7 @@ describe("git-storage migration via the Overseer constructor", () => {
     await abortAllDurableObjects();
 
     await inOverseer("git-migration-multi", async impl => {
-      expect(impl.storage.version.get()).toBe(3);
+      expect(impl.storage.version.get()).toBe(4);
 
       // Every gadget's head equals its own root's content in an independent replay of the log.
       await expectHeadsMatchDoc(impl.storage, impl.gitStore, ws.docAt("current"), 1);
@@ -177,7 +178,7 @@ describe("git-storage migration via the Overseer constructor", () => {
 });
 
 describe("action-index backfills via the Overseer constructor", () => {
-  it("backfills a version-2 workspace's indexes and stamps version 3", async () => {
+  it("backfills a version-2 workspace's indexes and stamps the current version", async () => {
     await inOverseer("pending-index-v2", async impl => {
       expect(impl.storage.version.get()).toBe(0);
       // Seed through an index-less view of the same real storage, simulating records written
@@ -194,7 +195,7 @@ describe("action-index backfills via the Overseer constructor", () => {
     await abortAllDurableObjects();
 
     await inOverseer("pending-index-v2", async impl => {
-      expect(impl.storage.version.get()).toBe(3);
+      expect(impl.storage.version.get()).toBe(4);
       // The pending index sees exactly the pendings (grouped by gatekeeper, so 1 before 3 here).
       expect([...impl.storage.actions.pendingByGatekeeper.list()].map((r: any) => r.id))
           .toEqual([1, 3]);

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -1352,6 +1352,20 @@ async function submissionDigest(submission: CodeChangeSubmission): Promise<strin
   return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes)).toHex();
 }
 
+// Delete retired rows past the retention horizon (see CHAT_CHANGE_RETIRED_TTL_MS): one ranged
+// index read, not a scan. Runs at materialization, epoch close, and subscribeToChat entry, so
+// an idle chat's retired rows can't outlive the horizon by more than the gap to the next
+// subscribe.
+function sweepRetiredChatChanges(storage: OverseerStorage): void {
+  let cutoff = Date.now() - CHAT_CHANGE_RETIRED_TTL_MS;
+  storage.transaction(() => {
+    for (let row of Array.from(storage.chatChanges.retiredByTimestamp.list({end: cutoff}))) {
+      storage.chatChanges.delete(
+          `${keyString(row.chatId)}.${keyString(row.generation)}.${keyString(row.revision)}`);
+    }
+  });
+}
+
 // Common internals that several interfaces implemented by the Overseer need to use. Can't just
 // declare private methods because some of the methods are needed by multiple classes.
 // Most format tokens one message may carry. Only formats picked from the composer menu become
@@ -2691,18 +2705,6 @@ class OverseerImpl implements AgentHooks {
     }
   }
 
-  // Lazily expire retired rows past the retention horizon, and drop retired generations that
-  // are no longer bridgeable at all.
-  #pruneRetiredChatChanges(chatId: number): void {
-    let cutoff = Date.now() - CHAT_CHANGE_RETIRED_TTL_MS;
-    for (let row of Array.from(this.storage.chatChanges.list({prefix: `${keyString(chatId)}.`}))) {
-      if (row.retired && row.timestamp.getTime() < cutoff) {
-        this.storage.chatChanges.delete(
-            `${keyString(chatId)}.${keyString(row.generation)}.${keyString(row.revision)}`);
-      }
-    }
-  }
-
   // Erase every change row of the chat (a destructive bump, or chat deletion): retired rows too,
   // since a destructively-closed stream is not bridgeable.
   deleteAllChatChanges(chatId: number): void {
@@ -2979,7 +2981,7 @@ class OverseerImpl implements AgentHooks {
     }
 
     this.#retireChatChanges(rows);
-    this.#pruneRetiredChatChanges(chatId);
+    sweepRetiredChatChanges(this.storage);
     return {sequence, meta: this.getChatMetaOrThrow(chatId)};
   }
 
@@ -3756,7 +3758,7 @@ class OverseerImpl implements AgentHooks {
     // meta so concurrent changes to other fields (e.g. a title rename during the awaits)
     // survive.
     this.#retireChatChanges(this.listLiveChatChanges(chatId, generationToken));
-    this.#pruneRetiredChatChanges(chatId);
+    sweepRetiredChatChanges(this.storage);
     this.storage.chatChangeBoundaries.put(
         {chatId, generation: generationToken, finalRevision: revisionToken, boundaries});
     this.#chatContentCache.delete(chatId);
@@ -10014,6 +10016,8 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
 
   async subscribeToChat(subscriber: RpcStub<AiChatSubscriber>, startAfter?: Date)
       : Promise<RpcStub<{}>> {
+    sweepRetiredChatChanges(this.impl.storage);
+
     let chats = this.impl.storage.chats;
     let chatMeta = this.impl.storage.chatMeta;
     let changedChatMetadata: AiChatMetadata[] = [];

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -1389,6 +1389,12 @@ export const ACTION_REPLAY_PAGE_SIZE = 256;
 export const ACTION_HISTORY_PAGE_DEFAULT_LIMIT = 50;
 
 /**
+ * Change rows delivered per awaited page of subscribeToChat()'s replay. Small because each row
+ * can carry a change of up to MAX_CODE_CHANGE_SIZE. Exported for tests.
+ */
+export const CHAT_REPLAY_PAGE_SIZE = 16;
+
+/**
  * Keeps `commandPosition` only if it's a real index into `args`. Anything else becomes undefined,
  * and the command renders at the front. Display-only, so a bad value isn't worth an error.
  */
@@ -10022,6 +10028,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     let chatMeta = this.impl.storage.chatMeta;
     let changedChatMetadata: AiChatMetadata[] = [];
     let replayCount = 0;
+    let disposed = false;
 
     subscriber = subscriber.dup();  // keep stub after return
     this.impl.addChatSubscriber(subscriber);
@@ -10064,11 +10071,21 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     }
 
     function unsubscribe() {
+      if (disposed) return;
+      disposed = true;
       chats.unsubscribe(msgSubscriber);
       chatMeta.unsubscribe(metaSubscriber);
       self.impl.removeChatSubscriber(subscriber);
       subscriber[Symbol.dispose]();
     };
+
+    // Live subscriptions attach before the catch-ups and replay: the replay below awaits, and a
+    // materialization landing mid-replay appends a "changes" message that must reach the client
+    // (its watermark absorbs the rows it retired). Anything delivered by both a catch-up and the
+    // live stream is idempotent client-side (messages are sequence-indexed, metadata
+    // last-write-wins, rows dedupe by (generation, revision)).
+    chatMeta.subscribe(metaSubscriber);
+    chats.subscribe(msgSubscriber);
 
     if (startAfter !== undefined) {
       // Catch up on metadata changes.
@@ -10090,26 +10107,49 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
       }
     }
 
-    // Replay every currently retained (not-yet-materialized) change row so the subscriber can
-    // reconstruct uncommitted chat content without a separate fetch. Rows a "changes" message
-    // has absorbed are not replayed -- the message's watermark covers them -- and the rows are
-    // delivered after the message catch-up above, matching their position in the stream (rows
-    // are strictly newer than every materialized message of their generation). Delivered
-    // unconditionally (no startAfter filtering): the client dedupes by (generation, revision).
-    for (let row of this.impl.storage.chatChanges.list()) {
-      if (row.retired) continue;
-      subscriber.changeApplied(row.chatId, row.generation, row.revision, row.author, row.change,
-                               row.submission).catch(unsubscribe);
-      ++replayCount;
+    // Replay every live (not-yet-materialized) change row so the subscriber can reconstruct
+    // uncommitted chat content without a separate fetch: per chat via the sparse liveByChat
+    // index, in awaited pages, so a large window can't queue unbounded callbacks. Rows a
+    // "changes" message has absorbed are not replayed -- the message's watermark covers them --
+    // and the rows are delivered after the message catch-up above, matching their position in
+    // the stream (rows are strictly newer than every materialized message of their generation).
+    // Delivered unconditionally (no startAfter filtering): the client dedupes by
+    // (generation, revision), which also absorbs rows the live stream delivers mid-replay.
+    let chatChanges = this.impl.storage.chatChanges;
+    try {
+      // hasProposedChanges is set with every row append and cleared only when no live rows
+      // remain, so it's a strict superset of "has live rows".
+      let chatIds = [...chatMeta.list()].filter(m => m.hasProposedChanges).map(m => m.id);
+      outer: for (let chatId of chatIds) {
+        let from: ListOptions<string> = {};
+        for (;;) {
+          if (disposed) break outer;
+          // Materialize each page: a concurrent write invalidates open kv.list() cursors, so
+          // the iterator must not be held across the await.
+          let page = [...chatChanges.liveByChat.get(chatId,
+              {...from, limit: CHAT_REPLAY_PAGE_SIZE})];
+          await Promise.all(page.map(row => subscriber.changeApplied(row.chatId, row.generation,
+              row.revision, row.author, row.change, row.submission)));
+          replayCount += page.length;
+          if (page.length < CHAT_REPLAY_PAGE_SIZE) break;
+          let last = page.at(-1)!;
+          from = {startAfter: `${keyString(last.chatId)}.${keyString(last.generation)}.` +
+              keyString(last.revision)};
+        }
+      }
+    } catch (err) {
+      // Not rethrown: the frontend never awaits subscribeToChat, so a rejection would surface as
+      // an unhandled rejection rather than an error signal.
+      this.impl.logger.warn("chat subscriber failed during replay; unsubscribed", {
+        event: "chat.subscription.replay.failed", error: err,
+      });
+      unsubscribe();
     }
 
     this.impl.logger.debug("chat subscription replay completed", {
       event: "chat.subscription.replay.completed",
       size: replayCount,
     });
-
-    chatMeta.subscribe(metaSubscriber);
-    chats.subscribe(msgSubscriber);
 
     // @ts-expect-error Bugs in native RPC types make this not work currently.
     return new NativeRpcStub<{}>({

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -996,6 +996,8 @@ export function makeOverseerStorage(storage: DurableObjectStorage) {
       //       collections are dead stored data from this version on.
       //   3 = the actions collection's indexes (pendingByGatekeeper, byHistoryFilter,
       //       byLastChanged) exist and are backfilled.
+      //   4 = the chatChanges collection's indexes (liveByChat, retiredByTimestamp) exist and
+      //       are backfilled.
       version: 0,
 
       // The workspace title. (Each chat, gatekeeper, and gadget has its own title, elsewhere.)
@@ -1215,7 +1217,21 @@ export function makeOverseerStorage(storage: DurableObjectStorage) {
         primaryKey(record: ChatChangeRecord) {
           return `${keyString(record.chatId)}.${keyString(record.generation)}.` +
               keyString(record.revision);
-        }
+        },
+
+        // Both sparse; backfilled by the version-4 migration.
+        nonUniqueIndexes: {
+          // Live (unretired) rows keyed by chat, so subscribe-replay reads exactly the rows it
+          // delivers, in (generation, revision) order (the primary key's sort).
+          liveByChat(record: ChatChangeRecord) {
+            return record.retired ? null : record.chatId;
+          },
+
+          // Retired rows by row timestamp, so the TTL sweep is one ranged read.
+          retiredByTimestamp(record: ChatChangeRecord) {
+            return record.retired ? record.timestamp.valueOf() : null;
+          },
+        },
       }),
 
       // Per-(user, client session) submission dedupe records (see ChatChangeClientRecord). The
@@ -1758,9 +1774,11 @@ class OverseerImpl implements AgentHooks {
       this.ctx.blockConcurrencyWhile(async () => {
         await this.#migrateToGitStorage();
         this.#migrateToActionIndexes();
+        this.#migrateToChatChangeIndexes();
       }).then(() => this.#resumeInterruptedAgents(), () => {});
     } else {
       this.#migrateToActionIndexes();
+      this.#migrateToChatChangeIndexes();
       this.#resumeInterruptedAgents();
     }
   }
@@ -1838,6 +1856,19 @@ class OverseerImpl implements AgentHooks {
     });
     this.logger.info("backfilled the action-log indexes", {
       event: "storage.migration.action-indexes.completed",
+    });
+  }
+
+  // Version 3 -> 4: backfill the chatChanges indexes. Same rules as #migrateToActionIndexes.
+  #migrateToChatChangeIndexes(): void {
+    if (this.storage.version.get() !== 3) return;
+    this.ctx.storage.transactionSync(() => {
+      this.storage.chatChanges.liveByChat.rebuild();
+      this.storage.chatChanges.retiredByTimestamp.rebuild();
+      this.storage.version.put(4);
+    });
+    this.logger.info("backfilled the chat-change indexes", {
+      event: "storage.migration.chat-change-indexes.completed",
     });
   }
 
@@ -8224,7 +8255,7 @@ export class OverseerDurableObject extends DurableObject<Cloudflare.Env> {
 
     // A workspace initialized by this version of the code is born at the current schema version;
     // there is nothing to migrate.
-    this.impl.storage.version.put(3);
+    this.impl.storage.version.put(4);
   }
 
   /**

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -947,6 +947,15 @@ function actionLastChangedKey(record: ActionRecord): string {
 }
 
 /**
+ * Primary key of the chatChanges collection: a generation's rows list in revision order under one
+ * prefix. Takes the parts rather than a record so range bounds can be built from synthetic
+ * revisions (see listChatChangesSince). Exported for the migration-backfill test fixture.
+ */
+export function chatChangeKey(chatId: number, generation: number, revision: number): string {
+  return `${keyString(chatId)}.${keyString(generation)}.${keyString(revision)}`;
+}
+
+/**
  * One incremental update in the workspace-wide Yjs code log (the `code` and `snapshots`
  * collections). Formerly the public `CodeUpdate` wire type; the git-storage transition removed it
  * from the API along with `subscribeToCode()` (mainline code becomes commits; see git-store.ts),
@@ -1215,8 +1224,7 @@ export function makeOverseerStorage(storage: DurableObjectStorage) {
       // revision order under one prefix.
       chatChanges: collection<ChatChangeRecord>()({
         primaryKey(record: ChatChangeRecord) {
-          return `${keyString(record.chatId)}.${keyString(record.generation)}.` +
-              keyString(record.revision);
+          return chatChangeKey(record.chatId, record.generation, record.revision);
         },
 
         // Both sparse; backfilled by the version-4 migration.
@@ -1358,12 +1366,12 @@ async function submissionDigest(submission: CodeChangeSubmission): Promise<strin
 // subscribe.
 function sweepRetiredChatChanges(storage: OverseerStorage): void {
   let cutoff = Date.now() - CHAT_CHANGE_RETIRED_TTL_MS;
-  storage.transaction(() => {
-    for (let row of Array.from(storage.chatChanges.retiredByTimestamp.list({end: cutoff}))) {
-      storage.chatChanges.delete(
-          `${keyString(row.chatId)}.${keyString(row.generation)}.${keyString(row.revision)}`);
-    }
-  });
+  // Drain the index to keys before deleting (deletes invalidate the open cursor) -- keys only,
+  // so a large backlog isn't buffered as full rows. Each delete is expendable on its own: a
+  // crash mid-sweep just leaves the rest for the next sweep.
+  let expired = Array.from(storage.chatChanges.retiredByTimestamp.list({end: cutoff}),
+      row => chatChangeKey(row.chatId, row.generation, row.revision));
+  for (let key of expired) storage.chatChanges.delete(key);
 }
 
 // Common internals that several interfaces implemented by the Overseer need to use. Can't just
@@ -1859,36 +1867,39 @@ class OverseerImpl implements AgentHooks {
     });
   }
 
-  // Version 2 -> 3: backfill the actions indexes. Indexes are only maintained at write time, so
-  // over records that predate their declaration they start empty -- and updating a pre-existing
-  // action would then throw on the index update. Runs synchronously in the constructor (chained
-  // after the git-storage migration when that one is still pending), so nothing can observe
-  // pre-migration state; transactionSync makes rebuilds-plus-stamp atomic, so a crash
-  // mid-rebuild retries whole. The `!== 2` guard keeps never-initialized DOs write-free (they
-  // stamp the current version at first initialization).
-  #migrateToActionIndexes(): void {
-    if (this.storage.version.get() !== 2) return;
+  // Version-gated index backfill. Indexes are only maintained at write time, so over records
+  // that predate their declaration they start empty -- and updating a pre-existing record would
+  // then throw on the index update. Runs synchronously in the constructor (chained after the
+  // git-storage migration when that one is still pending), so nothing can observe pre-migration
+  // state; transactionSync makes rebuilds-plus-stamp atomic, so a crash mid-rebuild retries
+  // whole. The `!== fromVersion` guard keeps never-initialized DOs write-free (they stamp the
+  // current version at first initialization).
+  #backfillIndexes(fromVersion: number, message: string, event: string,
+                   rebuild: () => void): void {
+    if (this.storage.version.get() !== fromVersion) return;
     this.ctx.storage.transactionSync(() => {
+      rebuild();
+      this.storage.version.put(fromVersion + 1);
+    });
+    this.logger.info(message, {event});
+  }
+
+  // Version 2 -> 3: backfill the actions indexes.
+  #migrateToActionIndexes(): void {
+    this.#backfillIndexes(2, "backfilled the action-log indexes",
+        "storage.migration.action-indexes.completed", () => {
       this.storage.actions.pendingByGatekeeper.rebuild();
       this.storage.actions.byHistoryFilter.rebuild();
       this.storage.actions.byLastChanged.rebuild();
-      this.storage.version.put(3);
-    });
-    this.logger.info("backfilled the action-log indexes", {
-      event: "storage.migration.action-indexes.completed",
     });
   }
 
-  // Version 3 -> 4: backfill the chatChanges indexes. Same rules as #migrateToActionIndexes.
+  // Version 3 -> 4: backfill the chatChanges indexes.
   #migrateToChatChangeIndexes(): void {
-    if (this.storage.version.get() !== 3) return;
-    this.ctx.storage.transactionSync(() => {
+    this.#backfillIndexes(3, "backfilled the chat-change indexes",
+        "storage.migration.chat-change-indexes.completed", () => {
       this.storage.chatChanges.liveByChat.rebuild();
       this.storage.chatChanges.retiredByTimestamp.rebuild();
-      this.storage.version.put(4);
-    });
-    this.logger.info("backfilled the chat-change indexes", {
-      event: "storage.migration.chat-change-indexes.completed",
     });
   }
 
@@ -2631,8 +2642,8 @@ class OverseerImpl implements AgentHooks {
     if (afterRevision >= throughRevision) return [];
     let rows = [...this.storage.chatChanges.list({
       prefix: `${keyString(chatId)}.${keyString(generation)}.`,
-      startAfter: `${keyString(chatId)}.${keyString(generation)}.${keyString(afterRevision)}`,
-      end: `${keyString(chatId)}.${keyString(generation)}.${keyString(throughRevision + 1)}`,
+      startAfter: chatChangeKey(chatId, generation, afterRevision),
+      end: chatChangeKey(chatId, generation, throughRevision + 1),
     })];
     if (rows.length !== throughRevision - afterRevision ||
         rows[0].revision !== afterRevision + 1) {
@@ -2715,8 +2726,7 @@ class OverseerImpl implements AgentHooks {
   // since a destructively-closed stream is not bridgeable.
   deleteAllChatChanges(chatId: number): void {
     for (let row of Array.from(this.storage.chatChanges.list({prefix: `${keyString(chatId)}.`}))) {
-      this.storage.chatChanges.delete(
-          `${keyString(chatId)}.${keyString(row.generation)}.${keyString(row.revision)}`);
+      this.storage.chatChanges.delete(chatChangeKey(chatId, row.generation, row.revision));
     }
     this.storage.chatChangeBoundaries.delete(chatId);
     this.#chatContentCache.delete(chatId);
@@ -10133,8 +10143,7 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
           replayCount += page.length;
           if (page.length < CHAT_REPLAY_PAGE_SIZE) break;
           let last = page.at(-1)!;
-          from = {startAfter: `${keyString(last.chatId)}.${keyString(last.generation)}.` +
-              keyString(last.revision)};
+          from = {startAfter: chatChangeKey(last.chatId, last.generation, last.revision)};
         }
       }
     } catch (err) {


### PR DESCRIPTION
On every page load and reconnect, `subscribeToChat` was replaying the workspace's entire code-change history which meant scanning every row for every chat ever, deserializing changes that can each be 2 MiB, skipping the dead ones by hand, and firing every delivery un-awaited. Worse, "retired" rows (edits already folded into a durable message) were only cleaned up if that same chat kept materializing, so a chat you edited once and abandoned kept its rows on disk forever.

Now the collection has two sparse indexes: replay reads exactly the live rows per chat (nothing else), and a 60-second TTL sweep deletes expired retired rows with one ranged read whenever anyone subscribes or a chat materializes. Deliveries go out in awaited pages of 16 so a big live window can't blow the DO's 128 MiB heap.

Same playbook we already ran for the action log in #298 and #334, applied to the last unbounded read path. Zero frontend changes, and clients see identical behavior.