### PR TITLE
Test the agent loop with a scripted model

### DIFF
--- a/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { z } from "zod";
+import type { AiChatAuthorInfo, AiModelConfig } from "@gadgets/workshop-shared/api";
+import {
+  startTestGatekeeperHarness, TEST_GATEKEEPER_WORKER, TEST_VENDOR_ID, type Harness,
+} from "../src/harness.js";
+import { scriptedChatCompletions } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import {
+  accountLabel, connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
+} from "../src/rpc-client.js";
+
+const MODEL_ID = "@cf/zai-org/glm-5.2";
+const MODEL_PROFILE: AiChatAuthorInfo = { type: "agent", id: MODEL_ID, name: "Scripted model" };
+const MODEL_CONFIG: AiModelConfig = {
+  provider: "cloudflare",
+  model: MODEL_ID,
+  accountId: "test-account",
+  apiToken: "test-token",
+};
+
+let harness: Harness;
+const model = scriptedChatCompletions([
+  {
+    toolCall: {
+      id: "write-test-value",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) { console.log(await env.TEST_AMBIENT.writeValue(7)); }",
+      },
+    },
+  },
+  { text: "The test value was updated." },
+]);
+const network = new NetworkInterceptor([model.handler]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startTestGatekeeperHarness({ enableGadgetExecution: true });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+const TEST_ACTION_STATE = z.object({
+  pending: z.array(z.object({ id: z.number(), value: z.number() })),
+  value: z.number().optional(),
+  applyCount: z.number(),
+});
+type TestActionState = z.infer<typeof TEST_ACTION_STATE>;
+
+async function actionState(label: string): Promise<TestActionState> {
+  const response = await harness.fetchWorker(
+      TEST_GATEKEEPER_WORKER, "http://gatekeeper-test.test/control/action-state",
+      { method: "POST", body: JSON.stringify({ label }) });
+  if (response.status !== 200) {
+    throw new Error(`Reading test action state failed with ${response.status}: ${await response.text()}`);
+  }
+  return TEST_ACTION_STATE.parse(await response.json());
+}
+
+it("holds a scripted agent write until the user approves it", async () => {
+  using publicApi = connect(harness.url);
+  const [username] = nextUsernames("agentaction");
+  if (username === undefined) throw new Error("Failed to allocate an action-test username");
+  using authenticated = await signUp(publicApi, username);
+
+  await authenticated.addModel(MODEL_PROFILE, MODEL_CONFIG);
+  await authenticated.setQuickModel(null);
+  await authenticated.setPreferredModel(MODEL_ID);
+  await authenticated.completeOnboarding();
+  await authenticated.provisionAmbientAccount(TEST_VENDOR_ID);
+  const account = await waitFor("the ambient test account to be provisioned", async () =>
+    (await listConnectedAccounts(authenticated)).find(entry => entry.vendorId === TEST_VENDOR_ID)
+      ?? null);
+  const label = accountLabel(account);
+
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Set the test value to 7.", MODEL_ID);
+  const pending = await waitFor("the test action to enter the approval queue", async () => {
+    const entries = (await workspace.listActions({ filter: "pending" })).entries;
+    return entries.length === 1 ? entries[0] : null;
+  });
+
+  expect(pending).toMatchObject({
+    type: "action",
+    state: "pending",
+    description: {
+      title: "Set the test value to 7",
+      awaitDecision: true,
+      implementsRevert: false,
+    },
+  });
+  expect(await actionState(label)).toEqual({
+    pending: [{ id: 1, value: 7 }],
+    applyCount: 0,
+  });
+  await waitFor("the agent turn to suspend for approval", async () => {
+    const chat = (await workspace.listChats()).find(entry => entry.id === chatId);
+    return chat !== undefined && chat.activeAgent === undefined ? true : null;
+  });
+  expect(model.requests).toHaveLength(1);
+  const suspendedHistory = await workspace.getChatHistory(chatId);
+  expect(suspendedHistory.messages.some(message =>
+    message.type === "message" && message.author.type === "agent" &&
+    message.message === "The test value was updated.")).toBe(false);
+
+  await workspace.approveAction(pending.id);
+  const history = await waitFor("the scripted agent to continue after approval", async () => {
+    const current = await workspace.getChatHistory(chatId);
+    const error = current.messages.find(message => message.type === "error");
+    if (error !== undefined) throw new Error(`The scripted agent failed: ${error.message}`);
+    return current.messages.some(message =>
+      message.type === "message" && message.author.type === "agent" &&
+      message.message === "The test value was updated.") ? current : null;
+  });
+
+  expect(await actionState(label)).toEqual({ pending: [], value: 7, applyCount: 1 });
+  const [approved] = (await workspace.listActions({ filter: "action" })).entries;
+  expect(approved).toMatchObject({ id: pending.id, state: "approved", type: "action" });
+  if (approved?.type !== "action") throw new Error("Approved test action was not an action record");
+  expect(approved.resolvedBy).toMatchObject({ type: "user", id: username });
+  expect(model.requests).toHaveLength(2);
+  expect(model.requests[1]).toMatchObject({
+    messages: expect.arrayContaining([
+      expect.objectContaining({ role: "tool", content: expect.stringContaining("1") }),
+    ]),
+  });
+  expect(history.messages).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      type: "message",
+      author: expect.objectContaining({ type: "agent" }),
+      message: "The test value was updated.",
+    }),
+  ]));
+  await expect(workspace.approveAction(pending.id)).rejects.toThrow();
+  expect((await actionState(label)).applyCount).toBe(1);
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/__tests__/workshop-agent.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent.test.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { afterAll, beforeAll, expect, it } from "vitest";
+import type { AiChatAuthorInfo, AiModelConfig } from "@gadgets/workshop-shared/api";
+import {
+  startTestGatekeeperHarness, TEST_VENDOR_ID, type Harness,
+} from "../src/harness.js";
+import { scriptedChatCompletions } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import { connect, listConnectedAccounts, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
+
+const MODEL_ID = "@cf/zai-org/glm-5.2";
+const MODEL_PROFILE: AiChatAuthorInfo = { type: "agent", id: MODEL_ID, name: "Scripted model" };
+const MODEL_CONFIG: AiModelConfig = {
+  provider: "cloudflare",
+  model: MODEL_ID,
+  accountId: "test-account",
+  apiToken: "test-token",
+};
+
+const CHAT_REQUEST = z.object({
+  messages: z.array(z.object({
+    role: z.string(),
+    content: z.string().nullish(),
+    tool_call_id: z.string().optional(),
+  })),
+  tools: z.array(z.object({
+    type: z.literal("function"),
+    function: z.object({ name: z.string() }),
+  })).optional(),
+});
+
+let harness: Harness;
+const model = scriptedChatCompletions([
+  {
+    toolCall: {
+      id: "read-test-value",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) { console.log(await env.TEST_AMBIENT.readValue()); }",
+      },
+    },
+  },
+  { text: "The test value is 42." },
+]);
+const network = new NetworkInterceptor([model.handler]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startTestGatekeeperHarness({ enableGadgetExecution: true });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+it("runs a scripted agent tool call through an ambient gatekeeper", async () => {
+  using publicApi = connect(harness.url);
+  const [username] = nextUsernames("agent");
+  if (username === undefined) throw new Error("Failed to allocate an agent-test username");
+  using authenticated = await signUp(publicApi, username);
+
+  await authenticated.addModel(MODEL_PROFILE, MODEL_CONFIG);
+  await authenticated.setQuickModel(null);
+  await authenticated.setPreferredModel(MODEL_ID);
+  await authenticated.completeOnboarding();
+  await authenticated.provisionAmbientAccount(TEST_VENDOR_ID);
+  await waitFor("the ambient test account to be provisioned", async () =>
+    (await listConnectedAccounts(authenticated)).some(account => account.vendorId === TEST_VENDOR_ID)
+      ? true : null);
+
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Read the test value and tell me what it is.", MODEL_ID);
+  const history = await waitFor("the scripted agent to return its final answer", async () => {
+    const current = await workspace.getChatHistory(chatId);
+    const error = current.messages.find(message => message.type === "error");
+    if (error !== undefined) throw new Error(`The scripted agent failed: ${error.message}`);
+    return current.messages.some(message =>
+      message.type === "message" && message.author.type === "agent" &&
+      message.message === "The test value is 42.") ? current : null;
+  });
+  expect(model.requests).toHaveLength(2);
+  const firstRequest = CHAT_REQUEST.parse(model.requests[0]);
+  expect(firstRequest.messages).toContainEqual(expect.objectContaining({
+    role: "user",
+    content: expect.stringContaining("Read the test value"),
+  }));
+  expect(firstRequest.tools).toContainEqual(expect.objectContaining({
+    type: "function",
+    function: expect.objectContaining({ name: "executeCode" }),
+  }));
+  const secondRequest = CHAT_REQUEST.parse(model.requests[1]);
+  expect(secondRequest.messages).toContainEqual(expect.objectContaining({
+    role: "tool",
+    tool_call_id: "read-test-value",
+    content: expect.stringContaining("42"),
+  }));
+  expect(history.messages).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      type: "message",
+      author: expect.objectContaining({ type: "agent" }),
+      toolCalls: expect.arrayContaining([
+        expect.objectContaining({ toolName: "executeCode", output: expect.stringContaining("42") }),
+      ]),
+    }),
+    expect.objectContaining({
+      type: "message",
+      author: expect.objectContaining({ type: "agent" }),
+      message: "The test value is 42.",
+    }),
+  ]));
+  await waitFor("the scripted agent to become idle", async () => {
+    const chat = (await workspace.listChats()).find(entry => entry.id === chatId);
+    return chat !== undefined && chat.activeAgent === undefined ? true : null;
+  });
+  expect((await workspace.listActions({ filter: "observation" })).entries).toContainEqual(
+      expect.objectContaining({
+        type: "observation",
+        description: expect.objectContaining({ title: "Read the test value" }),
+      }));
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -20,7 +20,7 @@
 // is one control knob here, `allow`, and the reason string is what carries the distinction to the
 // user. Tests exercise both narratives by choosing reason text.
 
-import { DurableObject, WorkerEntrypoint, type RpcStub } from "cloudflare:workers";
+import { DurableObject, RpcTarget, WorkerEntrypoint, type RpcStub } from "cloudflare:workers";
 import type {
   AccountDescription, ActionKind, ApprovalQueue, Gatekeeper, GatekeeperConnectCallback,
   GatekeeperUser, GatekeeperUserVerifier, ResourceDescription, ResourceConfiguratorFrame,
@@ -38,8 +38,10 @@ const SUPPORTED_RESOURCES: SupportedResource[] = [{
 }];
 
 const TYPES_CODE = `
-/** A stand-in resource. It has no operations; nothing here is ever called. */
-interface TestThing {}
+/** A stand-in resource whose one read is deterministic and audited. */
+interface TestThing {
+  readValue(): Promise<number>;
+}
 `;
 
 // A 1x1 transparent GIF, so nothing here reaches for a network asset.
@@ -243,8 +245,29 @@ export class TestVerifier
 // ---------------------------------------------------------------------------
 // Gatekeeper (one per bound resource, running as a facet under the gadget's Overseer)
 
-/** No operations: these tests never open a gadget's session, only verify observers. */
-export type TestSession = Record<string, never>;
+export interface TestSession {
+  readValue(): Promise<number>;
+}
+
+class TestSessionTarget extends RpcTarget implements TestSession {
+  private readonly approvalQueue: RpcStub<ApprovalQueue>;
+
+  constructor(approvalQueue: RpcStub<ApprovalQueue>) {
+    super();
+    this.approvalQueue = approvalQueue.dup();
+  }
+  async readValue(): Promise<number> {
+    await this.approvalQueue.authorizeObservation({
+      title: "Read the test value",
+      description: "Read the deterministic value exposed by the integration-test gatekeeper.",
+    });
+    return 42;
+  }
+
+  [Symbol.dispose](): void {
+    this.approvalQueue[Symbol.dispose]();
+  }
+}
 
 export class TestGatekeeper
     extends DurableObject<Cloudflare.Env, BindingProps> implements Gatekeeper<TestSession> {
@@ -277,8 +300,8 @@ export class TestGatekeeper
     return [];
   }
 
-  async startSession(_approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {
-    return {};
+  async startSession(approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {
+    return new TestSessionTarget(approvalQueue);
   }
 
   /**

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -38,9 +38,10 @@ const SUPPORTED_RESOURCES: SupportedResource[] = [{
 }];
 
 const TYPES_CODE = `
-/** A stand-in resource whose one read is deterministic and audited. */
+/** A stand-in resource whose reads and writes are deterministic and audited. */
 interface TestThing {
   readValue(): Promise<number>;
+  writeValue(value: number): Promise<number>;
 }
 `;
 
@@ -64,6 +65,14 @@ type VerifyOutcome = { allow: true } | { allow: false; reason: string };
  * also pins the add/remove ordering.
  */
 type ObserverEvent = { resourceUrl: string; type: "add" | "remove"; id: string };
+
+type PendingTestAction = { id: number; value: number };
+type TestActionState = {
+  nextId: number;
+  pending: PendingTestAction[];
+  value?: number;
+  applyCount: number;
+};
 
 function outcomeKey(label: string, resourceUrl?: string): string {
   return resourceUrl ? `outcome:${label}:${resourceUrl}` : `outcome:${label}`;
@@ -101,6 +110,38 @@ export class TestControl extends DurableObject<Cloudflare.Env> {
 
   getAmbientVerificationCount(label: string): number {
     return this.ctx.storage.kv.get<number>(`ambient-verifications:${label}`) ?? 0;
+  }
+
+  getActionState(label: string): TestActionState {
+    return this.ctx.storage.kv.get<TestActionState>(`actions:${label}`) ?? {
+      nextId: 1,
+      pending: [],
+      applyCount: 0,
+    };
+  }
+
+  stageAction(label: string, value: number): number {
+    const state = this.getActionState(label);
+    const id = state.nextId++;
+    state.pending.push({ id, value });
+    this.ctx.storage.kv.put(`actions:${label}`, state);
+    return id;
+  }
+
+  discardAction(label: string, id: number): void {
+    const state = this.getActionState(label);
+    state.pending = state.pending.filter(action => action.id !== id);
+    this.ctx.storage.kv.put(`actions:${label}`, state);
+  }
+
+  applyAction(label: string, id: number): void {
+    const state = this.getActionState(label);
+    const action = state.pending.find(candidate => candidate.id === id);
+    if (action === undefined) throw new Error(`Unknown pending test action ${id}`);
+    state.pending = state.pending.filter(candidate => candidate.id !== id);
+    state.value = action.value;
+    state.applyCount++;
+    this.ctx.storage.kv.put(`actions:${label}`, state);
   }
 }
 
@@ -247,21 +288,43 @@ export class TestVerifier
 
 export interface TestSession {
   readValue(): Promise<number>;
+  writeValue(value: number): Promise<number>;
 }
 
 class TestSessionTarget extends RpcTarget implements TestSession {
   private readonly approvalQueue: RpcStub<ApprovalQueue>;
 
-  constructor(approvalQueue: RpcStub<ApprovalQueue>) {
+  constructor(
+      approvalQueue: RpcStub<ApprovalQueue>,
+      private readonly state: DurableObjectStub<TestControl>,
+      private readonly label: string) {
     super();
     this.approvalQueue = approvalQueue.dup();
   }
+
   async readValue(): Promise<number> {
     await this.approvalQueue.authorizeObservation({
       title: "Read the test value",
       description: "Read the deterministic value exposed by the integration-test gatekeeper.",
     });
     return 42;
+  }
+
+  async writeValue(value: number): Promise<number> {
+    const id = await this.state.stageAction(this.label, value);
+    try {
+      await this.approvalQueue.submitAction(id, {
+        title: `Set the test value to ${value}`,
+        description: `Set the deterministic integration-test value to **${value}**.`,
+        implementsRevert: false,
+        awaitDecision: true,
+        actionKind: { tag: "set-value", label: "Set value" },
+      });
+      return id;
+    } catch (error) {
+      await this.state.discardAction(this.label, id);
+      throw error;
+    }
   }
 
   [Symbol.dispose](): void {
@@ -301,7 +364,8 @@ export class TestGatekeeper
   }
 
   async startSession(approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {
-    return new TestSessionTarget(approvalQueue);
+    return new TestSessionTarget(
+        approvalQueue, control(this.ctx.exports), this.ctx.props.label);
   }
 
   /**
@@ -330,14 +394,16 @@ export class TestGatekeeper
         { resourceUrl: this.ctx.props.resourceUrl, type: "remove", id });
   }
 
-  async applyAction(_action: number): Promise<void> {
-    throw new Error("The test gatekeeper submits no actions.");
+  async applyAction(action: number): Promise<void> {
+    await control(this.ctx.exports).applyAction(this.ctx.props.label, action);
   }
 
-  async rejectAction(_action: number): Promise<void> {}
+  async rejectAction(action: number): Promise<void> {
+    await control(this.ctx.exports).discardAction(this.ctx.props.label, action);
+  }
 
   async revertAction(_action: number): Promise<void> {
-    throw new Error("The test gatekeeper submits no actions.");
+    throw new Error("Test actions do not support revert.");
   }
 }
 
@@ -413,6 +479,17 @@ export default {
       const { label } = body as Record<string, unknown>;
       if (!isNonEmptyString(label)) return badRequest("`label` must be a non-empty string");
       return Response.json({ count: await control(ctx.exports).getAmbientVerificationCount(label) });
+    }
+
+    if (url.pathname === "/control/action-state" && req.method === "POST") {
+      const { label } = body as Record<string, unknown>;
+      if (!isNonEmptyString(label)) return badRequest("`label` must be a non-empty string");
+      const state = await control(ctx.exports).getActionState(label);
+      return Response.json({
+        pending: state.pending,
+        value: state.value,
+        applyCount: state.applyCount,
+      });
     }
 
     // Make this Worker issue a subrequest, so a test can prove that Worker-originated fetches really

--- a/packages/integration-tests/src/harness.ts
+++ b/packages/integration-tests/src/harness.ts
@@ -81,6 +81,7 @@ function readWorkerConfig(dir: string): WorkerConfig {
 
 function workshopConfig(
     gatekeepers: { binding: string; name: string }[],
+    enableGadgetExecution: boolean,
     patch?: (config: WorkerConfig) => void): WorkerConfig {
   const config = readWorkerConfig(WORKSHOP_DIR);
   // globalSetup completed the destructive shared `.wrangler/validate` build before file workers
@@ -99,9 +100,9 @@ function workshopConfig(
   // No CF_ACCESS_AUD, so /api takes the unauthenticated path and password signup is available.
   config.vars = { ...config.vars, ADMINS: [ADMIN_USERNAME] };
 
-  // Gadget code is never executed here (a gatekeeper is in observer scope purely by having a
-  // vendorId), so drop the Worker Loader rather than requiring it to start.
-  delete config.worker_loaders;
+  // Most integration tests need no Gadget execution. Keep the loader only for tests that exercise
+  // executeCode or a generated Gadget server.
+  if (!enableGadgetExecution) delete config.worker_loaders;
 
   patch?.(config);
   return config;
@@ -127,6 +128,7 @@ export type Harness = {
 export async function startHarness(opts: {
   gatekeepers: GatekeeperSpec[];
   patchWorkshop?: (config: WorkerConfig) => void;
+  enableGadgetExecution?: boolean;
   /** Defaults to this repo's root. Override when a gatekeeper lives outside it. */
   root?: string;
 }): Promise<Harness> {
@@ -142,7 +144,8 @@ export async function startHarness(opts: {
     root: opts.root ?? REPO_ROOT,
     // workshop-backend is primary, so unrouted requests (e.g. /api) go to it.
     workers: [
-      { config: workshopConfig(gatekeepers, opts.patchWorkshop) },
+      { config: workshopConfig(gatekeepers, opts.enableGadgetExecution ?? false,
+          opts.patchWorkshop) },
       ...gatekeepers.map(({ config }) => ({ config })),
     ],
   });
@@ -156,8 +159,10 @@ export async function startHarness(opts: {
 }
 
 /** Boot the Workshop with only the bundled fixture gatekeeper bound. */
-export function startTestGatekeeperHarness(): Promise<Harness> {
+export function startTestGatekeeperHarness(options: { enableGadgetExecution?: boolean } = {})
+    : Promise<Harness> {
   return startHarness({
     gatekeepers: [{ binding: TEST_GATEKEEPER_BINDING, dir: TEST_GATEKEEPER_DIR }],
+    enableGadgetExecution: options.enableGadgetExecution,
   });
 }


### PR DESCRIPTION
This stacks on #354 and adds the first deterministic public-API test of the real Workshop agent loop.

The test runs this path under local workerd:

```text
public Cap’n Web API
→ fresh account and workspace
→ scripted model tool call
→ real executeCode tool
→ ambient fixture Gatekeeper
→ authorized observation returning 42
→ tool result sent back to the model
→ scripted final answer
→ canonical chat history
```

The fake model first requests `executeCode`. The code calls `env.TEST_AMBIENT.readValue()`. The fixture Gatekeeper authorizes that observation through the real `ApprovalQueue` and returns `42`. The second model request must contain that tool result, after which the scripted model responds with `The test value is 42.`

The test checks the user prompt sent to the model, presence of the `executeCode` tool, matching tool-call ID and result, persisted tool-call output, final assistant message, and cleared `activeAgent` state. It fails at the boundary that breaks rather than reducing the whole run to a score.

The fixture Gatekeeper gains one read-only session method for this path. The harness keeps the Worker Loader only when a test asks to execute Gadget or agent code; existing integration tests retain their lighter setup.

No real model, AI Gateway credential, external Gatekeeper, or production deployment is used. The same test passes with and without AI Gateway values in a developer’s root `.dev.vars`.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->