### PR TITLE
Test Workshop sharing and presence over public RPC

### DIFF
--- a/packages/integration-tests/__tests__/workshop-presence.test.ts
+++ b/packages/integration-tests/__tests__/workshop-presence.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import type { PresenceParticipant, PresenceSubscriber } from "@gadgets/workshop-shared/api";
+import { type Harness, startHarness } from "../src/harness.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import { mockChatCompletion } from "../src/mock-model.js";
+import { RpcTarget, connect, nextUsernames, signUp, stubFor, waitFor } from "../src/rpc-client.js";
+
+class PresenceRecorder extends RpcTarget implements PresenceSubscriber {
+  readonly participants = new Map<string, PresenceParticipant>();
+  init(participants: PresenceParticipant[]): void {
+    this.participants.clear();
+    for (const participant of participants) this.participants.set(participant.key, participant);
+  }
+
+  add(participant: PresenceParticipant): void {
+    this.participants.set(participant.key, participant);
+  }
+
+  remove(key: string): void {
+    this.participants.delete(key);
+  }
+}
+
+let harness: Harness | undefined;
+const network = new NetworkInterceptor([mockChatCompletion("Test chat")]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startHarness({ gatekeepers: [] });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+it("reports collaborator presence and removes it when the capability closes", async () => {
+  if (harness === undefined) throw new Error("Workshop harness did not start");
+  const [ownerName, collaboratorName] = nextUsernames("presenceowner", "presencecollaborator");
+  if (!ownerName || !collaboratorName) throw new Error("Failed to allocate test usernames");
+
+  using ownerPublic = connect(harness.url);
+  using collaboratorPublic = connect(harness.url);
+  using owner = await signUp(ownerPublic, ownerName);
+  using collaborator = await signUp(collaboratorPublic, collaboratorName);
+  using workspace = await owner.newGadget();
+  const { id: workspaceId } = await workspace.getMetadata();
+  await workspace.newChat("Make this workspace visible without an agent", null);
+  await workspace.addCollaborator(collaboratorName, "build");
+
+  const collaboratorWorkspace = await collaborator.openGadget(workspaceId);
+  const recorder = new PresenceRecorder();
+  using recorderStub = stubFor(recorder);
+  using _subscription = await workspace.subscribeToPresence(recorderStub);
+  await waitFor("the initial presence roster", async () =>
+    recorder.participants.size >= 2 ? true : null);
+
+  expect([...recorder.participants.values()]).toEqual(expect.arrayContaining([
+    expect.objectContaining({ user: expect.objectContaining({ id: ownerName }), role: "build" }),
+    expect.objectContaining({ user: expect.objectContaining({ id: collaboratorName }), role: "build" }),
+  ]));
+
+  collaboratorWorkspace[Symbol.dispose]();
+  await waitFor("the disconnected collaborator to leave presence", async () =>
+    [...recorder.participants.values()].some(entry => entry.user.id === collaboratorName)
+      ? null
+      : true);
+  await workspace.deleteSelf();
+});

--- a/packages/integration-tests/__tests__/workshop-sharing.test.ts
+++ b/packages/integration-tests/__tests__/workshop-sharing.test.ts
@@ -1,0 +1,132 @@
+import type { RpcStub } from "capnweb";
+import { afterAll, beforeAll, expect, it } from "vitest";
+import {
+  getOpenGadgetErrorCode, OPEN_GADGET_ERROR_CODES, type AuthenticatedApi, type Overseer,
+} from "@gadgets/workshop-shared/api";
+import { type Harness, startHarness } from "../src/harness.js";
+import { mockChatCompletion } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import { connect, nextUsernames, signUp } from "../src/rpc-client.js";
+
+let harness: Harness | undefined;
+const network = new NetworkInterceptor([mockChatCompletion("Test chat")]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startHarness({ gatekeepers: [] });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+function requireHarness(): Harness {
+  if (harness === undefined) throw new Error("Workshop harness did not start");
+  return harness;
+}
+
+function usernames(...prefixes: string[]): string[] {
+  const values = nextUsernames(...prefixes);
+  if (values.length !== prefixes.length) throw new Error("Failed to allocate test usernames");
+  return values;
+}
+
+async function expectOpenDenied(
+    authenticated: RpcStub<AuthenticatedApi>, workspaceId: string, shareKey?: string): Promise<void> {
+  let denied: unknown;
+  try {
+    using _workspace = await authenticated.openGadget(workspaceId, shareKey);
+  } catch (error) {
+    denied = error;
+  }
+  if (denied === undefined) throw new Error("Expected workspace open to fail");
+  expect(getOpenGadgetErrorCode(denied)).toBe(OPEN_GADGET_ERROR_CODES.workspaceAccessDenied);
+}
+
+async function activate(workspace: RpcStub<Overseer>): Promise<string> {
+  const { id } = await workspace.getMetadata();
+  await workspace.newChat("Make this workspace visible without an agent", null);
+  return id;
+}
+
+it.concurrent("grants and revokes a use-only collaborator", async () => {
+  const [ownerName, collaboratorName, intruderName] = usernames(
+      "owner", "collaborator", "intruder");
+  if (!ownerName || !collaboratorName || !intruderName) throw new Error("Missing test username");
+
+  using ownerPublic = connect(requireHarness().url);
+  using collaboratorPublic = connect(requireHarness().url);
+  using intruderPublic = connect(requireHarness().url);
+  using owner = await signUp(ownerPublic, ownerName);
+  using collaborator = await signUp(collaboratorPublic, collaboratorName);
+  using intruder = await signUp(intruderPublic, intruderName);
+  using workspace = await owner.newGadget();
+  const workspaceId = await activate(workspace);
+
+  await expectOpenDenied(intruder, workspaceId);
+
+  const added = await workspace.addCollaborator(collaboratorName, "use", "reviewer");
+  expect(added).toMatchObject({
+    profile: { id: collaboratorName },
+    role: "use",
+  });
+  if (added === null) throw new Error("Collaborator was not added");
+
+  using collaboratorWorkspace = await collaborator.openGadget(workspaceId);
+  expect(await collaboratorWorkspace.getMetadata()).toMatchObject({
+    id: workspaceId,
+    role: "use",
+  });
+  await expect(collaboratorWorkspace.setTitle("Forbidden rename")).rejects.toThrow();
+
+  const affected = await workspace.removeCollaborator(added.profile.id, []);
+  expect(affected).toContainEqual(expect.objectContaining({
+    profile: expect.objectContaining({ id: collaboratorName }),
+    oldRole: "use",
+    newRole: null,
+  }));
+  await expectOpenDenied(collaborator, workspaceId);
+  await workspace.deleteSelf();
+});
+
+it.concurrent("revokes every key and recipient of one share link", async () => {
+  const [ownerName, firstName, secondName] = usernames("linkowner", "first", "second");
+  if (!ownerName || !firstName || !secondName) throw new Error("Missing test username");
+
+  using ownerPublic = connect(requireHarness().url);
+  using firstPublic = connect(requireHarness().url);
+  using secondPublic = connect(requireHarness().url);
+  using owner = await signUp(ownerPublic, ownerName);
+  using first = await signUp(firstPublic, firstName);
+  using second = await signUp(secondPublic, secondName);
+  using workspace = await owner.newGadget();
+  const workspaceId = await activate(workspace);
+
+  const link = await workspace.createShareLink("use", "review link");
+  const copied = await workspace.newShareLinkKey(link.linkId);
+  expect(await workspace.listShareLinks()).toContainEqual(expect.objectContaining({
+    linkId: link.linkId,
+    note: "review link",
+    role: "use",
+  }));
+
+  using firstWorkspace = await first.openGadget(workspaceId, link.key);
+  using secondWorkspace = await second.openGadget(workspaceId, copied.key);
+  expect(await firstWorkspace.getMetadata()).toMatchObject({ role: "use" });
+  expect(await secondWorkspace.getMetadata()).toMatchObject({ role: "use" });
+
+  const preview = await workspace.previewRevokeShareLink(link.linkId);
+  expect(preview.map(user => user.profile.id).toSorted()).toEqual([firstName, secondName].toSorted());
+  const affected = await workspace.revokeShareLink(link.linkId, []);
+  expect(affected.map(user => user.profile.id).toSorted()).toEqual([firstName, secondName].toSorted());
+  expect(await workspace.listShareLinks()).toEqual([]);
+
+  await expectOpenDenied(first, workspaceId, link.key);
+  await expectOpenDenied(second, workspaceId, copied.key);
+  await workspace.deleteSelf();
+});

--- a/packages/integration-tests/src/rpc-client.ts
+++ b/packages/integration-tests/src/rpc-client.ts
@@ -10,6 +10,8 @@ import type {
   AccountDescription, SupportedResource, VendorDescription,
 } from "@gadgets/workshop-shared/gatekeeper";
 
+export { RpcTarget };
+
 /**
  * Poll `attempt` until it returns non-null.
  *


### PR DESCRIPTION
Stacked on #349, this adds deterministic functional coverage for collaborator roles, presence, share-link redemption, and revocation. The tests use the same local workerd Workshop and public Cap’n Web API as a browser client. They do not start an agent or call a real model.


## Use-only collaborator

```text
owner creates an active workspace
→ unrelated user is denied
→ owner grants use-only access
→ collaborator opens with role = use
→ collaborator cannot rename the workspace
→ owner removes the collaborator
→ future opens are denied
```

The denial assertions inspect the public `WORKSPACE_ACCESS_DENIED` code rather than matching an internal storage state.

## Share-link lifecycle

```text
owner creates one use-role share link
→ owner mints a second key for the same link
→ two users redeem the two keys
→ both open with role = use
→ revocation preview names both users
→ one revoke removes both permission edges
→ both keys fail on the next open
```

This checks the user-visible invariant that keys belong to a link and revoking the link revokes every key.

## Presence lifecycle

```text
owner grants build access
→ collaborator opens the workspace
→ presence init contains both users
→ collaborator closes the capability
→ presence emits removal
```

The presence callback target is created through `stubFor()` from the existing integration toolkit, ensuring the Cap’n Web stub belongs to the same RPC runtime as the session.

## Existing infrastructure

The stack continues to use:

- one shared `startHarness()` workerd instance per file
- fresh users and workspaces per concurrent case
- `connect()` and `signUp()` over the real WebSocket
- `NetworkInterceptor` with no allowed outbound traffic
- public permission, share-link, and presence capabilities

The only toolkit change is re-exporting its canonical `RpcTarget` so callback implementations do not import a second Cap’n Web runtime.

## Failure diagnostics

The three tests are named after their public contracts:

```text
grants and revokes a use-only collaborator
revokes every key and recipient of one share link
reports collaborator presence and removes it when the capability closes
```

Failures include the test name, exact assertion, expected and received roles or user IDs, stable open-error code, or the `waitFor()` state that never arrived.

## Files

```text
packages/integration-tests/__tests__/workshop-sharing.test.ts
packages/integration-tests/__tests__/workshop-presence.test.ts
packages/integration-tests/src/rpc-client.ts
```

Run the focused stack with:

```sh
pnpm exec vp run -F @gadgets/workshop-backend build
pnpm --filter @gadgets/integration-tests test:run -- \
  __tests__/workshop-sharing.test.ts \
  __tests__/workshop-presence.test.ts
```

No Workshop production code or public API changes are included.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


Wall time: 0.56 seconds



Wall time: 0.79 seconds