### PR TITLE
Test the Workshop lifecycle over public RPC

### DIFF
--- a/packages/integration-tests/__tests__/workshop-lifecycle.test.ts
+++ b/packages/integration-tests/__tests__/workshop-lifecycle.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { type Harness, startHarness } from "../src/harness.js";
+import { mockChatCompletion } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import { connect, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
+
+let harness: Harness | undefined;
+const network = new NetworkInterceptor([mockChatCompletion("Test chat")]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startHarness({ gatekeepers: [] });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+function requireHarness(): Harness {
+  if (harness === undefined) throw new Error("Workshop harness did not start");
+  return harness;
+}
+
+function username(): string {
+  const value = nextUsernames("functional").at(0);
+  if (value === undefined) throw new Error("Failed to allocate a test username");
+  return value;
+}
+
+it.concurrent("lists workspace metadata after activity and removes it after deletion", async () => {
+  using publicApi = connect(requireHarness().url);
+  using authenticated = await signUp(publicApi, username());
+  using workspace = await authenticated.newGadget();
+  const { id } = await workspace.getMetadata();
+  expect(await authenticated.listGadgets()).not.toContainEqual(expect.objectContaining({ id }));
+
+  await workspace.setTitle("Renamed Workspace");
+  await workspace.setPinned(true);
+  await workspace.newChat("Record this without running an agent", null);
+
+  const listed = await waitFor("the active workspace to appear in the user's list", async () => {
+    const workspaces = await authenticated.listGadgets();
+    return workspaces.some(entry => entry.id === id) ? workspaces : null;
+  });
+  expect(listed).toContainEqual(expect.objectContaining({
+    id,
+    title: "Renamed Workspace",
+    pinned: true,
+  }));
+
+  await workspace.deleteSelf();
+  workspace[Symbol.dispose]();
+  await waitFor("the deleted workspace to disappear from the user's list", async () =>
+    (await authenticated.listGadgets()).some(entry => entry.id === id) ? null : true);
+});
+
+it.concurrent("persists an ordered human-only chat without starting an agent", async () => {
+  using publicApi = connect(requireHarness().url);
+  using authenticated = await signUp(publicApi, username());
+  using workspace = await authenticated.newGadget();
+
+  const chatId = await workspace.newChat("First message", null);
+  await workspace.sendChatMessage(chatId, "Second message", null);
+
+  const history = await workspace.getChatHistory(chatId);
+  expect(history.messages.map(message =>
+    message.type === "message" ? message.message : message.type)).toEqual([
+    "First message",
+    "Second message",
+  ]);
+  const chats = await workspace.listChats();
+  expect(chats).toEqual([expect.objectContaining({ id: chatId })]);
+  expect(chats[0]?.activeAgent).toBeUndefined();
+
+  await workspace.deleteChat(chatId);
+  expect(await workspace.listChats()).toEqual([]);
+  await workspace.deleteSelf();
+});
+
+it.concurrent("creates, renames, reopens, and removes a Gadget capability", async () => {
+  using publicApi = connect(requireHarness().url);
+  using authenticated = await signUp(publicApi, username());
+  using workspace = await authenticated.newGadget();
+
+  using gadget = await workspace.createGadget("Status", undefined, "STATUS");
+  const gadgetId = await gadget.getId();
+  expect(await gadget.getTitle()).toBe("Status");
+
+  await gadget.setTitle("Updated Status");
+  using reopened = await workspace.getGadget(gadgetId);
+  expect(await reopened.getTitle()).toBe("Updated Status");
+  await expect(workspace.createGadget("Conflict", undefined, "STATUS"))
+    .rejects.toThrow('already a gadget named "STATUS"');
+
+  await gadget.remove();
+  await expect(workspace.getGadget(gadgetId)).rejects.toThrow();
+  await workspace.deleteSelf();
+});

--- a/packages/integration-tests/src/mock-model.ts
+++ b/packages/integration-tests/src/mock-model.ts
@@ -1,0 +1,29 @@
+import type { Handler } from "./network-interceptor.js";
+
+const CHAT_COMPLETIONS_SUFFIX = "/workers-ai/v1/chat/completions";
+
+function event(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+/** Answer an OpenAI-compatible streaming chat request with one fixed text response. */
+export function mockChatCompletion(text: string): Handler {
+  return (url, method) => {
+    if (method !== "POST" || !url.pathname.endsWith(CHAT_COMPLETIONS_SUFFIX)) return null;
+    const base = {
+      id: "mock-completion",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "mock",
+    };
+    const body = event({
+      ...base,
+      choices: [{ index: 0, delta: { role: "assistant", content: text }, finish_reason: null }],
+    }) + event({
+      ...base,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }) + "data: [DONE]\n\n";
+    return new Response(body, { headers: { "content-type": "text/event-stream" } });
+  };
+}


### PR DESCRIPTION
This adds three deterministic functional tests for the Workshop's public lifecycle. They boot the real Workshop backend and Durable Objects under local workerd, connect over the same Cap’n Web API as the browser, and exercise account, workspace, chat, and Gadget capabilities without starting an agent or calling a real model.


## Runtime boundary

Every Worker, Durable Object, storage operation, WebSocket, and RPC capability in these tests is real. Code inside the Workshop is not mocked.

The tests build directly on the existing integration toolkit:

- `startHarness()` starts the Worker graph under workerd
- `connect()` opens the Workshop's Cap’n Web session
- `signUp()` creates a deterministic local identity
- `nextUsernames()` prevents collisions in shared harness storage
- `waitFor()` observes eventual state through the public API
- `NetworkInterceptor` rejects accidental internet access

`mockChatCompletion()` answers optional automatic-title requests locally when a developer has AI Gateway values in `.dev.vars`. No request reaches the configured gateway.

No new session abstraction or production helper is introduced.

## Scenarios

### Workspace lifecycle

```text
sign up a fresh account
→ create a provisional workspace
→ confirm it is hidden before activity
→ rename and pin it
→ create a human-only chat
→ wait for it to appear in listGadgets()
→ verify title and pinned metadata
→ delete it
→ wait for it to disappear
```

This covers provisional visibility, account indexing, metadata persistence, and deletion through public capabilities.

### Human-only chat

```text
create workspace
→ newChat("First message", null)
→ sendChatMessage("Second message", null)
→ read canonical history
→ verify sequence order
→ verify activeAgent is absent
→ delete the chat
```

The `null` model ID is the public API's human-only path. It commits messages without starting an agent. The test needs no AI Gateway binding, model credential, API token, or inference budget.

### Gadget capability lifecycle

```text
create permanent Gadget with binding STATUS
→ read ID and title
→ rename it
→ reopen it through getGadget(ID)
→ reject a second Gadget using STATUS
→ remove the Gadget
→ reject reopening the removed ID
```

This covers nested `GadgetClient` capability identity, mutation, lookup, binding-name uniqueness, removal, and invalidation.

## Why the tests are separate

Each `it()` names one user-visible contract:

```text
lists workspace metadata after activity and removes it after deletion
persists an ordered human-only chat without starting an agent
creates, renames, reopens, and removes a Gadget capability
```

A failure therefore reports the exact contract, assertion line, expected and received values, and RPC stack. `waitFor()` timeout descriptions name the state that never arrived. An unmatched network request reports its HTTP method and URL.

All three cases share one workerd harness but allocate fresh users and workspaces, so they stay independent without paying startup cost three times.

## Files

```text
packages/integration-tests/__tests__/workshop-lifecycle.test.ts
packages/integration-tests/src/mock-model.ts
```

Run the focused suite with:

```sh
pnpm exec vp run -F @gadgets/workshop-backend build
pnpm --filter @gadgets/integration-tests test:run -- __tests__/workshop-lifecycle.test.ts
```

The PR adds no production code, changes no Workshop API, and makes no real LLM call.


Wall time: 0.52 seconds


Wall time: 1.40 seconds


Wall time: 0.46 seconds



Wall time: 0.82 seconds