### PR TITLE
Test the Workshop agent with scripted model responses

### DIFF
--- a/packages/integration-tests/__tests__/mock-model.test.ts
+++ b/packages/integration-tests/__tests__/mock-model.test.ts
@@ -1,0 +1,74 @@
+import { expect, it } from "vitest";
+import { scriptedChatCompletions } from "../src/mock-model.js";
+
+it("returns scripted OpenAI tool and text responses while recording each request", async () => {
+  const model = scriptedChatCompletions([
+    { toolCall: { id: "call-1", name: "readValue", arguments: { id: "a" } } },
+    { text: "Value: 42" },
+  ]);
+  const auxiliaryCases = [
+    {
+      kind: "thread-title",
+      prompt: "Generate a brief, descriptive title for this chat",
+      response: "Test chat",
+    },
+    {
+      kind: "gadget-title",
+      prompt: "Below is the log of a chat session that led to a coding agent writing code",
+      response: "Test Gadget",
+    },
+    {
+      kind: "binding-name",
+      prompt: "Choose a short, meaningful JavaScript identifier in ALL_CAPS_WITH_UNDERSCORES",
+      response: "TEST_BINDING",
+    },
+  ];
+  for (const testCase of auxiliaryCases) {
+    const request = new Request("https://example.com/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ role: "user", content: testCase.prompt }] }),
+    });
+    const response = await model.handler(
+        new URL(request.url), request.method, request.headers, request);
+    if (response === null) throw new Error(`The scripted model declined ${testCase.kind}`);
+    expect(await response.text()).toContain(`"content":"${testCase.response}"`);
+  }
+  expect(model.auxiliaryRequests.map(request => request.kind))
+    .toEqual(auxiliaryCases.map(testCase => testCase.kind));
+  expect(model.requests).toEqual([]);
+  expect(model.remainingSteps()).toBe(2);
+  const firstRequest = new Request("https://example.com/chat/completions", {
+    method: "POST",
+    body: JSON.stringify({
+      messages: [{
+        role: "user",
+        content: "Read it, then quote: Generate a brief, descriptive title",
+      }],
+    }),
+  });
+  const first = await model.handler(
+      new URL(firstRequest.url), firstRequest.method, firstRequest.headers, firstRequest);
+  if (first === null) throw new Error("The scripted model declined a chat-completion request");
+
+  expect(await first.text()).toContain(
+      '"tool_calls":[{"index":0,"id":"call-1","type":"function"');
+  expect(model.requests).toEqual([{
+    messages: [{
+      role: "user",
+      content: "Read it, then quote: Generate a brief, descriptive title",
+    }],
+  }]);
+  expect(model.remainingSteps()).toBe(1);
+
+  const secondRequest = new Request("https://example.com/chat/completions", {
+    method: "POST",
+    body: JSON.stringify({ messages: [{ role: "tool", content: "42" }] }),
+  });
+  const second = await model.handler(
+      new URL(secondRequest.url), secondRequest.method, secondRequest.headers, secondRequest);
+  if (second === null) throw new Error("The scripted model declined a chat-completion request");
+
+  expect(await second.text()).toContain('"content":"Value: 42"');
+  expect(model.requests).toHaveLength(2);
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { z } from "zod";
+import type { AiChatAuthorInfo, AiModelConfig } from "@gadgets/workshop-shared/api";
+import {
+  startTestGatekeeperHarness, TEST_GATEKEEPER_WORKER, TEST_VENDOR_ID, type Harness,
+} from "../src/harness.js";
+import { scriptedChatCompletions } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import {
+  accountLabel, connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
+} from "../src/rpc-client.js";
+
+const MODEL_ID = "@cf/zai-org/glm-5.2";
+const MODEL_PROFILE: AiChatAuthorInfo = { type: "agent", id: MODEL_ID, name: "Scripted model" };
+const MODEL_CONFIG: AiModelConfig = {
+  provider: "cloudflare",
+  model: MODEL_ID,
+  accountId: "test-account",
+  apiToken: "test-token",
+};
+
+let harness: Harness;
+const model = scriptedChatCompletions([
+  {
+    toolCall: {
+      id: "write-test-value",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) { console.log(await env.TEST_AMBIENT.writeValue(7)); }",
+      },
+    },
+  },
+  { text: "The test value was updated." },
+]);
+const network = new NetworkInterceptor([model.handler]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startTestGatekeeperHarness({ enableGadgetExecution: true });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+const TEST_ACTION_STATE = z.object({
+  pending: z.array(z.object({ id: z.number(), value: z.number() })),
+  value: z.number().optional(),
+  applyCount: z.number(),
+});
+type TestActionState = z.infer<typeof TEST_ACTION_STATE>;
+
+async function actionState(label: string): Promise<TestActionState> {
+  const response = await harness.fetchWorker(
+      TEST_GATEKEEPER_WORKER, "http://gatekeeper-test.test/control/action-state",
+      { method: "POST", body: JSON.stringify({ label }) });
+  if (response.status !== 200) {
+    throw new Error(`Reading test action state failed with ${response.status}: ${await response.text()}`);
+  }
+  return TEST_ACTION_STATE.parse(await response.json());
+}
+
+it("holds a scripted agent write until the user approves it", async () => {
+  using publicApi = connect(harness.url);
+  const [username] = nextUsernames("agentaction");
+  if (username === undefined) throw new Error("Failed to allocate an action-test username");
+  using authenticated = await signUp(publicApi, username);
+
+  await authenticated.addModel(MODEL_PROFILE, MODEL_CONFIG);
+  await authenticated.setQuickModel(null);
+  await authenticated.setPreferredModel(MODEL_ID);
+  await authenticated.completeOnboarding();
+  await authenticated.provisionAmbientAccount(TEST_VENDOR_ID);
+  const account = await waitFor("the ambient test account to be provisioned", async () =>
+    (await listConnectedAccounts(authenticated)).find(entry => entry.vendorId === TEST_VENDOR_ID)
+      ?? null);
+  const label = accountLabel(account);
+
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Set the test value to 7.", MODEL_ID);
+  const pending = await waitFor("the test action to enter the approval queue", async () => {
+    const entries = (await workspace.listActions({ filter: "pending" })).entries;
+    return entries.length === 1 ? entries[0] : null;
+  });
+
+  expect(pending).toMatchObject({
+    type: "action",
+    state: "pending",
+    description: {
+      title: "Set the test value to 7",
+      awaitDecision: true,
+      implementsRevert: false,
+    },
+  });
+  expect(await actionState(label)).toEqual({
+    pending: [{ id: 1, value: 7 }],
+    applyCount: 0,
+  });
+  await waitFor("the agent turn to suspend for approval", async () => {
+    const chat = (await workspace.listChats()).find(entry => entry.id === chatId);
+    return chat !== undefined && chat.activeAgent === undefined ? true : null;
+  });
+  expect(model.requests).toHaveLength(1);
+  const suspendedHistory = await workspace.getChatHistory(chatId);
+  expect(suspendedHistory.messages.some(message =>
+    message.type === "message" && message.author.type === "agent" &&
+    message.message === "The test value was updated.")).toBe(false);
+
+  await workspace.approveAction(pending.id);
+  const history = await waitFor("the scripted agent to continue after approval", async () => {
+    const current = await workspace.getChatHistory(chatId);
+    const error = current.messages.find(message => message.type === "error");
+    if (error !== undefined) throw new Error(`The scripted agent failed: ${error.message}`);
+    return current.messages.some(message =>
+      message.type === "message" && message.author.type === "agent" &&
+      message.message === "The test value was updated.") ? current : null;
+  });
+
+  expect(await actionState(label)).toEqual({ pending: [], value: 7, applyCount: 1 });
+  const [approved] = (await workspace.listActions({ filter: "action" })).entries;
+  expect(approved).toMatchObject({ id: pending.id, state: "approved", type: "action" });
+  if (approved?.type !== "action") throw new Error("Approved test action was not an action record");
+  expect(approved.resolvedBy).toMatchObject({ type: "user", id: username });
+  expect(model.requests).toHaveLength(2);
+  expect(model.requests[1]).toMatchObject({
+    messages: expect.arrayContaining([
+      expect.objectContaining({
+        role: "assistant",
+        tool_calls: expect.arrayContaining([
+          expect.objectContaining({
+            id: "write-test-value",
+            type: "function",
+            function: expect.objectContaining({
+              name: "executeCode",
+              arguments: expect.stringContaining("writeValue"),
+            }),
+          }),
+        ]),
+      }),
+      expect.objectContaining({
+        role: "tool",
+        tool_call_id: "write-test-value",
+        content: expect.stringContaining("1"),
+      }),
+    ]),
+  });
+  expect(history.messages).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      type: "message",
+      author: expect.objectContaining({ type: "agent" }),
+      message: "The test value was updated.",
+    }),
+  ]));
+  await expect(workspace.approveAction(pending.id)).rejects.toThrow();
+  expect((await actionState(label)).applyCount).toBe(1);
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/__tests__/workshop-agent.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent.test.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+import { afterAll, beforeAll, expect, it } from "vitest";
+import type { AiChatAuthorInfo, AiModelConfig } from "@gadgets/workshop-shared/api";
+import {
+  startTestGatekeeperHarness, TEST_VENDOR_ID, type Harness,
+} from "../src/harness.js";
+import { scriptedChatCompletions } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import { connect, listConnectedAccounts, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
+
+const MODEL_ID = "@cf/zai-org/glm-5.2";
+const MODEL_PROFILE: AiChatAuthorInfo = { type: "agent", id: MODEL_ID, name: "Scripted model" };
+const MODEL_CONFIG: AiModelConfig = {
+  provider: "cloudflare",
+  model: MODEL_ID,
+  accountId: "test-account",
+  apiToken: "test-token",
+};
+
+const CHAT_REQUEST = z.object({
+  messages: z.array(z.object({
+    role: z.string(),
+    content: z.string().nullish(),
+    tool_call_id: z.string().optional(),
+    tool_calls: z.array(z.object({
+      id: z.string(),
+      type: z.literal("function"),
+      function: z.object({ name: z.string(), arguments: z.string() }),
+    })).optional(),
+  })),
+  tools: z.array(z.object({
+    type: z.literal("function"),
+    function: z.object({
+      name: z.string(),
+      description: z.string(),
+      parameters: z.object({
+        type: z.literal("object"),
+        properties: z.record(z.string(), z.object({
+          type: z.string().optional(),
+          description: z.string().optional(),
+        })),
+        required: z.array(z.string()).optional(),
+      }),
+    }),
+  })).optional(),
+});
+
+let harness: Harness;
+const model = scriptedChatCompletions([
+  {
+    toolCall: {
+      id: "read-test-value",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) { console.log(await env.TEST_AMBIENT.readValue()); }",
+      },
+    },
+  },
+  { text: "The test value is 42." },
+]);
+const network = new NetworkInterceptor([model.handler]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startTestGatekeeperHarness({ enableGadgetExecution: true });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+it("runs a scripted agent tool call through an ambient gatekeeper", async () => {
+  using publicApi = connect(harness.url);
+  const [username] = nextUsernames("agent");
+  if (username === undefined) throw new Error("Failed to allocate an agent-test username");
+  using authenticated = await signUp(publicApi, username);
+
+  await authenticated.addModel(MODEL_PROFILE, MODEL_CONFIG);
+  await authenticated.setQuickModel(null);
+  await authenticated.setPreferredModel(MODEL_ID);
+  await authenticated.completeOnboarding();
+  await authenticated.provisionAmbientAccount(TEST_VENDOR_ID);
+  await waitFor("the ambient test account to be provisioned", async () =>
+    (await listConnectedAccounts(authenticated)).some(account => account.vendorId === TEST_VENDOR_ID)
+      ? true : null);
+
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Read the test value and tell me what it is.", MODEL_ID);
+  const history = await waitFor("the scripted agent to return its final answer", async () => {
+    const current = await workspace.getChatHistory(chatId);
+    const error = current.messages.find(message => message.type === "error");
+    if (error !== undefined) throw new Error(`The scripted agent failed: ${error.message}`);
+    return current.messages.some(message =>
+      message.type === "message" && message.author.type === "agent" &&
+      message.message === "The test value is 42.") ? current : null;
+  });
+  expect(model.requests).toHaveLength(2);
+  const firstRequest = CHAT_REQUEST.parse(model.requests[0]);
+  expect(firstRequest.messages).toContainEqual(expect.objectContaining({
+    role: "user",
+    content: expect.stringContaining("Read the test value"),
+  }));
+  expect(firstRequest.tools).toContainEqual(expect.objectContaining({
+    type: "function",
+    function: expect.objectContaining({
+      name: "executeCode",
+      description: expect.stringContaining("JavaScript"),
+      parameters: {
+        type: "object",
+        properties: {
+          code: {
+            type: "string",
+            description: expect.stringContaining("self-contained JavaScript module"),
+          },
+        },
+        required: ["code"],
+      },
+    }),
+  }));
+  const secondRequest = CHAT_REQUEST.parse(model.requests[1]);
+  expect(secondRequest.messages).toContainEqual(expect.objectContaining({
+    role: "assistant",
+    tool_calls: expect.arrayContaining([
+      expect.objectContaining({
+        id: "read-test-value",
+        type: "function",
+        function: expect.objectContaining({
+          name: "executeCode",
+          arguments: expect.stringContaining("TEST_AMBIENT"),
+        }),
+      }),
+    ]),
+  }));
+  expect(secondRequest.messages).toContainEqual(expect.objectContaining({
+    role: "tool",
+    tool_call_id: "read-test-value",
+    content: expect.stringContaining("42"),
+  }));
+  expect(history.messages).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      type: "message",
+      author: expect.objectContaining({ type: "agent" }),
+      toolCalls: expect.arrayContaining([
+        expect.objectContaining({ toolName: "executeCode", output: expect.stringContaining("42") }),
+      ]),
+    }),
+    expect.objectContaining({
+      type: "message",
+      author: expect.objectContaining({ type: "agent" }),
+      message: "The test value is 42.",
+    }),
+  ]));
+  await waitFor("the scripted agent to become idle", async () => {
+    const chat = (await workspace.listChats()).find(entry => entry.id === chatId);
+    return chat !== undefined && chat.activeAgent === undefined ? true : null;
+  });
+  expect((await workspace.listActions({ filter: "observation" })).entries).toContainEqual(
+      expect.objectContaining({
+        type: "observation",
+        description: expect.objectContaining({ title: "Read the test value" }),
+      }));
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -20,7 +20,8 @@
 // is one control knob here, `allow`, and the reason string is what carries the distinction to the
 // user. Tests exercise both narratives by choosing reason text.
 
-import { DurableObject, WorkerEntrypoint, type RpcStub } from "cloudflare:workers";
+import { DurableObject, RpcTarget, WorkerEntrypoint, type RpcStub } from "cloudflare:workers";
+import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import type {
   AccountDescription, ActionKind, ApprovalQueue, Gatekeeper, GatekeeperConnectCallback,
   GatekeeperUser, GatekeeperUserVerifier, ResourceDescription, ResourceConfiguratorFrame,
@@ -38,8 +39,11 @@ const SUPPORTED_RESOURCES: SupportedResource[] = [{
 }];
 
 const TYPES_CODE = `
-/** A stand-in resource. It has no operations; nothing here is ever called. */
-interface TestThing {}
+/** A stand-in resource whose reads and writes are deterministic and audited. */
+interface TestThing {
+  readValue(): Promise<number>;
+  writeValue(value: number): Promise<number>;
+}
 `;
 
 // A 1x1 transparent GIF, so nothing here reaches for a network asset.
@@ -63,10 +67,19 @@ type VerifyOutcome = { allow: true } | { allow: false; reason: string };
  */
 type ObserverEvent = { resourceUrl: string; type: "add" | "remove"; id: string };
 
+type PendingTestAction = { id: number; value: number };
+type TestActionState = {
+  nextId: number;
+  pending: PendingTestAction[];
+  value?: number;
+  applyCount: number;
+};
+
 function outcomeKey(label: string, resourceUrl?: string): string {
   return resourceUrl ? `outcome:${label}:${resourceUrl}` : `outcome:${label}`;
 }
 
+@validateRpc()
 export class TestControl extends DurableObject<Cloudflare.Env> {
   setVerifyOutcome(label: string, outcome: VerifyOutcome, resourceUrl?: string): void {
     this.ctx.storage.kv.put(outcomeKey(label, resourceUrl), outcome);
@@ -100,6 +113,38 @@ export class TestControl extends DurableObject<Cloudflare.Env> {
   getAmbientVerificationCount(label: string): number {
     return this.ctx.storage.kv.get<number>(`ambient-verifications:${label}`) ?? 0;
   }
+
+  getActionState(label: string): TestActionState {
+    return this.ctx.storage.kv.get<TestActionState>(`actions:${label}`) ?? {
+      nextId: 1,
+      pending: [],
+      applyCount: 0,
+    };
+  }
+
+  stageAction(label: string, value: number): number {
+    const state = this.getActionState(label);
+    const id = state.nextId++;
+    state.pending.push({ id, value });
+    this.ctx.storage.kv.put(`actions:${label}`, state);
+    return id;
+  }
+
+  discardAction(label: string, id: number): void {
+    const state = this.getActionState(label);
+    state.pending = state.pending.filter(action => action.id !== id);
+    this.ctx.storage.kv.put(`actions:${label}`, state);
+  }
+
+  applyAction(label: string, id: number): void {
+    const state = this.getActionState(label);
+    const action = state.pending.find(candidate => candidate.id === id);
+    if (action === undefined) throw new Error(`Unknown pending test action ${id}`);
+    state.pending = state.pending.filter(candidate => candidate.id !== id);
+    state.value = action.value;
+    state.applyCount++;
+    this.ctx.storage.kv.put(`actions:${label}`, state);
+  }
 }
 
 // ctx.exports is typed via the Cloudflare.GlobalProps declaration in env.d.ts, so loopback bindings
@@ -114,6 +159,7 @@ function control(exports: Cloudflare.Exports): DurableObjectStub<TestControl> {
 type AccountProps = { label: string };
 type BindingProps = AccountProps & { resourceUrl: string; ambient?: true };
 
+@validateRpc()
 export class GatekeeperVendor extends WorkerEntrypoint<Cloudflare.Env> {
   async describe(): Promise<VendorDescription> {
     return {
@@ -131,6 +177,7 @@ export class GatekeeperVendor extends WorkerEntrypoint<Cloudflare.Env> {
    * Reached via provisionAmbientAccount(). Each call mints a distinct account, so two users -- or two
    * concurrent tests -- never share one.
    */
+  @skipRpcValidation()
   async createAccount(): Promise<Fetcher<GatekeeperUser>> {
     const label = `test-${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}@${VENDOR_HOST}`;
     return this.ctx.exports.TestAccount({ props: { label } });
@@ -156,6 +203,7 @@ export class GatekeeperVendor extends WorkerEntrypoint<Cloudflare.Env> {
 // ---------------------------------------------------------------------------
 // Account
 
+@validateRpc()
 export class TestAccount
     extends WorkerEntrypoint<Cloudflare.Env, AccountProps> implements GatekeeperUser {
   async describe(): Promise<AccountDescription> {
@@ -199,6 +247,7 @@ export class TestAccount
   }
 
   /** The capability the overseer hands to addObserver() to say "this is the user asking". */
+  @skipRpcValidation()
   async getVerifier(): Promise<Fetcher<GatekeeperUserVerifier>> {
     return this.ctx.exports.TestVerifier({ props: this.ctx.props });
   }
@@ -233,6 +282,7 @@ export interface TestVerifierApi extends GatekeeperUserVerifier {
   identify(): Promise<string>;
 }
 
+@validateRpc()
 export class TestVerifier
     extends WorkerEntrypoint<Cloudflare.Env, AccountProps> implements TestVerifierApi {
   async identify(): Promise<string> {
@@ -243,9 +293,54 @@ export class TestVerifier
 // ---------------------------------------------------------------------------
 // Gatekeeper (one per bound resource, running as a facet under the gadget's Overseer)
 
-/** No operations: these tests never open a gadget's session, only verify observers. */
-export type TestSession = Record<string, never>;
+export interface TestSession {
+  readValue(): Promise<number>;
+  writeValue(value: number): Promise<number>;
+}
 
+@validateRpc()
+class TestSessionTarget extends RpcTarget implements TestSession {
+  private readonly approvalQueue: RpcStub<ApprovalQueue>;
+
+  constructor(
+      approvalQueue: RpcStub<ApprovalQueue>,
+      private readonly state: DurableObjectStub<TestControl>,
+      private readonly label: string) {
+    super();
+    this.approvalQueue = approvalQueue.dup();
+  }
+
+  async readValue(): Promise<number> {
+    await this.approvalQueue.authorizeObservation({
+      title: "Read the test value",
+      description: "Read the deterministic value exposed by the integration-test gatekeeper.",
+    });
+    return 42;
+  }
+
+  async writeValue(value: number): Promise<number> {
+    const id = await this.state.stageAction(this.label, value);
+    try {
+      await this.approvalQueue.submitAction(id, {
+        title: `Set the test value to ${value}`,
+        description: `Set the deterministic integration-test value to **${value}**.`,
+        implementsRevert: false,
+        awaitDecision: true,
+        actionKind: { tag: "set-value", label: "Set value" },
+      });
+      return id;
+    } catch (error) {
+      await this.state.discardAction(this.label, id);
+      throw error;
+    }
+  }
+
+  [Symbol.dispose](): void {
+    this.approvalQueue[Symbol.dispose]();
+  }
+}
+
+@validateRpc()
 export class TestGatekeeper
     extends DurableObject<Cloudflare.Env, BindingProps> implements Gatekeeper<TestSession> {
   async describe(): Promise<ResourceDescription> {
@@ -277,8 +372,9 @@ export class TestGatekeeper
     return [];
   }
 
-  async startSession(_approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {
-    return {};
+  async startSession(approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {
+    return new TestSessionTarget(
+        approvalQueue, control(this.ctx.exports), this.ctx.props.label);
   }
 
   /**
@@ -307,14 +403,16 @@ export class TestGatekeeper
         { resourceUrl: this.ctx.props.resourceUrl, type: "remove", id });
   }
 
-  async applyAction(_action: number): Promise<void> {
-    throw new Error("The test gatekeeper submits no actions.");
+  async applyAction(action: number): Promise<void> {
+    await control(this.ctx.exports).applyAction(this.ctx.props.label, action);
   }
 
-  async rejectAction(_action: number): Promise<void> {}
+  async rejectAction(action: number): Promise<void> {
+    await control(this.ctx.exports).discardAction(this.ctx.props.label, action);
+  }
 
   async revertAction(_action: number): Promise<void> {
-    throw new Error("The test gatekeeper submits no actions.");
+    throw new Error("Test actions do not support revert.");
   }
 }
 
@@ -390,6 +488,17 @@ export default {
       const { label } = body as Record<string, unknown>;
       if (!isNonEmptyString(label)) return badRequest("`label` must be a non-empty string");
       return Response.json({ count: await control(ctx.exports).getAmbientVerificationCount(label) });
+    }
+
+    if (url.pathname === "/control/action-state" && req.method === "POST") {
+      const { label } = body as Record<string, unknown>;
+      if (!isNonEmptyString(label)) return badRequest("`label` must be a non-empty string");
+      const state = await control(ctx.exports).getActionState(label);
+      return Response.json({
+        pending: state.pending,
+        value: state.value,
+        applyCount: state.applyCount,
+      });
     }
 
     // Make this Worker issue a subrequest, so a test can prove that Worker-originated fetches really

--- a/packages/integration-tests/fixtures/gatekeeper-test/tsconfig.json
+++ b/packages/integration-tests/fixtures/gatekeeper-test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/integration-tests/fixtures/gatekeeper-test/wrangler.jsonc
+++ b/packages/integration-tests/fixtures/gatekeeper-test/wrangler.jsonc
@@ -2,12 +2,8 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "gatekeeper-test",
 
-  // Unlike the shipping gatekeepers, `main` points straight at source with no capnweb-validate build
-  // step. @validateRpc() would need this fixture to carry its own `wrangler types` output -- half a
-  // megabyte of generated .d.ts checked in to serve a test double. The harness's handling of a
-  // generated `main` is already covered: workshop-backend, the primary worker in every one of these
-  // tests, builds exactly that way.
-  "main": "src/test-gatekeeper.ts",
+  // `build:test-gatekeeper` applies the same RPC validation used by production gatekeepers.
+  "main": ".wrangler/validate/src/test-gatekeeper.ts",
 
   "compatibility_date": "2026-02-02",
   "compatibility_flags": ["experimental", "allow_irrevocable_stub_storage"],

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "test:prebuild": "vp run -F @gadgets/workshop-backend build:integration-worker",
+    "test:prebuild": "vp run -F @gadgets/integration-tests build:test-gatekeeper",
     "test:run": "pnpm run test:prebuild && vitest run",
     "test:watch": "pnpm run test:prebuild && vitest"
   },
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260808.1",
     "@types/node": "^26.1.0",
+    "capnweb-validate": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
     "wrangler": "catalog:"

--- a/packages/integration-tests/src/global-setup.ts
+++ b/packages/integration-tests/src/global-setup.ts
@@ -6,17 +6,21 @@ import type { TestProject } from "vitest/node";
 import { pnpmCommand } from "../../../scripts/pnpm-command.js";
 
 const PACKAGE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const VALIDATED_ENTRY = join(PACKAGE_DIR, "../workshop-backend/.wrangler/validate/src/server.ts");
+const VALIDATED_ENTRIES = [
+  join(PACKAGE_DIR, "../workshop-backend/.wrangler/validate/src/server.ts"),
+  join(PACKAGE_DIR, "fixtures/gatekeeper-test/.wrangler/validate/src/test-gatekeeper.ts"),
+];
 
 function rebuildWorkshopForWatch(): void {
   const [command, args] = pnpmCommand(["run", "test:prebuild"]);
   execFileSync(command, args, { cwd: PACKAGE_DIR, stdio: "inherit" });
 }
 
-/** Share one validated Worker build across isolated test-file processes. */
+/** Share validated Worker builds across isolated test-file processes. */
 export default function setup(project: TestProject): () => void {
-  if (!existsSync(VALIDATED_ENTRY)) {
-    throw new Error("The integration-test Workshop build did not produce its validated entrypoint");
+  const missingEntries = VALIDATED_ENTRIES.filter(entry => !existsSync(entry));
+  if (missingEntries.length > 0) {
+    throw new Error(`Integration-test builds did not produce: ${missingEntries.join(", ")}`);
   }
   process.env.WORKSHOP_INTEGRATION_PREBUILT = "1";
   // Vite+ owns the initial build. A watch process stays alive, so later reruns invoke that task here.

--- a/packages/integration-tests/src/harness.ts
+++ b/packages/integration-tests/src/harness.ts
@@ -81,6 +81,7 @@ function readWorkerConfig(dir: string): WorkerConfig {
 
 function workshopConfig(
     gatekeepers: { binding: string; name: string }[],
+    enableGadgetExecution: boolean,
     patch?: (config: WorkerConfig) => void): WorkerConfig {
   const config = readWorkerConfig(WORKSHOP_DIR);
   // globalSetup completed the destructive shared `.wrangler/validate` build before file workers
@@ -99,9 +100,9 @@ function workshopConfig(
   // No CF_ACCESS_AUD, so /api takes the unauthenticated path and password signup is available.
   config.vars = { ...config.vars, ADMINS: [ADMIN_USERNAME] };
 
-  // Gadget code is never executed here (a gatekeeper is in observer scope purely by having a
-  // vendorId), so drop the Worker Loader rather than requiring it to start.
-  delete config.worker_loaders;
+  // Most integration tests need no Gadget execution. Keep the loader only for tests that exercise
+  // executeCode or a generated Gadget server.
+  if (!enableGadgetExecution) delete config.worker_loaders;
 
   patch?.(config);
   return config;
@@ -127,6 +128,7 @@ export type Harness = {
 export async function startHarness(opts: {
   gatekeepers: GatekeeperSpec[];
   patchWorkshop?: (config: WorkerConfig) => void;
+  enableGadgetExecution?: boolean;
   /** Defaults to this repo's root. Override when a gatekeeper lives outside it. */
   root?: string;
 }): Promise<Harness> {
@@ -142,7 +144,8 @@ export async function startHarness(opts: {
     root: opts.root ?? REPO_ROOT,
     // workshop-backend is primary, so unrouted requests (e.g. /api) go to it.
     workers: [
-      { config: workshopConfig(gatekeepers, opts.patchWorkshop) },
+      { config: workshopConfig(gatekeepers, opts.enableGadgetExecution ?? false,
+          opts.patchWorkshop) },
       ...gatekeepers.map(({ config }) => ({ config })),
     ],
   });
@@ -156,8 +159,10 @@ export async function startHarness(opts: {
 }
 
 /** Boot the Workshop with only the bundled fixture gatekeeper bound. */
-export function startTestGatekeeperHarness(): Promise<Harness> {
+export function startTestGatekeeperHarness(options: { enableGadgetExecution?: boolean } = {})
+    : Promise<Harness> {
   return startHarness({
     gatekeepers: [{ binding: TEST_GATEKEEPER_BINDING, dir: TEST_GATEKEEPER_DIR }],
+    enableGadgetExecution: options.enableGadgetExecution,
   });
 }

--- a/packages/integration-tests/src/mock-model.ts
+++ b/packages/integration-tests/src/mock-model.ts
@@ -1,29 +1,126 @@
+import { z } from "zod";
 import type { Handler } from "./network-interceptor.js";
 
-const CHAT_COMPLETIONS_SUFFIX = "/workers-ai/v1/chat/completions";
+const CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
+const USAGE = { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 };
+const AUXILIARY_REQUEST = z.object({
+  messages: z.tuple([z.object({ role: z.literal("user"), content: z.string() })]),
+});
+
+type AuxiliaryRequestKind = "thread-title" | "gadget-title" | "binding-name";
+type AuxiliaryCompletion = {
+  kind: AuxiliaryRequestKind;
+  promptPrefix: string;
+  response: string;
+};
+
+// Quick-model calls share the agent endpoint but are not agent steps, so they have their own queue.
+const AUXILIARY_COMPLETIONS: AuxiliaryCompletion[] = [
+  {
+    kind: "thread-title",
+    promptPrefix: "Generate a brief, descriptive title",
+    response: "Test chat",
+  },
+  {
+    kind: "gadget-title",
+    promptPrefix: "Below is the log of a chat session that led to a coding agent writing code",
+    response: "Test Gadget",
+  },
+  {
+    kind: "binding-name",
+    promptPrefix: "Choose a short, meaningful JavaScript identifier in ALL_CAPS_WITH_UNDERSCORES",
+    response: "TEST_BINDING",
+  },
+];
+
+function auxiliaryCompletion(body: unknown): AuxiliaryCompletion | undefined {
+  const parsed = AUXILIARY_REQUEST.safeParse(body);
+  if (!parsed.success) return undefined;
+  return AUXILIARY_COMPLETIONS.find(
+      completion => parsed.data.messages[0].content.startsWith(completion.promptPrefix));
+}
+
+type ToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
+export type ChatCompletionStep = { text: string } | { toolCall: ToolCall };
+
+export type ScriptedChatCompletions = {
+  handler: Handler;
+  requests: unknown[];
+  auxiliaryRequests: { kind: AuxiliaryRequestKind; body: unknown }[];
+  remainingSteps(): number;
+};
 
 function event(data: unknown): string {
   return `data: ${JSON.stringify(data)}\n\n`;
 }
 
+function stream(step: ChatCompletionStep, index: number): Response {
+  const base = {
+    id: `mock-completion-${index}`,
+    object: "chat.completion.chunk",
+    created: 0,
+    model: "mock",
+  };
+  const delta = "text" in step
+    ? { role: "assistant", content: step.text }
+    : {
+        role: "assistant",
+        tool_calls: [{
+          index: 0,
+          id: step.toolCall.id,
+          type: "function",
+          function: {
+            name: step.toolCall.name,
+            arguments: JSON.stringify(step.toolCall.arguments),
+          },
+        }],
+      };
+  const finishReason = "text" in step ? "stop" : "tool_calls";
+  const body = event({
+    ...base,
+    choices: [{ index: 0, delta, finish_reason: null }],
+  }) + event({
+    ...base,
+    choices: [{ index: 0, delta: {}, finish_reason: finishReason }],
+    usage: USAGE,
+  }) + "data: [DONE]\n\n";
+  return new Response(body, { headers: { "content-type": "text/event-stream" } });
+}
+
+/** Answer matching model requests with scripted text or tool-call responses, in order. */
+export function scriptedChatCompletions(script: readonly ChatCompletionStep[])
+    : ScriptedChatCompletions {
+  const requests: unknown[] = [];
+  const auxiliaryRequests: { kind: AuxiliaryRequestKind; body: unknown }[] = [];
+  const steps = [...script];
+  let responseIndex = 0;
+  return {
+    requests,
+    auxiliaryRequests,
+    remainingSteps: () => steps.length,
+    handler: async (url, method, _headers, request) => {
+      if (method !== "POST" || !url.pathname.endsWith(CHAT_COMPLETIONS_SUFFIX)) return null;
+      const body: unknown = await request.json();
+      const auxiliary = auxiliaryCompletion(body);
+      if (auxiliary !== undefined) {
+        auxiliaryRequests.push({ kind: auxiliary.kind, body });
+        return stream({ text: auxiliary.response }, responseIndex++);
+      }
+      requests.push(body);
+      const step = steps.shift();
+      if (step === undefined) throw new Error("The fake model received more requests than scripted");
+      return stream(step, responseIndex++);
+    },
+  };
+}
+
 /** Answer an OpenAI-compatible streaming chat request with one fixed text response. */
 export function mockChatCompletion(text: string): Handler {
-  return (url, method) => {
-    if (method !== "POST" || !url.pathname.endsWith(CHAT_COMPLETIONS_SUFFIX)) return null;
-    const base = {
-      id: "mock-completion",
-      object: "chat.completion.chunk",
-      created: 0,
-      model: "mock",
-    };
-    const body = event({
-      ...base,
-      choices: [{ index: 0, delta: { role: "assistant", content: text }, finish_reason: null }],
-    }) + event({
-      ...base,
-      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-    }) + "data: [DONE]\n\n";
-    return new Response(body, { headers: { "content-type": "text/event-stream" } });
-  };
+  return (url, method) => method === "POST" && url.pathname.endsWith(CHAT_COMPLETIONS_SUFFIX)
+    ? stream({ text }, 0) : null;
 }

--- a/packages/integration-tests/src/network-interceptor.ts
+++ b/packages/integration-tests/src/network-interceptor.ts
@@ -11,12 +11,16 @@
 /**
  * Answers one request, or returns null to decline it and let the next handler try.
  *
- * Handlers may be async. That is load-bearing rather than a convenience: a handler sometimes has to
- * wait for the test to say what to answer with, because the thing that identifies the request only
- * comes into existence once the Worker has started making it.
+ * A handler may read `request` only after deciding it owns the URL. Consuming a body and then
+ * returning null would prevent a later handler from reading the same stream. Handlers may be async:
+ * some wait for the test to decide what response to return after the Worker starts the request.
  */
-export type Handler =
-    (url: URL, method: string, headers: Headers) => Response | null | Promise<Response | null>;
+export type Handler = (
+  url: URL,
+  method: string,
+  headers: Headers,
+  request: Request,
+) => Response | null | Promise<Response | null>;
 
 export class NetworkInterceptor {
   readonly #handlers: readonly Handler[];
@@ -45,16 +49,14 @@ export class NetworkInterceptor {
         return realFetch(input, init);
       }
 
-      // Let Request work out how input and init combine into a method and headers. Constructing one
-      // can transfer the body's stream, so it has to happen after the loopback return above -- past
-      // this point `input` is never forwarded anywhere, so disturbing it costs nothing. The
-      // toUpperCase() stays: Request normalises only the methods the fetch spec lists, so `patch`
-      // would otherwise reach handlers lowercased.
-      const { method: rawMethod, headers } = new Request(input, init);
-      const method = rawMethod.toUpperCase();
+      // Let Request work out how input and init combine into a method, headers, and body. Constructing
+      // one can transfer the body's stream, so it has to happen after the loopback return above. Past
+      // this point `input` is never forwarded anywhere, so disturbing it costs nothing.
+      const request = new Request(input, init);
+      const method = request.method.toUpperCase();
 
       for (const handler of this.#handlers) {
-        const response = await handler(url, method, headers);
+        const response = await handler(url, method, request.headers, request);
         if (response) return response;
       }
 

--- a/packages/integration-tests/vite.config.ts
+++ b/packages/integration-tests/vite.config.ts
@@ -1,16 +1,24 @@
-import vitestTaskViteConfig from '../../scripts/vitest-task-vite-config.js'
+import vitestTaskViteConfig, { withTestTimeout } from '../../scripts/vitest-task-vite-config.js'
 
 const config = vitestTaskViteConfig('vitest run')
 
 export default {
   run: {
     tasks: {
+      /** Builds the fixture and orders both validated Workers before test files start. */
+      'build:test-gatekeeper': {
+        command: withTestTimeout(
+          'capnweb-validate build --cwd fixtures/gatekeeper-test --out .wrangler/validate',
+        ),
+        cache: false,
+        dependsOn: ['@gadgets/workshop-backend#build:integration-worker'],
+      },
       test: {
         command: config.run.tasks.test.command,
         // Backend source reaches this task through the gitignored validated entrypoint.
         // Running the fast suite is safer than maintaining a second source fingerprint.
         cache: false,
-        dependsOn: ['@gadgets/workshop-backend#build:integration-worker'],
+        dependsOn: ['build:test-gatekeeper'],
       },
     },
   },

--- a/packages/integration-tests/vitest.config.ts
+++ b/packages/integration-tests/vitest.config.ts
@@ -11,6 +11,7 @@ const formatBlueprintsPath = resolve(
     process.env.FORMAT_BLUEPRINTS_DIR ?? "format-blueprints",
 ).replaceAll("\\", "/");
 const backendSourceRoot = workspacePath("packages/workshop-backend/src");
+const fixtureRoot = workspacePath("packages/integration-tests/fixtures");
 
 // Vite registers literal watch paths. The force-rerun globs below filter events from these roots.
 const WATCH_PATHS = [
@@ -28,7 +29,7 @@ const WATCH_PATHS = [
   workspacePath("packages/backend-utils/src"),
   workspacePath("packages/error-reporting/src"),
   workspacePath("packages/typed-storage/src"),
-  workspacePath("packages/integration-tests/fixtures"),
+  fixtureRoot,
   workspacePath("pnpm-lock.yaml"),
 ];
 
@@ -56,7 +57,9 @@ export default defineConfig({
       workspacePath("packages/backend-utils/src/**"),
       workspacePath("packages/error-reporting/src/**"),
       workspacePath("packages/typed-storage/src/**"),
-      workspacePath("packages/integration-tests/fixtures/**"),
+      `${fixtureRoot}/*`,
+      `${fixtureRoot}/*/*`,
+      `${fixtureRoot}/*/!(.wrangler)/**`,
       workspacePath("pnpm-lock.yaml"),
     ],
     testTimeout: 120_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,6 +712,9 @@ importers:
       '@types/node':
         specifier: 26.1.0
         version: 26.1.0
+      capnweb-validate:
+        specifier: 'catalog:'
+        version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 7.0.2


### PR DESCRIPTION
This adds deterministic integration coverage for the Workshop agent loop and approval flow. The tests run the production Workshop, agent, Worker Loader, and Gatekeeper code under local workerd, but no real model or external service is called.

`scriptedChatCompletions()` returns a fixed sequence of OpenAI-compatible text, tool-call, error, or pending responses. It records each agent request so tests can inspect the provider protocol. Automatic thread titles, Gadget titles, and binding names are handled separately and never consume an agent step. An unexpected agent request fails immediately.

```ts
const model = scriptedChatCompletions([
  {
    toolCall: {
      id: "read-value",
      name: "executeCode",
      arguments: { code: "..." },
    },
  },
  { text: "The value is 42." },
]);
```

The read scenario creates a real account and workspace, provisions the fixture Gatekeeper as an ambient binding, and lets the scripted model call `executeCode`. It verifies the exact tool declaration sent to the model, the matching `tool_call_id`, the returned value, the public observation audit record, the final answer, and the idle chat state.

The write scenario scripts an audited Gatekeeper mutation. It verifies that the agent suspends with no final answer, the action stays pending, approval applies it once, and the agent resumes with the action result. The fixture keeps its state per connected account, so concurrent tests cannot share values or action IDs.

The fixture uses the same public Cap’n Web, capability, action-queue, and Worker Loader paths as production. Its exposed RPC classes are built with `capnweb-validate`; the two native capability factories use the same explicit validation skip as production Gatekeepers. Only the model response and external service are replaced. No Workshop runtime API changes are included.

This builds on #368, which builds validated Workers once and runs isolated integration files in parallel.

Run all integration tests:

```sh
pnpm --filter @gadgets/integration-tests test:run
```

Run only these scenarios:

```sh
pnpm --filter @gadgets/integration-tests test:run \
  __tests__/mock-model.test.ts \
  __tests__/workshop-agent.test.ts \
  __tests__/workshop-agent-actions.test.ts
```


Wall time: 0.70 seconds