### PR TITLE
Test agent action approval through a gatekeeper

### DIFF
--- a/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { z } from "zod";
+import type { AiChatAuthorInfo, AiModelConfig } from "@gadgets/workshop-shared/api";
+import {
+  startTestGatekeeperHarness, TEST_GATEKEEPER_WORKER, TEST_VENDOR_ID, type Harness,
+} from "../src/harness.js";
+import { scriptedChatCompletions } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import {
+  accountLabel, connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
+} from "../src/rpc-client.js";
+
+const MODEL_ID = "@cf/zai-org/glm-5.2";
+const MODEL_PROFILE: AiChatAuthorInfo = { type: "agent", id: MODEL_ID, name: "Scripted model" };
+const MODEL_CONFIG: AiModelConfig = {
+  provider: "cloudflare",
+  model: MODEL_ID,
+  accountId: "test-account",
+  apiToken: "test-token",
+};
+
+let harness: Harness;
+const model = scriptedChatCompletions([
+  {
+    toolCall: {
+      id: "write-test-value",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) { console.log(await env.TEST_AMBIENT.writeValue(7)); }",
+      },
+    },
+  },
+  { text: "The test value was updated." },
+]);
+const network = new NetworkInterceptor([model.handler]);
+
+beforeAll(async () => {
+  network.install();
+  harness = await startTestGatekeeperHarness({ enableGadgetExecution: true });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+const TEST_ACTION_STATE = z.object({
+  pending: z.array(z.object({ id: z.number(), value: z.number() })),
+  value: z.number().optional(),
+  applyCount: z.number(),
+});
+type TestActionState = z.infer<typeof TEST_ACTION_STATE>;
+
+async function actionState(label: string): Promise<TestActionState> {
+  const response = await harness.fetchWorker(
+      TEST_GATEKEEPER_WORKER, "http://gatekeeper-test.test/control/action-state",
+      { method: "POST", body: JSON.stringify({ label }) });
+  if (response.status !== 200) {
+    throw new Error(`Reading test action state failed with ${response.status}: ${await response.text()}`);
+  }
+  return TEST_ACTION_STATE.parse(await response.json());
+}
+
+it("holds a scripted agent write until the user approves it", async () => {
+  using publicApi = connect(harness.url);
+  const [username] = nextUsernames("agentaction");
+  if (username === undefined) throw new Error("Failed to allocate an action-test username");
+  using authenticated = await signUp(publicApi, username);
+
+  await authenticated.addModel(MODEL_PROFILE, MODEL_CONFIG);
+  await authenticated.setQuickModel(null);
+  await authenticated.setPreferredModel(MODEL_ID);
+  await authenticated.completeOnboarding();
+  await authenticated.provisionAmbientAccount(TEST_VENDOR_ID);
+  const account = await waitFor("the ambient test account to be provisioned", async () =>
+    (await listConnectedAccounts(authenticated)).find(entry => entry.vendorId === TEST_VENDOR_ID)
+      ?? null);
+  const label = accountLabel(account);
+
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Set the test value to 7.", MODEL_ID);
+  const pending = await waitFor("the test action to enter the approval queue", async () => {
+    const entries = (await workspace.listActions({ filter: "pending" })).entries;
+    return entries.length === 1 ? entries[0] : null;
+  });
+
+  expect(pending).toMatchObject({
+    type: "action",
+    state: "pending",
+    description: {
+      title: "Set the test value to 7",
+      awaitDecision: true,
+      implementsRevert: false,
+    },
+  });
+  expect(await actionState(label)).toEqual({
+    pending: [{ id: 1, value: 7 }],
+    applyCount: 0,
+  });
+  await waitFor("the agent turn to suspend for approval", async () => {
+    const chat = (await workspace.listChats()).find(entry => entry.id === chatId);
+    return chat !== undefined && chat.activeAgent === undefined ? true : null;
+  });
+  expect(model.requests).toHaveLength(1);
+  const suspendedHistory = await workspace.getChatHistory(chatId);
+  expect(suspendedHistory.messages.some(message =>
+    message.type === "message" && message.author.type === "agent" &&
+    message.message === "The test value was updated.")).toBe(false);
+
+  await workspace.approveAction(pending.id);
+  const history = await waitFor("the scripted agent to continue after approval", async () => {
+    const current = await workspace.getChatHistory(chatId);
+    const error = current.messages.find(message => message.type === "error");
+    if (error !== undefined) throw new Error(`The scripted agent failed: ${error.message}`);
+    return current.messages.some(message =>
+      message.type === "message" && message.author.type === "agent" &&
+      message.message === "The test value was updated.") ? current : null;
+  });
+
+  expect(await actionState(label)).toEqual({ pending: [], value: 7, applyCount: 1 });
+  const [approved] = (await workspace.listActions({ filter: "action" })).entries;
+  expect(approved).toMatchObject({ id: pending.id, state: "approved", type: "action" });
+  if (approved?.type !== "action") throw new Error("Approved test action was not an action record");
+  expect(approved.resolvedBy).toMatchObject({ type: "user", id: username });
+  expect(model.requests).toHaveLength(2);
+  expect(model.requests[1]).toMatchObject({
+    messages: expect.arrayContaining([
+      expect.objectContaining({ role: "tool", content: expect.stringContaining("1") }),
+    ]),
+  });
+  expect(history.messages).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      type: "message",
+      author: expect.objectContaining({ type: "agent" }),
+      message: "The test value was updated.",
+    }),
+  ]));
+  await expect(workspace.approveAction(pending.id)).rejects.toThrow();
+  expect((await actionState(label)).applyCount).toBe(1);
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -38,9 +38,10 @@ const SUPPORTED_RESOURCES: SupportedResource[] = [{
 }];
 
 const TYPES_CODE = `
-/** A stand-in resource whose one read is deterministic and audited. */
+/** A stand-in resource whose reads and writes are deterministic and audited. */
 interface TestThing {
   readValue(): Promise<number>;
+  writeValue(value: number): Promise<number>;
 }
 `;
 
@@ -64,6 +65,14 @@ type VerifyOutcome = { allow: true } | { allow: false; reason: string };
  * also pins the add/remove ordering.
  */
 type ObserverEvent = { resourceUrl: string; type: "add" | "remove"; id: string };
+
+type PendingTestAction = { id: number; value: number };
+type TestActionState = {
+  nextId: number;
+  pending: PendingTestAction[];
+  value?: number;
+  applyCount: number;
+};
 
 function outcomeKey(label: string, resourceUrl?: string): string {
   return resourceUrl ? `outcome:${label}:${resourceUrl}` : `outcome:${label}`;
@@ -101,6 +110,38 @@ export class TestControl extends DurableObject<Cloudflare.Env> {
 
   getAmbientVerificationCount(label: string): number {
     return this.ctx.storage.kv.get<number>(`ambient-verifications:${label}`) ?? 0;
+  }
+
+  getActionState(label: string): TestActionState {
+    return this.ctx.storage.kv.get<TestActionState>(`actions:${label}`) ?? {
+      nextId: 1,
+      pending: [],
+      applyCount: 0,
+    };
+  }
+
+  stageAction(label: string, value: number): number {
+    const state = this.getActionState(label);
+    const id = state.nextId++;
+    state.pending.push({ id, value });
+    this.ctx.storage.kv.put(`actions:${label}`, state);
+    return id;
+  }
+
+  discardAction(label: string, id: number): void {
+    const state = this.getActionState(label);
+    state.pending = state.pending.filter(action => action.id !== id);
+    this.ctx.storage.kv.put(`actions:${label}`, state);
+  }
+
+  applyAction(label: string, id: number): void {
+    const state = this.getActionState(label);
+    const action = state.pending.find(candidate => candidate.id === id);
+    if (action === undefined) throw new Error(`Unknown pending test action ${id}`);
+    state.pending = state.pending.filter(candidate => candidate.id !== id);
+    state.value = action.value;
+    state.applyCount++;
+    this.ctx.storage.kv.put(`actions:${label}`, state);
   }
 }
 
@@ -247,21 +288,43 @@ export class TestVerifier
 
 export interface TestSession {
   readValue(): Promise<number>;
+  writeValue(value: number): Promise<number>;
 }
 
 class TestSessionTarget extends RpcTarget implements TestSession {
   private readonly approvalQueue: RpcStub<ApprovalQueue>;
 
-  constructor(approvalQueue: RpcStub<ApprovalQueue>) {
+  constructor(
+      approvalQueue: RpcStub<ApprovalQueue>,
+      private readonly state: DurableObjectStub<TestControl>,
+      private readonly label: string) {
     super();
     this.approvalQueue = approvalQueue.dup();
   }
+
   async readValue(): Promise<number> {
     await this.approvalQueue.authorizeObservation({
       title: "Read the test value",
       description: "Read the deterministic value exposed by the integration-test gatekeeper.",
     });
     return 42;
+  }
+
+  async writeValue(value: number): Promise<number> {
+    const id = await this.state.stageAction(this.label, value);
+    try {
+      await this.approvalQueue.submitAction(id, {
+        title: `Set the test value to ${value}`,
+        description: `Set the deterministic integration-test value to **${value}**.`,
+        implementsRevert: false,
+        awaitDecision: true,
+        actionKind: { tag: "set-value", label: "Set value" },
+      });
+      return id;
+    } catch (error) {
+      await this.state.discardAction(this.label, id);
+      throw error;
+    }
   }
 
   [Symbol.dispose](): void {
@@ -301,7 +364,8 @@ export class TestGatekeeper
   }
 
   async startSession(approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {
-    return new TestSessionTarget(approvalQueue);
+    return new TestSessionTarget(
+        approvalQueue, control(this.ctx.exports), this.ctx.props.label);
   }
 
   /**
@@ -330,14 +394,16 @@ export class TestGatekeeper
         { resourceUrl: this.ctx.props.resourceUrl, type: "remove", id });
   }
 
-  async applyAction(_action: number): Promise<void> {
-    throw new Error("The test gatekeeper submits no actions.");
+  async applyAction(action: number): Promise<void> {
+    await control(this.ctx.exports).applyAction(this.ctx.props.label, action);
   }
 
-  async rejectAction(_action: number): Promise<void> {}
+  async rejectAction(action: number): Promise<void> {
+    await control(this.ctx.exports).discardAction(this.ctx.props.label, action);
+  }
 
   async revertAction(_action: number): Promise<void> {
-    throw new Error("The test gatekeeper submits no actions.");
+    throw new Error("Test actions do not support revert.");
   }
 }
 
@@ -413,6 +479,17 @@ export default {
       const { label } = body as Record<string, unknown>;
       if (!isNonEmptyString(label)) return badRequest("`label` must be a non-empty string");
       return Response.json({ count: await control(ctx.exports).getAmbientVerificationCount(label) });
+    }
+
+    if (url.pathname === "/control/action-state" && req.method === "POST") {
+      const { label } = body as Record<string, unknown>;
+      if (!isNonEmptyString(label)) return badRequest("`label` must be a non-empty string");
+      const state = await control(ctx.exports).getActionState(label);
+      return Response.json({
+        pending: state.pending,
+        value: state.value,
+        applyCount: state.applyCount,
+      });
     }
 
     // Make this Worker issue a subrequest, so a test can prove that Worker-originated fetches really


### PR DESCRIPTION
This adds a deterministic public-API test for the agent write-action approval path.

The scripted model asks `executeCode` to call `env.TEST_AMBIENT.writeValue(7)`. The fixture Gatekeeper submits that write through the real `ApprovalQueue` with `awaitDecision: true`, so the agent turn pauses while the action is pending.

The test then verifies this sequence:

```text
scripted agent requests a write
→ fixture Gatekeeper stages the value
→ Workshop records one pending action
→ staged value has not been applied
→ user approves through Overseer.approveAction()
→ Gatekeeper applies the action exactly once
→ action history becomes approved
→ agent resumes and returns its final answer
```

The assertions cover the action title and policy fields, pending state, absence of an early side effect, resolver identity, final stored value, apply count, model continuation, canonical final chat message, and rejection of a second approval attempt.

The fixture’s `TestThing` session gains `writeValue()`. Its control surface exposes only the staged/applied state required to prove the security boundary. The existing `readValue()` observation path is unchanged.

Everything runs under local workerd using the real Workshop backend, agent loop, Worker Loader, Gatekeeper protocol, Durable Objects, action log, and public Cap’n Web API. The model and Gatekeeper responses are controlled locally; no provider request or external service is used. The same test passes with and without AI Gateway values in a root `.dev.vars`.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->