### PR TITLE
Test Workshop blueprints and output indexing

### DIFF
--- a/packages/integration-tests/__tests__/workshop-blueprints.test.ts
+++ b/packages/integration-tests/__tests__/workshop-blueprints.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { type Harness, startHarness } from "../src/harness.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import { connect, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
+
+let harness: Harness | undefined;
+const network = new NetworkInterceptor();
+
+beforeAll(async () => {
+  network.install();
+  harness = await startHarness({ gatekeepers: [] });
+});
+
+afterAll(async () => {
+  try {
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+    await harness?.server.close();
+  }
+});
+
+function requireHarness(): Harness {
+  if (harness === undefined) throw new Error("Workshop harness did not start");
+  return harness;
+}
+
+function username(prefix: string): string {
+  const value = nextUsernames(prefix).at(0);
+  if (value === undefined) throw new Error("Failed to allocate a test username");
+  return value;
+}
+
+it.concurrent("publishes, instantiates, and deletes an owned blueprint", async () => {
+  using publicApi = connect(requireHarness().url);
+  using authenticated = await signUp(publicApi, username("blueprint"));
+  const formats = await waitFor("bundled output formats to install", async () => {
+    const offers = await authenticated.listOutputFormats();
+    return offers.length > 0 ? offers : null;
+  });
+  const document = formats.find(format => format.output.id === "document");
+  if (document === undefined) throw new Error("Document output format is not installed");
+  using sourceWorkspace = await authenticated.newGadgetFromBlueprint(document.blueprintId, {});
+  const sourceMetadata = await sourceWorkspace.getMetadata();
+  const sourceGadgetId = sourceMetadata.defaultGadgetId;
+  if (sourceGadgetId === undefined) throw new Error("Source workspace has no default Gadget");
+  using sourceGadget = await sourceWorkspace.getGadget(sourceGadgetId);
+
+  const blueprint = await sourceGadget.createBlueprint("Starter", "Deterministic starter");
+  expect(await sourceWorkspace.listBlueprints()).toContainEqual(expect.objectContaining({
+    id: blueprint.id,
+    title: "Starter",
+    description: "Deterministic starter",
+  }));
+
+  const owned = await waitFor("the published blueprint to reach the owner's list", async () => {
+    const blueprints = await authenticated.listOwnBlueprints();
+    return blueprints.some(entry => entry.id === blueprint.id) ? blueprints : null;
+  });
+  expect(owned).toContainEqual(expect.objectContaining({
+    id: blueprint.id,
+    source: {
+      type: "workspace",
+      workspaceId: sourceMetadata.id,
+      workspaceTitle: sourceMetadata.title,
+    },
+  }));
+  using installedWorkspace = await authenticated.newGadgetFromBlueprint(blueprint.id, {});
+  const installedMetadata = await installedWorkspace.getMetadata();
+  const installedGadgetId = installedMetadata.defaultGadgetId;
+  if (installedGadgetId === undefined) throw new Error("Installed workspace has no default Gadget");
+  using installedGadget = await installedWorkspace.getGadget(installedGadgetId);
+  expect(await installedGadget.getTitle()).toBe("Starter");
+
+  await sourceWorkspace.deleteBlueprint(blueprint.id);
+  await waitFor("the deleted blueprint to leave the owner's list", async () =>
+    (await authenticated.listOwnBlueprints()).some(entry => entry.id === blueprint.id)
+      ? null
+      : true);
+  await installedWorkspace.deleteSelf();
+  await sourceWorkspace.deleteSelf();
+});
+
+it.concurrent("creates and removes an indexed standard output", async () => {
+  using publicApi = connect(requireHarness().url);
+  using authenticated = await signUp(publicApi, username("output"));
+  const formats = await waitFor("bundled output formats to install", async () => {
+    const offers = await authenticated.listOutputFormats();
+    return offers.length > 0 ? offers : null;
+  });
+  const document = formats.find(format => format.output.id === "document");
+  if (document === undefined) throw new Error("Document output format is not installed");
+  expect(document.requiresSetup).toBe(false);
+
+  using workspace = await authenticated.newGadgetFromBlueprint(document.blueprintId, {});
+  const metadata = await workspace.getMetadata();
+  const gadgetId = metadata.defaultGadgetId;
+  if (gadgetId === undefined) throw new Error("Output workspace has no default Gadget");
+
+  const indexed = await waitFor("the document to appear in the output index", async () => {
+    const result = await authenticated.listOutputs();
+    return result.outputs.some(output =>
+      output.workspaceId === metadata.id && output.workpieceId === gadgetId)
+      ? result.outputs
+      : null;
+  });
+  expect(indexed).toContainEqual(expect.objectContaining({
+    workspaceId: metadata.id,
+    workpieceId: gadgetId,
+    output: expect.objectContaining({ id: "document" }),
+  }));
+
+  using gadget = await workspace.getGadget(gadgetId);
+  await gadget.remove();
+  await waitFor("the removed document to leave the output index", async () =>
+    (await authenticated.listOutputs()).outputs.some(output =>
+      output.workspaceId === metadata.id && output.workpieceId === gadgetId)
+      ? null
+      : true);
+  await workspace.deleteSelf();
+});


### PR DESCRIPTION
Stacked on #351, this adds deterministic public-RPC coverage for publishing and instantiating blueprints and for indexing standard outputs. Both cases use bundled code under local workerd; neither starts an agent or calls a model.


## Owned-blueprint round trip

```text
instantiate the bundled Workspace Docs blueprint
→ publish its Gadget as an owned blueprint
→ verify workspace and account blueprint indexes
→ instantiate the new blueprint into another workspace
→ reopen its default Gadget capability
→ delete the blueprint
→ wait for it to leave the owner index
```

The source is a shipped format blueprint so it contains real, deterministic Gadget code without generated code or inference. The account-side source metadata must identify the originating workspace.

## Standard-output index lifecycle

```text
wait for bundled output formats
→ select the document format
→ instantiate it into a fresh workspace
→ wait for listOutputs() to index it
→ verify workspace ID, workpiece ID, and document metadata
→ remove the output Gadget
→ wait for the output index entry to disappear
```

This exercises the user-visible Outputs-page data path through public capabilities rather than reading the workspace or account storage directly.

## Existing infrastructure

The tests reuse the stack below them unchanged:

- one local `startHarness()` workerd instance
- fresh accounts and workspaces per concurrent case
- `connect()`, `signUp()`, `nextUsernames()`, and `waitFor()`
- bundled format blueprints generated by the normal backend build
- `NetworkInterceptor` with no permitted outbound traffic

## Failure diagnostics

The two tests name the public contracts they protect:

```text
publishes, instantiates, and deletes an owned blueprint
creates and removes an indexed standard output
```

Timeouts name the missing propagation step: format installation, owner blueprint indexing, blueprint deletion, output indexing, or output removal. Assertions retain the expected and received IDs and output metadata.

## Files

```text
packages/integration-tests/__tests__/workshop-blueprints.test.ts
```

Run the focused test with:

```sh
pnpm exec vp run -F @gadgets/workshop-backend build
pnpm --filter @gadgets/integration-tests test:run -- __tests__/workshop-blueprints.test.ts
```

No Workshop production code, public API, model configuration, or README is changed.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


Wall time: 0.51 seconds



Wall time: 0.47 seconds