### PR TITLE
Add local Workshop trajectory evals

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "vp run -r --cache build",
     "run-local": "node scripts/run-local.ts",
     "test": "vp run --filter '!cloudflare-os' --cache test",
+    "evals": "pnpm --filter @gadgets/workshop-evals evals",
+    "evals:ui": "pnpm --filter @gadgets/workshop-evals evals:ui",
     "preview:config": "node scripts/preview/preview.ts config",
     "preview:deploy": "node scripts/preview/preview.ts deploy",
     "preview:delete": "node scripts/preview/preview.ts delete",

--- a/packages/integration-tests/__tests__/network-interceptor.test.ts
+++ b/packages/integration-tests/__tests__/network-interceptor.test.ts
@@ -12,10 +12,10 @@ let fetchedByReal: string[];
 
 beforeEach(() => {
   fetchedByReal = [];
-  globalThis.fetch = (async (input: unknown) => {
-    fetchedByReal.push(String(input));
+  globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
+    fetchedByReal.push(input instanceof Request ? input.url : String(input));
     return new Response("from the real fetch");
-  }) as typeof globalThis.fetch;
+  };
 });
 
 afterEach(() => {
@@ -40,7 +40,7 @@ it("asks handlers in order and takes the first non-null answer", async () => {
   const asked: string[] = [];
   const declines: Handler = url => { asked.push(`declines ${url.host}`); return null; };
   const answers: Handler = url => { asked.push(`answers ${url.host}`); return new Response("two"); };
-  new NetworkInterceptor([declines, answers, neverAsked]).install();
+  new NetworkInterceptor({ handlers: [declines, answers, neverAsked] }).install();
 
   const res = await fetch("https://vendor.test/api");
   expect(await res.text()).toBe("two");
@@ -48,12 +48,22 @@ it("asks handlers in order and takes the first non-null answer", async () => {
   expect(fetchedByReal).toEqual([]);
 });
 
+it("passes an explicitly allowed external request to the real fetch", async () => {
+  const interceptor = new NetworkInterceptor({ handlers: [], allow: url => url.hostname === "model.test" });
+  interceptor.install();
+
+  const response = await fetch("https://model.test/chat");
+  expect(await response.text()).toBe("from the real fetch");
+  expect(fetchedByReal).toEqual(["https://model.test/chat"]);
+  expect(interceptor.getUnmockedCalls()).toEqual([]);
+});
+
 it("supports a handler that parks until the test provides an answer", async () => {
   // Load-bearing for the CF Access transfer mock: the Worker starts polling before the test knows
   // what to serve, so a handler must be able to wait (see the Handler type's doc comment).
   let serve!: (body: string) => void;
   const parked = new Promise<string>(resolve => { serve = resolve; });
-  new NetworkInterceptor([async () => new Response(await parked)]).install();
+  new NetworkInterceptor({ handlers: [async () => new Response(await parked)] }).install();
 
   const pending = fetch("https://vendor.test/poll");
   serve("finally");
@@ -66,7 +76,7 @@ it("hands handlers the method and headers from any fetch input form", async () =
     seen.push(`${method} ${url.href} auth=${headers.get("authorization")}`);
     return new Response(null, { status: 204 });
   };
-  new NetworkInterceptor([record]).install();
+  new NetworkInterceptor({ handlers: [record] }).install();
 
   await fetch("https://a.test/", { method: "post", headers: { authorization: "one" } });
   await fetch(new URL("https://b.test/"));
@@ -79,7 +89,7 @@ it("hands handlers the method and headers from any fetch input form", async () =
 });
 
 it("throws on an unmatched request and records it", async () => {
-  const interceptor = new NetworkInterceptor([() => null]);
+  const interceptor = new NetworkInterceptor({ handlers: [() => null] });
   interceptor.install();
 
   await expect(fetch("https://escaped.test/x")).rejects.toThrow(

--- a/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-actions.test.ts
@@ -24,7 +24,7 @@ const model = scriptedChatCompletions([
   },
   { text: "The test value was updated." },
 ]);
-const network = new NetworkInterceptor([model.handler]);
+const network = new NetworkInterceptor({ handlers: [model.handler] });
 
 beforeAll(async () => {
   network.install();

--- a/packages/integration-tests/__tests__/workshop-agent.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent.test.ts
@@ -64,7 +64,7 @@ const model = scriptedChatCompletions([
   { error: { status: 503, message: "scripted provider outage" } },
   { pending: true },
 ]);
-const network = new NetworkInterceptor([model.handler]);
+const network = new NetworkInterceptor({ handlers: [model.handler] });
 
 beforeAll(async () => {
   network.install();

--- a/packages/integration-tests/__tests__/workshop-lifecycle.test.ts
+++ b/packages/integration-tests/__tests__/workshop-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { NetworkInterceptor } from "../src/network-interceptor.js";
 import { connect, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
 
 let harness: Harness | undefined;
-const network = new NetworkInterceptor([mockChatCompletion("Test chat")]);
+const network = new NetworkInterceptor({ handlers: [mockChatCompletion("Test chat")] });
 
 beforeAll(async () => {
   network.install();

--- a/packages/integration-tests/__tests__/workshop-presence.test.ts
+++ b/packages/integration-tests/__tests__/workshop-presence.test.ts
@@ -22,7 +22,7 @@ class PresenceRecorder extends RpcTarget implements PresenceSubscriber {
 }
 
 let harness: Harness | undefined;
-const network = new NetworkInterceptor([mockChatCompletion("Test chat")]);
+const network = new NetworkInterceptor({ handlers: [mockChatCompletion("Test chat")] });
 
 beforeAll(async () => {
   network.install();

--- a/packages/integration-tests/__tests__/workshop-sharing.test.ts
+++ b/packages/integration-tests/__tests__/workshop-sharing.test.ts
@@ -9,7 +9,7 @@ import { NetworkInterceptor } from "../src/network-interceptor.js";
 import { connect, logIn, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
 
 let harness: Harness | undefined;
-const network = new NetworkInterceptor([mockChatCompletion("Test chat")]);
+const network = new NetworkInterceptor({ handlers: [mockChatCompletion("Test chat")] });
 
 beforeAll(async () => {
   network.install();

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -7,7 +7,8 @@
     "./harness": "./src/harness.ts",
     "./agent-session": "./src/agent-session.ts",
     "./network-interceptor": "./src/network-interceptor.ts",
-    "./rpc-client": "./src/rpc-client.ts"
+    "./rpc-client": "./src/rpc-client.ts",
+    "./mock-model": "./src/mock-model.ts"
   },
   "scripts": {
     "build": "tsc --noEmit",

--- a/packages/integration-tests/src/agent-session.ts
+++ b/packages/integration-tests/src/agent-session.ts
@@ -1,8 +1,8 @@
 import type { RpcPromise, RpcStub } from "capnweb";
 import type {
   ActionHistoryFilter, ActionHistoryPage, AiChatAuthorInfo, AiChatHistoryPage, AiChatMessage,
-  AiChatMetadata, AiChatStreamEvent, AiChatSubscriber, AiModelConfig, AuthenticatedApi, Overseer,
-  PublicApi, WorkpieceId, WorkpieceSummary, WorkpiecesSubscriber,
+  AiChatMetadata, AiChatStreamEvent, AiChatSubscriber, AiModelConfig, AuthenticatedApi, GadgetClient,
+  Overseer, PublicApi, WorkpieceId, WorkpieceSummary, WorkpiecesSubscriber,
 } from "@gadgets/workshop-shared/api";
 import type { CodeChange } from "@gadgets/workshop-shared/code-change";
 import {
@@ -54,6 +54,9 @@ export type AgentTurnResult = {
 /** Filters accepted by the public action-history API. */
 export type ActionListOptions = { beforeId?: number; filter?: ActionHistoryFilter };
 
+/** Gadget client and chat branch needed to connect to provisional agent code. */
+export type ProvisionalGadget = { client: RpcStub<GadgetClient>; chatId: number };
+
 /**
  * Drives a fresh local Workshop account and workspace through the public Cap'n Web API.
  * `runTurn()` observes one active-to-idle agent activation. It does not claim that late callbacks
@@ -66,6 +69,7 @@ export interface WorkshopAgentSession extends AsyncDisposable {
       ids: readonly [number, ...number[]], options?: AgentTurnOptions): Promise<AgentTurnResult>;
   listActions(options?: ActionListOptions): Promise<ActionHistoryPage>;
   connectedAccount(vendorId: string): ConnectedAccount;
+  openGadget(id: WorkpieceId): Promise<ProvisionalGadget>;
   close(): Promise<void>;
 }
 
@@ -444,6 +448,13 @@ class WorkshopAgentSessionImpl implements WorkshopAgentSession {
     return account;
   }
 
+  async openGadget(id: WorkpieceId): Promise<ProvisionalGadget> {
+    this.#assertNotClosed();
+    const chatId = this.#chatId;
+    if (chatId === undefined) throw new Error("The session has no chat branch");
+    return { client: await this.#workspace.getGadget(id), chatId };
+  }
+
   close(): Promise<void> {
     this.#closePromise ??= this.#close();
     return this.#closePromise;
@@ -695,8 +706,12 @@ class WorkshopAgentSessionImpl implements WorkshopAgentSession {
   }
 
   #assertOpen(): void {
-    if (this.#closed) throw new Error("WorkshopAgentSession is closed");
+    this.#assertNotClosed();
     if (this.#terminal) throw new Error("WorkshopAgentSession cannot continue after interruption");
+  }
+
+  #assertNotClosed(): void {
+    if (this.#closed) throw new Error("WorkshopAgentSession is closed");
   }
 }
 

--- a/packages/integration-tests/src/harness.ts
+++ b/packages/integration-tests/src/harness.ts
@@ -36,6 +36,11 @@ export const ADMIN_USERNAME = "admin";
 const WORKER_CONFIG = z.looseObject({
   name: z.string(),
   main: z.string(),
+  account_id: z.string().optional(),
+  ai: z.looseObject({
+    binding: z.string(),
+    remote: z.boolean().optional(),
+  }).optional(),
   build: z.looseObject({ command: z.string().optional(), cwd: z.string().optional() }).optional(),
   services: z.array(z.looseObject({
     binding: z.string(),

--- a/packages/integration-tests/src/network-interceptor.ts
+++ b/packages/integration-tests/src/network-interceptor.ts
@@ -22,13 +22,28 @@ export type Handler = (
   request: Request,
 ) => Response | null | Promise<Response | null>;
 
+/** Decides whether one request may use the real network. */
+export type AllowRequest = (url: URL, method: string, headers: Headers) => boolean;
+
+type NetworkInterceptorOptions = {
+  handlers?: Handler[];
+  allow?: AllowRequest;
+  allowLoopback?: boolean;
+};
+
 export class NetworkInterceptor {
   readonly #handlers: readonly Handler[];
+  readonly #allow: AllowRequest | undefined;
+  readonly #allowLoopback: boolean;
   #realFetch: typeof globalThis.fetch | null = null;
   #unmockedCalls: string[] = [];
 
-  constructor(handlers: Handler[] = []) {
+  constructor({
+    handlers = [], allow, allowLoopback = true,
+  }: NetworkInterceptorOptions = {}) {
     this.#handlers = [...handlers];
+    this.#allow = allow;
+    this.#allowLoopback = allowLoopback;
   }
 
   install(): void {
@@ -44,8 +59,11 @@ export class NetworkInterceptor {
         : input.url;
       const url = new URL(raw);
 
-      // The harness dispatches its own traffic over loopback; let that through untouched.
-      if (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") {
+      // Test clients use loopback by default. Security-sensitive callers can route it through
+      // their handlers instead so model-authored requests cannot reach host services.
+      if (this.#allowLoopback &&
+          (url.hostname === "localhost" || url.hostname === "127.0.0.1" ||
+           url.hostname === "[::1]")) {
         return realFetch(input, init);
       }
 
@@ -54,6 +72,8 @@ export class NetworkInterceptor {
       // this point `input` is never forwarded anywhere, so disturbing it costs nothing.
       const request = new Request(input, init);
       const method = request.method.toUpperCase();
+
+      if (this.#allow?.(url, method, request.headers)) return realFetch(request);
 
       for (const handler of this.#handlers) {
         const response = await handler(url, method, request.headers, request);

--- a/packages/workshop-backend/src/ai-gateway.ts
+++ b/packages/workshop-backend/src/ai-gateway.ts
@@ -1,4 +1,6 @@
-import { AiChatAuthorInfo, AiModelConfig, SUGGESTED_MODELS } from "@gadgets/workshop-shared/api";
+import {
+  AiChatAuthorInfo, AiModelConfig, HTTPS_ONLY_PROVIDERS, SUGGESTED_MODELS,
+} from "@gadgets/workshop-shared/api";
 import { UserAiModelRecord } from "./user.js";
 
 // The model used for quick tasks like title generation when AI Gateway mode is active.
@@ -6,21 +8,6 @@ import { UserAiModelRecord } from "./user.js";
 // This 70B model is quite fast and cheap and produces pretty good titles. The cost is insignificant
 // compared to the actual coding model so there's not much reason to use a smaller model.
 const QUICK_MODEL_ID = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
-
-/**
- * Providers whose pi API adapter refuses a custom fetch, so their inference cannot ride the
- * Workers AI binding and needs CF_AI_GATEWAY_API_TOKEN over HTTPS. pi's Google adapter throws
- * "Custom fetch is not supported by the Google Generative AI adapter" whenever the fetch it is
- * given is not globalThis.fetch, and the client it builds on offers no hook to route around that:
- * @google/genai's `GoogleGenAI` takes only `httpOptions`, whose knobs are
- * baseUrl/apiVersion/headers/timeout/extraBody/retryOptions.
- * https://github.com/earendil-works/pi/blob/v0.84.2/packages/ai/src/api/google-generative-ai.ts#L80
- *
- * pi's Vertex adapter throws the same way, so a google-vertex provider would belong here too; it
- * is absent only because this deployment has no such provider.
- * https://github.com/earendil-works/pi/blob/v0.84.2/packages/ai/src/api/google-vertex.ts#L98
- */
-const HTTPS_ONLY_PROVIDERS = new Set(["google"]);
 
 export class AiGatewayConfig {
   readonly gateway: string;

--- a/packages/workshop-evals/evals/project-doc.eval.ts
+++ b/packages/workshop-evals/evals/project-doc.eval.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+import { defineTaskEval } from "../src/eval.js";
+import { defineEvalTask } from "../src/task.js";
+
+const DOCUMENT = z.object({
+  revision: z.number().int().nonnegative(),
+  title: z.string(),
+  blocks: z.array(z.object({
+    id: z.string(),
+    html: z.string(),
+    version: z.number().int().nonnegative(),
+  }).loose()).nullable(),
+}).loose();
+
+type Document = z.infer<typeof DOCUMENT>;
+
+interface DocsApi {
+  getDocument(): Promise<Document>;
+}
+
+const TITLE = "Harbour Refit";
+
+function plainText(html: string): string {
+  return html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function distinctTopicIndexes(items: readonly string[], topics: readonly string[]): number[] | null {
+  const indexes: number[] = [];
+  const used = new Set<number>();
+  const assign = (topicIndex: number): boolean => {
+    const topic = topics.at(topicIndex);
+    if (topic === undefined) return true;
+    for (const [itemIndex, item] of items.entries()) {
+      if (used.has(itemIndex) || !item.includes(topic) ||
+          item.length < topic.length + 12 || !/[.!?]/.test(item)) continue;
+      used.add(itemIndex);
+      indexes.push(itemIndex);
+      if (assign(topicIndex + 1)) return true;
+      indexes.pop();
+      used.delete(itemIndex);
+    }
+    return false;
+  };
+  return assign(0) ? indexes : null;
+}
+
+const task = defineEvalTask({
+  id: "project-doc",
+  turns: [{
+    prompt: `I'm kicking off a project called Harbour Refit. Set me up a doc named exactly
+"${TITLE}" for my running notes on it.
+
+Start it off with a heading for the project and three bullet points, one each for scope, budget and
+timeline. Put a sentence of placeholder detail under each. I'll replace them as things firm up.`,
+    verify: async verifier => {
+      await verifier.check("is-presented-as-a-document-output", async () => {
+        const doc = verifier.workpieces.find(workpiece => workpiece.title === TITLE);
+        return {
+          pass: doc?.output?.id === "document",
+          evidence: verifier.workpieces.map(workpiece => ({
+            title: workpiece.title,
+            outputId: workpiece.output?.id ?? null,
+          })),
+        };
+      });
+
+      await verifier.check("answers-the-docs-contract-with-real-content", async () => {
+        using api = await verifier.connect<DocsApi>(TITLE);
+        const document = DOCUMENT.parse(await api.getDocument());
+        const html = (document.blocks ?? []).map(block => block.html).join("\n");
+        const listItems = [...html.matchAll(/<li(?:\s[^>]*)?>([\s\S]*?)<\/li>/gi)]
+            .map(match => plainText(match[1] ?? ""));
+        const headings = [...html.matchAll(/<h[1-6](?:\s[^>]*)?>([\s\S]*?)<\/h[1-6]>/gi)]
+            .map(match => plainText(match[1] ?? ""));
+        const requiredItems = ["scope", "budget", "timeline"];
+        const topicIndexes = distinctTopicIndexes(listItems, requiredItems);
+
+        // Collect headings and list items with their source positions rather than as
+        // independent collections: the prompt asks the document to START with the project
+        // heading, so the matching heading must precede the first list item in source order.
+        let headingIndex: number | null = null;
+        for (const match of html.matchAll(/<h[1-6](?:\s[^>]*)?>([\s\S]*?)<\/h[1-6]>/gi)) {
+          const heading = plainText(match[1] ?? "");
+          if (heading.includes("harbour") && heading.includes("refit")) {
+            headingIndex = match.index ?? null;
+            break;
+          }
+        }
+        let listItemIndex: number | null = null;
+        for (const match of html.matchAll(/<li(?:\s[^>]*)?>/gi)) {
+          listItemIndex = match.index ?? null;
+          break;
+        }
+
+        return {
+          pass: document.revision >= 1 && document.blocks !== null &&
+            document.title === TITLE &&
+            headingIndex !== null && listItemIndex !== null &&
+            headingIndex < listItemIndex &&
+            listItems.length === 3 && topicIndexes !== null,
+          evidence: {
+            revision: document.revision,
+            title: document.title,
+            blockCount: document.blocks?.length ?? null,
+            listItems,
+            headings,
+            topicIndexes,
+            headingIndex,
+            listItemIndex,
+          },
+        };
+      });
+    },
+  }],
+});
+
+defineTaskEval(task);

--- a/packages/workshop-evals/package.json
+++ b/packages/workshop-evals/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@gadgets/workshop-evals",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test:run": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts",
+    "evals": "pnpm exec vp run -F @gadgets/integration-tests build:test-gatekeeper && vitest run --config vitest.eval.config.ts --reporter=vitest-evals/reporter --reporter=json --outputFile.json=.wrangler/evals/results.json",
+    "evals:ui": "vitest-evals serve .wrangler/evals/results.json"
+  },
+  "dependencies": {
+    "@gadgets/integration-tests": "workspace:*",
+    "@gadgets/workshop-shared": "workspace:*",
+    "capnweb": "catalog:",
+    "vitest-evals": "0.16.1",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260808.1",
+    "@types/node": "^26.1.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/workshop-evals/src/config.test.ts
+++ b/packages/workshop-evals/src/config.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "vitest";
+import {
+  EVAL_AGENT_BUDGET_MS, EVAL_TEST_TIMEOUT_MS, EVAL_VERIFICATION_BUDGET_MS, evalMatrix,
+  resolveEvalCommit,
+} from "./config.js";
+import { taskVersion, type EvalTask } from "./task.js";
+
+it("leaves an outer margin for setup and cleanup", () => {
+  expect(EVAL_TEST_TIMEOUT_MS)
+    .toBeGreaterThan(EVAL_AGENT_BUDGET_MS + EVAL_VERIFICATION_BUDGET_MS);
+});
+
+it("uses DeepSeek V4 Pro and one trial by default", () => {
+  expect(evalMatrix({})).toEqual({
+    models: ["@cf/deepseek-ai/deepseek-v4-pro-0813"],
+    trials: 1,
+  });
+});
+
+it("accepts model and trial overrides", () => {
+  expect(evalMatrix({
+    WORKSHOP_EVAL_MODELS: " model-a, model-b ",
+    WORKSHOP_EVAL_TRIALS: "3",
+  })).toEqual({ models: ["model-a", "model-b"], trials: 3 });
+});
+
+it("rejects an invalid trial count", () => {
+  expect(() => evalMatrix({ WORKSHOP_EVAL_TRIALS: "0" })).toThrow("positive integer");
+});
+
+const COMMIT = "a".repeat(40);
+
+it("records the checkout commit", () => {
+  expect(resolveEvalCommit({ GITHUB_SHA: COMMIT }, () => "unused", () => true)).toBe(COMMIT);
+  expect(resolveEvalCommit({}, () => COMMIT, () => false)).toBe(COMMIT);
+  expect(() => resolveEvalCommit({}, () => COMMIT, () => true)).toThrow("clean worktree");
+  expect(() => resolveEvalCommit({ WORKSHOP_EVAL_COMMIT: "main" }, () => COMMIT, () => false))
+    .toThrow("40-character Git SHA");
+});
+
+it("versions only the task prompts", () => {
+  const task: EvalTask = {
+    id: "one",
+    turns: [{ prompt: "Build it", verify: () => Promise.resolve() }],
+  };
+  const version = taskVersion(task);
+  expect(version).toMatch(/^[a-f0-9]{64}$/);
+  expect(taskVersion({
+    ...task,
+    turns: [{ prompt: "Build it", verify: async () => { await Promise.resolve(); } }],
+  })).toBe(version);
+  expect(taskVersion({ ...task, turns: [{ ...task.turns[0], prompt: "Build it better" }] }))
+    .not.toBe(version);
+});

--- a/packages/workshop-evals/src/config.test.ts
+++ b/packages/workshop-evals/src/config.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest";
 import {
   EVAL_AGENT_BUDGET_MS, EVAL_TEST_TIMEOUT_MS, EVAL_VERIFICATION_BUDGET_MS, evalMatrix,
-  resolveEvalCommit,
+  resolveEvalCommit, resolveEvalModel,
 } from "./config.js";
 import { taskVersion, type EvalTask } from "./task.js";
 
@@ -26,6 +26,20 @@ it("accepts model and trial overrides", () => {
 
 it("rejects an invalid trial count", () => {
   expect(() => evalMatrix({ WORKSHOP_EVAL_TRIALS: "0" })).toThrow("positive integer");
+});
+
+it("resolves catalog models to their provider", () => {
+  expect(resolveEvalModel("gemini-3.6-flash"))
+    .toEqual({ provider: "google", model: "gemini-3.6-flash" });
+  expect(resolveEvalModel("claude-sonnet-5"))
+    .toEqual({ provider: "anthropic", model: "claude-sonnet-5" });
+  expect(resolveEvalModel("@cf/deepseek-ai/deepseek-v4-pro-0813"))
+    .toEqual({ provider: "cloudflare", model: "@cf/deepseek-ai/deepseek-v4-pro-0813" });
+});
+
+it("treats unlisted models as Workers AI models", () => {
+  expect(resolveEvalModel("@cf/vendor/not-in-catalog"))
+    .toEqual({ provider: "cloudflare", model: "@cf/vendor/not-in-catalog" });
 });
 
 const COMMIT = "a".repeat(40);

--- a/packages/workshop-evals/src/config.test.ts
+++ b/packages/workshop-evals/src/config.test.ts
@@ -19,9 +19,14 @@ it("uses DeepSeek V4 Pro and one trial by default", () => {
 
 it("accepts model and trial overrides", () => {
   expect(evalMatrix({
-    WORKSHOP_EVAL_MODELS: " model-a, model-b ",
+    WORKSHOP_EVAL_MODELS: " @cf/zai-org/glm-5.2, claude-sonnet-5 ",
     WORKSHOP_EVAL_TRIALS: "3",
-  })).toEqual({ models: ["model-a", "model-b"], trials: 3 });
+  })).toEqual({ models: ["@cf/zai-org/glm-5.2", "claude-sonnet-5"], trials: 3 });
+});
+
+it("rejects a model that is not in the catalog", () => {
+  expect(() => evalMatrix({ WORKSHOP_EVAL_MODELS: "@cf/zai-org/glm-5.2, model-b" }))
+    .toThrow('Unknown eval model "model-b"');
 });
 
 it("rejects an invalid trial count", () => {
@@ -37,9 +42,14 @@ it("resolves catalog models to their provider", () => {
     .toEqual({ provider: "cloudflare", model: "@cf/deepseek-ai/deepseek-v4-pro-0813" });
 });
 
-it("treats unlisted models as Workers AI models", () => {
-  expect(resolveEvalModel("@cf/vendor/not-in-catalog"))
-    .toEqual({ provider: "cloudflare", model: "@cf/vendor/not-in-catalog" });
+it("resolves eval-only models that the picker does not offer", () => {
+  expect(resolveEvalModel("@cf/meta/llama-3.3-70b-instruct-fp8-fast"))
+    .toEqual({ provider: "cloudflare", model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast" });
+});
+
+it("does not guess a provider for an unlisted model", () => {
+  expect(() => resolveEvalModel("@cf/vendor/not-in-catalog"))
+    .toThrow("must be listed in SUGGESTED_MODELS or EVAL_ONLY_MODELS");
 });
 
 const COMMIT = "a".repeat(40);

--- a/packages/workshop-evals/src/config.ts
+++ b/packages/workshop-evals/src/config.ts
@@ -1,0 +1,50 @@
+import { execFileSync } from "node:child_process";
+
+const DEFAULT_MODELS = ["@cf/deepseek-ai/deepseek-v4-pro-0813"];
+const GIT_SHA_PATTERN = /^[a-f0-9]{40}$/;
+
+export const EVAL_AGENT_BUDGET_MS = 28 * 60_000;
+export const EVAL_VERIFICATION_BUDGET_MS = 2 * 60_000;
+export const EVAL_TEST_TIMEOUT_MS = 40 * 60_000;
+export type EvalIdentity = { gitCommit: string; taskVersion: string };
+export type EvalMatrix = { models: string[]; trials: number };
+
+function commaList(value: string): string[] {
+  return value.split(",").map(item => item.trim()).filter(Boolean);
+}
+
+function localGitCommit(): string {
+  return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+}
+
+function localWorktreeDirty(): boolean {
+  return execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" }).trim() !== "";
+}
+
+/** Identify the checkout that supplied the local Workshop and eval code. */
+export function resolveEvalCommit(
+    environment: NodeJS.ProcessEnv = process.env,
+    readLocalCommit: () => string = localGitCommit,
+    isLocalWorktreeDirty: () => boolean = localWorktreeDirty): string {
+  const configured = environment.WORKSHOP_EVAL_COMMIT?.trim() || environment.GITHUB_SHA?.trim();
+  if (configured === undefined && isLocalWorktreeDirty()) {
+    throw new Error(
+      "Local evals require a clean worktree or an explicit WORKSHOP_EVAL_COMMIT");
+  }
+  const commit = configured ?? readLocalCommit();
+  if (!GIT_SHA_PATTERN.test(commit)) {
+    throw new Error("WORKSHOP_EVAL_COMMIT must be a full 40-character Git SHA");
+  }
+  return commit;
+}
+
+/** Parse the model and repetition controls before a trial can spend inference. */
+export function evalMatrix(environment: NodeJS.ProcessEnv = process.env): EvalMatrix {
+  const models = commaList(environment.WORKSHOP_EVAL_MODELS ?? "");
+  const rawTrials = environment.WORKSHOP_EVAL_TRIALS?.trim();
+  const trials = rawTrials === undefined || rawTrials === "" ? 1 : Number(rawTrials);
+  if (!Number.isInteger(trials) || trials < 1) {
+    throw new Error("WORKSHOP_EVAL_TRIALS must be a positive integer");
+  }
+  return { models: models.length > 0 ? models : [...DEFAULT_MODELS], trials };
+}

--- a/packages/workshop-evals/src/config.ts
+++ b/packages/workshop-evals/src/config.ts
@@ -1,13 +1,23 @@
 import { execFileSync } from "node:child_process";
+import {
+  SUGGESTED_MODELS, type AiModelProvider, type SuggestedModelId,
+} from "@gadgets/workshop-shared/api";
 
-const DEFAULT_MODELS = ["@cf/deepseek-ai/deepseek-v4-pro-0813"];
+/** A model ID: catalog IDs autocomplete, but WORKSHOP_EVAL_MODELS may name any model. */
+export type EvalModelId = SuggestedModelId | (string & {});
+/** A model resolved to the provider that serves it. */
+export type EvalModel = { provider: AiModelProvider; model: string };
+
+// The default must be a Workers AI catalog model so it runs in both direct and gateway mode.
+const DEFAULT_MODELS: readonly SuggestedModelId<"cloudflare">[] =
+  ["@cf/deepseek-ai/deepseek-v4-pro-0813"];
 const GIT_SHA_PATTERN = /^[a-f0-9]{40}$/;
 
 export const EVAL_AGENT_BUDGET_MS = 28 * 60_000;
 export const EVAL_VERIFICATION_BUDGET_MS = 2 * 60_000;
 export const EVAL_TEST_TIMEOUT_MS = 40 * 60_000;
 export type EvalIdentity = { gitCommit: string; taskVersion: string };
-export type EvalMatrix = { models: string[]; trials: number };
+export type EvalMatrix = { models: EvalModelId[]; trials: number };
 
 function commaList(value: string): string[] {
   return value.split(",").map(item => item.trim()).filter(Boolean);
@@ -36,6 +46,20 @@ export function resolveEvalCommit(
     throw new Error("WORKSHOP_EVAL_COMMIT must be a full 40-character Git SHA");
   }
   return commit;
+}
+
+/**
+ * Resolve a model ID to the provider listed for it in SUGGESTED_MODELS. Unlisted IDs fall back
+ * to Workers AI (every Workers AI ID is `@cf/...`, and cloudflare is the only provider the direct
+ * transport serves), so an unknown model runs exactly as a catalog Workers AI model does.
+ */
+export function resolveEvalModel(modelId: string): EvalModel {
+  for (const [provider, models] of Object.entries(SUGGESTED_MODELS)) {
+    if (Object.hasOwn(models, modelId)) {
+      return { provider: provider as AiModelProvider, model: modelId };
+    }
+  }
+  return { provider: "cloudflare", model: modelId };
 }
 
 /** Parse the model and repetition controls before a trial can spend inference. */

--- a/packages/workshop-evals/src/config.ts
+++ b/packages/workshop-evals/src/config.ts
@@ -3,12 +3,22 @@ import {
   SUGGESTED_MODELS, type AiModelProvider, type SuggestedModelId,
 } from "@gadgets/workshop-shared/api";
 
-/** A model ID: catalog IDs autocomplete, but WORKSHOP_EVAL_MODELS may name any model. */
-export type EvalModelId = SuggestedModelId | (string & {});
-/** A model resolved to the provider that serves it. */
-export type EvalModel = { provider: AiModelProvider; model: string };
+/**
+ * Models evals may run that the picker does not offer, each with the provider that serves it. The
+ * eval catalog is SUGGESTED_MODELS plus this map: every picker model is an eval model, and a model
+ * that is in neither is rejected rather than assigned a guessed provider.
+ */
+const EVAL_ONLY_MODELS = {
+  // The backend's quick model: a cheap Workers AI model for smoke runs of the eval pipeline.
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": "cloudflare",
+} satisfies Record<string, AiModelProvider>;
 
-// The default must be a Workers AI catalog model so it runs in both direct and gateway mode.
+/** A model ID from the eval catalog: SUGGESTED_MODELS or EVAL_ONLY_MODELS. */
+export type EvalModelId = SuggestedModelId | (keyof typeof EVAL_ONLY_MODELS & string);
+/** An eval catalog model resolved to the provider that serves it. */
+export type EvalModel = { provider: AiModelProvider; model: EvalModelId };
+
+// The default must be a Workers AI picker model so it runs in both direct and gateway mode.
 const DEFAULT_MODELS: readonly SuggestedModelId<"cloudflare">[] =
   ["@cf/deepseek-ai/deepseek-v4-pro-0813"];
 const GIT_SHA_PATTERN = /^[a-f0-9]{40}$/;
@@ -48,23 +58,26 @@ export function resolveEvalCommit(
   return commit;
 }
 
-/**
- * Resolve a model ID to the provider listed for it in SUGGESTED_MODELS. Unlisted IDs fall back
- * to Workers AI (every Workers AI ID is `@cf/...`, and cloudflare is the only provider the direct
- * transport serves), so an unknown model runs exactly as a catalog Workers AI model does.
- */
+/** Resolve a model ID to the provider the eval catalog lists for it. */
 export function resolveEvalModel(modelId: string): EvalModel {
   for (const [provider, models] of Object.entries(SUGGESTED_MODELS)) {
     if (Object.hasOwn(models, modelId)) {
-      return { provider: provider as AiModelProvider, model: modelId };
+      return { provider: provider as AiModelProvider, model: modelId as EvalModelId };
     }
   }
-  return { provider: "cloudflare", model: modelId };
+  if (Object.hasOwn(EVAL_ONLY_MODELS, modelId)) {
+    const provider = EVAL_ONLY_MODELS[modelId as keyof typeof EVAL_ONLY_MODELS];
+    return { provider, model: modelId as EvalModelId };
+  }
+  throw new Error(
+    `Unknown eval model ${JSON.stringify(modelId)}: eval models must be listed in ` +
+    "SUGGESTED_MODELS or EVAL_ONLY_MODELS");
 }
 
 /** Parse the model and repetition controls before a trial can spend inference. */
 export function evalMatrix(environment: NodeJS.ProcessEnv = process.env): EvalMatrix {
-  const models = commaList(environment.WORKSHOP_EVAL_MODELS ?? "");
+  const models = commaList(environment.WORKSHOP_EVAL_MODELS ?? "")
+      .map(modelId => resolveEvalModel(modelId).model);
   const rawTrials = environment.WORKSHOP_EVAL_TRIALS?.trim();
   const trials = rawTrials === undefined || rawTrials === "" ? 1 : Number(rawTrials);
   if (!Number.isInteger(trials) || trials < 1) {

--- a/packages/workshop-evals/src/eval.ts
+++ b/packages/workshop-evals/src/eval.ts
@@ -1,0 +1,50 @@
+import { createJudge, describeEval } from "vitest-evals";
+import { expect } from "vitest";
+import { evalMatrix, resolveEvalCommit } from "./config.js";
+import { createWorkshopHarness } from "./harness.js";
+import { taskVersion, type EvalRunInput, type EvalRunOutput, type EvalTask } from "./task.js";
+import { resolveModelAccess } from "./target.js";
+
+const gitCommit = resolveEvalCommit();
+const modelAccess = resolveModelAccess();
+
+const FunctionalJudge = createJudge<EvalRunInput, EvalRunOutput>(
+  "functional result",
+  ({ output }) => {
+    const checks = output.turns.flatMap(turn => turn.checks);
+    const failed = checks.filter(check => !check.pass);
+    const passed = checks.length - failed.length;
+    return {
+      score: output.success ? 1 : 0,
+      metadata: {
+        rationale: output.success
+          ? "All turns and checks passed"
+          : `Failed checks: ${failed.map(check => check.id).join(", ") || "agent turn failed"}`,
+        passedChecks: passed,
+        totalChecks: checks.length,
+        checkFraction: checks.length === 0 ? 0 : passed / checks.length,
+        failedChecks: failed.map(check => check.id),
+      },
+    };
+  },
+);
+
+/** Register one task as model-by-trial Vitest cases. */
+export function defineTaskEval(task: EvalTask): void {
+  const matrix = evalMatrix();
+  const cases = matrix.models.flatMap(model =>
+    Array.from({ length: matrix.trials }, (_unused, trial) => ({
+      name: `${model} | trial ${trial + 1}`,
+      model,
+      trial: trial + 1,
+    })));
+  const identity = { gitCommit, taskVersion: taskVersion(task) };
+  const harness = createWorkshopHarness(task, modelAccess, identity);
+
+  describeEval(task.id, { harness }, it => {
+    it.for(cases)("$name", async ({ model, trial }, { run }) => {
+      const result = await run({ model, trial });
+      await expect(result).toSatisfyJudge(FunctionalJudge, { threshold: 1 });
+    });
+  });
+}

--- a/packages/workshop-evals/src/eval.ts
+++ b/packages/workshop-evals/src/eval.ts
@@ -1,9 +1,9 @@
 import { createJudge, describeEval } from "vitest-evals";
 import { expect } from "vitest";
-import { evalMatrix, resolveEvalCommit } from "./config.js";
+import { evalMatrix, resolveEvalCommit, resolveEvalModel } from "./config.js";
 import { createWorkshopHarness } from "./harness.js";
 import { taskVersion, type EvalRunInput, type EvalRunOutput, type EvalTask } from "./task.js";
-import { resolveModelAccess } from "./target.js";
+import { assertModelAccess, resolveModelAccess } from "./target.js";
 
 const gitCommit = resolveEvalCommit();
 const modelAccess = resolveModelAccess();
@@ -32,6 +32,8 @@ const FunctionalJudge = createJudge<EvalRunInput, EvalRunOutput>(
 /** Register one task as model-by-trial Vitest cases. */
 export function defineTaskEval(task: EvalTask): void {
   const matrix = evalMatrix();
+  // Fail at collection, before any inference, if the access cannot serve a model in the matrix.
+  matrix.models.map(resolveEvalModel).forEach(model => assertModelAccess(modelAccess, model));
   const cases = matrix.models.flatMap(model =>
     Array.from({ length: matrix.trials }, (_unused, trial) => ({
       name: `${model} | trial ${trial + 1}`,

--- a/packages/workshop-evals/src/harness.ts
+++ b/packages/workshop-evals/src/harness.ts
@@ -1,0 +1,178 @@
+import type { AgentTurnResult } from "@gadgets/integration-tests/agent-session";
+import type { AiChatMessage } from "@gadgets/workshop-shared/api";
+import {
+  attachHarnessRunToError, createHarness, normalizeHarnessRun, type JsonValue,
+  type TranscriptEvent,
+} from "vitest-evals";
+import {
+  EVAL_AGENT_BUDGET_MS, EVAL_VERIFICATION_BUDGET_MS, type EvalIdentity,
+} from "./config.js";
+import type { EvalCheck, EvalRunInput, EvalRunOutput, EvalTask, EvalTurnResult } from "./task.js";
+import { measureHistory, toTranscriptEvents } from "./transcript.js";
+import {
+  openLocalEvalTarget, type LocalEvalTarget, type LocalModelAccess,
+} from "./target.js";
+import { EvalVerifier } from "./verifier.js";
+
+class EvalDeadlineError extends Error {}
+
+async function withTimeout<T>(operation: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  const expired = Promise.withResolvers<never>();
+  const timer = setTimeout(() => expired.reject(new EvalDeadlineError(message)), timeoutMs);
+  expired.promise.catch(() => {});
+  operation.catch(() => {});
+  try {
+    return await Promise.race([operation, expired.promise]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Run one real Workshop task and retain its functional result and trajectory. */
+export function createWorkshopHarness(
+    task: EvalTask, access: LocalModelAccess, identity: EvalIdentity) {
+  return createHarness<EvalRunInput, EvalRunOutput>({
+    name: "workshop-agent",
+    run: async ({ input, signal }) => {
+      const turns: EvalTurnResult[] = [];
+      let history: AiChatMessage[] = [];
+      let usage: AgentTurnResult["usage"] = {};
+      let opened: LocalEvalTarget | undefined;
+      let runError: Error | undefined;
+      let cleanupError: Error | undefined;
+      let unrecordedPrompt: string | undefined;
+
+      try {
+        const agentTurnBudget = Math.floor(EVAL_AGENT_BUDGET_MS / task.turns.length);
+        const verificationBudget = Math.floor(EVAL_VERIFICATION_BUDGET_MS / task.turns.length);
+        opened = await openLocalEvalTarget(access, input.model, agentTurnBudget);
+
+        for (const turn of task.turns) {
+          const turnStartedAt = Date.now();
+          const previousSequence = history.at(-1)?.sequence ?? -1;
+          unrecordedPrompt = turn.prompt;
+          const running = opened.session.runTurn(turn.prompt, {
+            timeoutMs: agentTurnBudget,
+            signal,
+          });
+          const result = await withTimeout(
+              running, agentTurnBudget + verificationBudget,
+              "Agent turn and canonical snapshot exceeded their time budget");
+          const turnWallMs = Date.now() - turnStartedAt;
+          if (result.history.some(message =>
+            message.sequence > previousSequence && message.type === "message" &&
+            message.author.type === "user" && message.message === turn.prompt)) {
+            unrecordedPrompt = undefined;
+          }
+          if (result.history.length > 0) history = result.history;
+          const cumulativeCost = result.usage.observedCumulativeChatCostUsd ??
+            usage.observedCumulativeChatCostUsd;
+          usage = {};
+          if (result.usage.lastStepTokens !== undefined) {
+            usage.lastStepTokens = result.usage.lastStepTokens;
+          }
+          if (cumulativeCost !== undefined) {
+            usage.observedCumulativeChatCostUsd = cumulativeCost;
+          }
+          const verificationStartedAt = Date.now();
+          const verifier = new EvalVerifier(opened.session, result.workpieces);
+          let checks: EvalCheck[];
+          try {
+            checks = await withTimeout(
+                verifier.collect(turn.verify), verificationBudget,
+                "Eval verification exceeded its time budget");
+          } catch (error) {
+            checks = [...verifier.results(), {
+              id: "verifier.timeout",
+              pass: false,
+              evidence: error instanceof Error ? error.message : String(error),
+            }];
+            turns.push({
+              outcome: result.outcome,
+              checks,
+              turnWallMs,
+              verificationWallMs: Date.now() - verificationStartedAt,
+            });
+            throw error;
+          }
+          turns.push({
+            outcome: result.outcome,
+            checks,
+            turnWallMs,
+            verificationWallMs: Date.now() - verificationStartedAt,
+          });
+          if (result.outcome.status !== "completed") break;
+        }
+      } catch (error) {
+        runError = error instanceof Error ? error : new Error(String(error));
+      }
+
+      if (opened !== undefined) {
+        try {
+          await opened[Symbol.asyncDispose]();
+        } catch (error) {
+          cleanupError = error instanceof Error ? error : new Error(String(error));
+        }
+      }
+
+      const metrics = measureHistory(history);
+      const checks = turns.flatMap(turn => turn.checks);
+      const success = runError === undefined && cleanupError === undefined &&
+        turns.length === task.turns.length &&
+        turns.every(turn => turn.outcome.status === "completed") &&
+        checks.length > 0 && checks.every(check => check.pass);
+      const usageMetadata: Record<string, JsonValue> = {};
+      if (usage.lastStepTokens !== undefined) usageMetadata.lastStepTokens = usage.lastStepTokens;
+      if (usage.observedCumulativeChatCostUsd !== undefined) {
+        usageMetadata.observedCumulativeChatCostUsd = usage.observedCumulativeChatCostUsd;
+      }
+      const events: TranscriptEvent[] = toTranscriptEvents(history);
+      if (unrecordedPrompt !== undefined) {
+        events.push({
+          type: "message",
+          role: "user",
+          content: unrecordedPrompt,
+          metadata: { attempted: true },
+        });
+      }
+      if (events.length === 0) {
+        events.push({ type: "message", role: "user", content: task.turns[0].prompt });
+      }
+      const errors = history.flatMap(message =>
+        message.type === "error" ? [{ name: "AgentError", message: message.message }] : []);
+      if (runError !== undefined) errors.push({ name: "EvalRunError", message: runError.message });
+      if (cleanupError !== undefined) {
+        errors.push({ name: "EvalCleanupError", message: cleanupError.message });
+      }
+      for (const turn of turns) {
+        if (turn.outcome.status === "timedOut") {
+          errors.push({ name: "AgentTimeout", message: turn.outcome.message });
+        }
+      }
+      const result = {
+        output: { success, turns, metrics },
+        events,
+        usage: {
+          provider: "cloudflare",
+          model: input.model,
+          toolCalls: metrics.toolCalls,
+          metadata: usageMetadata,
+        },
+        errors,
+        metadata: {
+          taskId: task.id,
+          target: "local",
+          ...identity,
+        },
+      };
+
+      if (runError !== undefined || cleanupError !== undefined) {
+        const error = runError !== undefined && cleanupError !== undefined
+          ? new AggregateError([runError, cleanupError], "Eval run and cleanup failed")
+          : runError ?? cleanupError ?? new Error("Eval failed");
+        throw attachHarnessRunToError(error, normalizeHarnessRun(input, result));
+      }
+      return result;
+    },
+  });
+}

--- a/packages/workshop-evals/src/harness.ts
+++ b/packages/workshop-evals/src/harness.ts
@@ -5,7 +5,7 @@ import {
   type TranscriptEvent,
 } from "vitest-evals";
 import {
-  EVAL_AGENT_BUDGET_MS, EVAL_VERIFICATION_BUDGET_MS, type EvalIdentity,
+  EVAL_AGENT_BUDGET_MS, EVAL_VERIFICATION_BUDGET_MS, resolveEvalModel, type EvalIdentity,
 } from "./config.js";
 import type { EvalCheck, EvalRunInput, EvalRunOutput, EvalTask, EvalTurnResult } from "./task.js";
 import { measureHistory, toTranscriptEvents } from "./transcript.js";
@@ -41,11 +41,12 @@ export function createWorkshopHarness(
       let runError: Error | undefined;
       let cleanupError: Error | undefined;
       let unrecordedPrompt: string | undefined;
+      const model = resolveEvalModel(input.model);
 
       try {
         const agentTurnBudget = Math.floor(EVAL_AGENT_BUDGET_MS / task.turns.length);
         const verificationBudget = Math.floor(EVAL_VERIFICATION_BUDGET_MS / task.turns.length);
-        opened = await openLocalEvalTarget(access, input.model, agentTurnBudget);
+        opened = await openLocalEvalTarget(access, model, agentTurnBudget);
 
         for (const turn of task.turns) {
           const turnStartedAt = Date.now();
@@ -153,7 +154,7 @@ export function createWorkshopHarness(
         output: { success, turns, metrics },
         events,
         usage: {
-          provider: "cloudflare",
+          provider: model.provider,
           model: input.model,
           toolCalls: metrics.toolCalls,
           metadata: usageMetadata,

--- a/packages/workshop-evals/src/target-egress.test.ts
+++ b/packages/workshop-evals/src/target-egress.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import type { LocalModelAccess } from "./target.js";
+
+type CapturedConfig = {
+  account_id?: string;
+  ai?: { binding: string; remote?: boolean };
+  vars?: Record<string, string>;
+};
+
+type StartOptions = {
+  patchWorkshop?: (config: CapturedConfig) => void;
+};
+
+const fakes = vi.hoisted(() => {
+  const requestUrls: string[] = [];
+  const responseStatuses: number[] = [];
+  const configs: CapturedConfig[] = [];
+  const session = { close: vi.fn(() => Promise.resolve()) };
+  return {
+    requestUrls,
+    configs,
+    responseStatuses,
+    session,
+    openSession: vi.fn(() => Promise.resolve(session)),
+    server: { close: vi.fn(() => Promise.resolve()) },
+  };
+});
+
+vi.mock("@gadgets/integration-tests/agent-session", () => ({
+  openAgentSession: fakes.openSession,
+}));
+
+vi.mock("@gadgets/integration-tests/harness", () => ({
+  startHarness: vi.fn((options: StartOptions) => {
+    const config: CapturedConfig = {};
+    options.patchWorkshop?.(config);
+    fakes.configs.push(config);
+    return Promise.resolve({
+      url: new URL("http://127.0.0.1:8787"),
+      server: fakes.server,
+    });
+  }),
+}));
+
+import { openLocalEvalTarget } from "./target.js";
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fakes.requestUrls.splice(0);
+  fakes.responseStatuses.splice(0);
+  fakes.configs.splice(0);
+  fakes.openSession.mockImplementation(async () => {
+    for (const url of fakes.requestUrls) {
+      const method = url.includes("/logs/") ? "GET" : "POST";
+      fakes.responseStatuses.push((await fetch(url, { method })).status);
+    }
+    return fakes.session;
+  });
+  fakes.session.close.mockImplementation(() => Promise.resolve());
+  fakes.server.close.mockImplementation(() => Promise.resolve());
+  globalThis.fetch = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })));
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.clearAllMocks();
+});
+
+async function run(access: LocalModelAccess): Promise<void> {
+  const opened = await openLocalEvalTarget(access, "@cf/model", 25);
+  await opened[Symbol.asyncDispose]();
+}
+
+it("allows the direct Workers AI route", async () => {
+  fakes.requestUrls.push(
+      "https://api.cloudflare.com/client/v4/accounts/account-id/ai/v1/chat/completions");
+
+  await run({ kind: "direct", accountId: "account-id", apiToken: "token" });
+
+  expect(globalThis.fetch).toHaveBeenCalledOnce();
+  expect(fakes.responseStatuses).toEqual([204]);
+});
+
+it("allows AI Gateway inference and cost-log routes", async () => {
+  fakes.requestUrls.push(
+    "https://gateway.ai.cloudflare.com/v1/account-id/gateway/workers-ai/v1/chat/completions",
+    "https://api.cloudflare.com/client/v4/accounts/account-id/ai-gateway/gateways/gateway/logs/log-id",
+  );
+
+  await run({
+    kind: "gateway",
+    gateway: "gateway",
+    accountId: "account-id",
+    apiToken: "token",
+  });
+
+  expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  expect(fakes.configs).toEqual([{
+    vars: {
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account-id",
+      CF_AI_GATEWAY_API_TOKEN: "token",
+      CF_AI_GATEWAY_PROVIDERS: "cloudflare",
+      CF_AI_GATEWAY_USE_BINDING: "false",
+    },
+  }]);
+  expect(fakes.responseStatuses).toEqual([204, 204]);
+});
+
+it("keeps HTTPS model routes closed in binding mode", async () => {
+  fakes.requestUrls.push(
+    "https://gateway.ai.cloudflare.com/v1/account-id/gateway/workers-ai/v1/chat/completions",
+    "https://api.cloudflare.com/client/v4/accounts/account-id/ai-gateway/gateways/gateway/logs/log-id",
+  );
+
+  await run({
+    kind: "gateway",
+    gateway: "gateway",
+    accountId: "account-id",
+  });
+
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  expect(fakes.configs).toEqual([{
+    account_id: "account-id",
+    ai: { binding: "WORKERS_AI", remote: true },
+    vars: {
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account-id",
+      CF_AI_GATEWAY_PROVIDERS: "cloudflare",
+      CF_AI_GATEWAY_USE_BINDING: "true",
+    },
+  }]);
+  expect(fakes.responseStatuses).toEqual([403, 403]);
+});
+
+it("returns a deterministic denial for every other route", async () => {
+  fakes.requestUrls.push(
+    "https://example.com/collect",
+    "https://api.cloudflare.com/client/v4/accounts/account-id/ai/v1anything",
+    "http://127.0.0.1:9999/admin",
+  );
+
+  await run({ kind: "direct", accountId: "account-id", apiToken: "token" });
+
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  expect(fakes.responseStatuses).toEqual([403, 403, 403]);
+});
+
+it("keeps the deny filter installed when runtime shutdown fails", async () => {
+  fakes.server.close.mockImplementation(
+      () => Promise.reject(new Error("workerd failed to terminate")));
+
+  const opened = await openLocalEvalTarget(
+      { kind: "direct", accountId: "account-id", apiToken: "token" }, "@cf/model", 25);
+  const fetchDuringCleanup = globalThis.fetch;
+  await expect(opened[Symbol.asyncDispose]())
+      .rejects.toThrow("workerd failed to terminate");
+
+  // Cleanup failed, so the interceptor must still own globalThis.fetch: unrestricted network
+  // access is not restored while the runtime may still run model-authored code.
+  expect(globalThis.fetch).toBe(fetchDuringCleanup);
+
+  // An outbound request after the failed shutdown is still answered by the deny filter.
+  fakes.responseStatuses.push((await fetch("https://example.com/collect", { method: "POST" })).status);
+  expect(fakes.responseStatuses).toEqual([403]);
+
+  globalThis.fetch = realFetch;
+});
+
+it("preserves session and runtime cleanup failures", async () => {
+  fakes.session.close.mockImplementation(
+      () => Promise.reject(new Error("session refused to close")));
+  fakes.server.close.mockImplementation(
+      () => Promise.reject(new Error("workerd failed to terminate")));
+
+  const opened = await openLocalEvalTarget(
+      { kind: "direct", accountId: "account-id", apiToken: "token" }, "@cf/model", 25);
+  const fetchDuringCleanup = globalThis.fetch;
+  const failure = await opened[Symbol.asyncDispose]().then(() => undefined, error => error);
+
+  if (!(failure instanceof AggregateError)) throw new Error("Expected aggregate cleanup failure");
+  expect(failure.errors.map(error => error instanceof Error ? error.message : String(error)))
+    .toEqual(["session refused to close", "workerd failed to terminate"]);
+  expect(globalThis.fetch).toBe(fetchDuringCleanup);
+  globalThis.fetch = realFetch;
+});
+
+it("keeps the deny filter installed when setup cleanup cannot stop workerd", async () => {
+  fakes.openSession.mockRejectedValueOnce(new Error("session setup failed"));
+  fakes.server.close.mockRejectedValueOnce(new Error("workerd failed to terminate"));
+  const unrestrictedFetch = globalThis.fetch;
+
+  await expect(openLocalEvalTarget(
+      { kind: "direct", accountId: "account-id", apiToken: "token" }, "@cf/model", 25))
+    .rejects.toThrow("Eval session setup and cleanup failed");
+  expect(globalThis.fetch).not.toBe(unrestrictedFetch);
+  expect((await fetch("https://example.com/collect", { method: "POST" })).status).toBe(403);
+  globalThis.fetch = realFetch;
+});

--- a/packages/workshop-evals/src/target-egress.test.ts
+++ b/packages/workshop-evals/src/target-egress.test.ts
@@ -68,7 +68,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-const WORKERS_AI_MODEL: EvalModel = { provider: "cloudflare", model: "@cf/model" };
+const WORKERS_AI_MODEL: EvalModel = { provider: "cloudflare", model: "@cf/zai-org/glm-5.2" };
 const DIRECT: LocalModelAccess = { kind: "direct", accountId: "account-id", apiToken: "token" };
 const BINDING: LocalModelAccess = {
   kind: "gateway", gateway: "gateway", accountId: "account-id", transport: "binding",

--- a/packages/workshop-evals/src/target-egress.test.ts
+++ b/packages/workshop-evals/src/target-egress.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import type { EvalModel } from "./config.js";
 import type { LocalModelAccess } from "./target.js";
 
 type CapturedConfig = {
@@ -67,8 +68,24 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-async function run(access: LocalModelAccess): Promise<void> {
-  const opened = await openLocalEvalTarget(access, "@cf/model", 25);
+const WORKERS_AI_MODEL: EvalModel = { provider: "cloudflare", model: "@cf/model" };
+const DIRECT: LocalModelAccess = { kind: "direct", accountId: "account-id", apiToken: "token" };
+const BINDING: LocalModelAccess = {
+  kind: "gateway", gateway: "gateway", accountId: "account-id", transport: "binding",
+};
+const BINDING_WITH_TOKEN: LocalModelAccess = { ...BINDING, apiToken: "token" };
+const HTTPS: LocalModelAccess = {
+  kind: "gateway", gateway: "gateway", accountId: "account-id", transport: "https",
+  apiToken: "token",
+};
+
+const WORKERS_AI_INFERENCE_URL =
+    "https://gateway.ai.cloudflare.com/v1/account-id/gateway/workers-ai/v1/chat/completions";
+const COST_LOG_URL =
+    "https://api.cloudflare.com/client/v4/accounts/account-id/ai-gateway/gateways/gateway/logs/log-id";
+
+async function run(access: LocalModelAccess, model: EvalModel = WORKERS_AI_MODEL): Promise<void> {
+  const opened = await openLocalEvalTarget(access, model, 25);
   await opened[Symbol.asyncDispose]();
 }
 
@@ -76,24 +93,16 @@ it("allows the direct Workers AI route", async () => {
   fakes.requestUrls.push(
       "https://api.cloudflare.com/client/v4/accounts/account-id/ai/v1/chat/completions");
 
-  await run({ kind: "direct", accountId: "account-id", apiToken: "token" });
+  await run(DIRECT);
 
   expect(globalThis.fetch).toHaveBeenCalledOnce();
   expect(fakes.responseStatuses).toEqual([204]);
 });
 
-it("allows AI Gateway inference and cost-log routes", async () => {
-  fakes.requestUrls.push(
-    "https://gateway.ai.cloudflare.com/v1/account-id/gateway/workers-ai/v1/chat/completions",
-    "https://api.cloudflare.com/client/v4/accounts/account-id/ai-gateway/gateways/gateway/logs/log-id",
-  );
+it("allows AI Gateway inference and cost-log routes over HTTPS", async () => {
+  fakes.requestUrls.push(WORKERS_AI_INFERENCE_URL, COST_LOG_URL);
 
-  await run({
-    kind: "gateway",
-    gateway: "gateway",
-    accountId: "account-id",
-    apiToken: "token",
-  });
+  await run(HTTPS);
 
   expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   expect(fakes.configs).toEqual([{
@@ -109,16 +118,9 @@ it("allows AI Gateway inference and cost-log routes", async () => {
 });
 
 it("keeps HTTPS model routes closed in binding mode", async () => {
-  fakes.requestUrls.push(
-    "https://gateway.ai.cloudflare.com/v1/account-id/gateway/workers-ai/v1/chat/completions",
-    "https://api.cloudflare.com/client/v4/accounts/account-id/ai-gateway/gateways/gateway/logs/log-id",
-  );
+  fakes.requestUrls.push(WORKERS_AI_INFERENCE_URL, COST_LOG_URL);
 
-  await run({
-    kind: "gateway",
-    gateway: "gateway",
-    accountId: "account-id",
-  });
+  await run(BINDING);
 
   expect(globalThis.fetch).not.toHaveBeenCalled();
   expect(fakes.configs).toEqual([{
@@ -134,6 +136,63 @@ it("keeps HTTPS model routes closed in binding mode", async () => {
   expect(fakes.responseStatuses).toEqual([403, 403]);
 });
 
+it("keeps HTTPS model routes closed in binding mode even when a token is available", async () => {
+  fakes.requestUrls.push(WORKERS_AI_INFERENCE_URL, COST_LOG_URL);
+
+  await run(BINDING_WITH_TOKEN);
+
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  expect(fakes.configs).toEqual([{
+    account_id: "account-id",
+    ai: { binding: "WORKERS_AI", remote: true },
+    vars: {
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account-id",
+      CF_AI_GATEWAY_API_TOKEN: "token",
+      CF_AI_GATEWAY_PROVIDERS: "cloudflare",
+      CF_AI_GATEWAY_USE_BINDING: "true",
+    },
+  }]);
+  expect(fakes.responseStatuses).toEqual([403, 403]);
+});
+
+it("opens only the HTTPS inference route for an HTTPS-only provider in binding mode", async () => {
+  fakes.requestUrls.push(
+    "https://gateway.ai.cloudflare.com/v1/account-id/gateway/google-ai-studio/v1beta/models/gemini-3.6-flash:streamGenerateContent",
+    WORKERS_AI_INFERENCE_URL,
+    COST_LOG_URL,
+  );
+
+  await run(BINDING_WITH_TOKEN, { provider: "google", model: "gemini-3.6-flash" });
+
+  expect(globalThis.fetch).toHaveBeenCalledOnce();
+  expect(fakes.configs).toEqual([{
+    account_id: "account-id",
+    ai: { binding: "WORKERS_AI", remote: true },
+    vars: {
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account-id",
+      CF_AI_GATEWAY_API_TOKEN: "token",
+      CF_AI_GATEWAY_PROVIDERS: "google",
+      CF_AI_GATEWAY_USE_BINDING: "true",
+    },
+  }]);
+  expect(fakes.responseStatuses).toEqual([204, 403, 403]);
+});
+
+it("scopes HTTPS inference to the model's own gateway route", async () => {
+  fakes.requestUrls.push(
+    "https://gateway.ai.cloudflare.com/v1/account-id/gateway/anthropic/v1/messages",
+    WORKERS_AI_INFERENCE_URL,
+  );
+
+  await run(HTTPS, { provider: "anthropic", model: "claude-sonnet-5" });
+
+  expect(globalThis.fetch).toHaveBeenCalledOnce();
+  expect(fakes.configs[0]?.vars?.CF_AI_GATEWAY_PROVIDERS).toBe("anthropic");
+  expect(fakes.responseStatuses).toEqual([204, 403]);
+});
+
 it("returns a deterministic denial for every other route", async () => {
   fakes.requestUrls.push(
     "https://example.com/collect",
@@ -141,7 +200,7 @@ it("returns a deterministic denial for every other route", async () => {
     "http://127.0.0.1:9999/admin",
   );
 
-  await run({ kind: "direct", accountId: "account-id", apiToken: "token" });
+  await run(DIRECT);
 
   expect(globalThis.fetch).not.toHaveBeenCalled();
   expect(fakes.responseStatuses).toEqual([403, 403, 403]);
@@ -152,7 +211,7 @@ it("keeps the deny filter installed when runtime shutdown fails", async () => {
       () => Promise.reject(new Error("workerd failed to terminate")));
 
   const opened = await openLocalEvalTarget(
-      { kind: "direct", accountId: "account-id", apiToken: "token" }, "@cf/model", 25);
+      DIRECT, WORKERS_AI_MODEL, 25);
   const fetchDuringCleanup = globalThis.fetch;
   await expect(opened[Symbol.asyncDispose]())
       .rejects.toThrow("workerd failed to terminate");
@@ -175,7 +234,7 @@ it("preserves session and runtime cleanup failures", async () => {
       () => Promise.reject(new Error("workerd failed to terminate")));
 
   const opened = await openLocalEvalTarget(
-      { kind: "direct", accountId: "account-id", apiToken: "token" }, "@cf/model", 25);
+      DIRECT, WORKERS_AI_MODEL, 25);
   const fetchDuringCleanup = globalThis.fetch;
   const failure = await opened[Symbol.asyncDispose]().then(() => undefined, error => error);
 
@@ -192,7 +251,7 @@ it("keeps the deny filter installed when setup cleanup cannot stop workerd", asy
   const unrestrictedFetch = globalThis.fetch;
 
   await expect(openLocalEvalTarget(
-      { kind: "direct", accountId: "account-id", apiToken: "token" }, "@cf/model", 25))
+      DIRECT, WORKERS_AI_MODEL, 25))
     .rejects.toThrow("Eval session setup and cleanup failed");
   expect(globalThis.fetch).not.toBe(unrestrictedFetch);
   expect((await fetch("https://example.com/collect", { method: "POST" })).status).toBe(403);

--- a/packages/workshop-evals/src/target.test.ts
+++ b/packages/workshop-evals/src/target.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelAccess } from "./target.js";
+
+describe("resolveModelAccess", () => {
+  it("uses a complete AI Gateway configuration", () => {
+    expect(resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_API_TOKEN: "token",
+    })).toEqual({
+      kind: "gateway",
+      gateway: "gateway",
+      accountId: "account",
+      apiToken: "token",
+    });
+  });
+
+  it("uses the Workers AI binding when the Gateway token is absent", () => {
+    expect(resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+    })).toEqual({
+      kind: "gateway",
+      gateway: "gateway",
+      accountId: "account",
+    });
+  });
+
+  it("lets an explicit binding override an injected Gateway token", () => {
+    expect(resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_API_TOKEN: "injected-token",
+      CF_AI_GATEWAY_USE_BINDING: " TrUe ",
+    })).toEqual({
+      kind: "gateway",
+      gateway: "gateway",
+      accountId: "account",
+    });
+  });
+
+  it("uses direct Workers AI credentials", () => {
+    expect(resolveModelAccess({
+      CLOUDFLARE_ACCOUNT_ID: "account",
+      CLOUDFLARE_API_TOKEN: "token",
+    })).toEqual({ kind: "direct", accountId: "account", apiToken: "token" });
+  });
+
+  it("rejects a partial Gateway configuration", () => {
+    expect(() => resolveModelAccess({ CF_AI_GATEWAY: "gateway" }))
+      .toThrow("require CF_AI_GATEWAY");
+  });
+
+  it("rejects a Gateway token without a Gateway", () => {
+    expect(() => resolveModelAccess({ CF_AI_GATEWAY_API_TOKEN: "token" }))
+      .toThrow("require CF_AI_GATEWAY");
+  });
+
+  it("requires a token when the binding is explicitly disabled", () => {
+    expect(() => resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_USE_BINDING: "false",
+    })).toThrow("CF_AI_GATEWAY_API_TOKEN");
+  });
+
+  it("rejects an invalid binding preference", () => {
+    expect(() => resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_USE_BINDING: "sometimes",
+    })).toThrow("true or false");
+  });
+
+  it("rejects missing model access", () => {
+    expect(() => resolveModelAccess({})).toThrow("model access");
+  });
+});

--- a/packages/workshop-evals/src/target.test.ts
+++ b/packages/workshop-evals/src/target.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveModelAccess } from "./target.js";
+import { assertModelAccess, resolveModelAccess, type LocalModelAccess } from "./target.js";
 
 describe("resolveModelAccess", () => {
-  it("uses a complete AI Gateway configuration", () => {
+  it("uses HTTPS when a Gateway token is present and no binding preference is set", () => {
     expect(resolveModelAccess({
       CF_AI_GATEWAY: "gateway",
       CF_AI_GATEWAY_ACCOUNT_ID: "account",
@@ -11,6 +11,7 @@ describe("resolveModelAccess", () => {
       kind: "gateway",
       gateway: "gateway",
       accountId: "account",
+      transport: "https",
       apiToken: "token",
     });
   });
@@ -23,10 +24,11 @@ describe("resolveModelAccess", () => {
       kind: "gateway",
       gateway: "gateway",
       accountId: "account",
+      transport: "binding",
     });
   });
 
-  it("lets an explicit binding override an injected Gateway token", () => {
+  it("keeps an injected Gateway token available when the binding is explicitly requested", () => {
     expect(resolveModelAccess({
       CF_AI_GATEWAY: "gateway",
       CF_AI_GATEWAY_ACCOUNT_ID: "account",
@@ -36,7 +38,47 @@ describe("resolveModelAccess", () => {
       kind: "gateway",
       gateway: "gateway",
       accountId: "account",
+      transport: "binding",
+      apiToken: "injected-token",
     });
+  });
+
+  it("uses HTTPS when the binding is opted out", () => {
+    const https = {
+      kind: "gateway",
+      gateway: "gateway",
+      accountId: "account",
+      transport: "https",
+      apiToken: "token",
+    };
+    expect(resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_API_TOKEN: "token",
+      CF_AI_GATEWAY_USE_BINDING: "false",
+    })).toEqual(https);
+    expect(resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_API_TOKEN: "token",
+      CF_AI_GATEWAY_USE_BINDING: " False ",
+    })).toEqual(https);
+  });
+
+  it("requires the Gateway token when the binding is opted out", () => {
+    expect(() => resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_USE_BINDING: "false",
+    })).toThrow("CF_AI_GATEWAY_API_TOKEN must be set when CF_AI_GATEWAY_USE_BINDING is false");
+  });
+
+  it("rejects an unrecognized binding flag", () => {
+    expect(() => resolveModelAccess({
+      CF_AI_GATEWAY: "gateway",
+      CF_AI_GATEWAY_ACCOUNT_ID: "account",
+      CF_AI_GATEWAY_USE_BINDING: "yes",
+    })).toThrow('CF_AI_GATEWAY_USE_BINDING must be "true" or "false"');
   });
 
   it("uses direct Workers AI credentials", () => {
@@ -56,23 +98,41 @@ describe("resolveModelAccess", () => {
       .toThrow("require CF_AI_GATEWAY");
   });
 
-  it("requires a token when the binding is explicitly disabled", () => {
-    expect(() => resolveModelAccess({
-      CF_AI_GATEWAY: "gateway",
-      CF_AI_GATEWAY_ACCOUNT_ID: "account",
-      CF_AI_GATEWAY_USE_BINDING: "false",
-    })).toThrow("CF_AI_GATEWAY_API_TOKEN");
-  });
-
-  it("rejects an invalid binding preference", () => {
-    expect(() => resolveModelAccess({
-      CF_AI_GATEWAY: "gateway",
-      CF_AI_GATEWAY_ACCOUNT_ID: "account",
-      CF_AI_GATEWAY_USE_BINDING: "sometimes",
-    })).toThrow("true or false");
+  it("rejects a binding flag without a Gateway", () => {
+    expect(() => resolveModelAccess({ CF_AI_GATEWAY_USE_BINDING: "true" }))
+      .toThrow("require CF_AI_GATEWAY");
   });
 
   it("rejects missing model access", () => {
     expect(() => resolveModelAccess({})).toThrow("model access");
+  });
+});
+
+describe("assertModelAccess", () => {
+  const direct: LocalModelAccess = { kind: "direct", accountId: "account", apiToken: "token" };
+  const binding: LocalModelAccess = {
+    kind: "gateway", gateway: "gateway", accountId: "account", transport: "binding",
+  };
+  const bindingWithToken: LocalModelAccess = { ...binding, apiToken: "token" };
+  const https: LocalModelAccess = {
+    kind: "gateway", gateway: "gateway", accountId: "account", transport: "https",
+    apiToken: "token",
+  };
+  const google = { provider: "google", model: "gemini-3.6-flash" } as const;
+  const cloudflare = { provider: "cloudflare", model: "@cf/model" } as const;
+
+  it("limits direct Workers AI credentials to cloudflare models", () => {
+    expect(() => assertModelAccess(direct, google)).toThrow("only run cloudflare models");
+    expect(() => assertModelAccess(direct, cloudflare)).not.toThrow();
+  });
+
+  it("requires the Gateway token for HTTPS-only providers on the binding transport", () => {
+    expect(() => assertModelAccess(binding, google)).toThrow("requires CF_AI_GATEWAY_API_TOKEN");
+    expect(() => assertModelAccess(bindingWithToken, google)).not.toThrow();
+    expect(() => assertModelAccess(https, google)).not.toThrow();
+  });
+
+  it("lets cloudflare models ride the binding without a token", () => {
+    expect(() => assertModelAccess(binding, cloudflare)).not.toThrow();
   });
 });

--- a/packages/workshop-evals/src/target.test.ts
+++ b/packages/workshop-evals/src/target.test.ts
@@ -119,7 +119,7 @@ describe("assertModelAccess", () => {
     apiToken: "token",
   };
   const google = { provider: "google", model: "gemini-3.6-flash" } as const;
-  const cloudflare = { provider: "cloudflare", model: "@cf/model" } as const;
+  const cloudflare = { provider: "cloudflare", model: "@cf/zai-org/glm-5.2" } as const;
 
   it("limits direct Workers AI credentials to cloudflare models", () => {
     expect(() => assertModelAccess(direct, google)).toThrow("only run cloudflare models");

--- a/packages/workshop-evals/src/target.ts
+++ b/packages/workshop-evals/src/target.ts
@@ -1,0 +1,181 @@
+import {
+  openAgentSession, type AgentSessionOptions, type WorkshopAgentSession,
+} from "@gadgets/integration-tests/agent-session";
+import { startHarness, type WorkerConfig } from "@gadgets/integration-tests/harness";
+import { NetworkInterceptor } from "@gadgets/integration-tests/network-interceptor";
+
+export type LocalModelAccess = {
+  kind: "gateway";
+  gateway: string;
+  accountId: string;
+  apiToken?: string;
+} | {
+  kind: "direct";
+  accountId: string;
+  apiToken: string;
+};
+
+const GATEWAY_COST_ACCOUNTING_TIMEOUT_MS = 10_000;
+
+export type LocalEvalTarget = AsyncDisposable & { session: WorkshopAgentSession };
+
+function value(environment: NodeJS.ProcessEnv, key: string): string | undefined {
+  const candidate = environment[key]?.trim();
+  return candidate === "" ? undefined : candidate;
+}
+
+/** Resolve the model transport used by the local Workshop. */
+export function resolveModelAccess(
+    environment: NodeJS.ProcessEnv = process.env): LocalModelAccess {
+  const gateway = value(environment, "CF_AI_GATEWAY");
+  const gatewayAccountId = value(environment, "CF_AI_GATEWAY_ACCOUNT_ID");
+  const gatewayApiToken = value(environment, "CF_AI_GATEWAY_API_TOKEN");
+  const rawUseBinding = value(environment, "CF_AI_GATEWAY_USE_BINDING");
+  const useBindingOverride = rawUseBinding?.toLowerCase();
+  if (useBindingOverride !== undefined &&
+      useBindingOverride !== "true" && useBindingOverride !== "false") {
+    throw new Error("CF_AI_GATEWAY_USE_BINDING must be true or false");
+  }
+  if (gateway !== undefined || gatewayAccountId !== undefined ||
+      gatewayApiToken !== undefined || useBindingOverride !== undefined) {
+    if (gateway === undefined || gatewayAccountId === undefined) {
+      throw new Error(
+        "Local AI Gateway evals require CF_AI_GATEWAY and CF_AI_GATEWAY_ACCOUNT_ID together",
+      );
+    }
+    const useBinding = useBindingOverride === "true" ||
+      (useBindingOverride === undefined && gatewayApiToken === undefined);
+    if (!useBinding && gatewayApiToken === undefined) {
+      throw new Error(
+        "CF_AI_GATEWAY_API_TOKEN is required when CF_AI_GATEWAY_USE_BINDING=false",
+      );
+    }
+    return useBinding
+      ? { kind: "gateway", gateway, accountId: gatewayAccountId }
+      : { kind: "gateway", gateway, accountId: gatewayAccountId, apiToken: gatewayApiToken };
+  }
+
+  const accountId = value(environment, "CLOUDFLARE_ACCOUNT_ID");
+  const apiToken = value(environment, "CLOUDFLARE_API_TOKEN");
+  if (accountId !== undefined && apiToken !== undefined) {
+    return { kind: "direct", accountId, apiToken };
+  }
+  throw new Error(
+    "Local Workshop evals need model access: configure an AI Gateway name and account, or " +
+    "CLOUDFLARE_ACCOUNT_ID with CLOUDFLARE_API_TOKEN",
+  );
+}
+
+function configureGateway(
+    config: WorkerConfig, access: Extract<LocalModelAccess, { kind: "gateway" }>): void {
+  config.vars = {
+    ...config.vars,
+    CF_AI_GATEWAY: access.gateway,
+    CF_AI_GATEWAY_ACCOUNT_ID: access.accountId,
+    CF_AI_GATEWAY_PROVIDERS: "cloudflare",
+    CF_AI_GATEWAY_USE_BINDING: access.apiToken === undefined ? "true" : "false",
+    ...(access.apiToken === undefined ? {} : { CF_AI_GATEWAY_API_TOKEN: access.apiToken }),
+  };
+  if (access.apiToken === undefined) {
+    config.account_id = access.accountId;
+    config.ai = { binding: "WORKERS_AI", remote: true };
+  } else {
+    delete config.ai;
+  }
+}
+
+function allowsModelEgress(
+    access: LocalModelAccess, url: URL, method: string): boolean {
+  const account = encodeURIComponent(access.accountId);
+  if (access.kind === "gateway") {
+    if (access.apiToken === undefined) return false;
+    const gateway = encodeURIComponent(access.gateway);
+    if (method === "POST") {
+      return url.origin === "https://gateway.ai.cloudflare.com" &&
+        url.pathname === `/v1/${account}/${gateway}/workers-ai/v1/chat/completions`;
+    }
+    const logPrefix =
+        `/client/v4/accounts/${account}/ai-gateway/gateways/${gateway}/logs/`;
+    const logId = url.pathname.slice(logPrefix.length);
+    return method === "GET" && url.origin === "https://api.cloudflare.com" &&
+      url.pathname.startsWith(logPrefix) && logId !== "" && !logId.includes("/");
+  }
+  return method === "POST" && url.origin === "https://api.cloudflare.com" &&
+    url.pathname === `/client/v4/accounts/${account}/ai/v1/chat/completions`;
+}
+
+/** Start an isolated local workerd Workshop and one fresh agent session. */
+export async function openLocalEvalTarget(
+    access: LocalModelAccess, modelId: string, turnTimeoutMs: number): Promise<LocalEvalTarget> {
+  const interceptor = new NetworkInterceptor({
+    handlers: [
+      () => new Response("External network access is disabled during this eval.", { status: 403 }),
+    ],
+    allow: (url, method) => allowsModelEgress(access, url, method),
+    allowLoopback: false,
+  });
+
+  const harness = await startHarness({
+    gatekeepers: [],
+    enableGadgetExecution: true,
+    ...(access.kind === "gateway"
+      ? { patchWorkshop: (config: WorkerConfig) => configureGateway(config, access) }
+      : {}),
+  });
+  interceptor.install();
+
+  const options: AgentSessionOptions = {
+    modelId,
+    turnTimeoutMs,
+    costAccountingTimeoutMs: access.kind === "gateway" ? GATEWAY_COST_ACCOUNTING_TIMEOUT_MS : 0,
+    userModel: {
+      profile: { type: "agent", id: modelId, name: modelId },
+      config: {
+        provider: "cloudflare",
+        model: modelId,
+        accountId: access.accountId,
+        // Gateway mode takes transport credentials from the Worker environment.
+        apiToken: access.kind === "direct" ? access.apiToken : "",
+      },
+    },
+  };
+
+  try {
+    const session = await openAgentSession(harness.url, options);
+    return {
+      session,
+      [Symbol.asyncDispose]: async () => {
+        const failures: Error[] = [];
+        try {
+          await session.close();
+        } catch (error) {
+          failures.push(error instanceof Error ? error : new Error(String(error)));
+        }
+        try {
+          await harness.server.close();
+          interceptor.uninstall();
+        } catch (error) {
+          failures.push(error instanceof Error ? error : new Error(String(error)));
+        }
+        const first = failures.at(0);
+        if (failures.length === 1 && first !== undefined) throw first;
+        if (failures.length > 1) throw new AggregateError(failures, "Eval target cleanup failed");
+      },
+    };
+  } catch (error) {
+    const setupError = error instanceof Error ? error : new Error(String(error));
+    try {
+      await harness.server.close();
+      interceptor.uninstall();
+    } catch (failure) {
+      const closeError = failure instanceof Error ? failure : new Error(String(failure));
+      const aggregate = new AggregateError(
+        [setupError, closeError],
+        "Eval session setup and cleanup failed",
+      );
+      aggregate.cause = failure;
+      throw aggregate;
+    }
+    throw setupError;
+  }
+}

--- a/packages/workshop-evals/src/target.ts
+++ b/packages/workshop-evals/src/target.ts
@@ -3,19 +3,45 @@ import {
 } from "@gadgets/integration-tests/agent-session";
 import { startHarness, type WorkerConfig } from "@gadgets/integration-tests/harness";
 import { NetworkInterceptor } from "@gadgets/integration-tests/network-interceptor";
+import { HTTPS_ONLY_PROVIDERS, type AiModelProvider } from "@gadgets/workshop-shared/api";
+import type { EvalModel } from "./config.js";
 
+/**
+ * Gateway access uses one of the backend's two AiGatewayConfig transports. With
+ * CF_AI_GATEWAY_USE_BINDING unset, a CF_AI_GATEWAY_API_TOKEN selects HTTPS and its absence selects
+ * the Workers AI binding; the flag overrides that choice either way, and "true" keeps any token
+ * available for providers whose inference cannot ride the binding. Direct access is Workers AI's
+ * own REST endpoint.
+ */
 export type LocalModelAccess = {
   kind: "gateway";
   gateway: string;
   accountId: string;
+  transport: "binding";
   apiToken?: string;
+} | {
+  kind: "gateway";
+  gateway: string;
+  accountId: string;
+  transport: "https";
+  apiToken: string;
 } | {
   kind: "direct";
   accountId: string;
   apiToken: string;
 };
 
+type GatewayAccess = Extract<LocalModelAccess, { kind: "gateway" }>;
+
 const GATEWAY_COST_ACCOUNTING_TIMEOUT_MS = 10_000;
+
+/** The gateway route each provider's inference is addressed through (see gatewayNativeModel). */
+const GATEWAY_ROUTES: Readonly<Partial<Record<AiModelProvider, string>>> = {
+  cloudflare: "workers-ai",
+  anthropic: "anthropic",
+  openai: "openai",
+  google: "google-ai-studio",
+};
 
 export type LocalEvalTarget = AsyncDisposable & { session: WorkshopAgentSession };
 
@@ -30,29 +56,39 @@ export function resolveModelAccess(
   const gateway = value(environment, "CF_AI_GATEWAY");
   const gatewayAccountId = value(environment, "CF_AI_GATEWAY_ACCOUNT_ID");
   const gatewayApiToken = value(environment, "CF_AI_GATEWAY_API_TOKEN");
-  const rawUseBinding = value(environment, "CF_AI_GATEWAY_USE_BINDING");
-  const useBindingOverride = rawUseBinding?.toLowerCase();
-  if (useBindingOverride !== undefined &&
-      useBindingOverride !== "true" && useBindingOverride !== "false") {
-    throw new Error("CF_AI_GATEWAY_USE_BINDING must be true or false");
-  }
-  if (gateway !== undefined || gatewayAccountId !== undefined ||
-      gatewayApiToken !== undefined || useBindingOverride !== undefined) {
+  // Normalized like the backend, so a stray " False " opts out rather than reading as unset.
+  const useBinding = value(environment, "CF_AI_GATEWAY_USE_BINDING")?.toLowerCase();
+  if (gateway !== undefined || gatewayAccountId !== undefined || gatewayApiToken !== undefined ||
+      useBinding !== undefined) {
     if (gateway === undefined || gatewayAccountId === undefined) {
       throw new Error(
         "Local AI Gateway evals require CF_AI_GATEWAY and CF_AI_GATEWAY_ACCOUNT_ID together",
       );
     }
-    const useBinding = useBindingOverride === "true" ||
-      (useBindingOverride === undefined && gatewayApiToken === undefined);
-    if (!useBinding && gatewayApiToken === undefined) {
-      throw new Error(
-        "CF_AI_GATEWAY_API_TOKEN is required when CF_AI_GATEWAY_USE_BINDING=false",
-      );
+    if (useBinding !== undefined && useBinding !== "true" && useBinding !== "false") {
+      throw new Error('CF_AI_GATEWAY_USE_BINDING must be "true" or "false"');
     }
-    return useBinding
-      ? { kind: "gateway", gateway, accountId: gatewayAccountId }
-      : { kind: "gateway", gateway, accountId: gatewayAccountId, apiToken: gatewayApiToken };
+    // Unset: the token decides, so an injected token rides HTTPS unless the binding is asked for.
+    const ridesHttps =
+        useBinding === undefined ? gatewayApiToken !== undefined : useBinding === "false";
+    if (ridesHttps) {
+      if (gatewayApiToken === undefined) {
+        throw new Error(
+          "CF_AI_GATEWAY_API_TOKEN must be set when CF_AI_GATEWAY_USE_BINDING is false: " +
+          "opting out of the Workers AI binding leaves HTTPS as the only gateway transport",
+        );
+      }
+      return {
+        kind: "gateway", gateway, accountId: gatewayAccountId, transport: "https",
+        apiToken: gatewayApiToken,
+      };
+    }
+    return gatewayApiToken === undefined
+      ? { kind: "gateway", gateway, accountId: gatewayAccountId, transport: "binding" }
+      : {
+        kind: "gateway", gateway, accountId: gatewayAccountId, transport: "binding",
+        apiToken: gatewayApiToken,
+      };
   }
 
   const accountId = value(environment, "CLOUDFLARE_ACCOUNT_ID");
@@ -66,17 +102,40 @@ export function resolveModelAccess(
   );
 }
 
-function configureGateway(
-    config: WorkerConfig, access: Extract<LocalModelAccess, { kind: "gateway" }>): void {
+/**
+ * Reject a model the configured access cannot serve, mirroring the backend's AiGatewayConfig
+ * constructor and getModelViaGateway checks so a misconfigured matrix fails before inference.
+ */
+export function assertModelAccess(access: LocalModelAccess, model: EvalModel): void {
+  if (access.kind === "direct") {
+    if (model.provider !== "cloudflare") {
+      throw new Error(
+        `Direct Workers AI credentials only run cloudflare models, not ${model.provider} ` +
+        `(${model.model}); configure an AI Gateway to run it.`,
+      );
+    }
+    return;
+  }
+  if (access.transport === "binding" && HTTPS_ONLY_PROVIDERS.has(model.provider) &&
+      access.apiToken === undefined) {
+    throw new Error(
+      `${model.provider} inference cannot ride the Workers AI binding transport, so running a ` +
+      `${model.provider} model requires CF_AI_GATEWAY_API_TOKEN.`,
+    );
+  }
+}
+
+function configureGateway(config: WorkerConfig, access: GatewayAccess, model: EvalModel): void {
   config.vars = {
     ...config.vars,
     CF_AI_GATEWAY: access.gateway,
     CF_AI_GATEWAY_ACCOUNT_ID: access.accountId,
-    CF_AI_GATEWAY_PROVIDERS: "cloudflare",
-    CF_AI_GATEWAY_USE_BINDING: access.apiToken === undefined ? "true" : "false",
+    CF_AI_GATEWAY_PROVIDERS: model.provider,
+    // Explicit, so the backend fails loudly if the binding it expects went missing.
+    CF_AI_GATEWAY_USE_BINDING: access.transport === "binding" ? "true" : "false",
     ...(access.apiToken === undefined ? {} : { CF_AI_GATEWAY_API_TOKEN: access.apiToken }),
   };
-  if (access.apiToken === undefined) {
+  if (access.transport === "binding") {
     config.account_id = access.accountId;
     config.ai = { binding: "WORKERS_AI", remote: true };
   } else {
@@ -85,15 +144,23 @@ function configureGateway(
 }
 
 function allowsModelEgress(
-    access: LocalModelAccess, url: URL, method: string): boolean {
+    access: LocalModelAccess, model: EvalModel, url: URL, method: string): boolean {
   const account = encodeURIComponent(access.accountId);
   if (access.kind === "gateway") {
-    if (access.apiToken === undefined) return false;
     const gateway = encodeURIComponent(access.gateway);
     if (method === "POST") {
-      return url.origin === "https://gateway.ai.cloudflare.com" &&
-        url.pathname === `/v1/${account}/${gateway}/workers-ai/v1/chat/completions`;
+      // Inference rides HTTPS when the binding is opted out, or for providers whose adapter
+      // cannot ride the binding at all (the backend's AiGatewayConfig.bindingFor).
+      const route = GATEWAY_ROUTES[model.provider];
+      const ridesHttps =
+          access.transport === "https" || HTTPS_ONLY_PROVIDERS.has(model.provider);
+      return route !== undefined && ridesHttps &&
+        url.origin === "https://gateway.ai.cloudflare.com" &&
+        url.pathname.startsWith(`/v1/${account}/${gateway}/${route}/`);
     }
+    // Cost-log reads are same-account, so the backend reads them through the binding whenever
+    // the binding transport is active, even for HTTPS-only inference providers.
+    if (access.transport !== "https") return false;
     const logPrefix =
         `/client/v4/accounts/${account}/ai-gateway/gateways/${gateway}/logs/`;
     const logId = url.pathname.slice(logPrefix.length);
@@ -106,12 +173,12 @@ function allowsModelEgress(
 
 /** Start an isolated local workerd Workshop and one fresh agent session. */
 export async function openLocalEvalTarget(
-    access: LocalModelAccess, modelId: string, turnTimeoutMs: number): Promise<LocalEvalTarget> {
+    access: LocalModelAccess, model: EvalModel, turnTimeoutMs: number): Promise<LocalEvalTarget> {
   const interceptor = new NetworkInterceptor({
     handlers: [
       () => new Response("External network access is disabled during this eval.", { status: 403 }),
     ],
-    allow: (url, method) => allowsModelEgress(access, url, method),
+    allow: (url, method) => allowsModelEgress(access, model, url, method),
     allowLoopback: false,
   });
 
@@ -119,20 +186,20 @@ export async function openLocalEvalTarget(
     gatekeepers: [],
     enableGadgetExecution: true,
     ...(access.kind === "gateway"
-      ? { patchWorkshop: (config: WorkerConfig) => configureGateway(config, access) }
+      ? { patchWorkshop: (config: WorkerConfig) => configureGateway(config, access, model) }
       : {}),
   });
   interceptor.install();
 
   const options: AgentSessionOptions = {
-    modelId,
+    modelId: model.model,
     turnTimeoutMs,
     costAccountingTimeoutMs: access.kind === "gateway" ? GATEWAY_COST_ACCOUNTING_TIMEOUT_MS : 0,
     userModel: {
-      profile: { type: "agent", id: modelId, name: modelId },
+      profile: { type: "agent", id: model.model, name: model.model },
       config: {
-        provider: "cloudflare",
-        model: modelId,
+        provider: model.provider,
+        model: model.model,
         accountId: access.accountId,
         // Gateway mode takes transport credentials from the Worker environment.
         apiToken: access.kind === "direct" ? access.apiToken : "",

--- a/packages/workshop-evals/src/task.ts
+++ b/packages/workshop-evals/src/task.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import type { AgentTurnOutcome } from "@gadgets/integration-tests/agent-session";
+import type { JsonValue } from "vitest-evals";
+import type { EvalVerifier } from "./verifier.js";
+
+export type EvalCheckOutcome = {
+  pass: boolean;
+  evidence?: JsonValue;
+};
+
+export type EvalCheck = {
+  id: string;
+  pass: boolean;
+  evidence?: JsonValue;
+};
+
+export type EvalTurn = {
+  prompt: string;
+  verify(verifier: EvalVerifier): Promise<void>;
+};
+
+export type EvalTask = {
+  id: string;
+  turns: readonly [EvalTurn, ...EvalTurn[]];
+};
+
+const ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Validate one task before it can spend inference. */
+export function defineEvalTask(task: EvalTask): EvalTask {
+  if (!ID_PATTERN.test(task.id)) throw new Error(`Invalid eval task ID ${JSON.stringify(task.id)}`);
+  task.turns.forEach((turn, index) => {
+    if (turn.prompt.trim() === "") throw new Error(`Eval task ${task.id} turn ${index} is empty`);
+  });
+  return task;
+}
+
+/** Hash the prompts that define what the agent was asked to do. */
+export function taskVersion(task: EvalTask): string {
+  return createHash("sha256").update(JSON.stringify(task.turns.map(turn => turn.prompt))).digest("hex");
+}
+
+export type EvalRunInput = {
+  model: string;
+  trial: number;
+};
+
+export type EvalTurnResult = {
+  outcome: AgentTurnOutcome;
+  checks: EvalCheck[];
+  turnWallMs: number;
+  verificationWallMs: number;
+};
+
+export type EvalRunOutput = {
+  success: boolean;
+  turns: EvalTurnResult[];
+  metrics: {
+    modelTurns: number;
+    toolCalls: number;
+    toolErrors: number;
+  };
+};

--- a/packages/workshop-evals/src/transcript.test.ts
+++ b/packages/workshop-evals/src/transcript.test.ts
@@ -1,0 +1,213 @@
+import type { AiChatAuthorInfo, AiChatMessage } from "@gadgets/workshop-shared/api";
+import { expect, it } from "vitest";
+import { measureHistory, toTranscriptEvents } from "./transcript.js";
+
+const user: AiChatAuthorInfo = { type: "user", id: "user", name: "User" };
+const agent: AiChatAuthorInfo = { type: "agent", id: "model", name: "Model" };
+const gadget: AiChatAuthorInfo = { type: "gadget", id: "gadget-owner", name: "Spawner" };
+
+it("normalizes Workshop messages and failed tools", () => {
+  const history: AiChatMessage[] = [{
+    chatId: 1,
+    sequence: 0,
+    timestamp: new Date(0),
+    author: user,
+    type: "message",
+    message: "Build it",
+  }, {
+    chatId: 1,
+    sequence: 1,
+    timestamp: new Date(1),
+    author: agent,
+    type: "message",
+    message: "Trying",
+    toolCalls: [{
+      toolCallId: "call-1",
+      toolName: "listBlueprints",
+      input: {},
+      error: "catalog unavailable",
+    }],
+  }, {
+    chatId: 1,
+    sequence: 2,
+    timestamp: new Date(2),
+    author: agent,
+    type: "error",
+    message: "model stopped",
+  }];
+
+  expect(toTranscriptEvents(history)).toMatchObject([
+    { type: "message", role: "user", content: "Build it" },
+    { type: "message", role: "assistant", content: "Trying" },
+    { type: "tool_call", id: "call-1", name: "listBlueprints" },
+    {
+      type: "tool_result",
+      toolCallId: "call-1",
+      name: "listBlueprints",
+      error: { message: "catalog unavailable" },
+    },
+  ]);
+  expect(measureHistory(history)).toEqual({
+    modelTurns: 1,
+    toolCalls: 1,
+    toolErrors: 1,
+  });
+});
+
+it("keeps every model-visible input in the trajectory", () => {
+  const history: AiChatMessage[] = [{
+    chatId: 1,
+    sequence: 0,
+    timestamp: new Date(0),
+    author: user,
+    type: "message",
+    message: "Build it",
+  }, {
+    chatId: 1,
+    sequence: 1,
+    timestamp: new Date(1),
+    author: agent,
+    type: "message",
+    message: "Working",
+  }, {
+    chatId: 1,
+    sequence: 2,
+    timestamp: new Date(2),
+    author: gadget,
+    type: "message",
+    message: "Gadget-authored prompt",
+  }, {
+    chatId: 1,
+    sequence: 3,
+    timestamp: new Date(3),
+    author: agent,
+    type: "agentCallback",
+    methodName: "run",
+    argsSummary: "[1]",
+  }, {
+    chatId: 1,
+    sequence: 4,
+    timestamp: new Date(4),
+    author: agent,
+    type: "message",
+    message: "Handling callback",
+  }, {
+    chatId: 1,
+    sequence: 5,
+    timestamp: new Date(5),
+    author: agent,
+    type: "agentNudge",
+    text: "Callbacks are still open",
+  }, {
+    chatId: 1,
+    sequence: 6,
+    timestamp: new Date(6),
+    author: agent,
+    type: "message",
+    message: "Continuing",
+  }];
+
+  const events = toTranscriptEvents(history);
+  expect(events).toMatchObject([
+    { type: "message", role: "user", content: "Build it" },
+    { type: "message", role: "assistant", content: "Working" },
+    { type: "message", role: "user", content: "Gadget-authored prompt" },
+    { type: "message", role: "user", content: expect.stringMatching(/self\.run\(\).*\[1\]/s) },
+    { type: "message", role: "assistant", content: "Handling callback" },
+    { type: "message", role: "user", content: "Callbacks are still open" },
+    { type: "message", role: "assistant", content: "Continuing" },
+  ]);
+});
+
+it("stamps canonical sequence and timestamp metadata on every event", () => {
+  const history: AiChatMessage[] = [{
+    chatId: 1,
+    sequence: 2,
+    timestamp: new Date(2),
+    author: user,
+    type: "message",
+    message: "Start",
+  }, {
+    chatId: 1,
+    sequence: 3,
+    timestamp: new Date(3),
+    author: agent,
+    type: "message",
+    message: "Done",
+  }, {
+    chatId: 1,
+    sequence: 4,
+    timestamp: new Date(4),
+    author: agent,
+    type: "agentNudge",
+    text: "Try again",
+  }];
+
+  expect(toTranscriptEvents(history)).toMatchObject([
+    {
+      type: "message",
+      role: "user",
+      content: "Start",
+      metadata: { sequence: 2, timestamp: new Date(2).toISOString() },
+    },
+    {
+      type: "message",
+      role: "assistant",
+      content: "Done",
+      metadata: { sequence: 3, timestamp: new Date(3).toISOString() },
+    },
+    {
+      type: "message",
+      role: "user",
+      content: "Try again",
+      metadata: { sequence: 4, timestamp: new Date(4).toISOString() },
+    },
+  ]);
+});
+
+it("excludes display-only and non-model records", () => {
+  const history: AiChatMessage[] = [{
+    chatId: 1,
+    sequence: 0,
+    timestamp: new Date(0),
+    author: user,
+    type: "slashCommand",
+    request: { command: "summarize" } as never,
+  }, {
+    chatId: 1,
+    sequence: 1,
+    timestamp: new Date(1),
+    author: agent,
+    type: "error",
+    message: "model stopped",
+  }];
+
+  expect(toTranscriptEvents(history)).toEqual([]);
+});
+
+it("keeps batched tool calls before their results", () => {
+  const history: AiChatMessage[] = [{
+    chatId: 1,
+    sequence: 0,
+    timestamp: new Date(0),
+    author: agent,
+    type: "message",
+    message: "",
+    toolCalls: [{
+      toolCallId: "call-1",
+      toolName: "listBlueprints",
+      input: {},
+      error: "first failed",
+    }, {
+      toolCallId: "call-2",
+      toolName: "listBlueprints",
+      input: {},
+      error: "second failed",
+    }],
+  }];
+
+  expect(toTranscriptEvents(history).map(event =>
+    event.type === "tool_call" ? `call:${event.id}`
+      : event.type === "tool_result" ? `result:${event.toolCallId}` : event.type))
+    .toEqual(["call:call-1", "call:call-2", "result:call-1", "result:call-2"]);
+});

--- a/packages/workshop-evals/src/transcript.ts
+++ b/packages/workshop-evals/src/transcript.ts
@@ -1,0 +1,106 @@
+import type { AiChatMessage, AiToolCall } from "@gadgets/workshop-shared/api";
+import { toJsonValue, type JsonValue, type TranscriptEvent } from "vitest-evals";
+import { z } from "zod";
+
+const TOOL_ARGUMENTS = z.record(z.string(), z.json());
+
+function toolArguments(call: AiToolCall): Record<string, JsonValue> | undefined {
+  const result = TOOL_ARGUMENTS.safeParse(call.input);
+  return result.success ? result.data : undefined;
+}
+
+/** Convert canonical Workshop history into vitest-evals trajectory events. */
+export function toTranscriptEvents(history: readonly AiChatMessage[]): TranscriptEvent[] {
+  const events: TranscriptEvent[] = [];
+  for (const message of history) {
+    const metadata = {
+      sequence: message.sequence,
+      timestamp: message.timestamp.toISOString(),
+    };
+    if (message.type === "message") {
+      // The model receives regular messages from both users and Gadgets; agent-authored
+      // ones replay as assistant messages with their tool activity below.
+      const role = message.author.type === "user" || message.author.type === "gadget"
+        ? "user"
+        : message.author.type === "agent" ? "assistant" : undefined;
+      if (role === undefined) continue;
+      if (message.message !== "") {
+        events.push({ type: "message", role, content: message.message, metadata });
+      }
+      if (role !== "assistant") continue;
+      const calls = message.toolCalls ?? [];
+      for (const call of calls) {
+        const argumentsValue = toolArguments(call);
+        const toolCall = {
+          type: "tool_call",
+          id: call.toolCallId,
+          name: call.toolName,
+          metadata,
+        } satisfies TranscriptEvent;
+        events.push(argumentsValue === undefined
+          ? toolCall
+          : { ...toolCall, arguments: argumentsValue });
+      }
+      for (const call of calls) {
+        if (call.error !== undefined) {
+          events.push({
+            type: "tool_result",
+            toolCallId: call.toolCallId,
+            name: call.toolName,
+            error: { name: "Error", message: call.error },
+            metadata,
+          });
+          continue;
+        }
+        const output = "output" in call ? toJsonValue(call.output) : undefined;
+        const result = {
+          type: "tool_result",
+          toolCallId: call.toolCallId,
+          name: call.toolName,
+          metadata,
+        } satisfies TranscriptEvent;
+        events.push(output === undefined ? result : { ...result, content: output });
+      }
+      continue;
+    }
+    if (message.type === "agentCallback") {
+      // agent.ts replays a received callback as a user message naming self.<methodName>()
+      // and the callback args, so it is model input too.
+      events.push({
+        type: "message",
+        role: "user",
+        content: `A callback was received: \`self.${message.methodName}()\`\n` +
+          `Arguments: ${message.argsSummary}`,
+        metadata,
+      });
+      continue;
+    }
+    if (message.type === "agentNudge") {
+      // agent.ts replays a system-generated nudge as a user message so the model is
+      // prompted to continue.
+      events.push({ type: "message", role: "user", content: message.text, metadata });
+      continue;
+    }
+  }
+  return events;
+}
+
+/** Count model turns and tool outcomes from canonical history. */
+export function measureHistory(history: readonly AiChatMessage[]): {
+  modelTurns: number;
+  toolCalls: number;
+  toolErrors: number;
+} {
+  let modelTurns = 0;
+  let toolCalls = 0;
+  let toolErrors = 0;
+  for (const message of history) {
+    if (message.type !== "message" || message.author.type !== "agent") continue;
+    modelTurns++;
+    for (const call of message.toolCalls ?? []) {
+      toolCalls++;
+      if (call.error !== undefined) toolErrors++;
+    }
+  }
+  return { modelTurns, toolCalls, toolErrors };
+}

--- a/packages/workshop-evals/src/verifier.test.ts
+++ b/packages/workshop-evals/src/verifier.test.ts
@@ -1,0 +1,109 @@
+import type { WorkpieceSummary } from "@gadgets/workshop-shared/api";
+import { describe, expect, it } from "vitest";
+import { EvalVerifier, resolveGadget, type VerifierSession } from "./verifier.js";
+import type { EvalCheck } from "./task.js";
+
+const unusedSession: VerifierSession = {
+  openGadget: async () => { throw new Error("openGadget is not used by this test"); },
+};
+
+function gadget(id: number, title: string): WorkpieceSummary {
+  return { id, type: "gadget", title };
+}
+
+function collect(
+    verify: (verifier: EvalVerifier) => Promise<void>,
+    workpieces: readonly WorkpieceSummary[] = []): Promise<EvalCheck[]> {
+  return new EvalVerifier(unusedSession, workpieces).collect(verify);
+}
+
+describe("resolveGadget", () => {
+  it("resolves an exact title", () => {
+    expect(resolveGadget([gadget(3, "Split"), gadget(4, "Shelf")], "Shelf")).toBe(4);
+  });
+
+  it("reports what was built when the title is missing", () => {
+    expect(() => resolveGadget([gadget(3, "Splitter")], "Split"))
+      .toThrow('found 0 among ["Splitter"]');
+  });
+
+  it("refuses an ambiguous title", () => {
+    expect(() => resolveGadget([gadget(3, "Split"), gadget(4, "Split")], "Split"))
+      .toThrow("found 2");
+  });
+});
+
+describe("EvalVerifier", () => {
+  it("records outcomes with and without evidence", async () => {
+    expect(await collect(async verifier => {
+      await verifier.check("bare", async () => ({ pass: true }));
+      await verifier.check("detailed", async () => ({ pass: false, evidence: { seen: 2 } }));
+    })).toEqual([
+      { id: "bare", pass: true },
+      { id: "detailed", pass: false, evidence: { seen: 2 } },
+    ]);
+  });
+
+  it("records a failed check and continues", async () => {
+    expect(await collect(async verifier => {
+      await verifier.check("explodes", async () => { throw new Error("RPC refused"); });
+      await verifier.check("still-runs", async () => ({ pass: true }));
+    })).toEqual([
+      { id: "explodes", pass: false, evidence: "Error: RPC refused" },
+      { id: "still-runs", pass: true },
+    ]);
+  });
+
+  it("keeps checks recorded before the verifier body fails", async () => {
+    const checks = await collect(async verifier => {
+      await verifier.check("recorded", async () => ({ pass: true }));
+      throw new Error("resolveGadget failed outside a check");
+    });
+    expect(checks.at(0)).toEqual({ id: "recorded", pass: true });
+    expect(checks.at(1)).toMatchObject({ id: "verifier.threw", pass: false });
+  });
+
+  it("keeps registration order when checks finish out of order", async () => {
+    const gate = Promise.withResolvers<void>();
+    const checks = await collect(async verifier => {
+      const slow = verifier.check("slow", async () => {
+        await gate.promise;
+        return { pass: true };
+      });
+      const fast = verifier.check("fast", async () => ({ pass: true }));
+      await fast;
+      gate.resolve();
+      await slow;
+    });
+    expect(checks.map(check => check.id)).toEqual(["slow", "fast"]);
+  });
+
+  it("settles a check the author did not await", async () => {
+    expect(await collect(async verifier => {
+      void verifier.check("forgotten", async () => ({ pass: true }));
+    })).toEqual([{ id: "forgotten", pass: true }]);
+  });
+
+  it("exposes checks that are still pending", async () => {
+    const gate = Promise.withResolvers<void>();
+    const verifier = new EvalVerifier(unusedSession, []);
+    const pending = verifier.check("pending", async () => {
+      await gate.promise;
+      return { pass: true };
+    });
+    expect(verifier.results()).toEqual([
+      { id: "pending", pass: false, evidence: "check did not complete" },
+    ]);
+    gate.resolve();
+    await pending;
+  });
+
+  it("records a duplicate check ID as a verifier failure", async () => {
+    const checks = await collect(async verifier => {
+      await verifier.check("same", async () => ({ pass: true }));
+      await verifier.check("same", async () => ({ pass: true }));
+    });
+    expect(checks.at(0)).toEqual({ id: "same", pass: true });
+    expect(checks.at(1)?.evidence).toContain("Duplicate eval check ID");
+  });
+});

--- a/packages/workshop-evals/src/verifier.ts
+++ b/packages/workshop-evals/src/verifier.ts
@@ -1,0 +1,90 @@
+import type { RpcCompatible, RpcStub } from "capnweb";
+import type { WorkshopAgentSession } from "@gadgets/integration-tests/agent-session";
+import type { GadgetClient, WorkpieceId, WorkpieceSummary } from "@gadgets/workshop-shared/api";
+import type { EvalCheck, EvalCheckOutcome } from "./task.js";
+
+const EVIDENCE_LIMIT = 2_000;
+const VERIFIER_THREW = "verifier.threw";
+
+export type VerifierSession = Pick<WorkshopAgentSession, "openGadget">;
+
+function truncate(value: string): string {
+  return value.length > EVIDENCE_LIMIT ? `${value.slice(0, EVIDENCE_LIMIT)}...` : value;
+}
+
+function connectTyped<Session extends RpcCompatible<Session>>(
+    client: RpcStub<GadgetClient>, chatId: number): Promise<RpcStub<Session>>;
+function connectTyped(client: RpcStub<GadgetClient>, chatId: number) {
+  return client.connectToGadget(chatId);
+}
+
+/** Find the single Gadget with the exact title required by a task. */
+export function resolveGadget(
+    workpieces: readonly WorkpieceSummary[], title: string): WorkpieceId {
+  const matches = workpieces.filter(
+      workpiece => workpiece.type === "gadget" && workpiece.title === title);
+  const match = matches.at(0);
+  if (matches.length !== 1 || match === undefined) {
+    const built = workpieces.map(workpiece => JSON.stringify(workpiece.title)).join(", ");
+    throw new Error(`Expected exactly one Gadget titled ${JSON.stringify(title)}, ` +
+      `found ${matches.length} among [${built}]`);
+  }
+  return match.id;
+}
+
+/** Runs independent functional checks against the agent's provisional Gadget branch. */
+export class EvalVerifier {
+  readonly workpieces: readonly WorkpieceSummary[];
+  readonly #session: VerifierSession;
+  readonly #checks: EvalCheck[] = [];
+  readonly #pending: Promise<void>[] = [];
+
+  constructor(session: VerifierSession, workpieces: readonly WorkpieceSummary[]) {
+    this.#session = session;
+    this.workpieces = workpieces;
+  }
+
+  async check(id: string, body: () => Promise<EvalCheckOutcome>): Promise<void> {
+    if (this.#checks.some(check => check.id === id)) {
+      throw new Error(`Duplicate eval check ID ${JSON.stringify(id)} within one turn`);
+    }
+    const index = this.#checks.length;
+    this.#checks.push({ id, pass: false, evidence: "check did not complete" });
+    const settled = this.#run(index, id, body);
+    this.#pending.push(settled);
+    await settled;
+  }
+
+  async connect<Session extends RpcCompatible<Session>>(
+      gadgetTitle: string): Promise<RpcStub<Session>> {
+    const opened = await this.#session.openGadget(
+        resolveGadget(this.workpieces, gadgetTitle));
+    try {
+      return connectTyped<Session>(opened.client, opened.chatId);
+    } finally {
+      opened.client[Symbol.dispose]();
+    }
+  }
+
+  async collect(verify: (verifier: EvalVerifier) => Promise<void>): Promise<EvalCheck[]> {
+    try {
+      await verify(this);
+    } catch (error) {
+      this.#checks.push({ id: VERIFIER_THREW, pass: false, evidence: truncate(String(error)) });
+    }
+    await Promise.all(this.#pending);
+    return this.#checks;
+  }
+
+  results(): EvalCheck[] {
+    return this.#checks.map(check => ({ ...check }));
+  }
+
+  async #run(index: number, id: string, body: () => Promise<EvalCheckOutcome>): Promise<void> {
+    try {
+      this.#checks[index] = { id, ...await body() };
+    } catch (error) {
+      this.#checks[index] = { id, pass: false, evidence: truncate(String(error)) };
+    }
+  }
+}

--- a/packages/workshop-evals/tsconfig.json
+++ b/packages/workshop-evals/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node", "@cloudflare/workers-types"],
+    "noEmit": true,
+    "paths": {
+      "@gadgets/integration-tests/*": ["../integration-tests/src/*"],
+      "@gadgets/workshop-shared/*": ["../workshop-shared/src/*"]
+    }
+  },
+  "include": ["src", "evals", "*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/workshop-evals/vite.config.ts
+++ b/packages/workshop-evals/vite.config.ts
@@ -1,0 +1,3 @@
+import vitestTaskViteConfig from "../../scripts/vitest-task-vite-config.js";
+
+export default vitestTaskViteConfig("vitest run --config vitest.config.ts");

--- a/packages/workshop-evals/vitest.config.ts
+++ b/packages/workshop-evals/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/workshop-evals/vitest.eval.config.ts
+++ b/packages/workshop-evals/vitest.eval.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import { EVAL_TEST_TIMEOUT_MS } from "./src/config.js";
+
+export default defineConfig({
+  test: {
+    include: ["evals/**/*.eval.ts"],
+    globalSetup: ["../integration-tests/src/global-setup.ts"],
+    environment: "node",
+    testTimeout: EVAL_TEST_TIMEOUT_MS,
+    hookTimeout: 3 * 60_000,
+  },
+});

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -1183,10 +1183,7 @@ export const WORKERS_AI_OUTPUT_LIMIT = 32768;
  * `outputLimit`, when present, is both the requested response cap and the space reserved for it,
  * leaving the remainder as the prompt budget context compaction sizes against.
  */
-export const SUGGESTED_MODELS: Record<
-  AiModelProvider,
-  Record<string, {name: string, contextWindow: number, outputLimit?: number}>
-> = {
+const SUGGESTED_MODEL_CATALOG = {
   "cloudflare": {
     "@cf/moonshotai/kimi-k2.7-code": {
       name: "Kimi K2.7 Code (Workers AI)", contextWindow: 262144,
@@ -1221,7 +1218,34 @@ export const SUGGESTED_MODELS: Record<
   },
   "ollama": {
   },
-};
+} satisfies Record<
+  AiModelProvider,
+  Record<string, {name: string, contextWindow: number, outputLimit?: number}>
+>;
+
+export const SUGGESTED_MODELS: Record<
+  AiModelProvider,
+  Record<string, {name: string, contextWindow: number, outputLimit?: number}>
+> = SUGGESTED_MODEL_CATALOG;
+
+/** A model ID listed in SUGGESTED_MODELS, optionally narrowed to one provider's catalog. */
+export type SuggestedModelId<P extends AiModelProvider = AiModelProvider> =
+  { [K in P]: keyof (typeof SUGGESTED_MODEL_CATALOG)[K] & string }[P];
+
+/**
+ * Providers whose pi API adapter refuses a custom fetch, so their inference cannot ride the
+ * Workers AI binding and needs CF_AI_GATEWAY_API_TOKEN over HTTPS. pi's Google adapter throws
+ * "Custom fetch is not supported by the Google Generative AI adapter" whenever the fetch it is
+ * given is not globalThis.fetch, and the client it builds on offers no hook to route around that:
+ * @google/genai's `GoogleGenAI` takes only `httpOptions`, whose knobs are
+ * baseUrl/apiVersion/headers/timeout/extraBody/retryOptions.
+ * https://github.com/earendil-works/pi/blob/v0.84.2/packages/ai/src/api/google-generative-ai.ts#L80
+ *
+ * pi's Vertex adapter throws the same way, so a google-vertex provider would belong here too; it
+ * is absent only because this deployment has no such provider.
+ * https://github.com/earendil-works/pi/blob/v0.84.2/packages/ai/src/api/google-vertex.ts#L98
+ */
+export const HTTPS_ONLY_PROVIDERS: ReadonlySet<string> = new Set<AiModelProvider>(["google"]);
 
 /**
  * Metadata about a workspace (one Overseer DO and everything in it). Includes everything needed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,6 +947,37 @@ importers:
         specifier: 'catalog:'
         version: 4.125.0(@cloudflare/workers-types@5.20260825.1)
 
+  packages/workshop-evals:
+    dependencies:
+      '@gadgets/integration-tests':
+        specifier: workspace:*
+        version: link:../integration-tests
+      '@gadgets/workshop-shared':
+        specifier: workspace:*
+        version: link:../workshop-shared
+      capnweb:
+        specifier: 'catalog:'
+        version: 0.12.0
+      vitest-evals:
+        specifier: 0.16.1
+        version: 0.16.1(tinyrainbow@3.1.1)(vitest@4.1.10)(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^5.20260808.1
+        version: 5.20260825.1
+      '@types/node':
+        specifier: 26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+
   packages/workshop-frontend:
     dependencies:
       '@cloudflare/kumo':
@@ -2967,6 +2998,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: 7.3.6
+
+  '@vitest-evals/core@0.16.1':
+    resolution: {integrity: sha512-e4BfGirm4HOP2HfoYvE61iWp7K389tYwUOdPj+CS8lCI1D2efIlLptClU1knhDocLVaU6F/9ty2+p7u1tDkaIg==}
+
+  '@vitest-evals/report-ui@0.16.1':
+    resolution: {integrity: sha512-3oHbMntbksRWQB1Nu1j8UXIy8+we6iUng24wAKxhSli7vjIgkaX02JjjfXgK4CWG4DhgOQkwJqw+wNaOMduY5A==}
 
   '@vitest/browser-preview@4.1.10':
     resolution: {integrity: sha512-14MJrL59ZFkqXLjwfSk6RzTDy5Czf9UG4+8q8L6Gxjs2aPjEce/cVNYV14bXAc2BvMjUNu904+ZEZA1Xc1wtvQ==}
@@ -5061,6 +5098,20 @@ packages:
       yaml:
         optional: true
 
+  vitest-evals@0.16.1:
+    resolution: {integrity: sha512-MuPVetClAOn55ewgajxGxZcQDFWUftrQ19/rZQn8zXvaxHri+ElgEb5W0OIMRQwSvF5TBYIsE5rWdQB/qrWJkg==}
+    hasBin: true
+    peerDependencies:
+      ai: '>=4 <7'
+      tinyrainbow: '>=2 <4'
+      vitest: '>=4 <5'
+      zod: '>=3 <5'
+    peerDependenciesMeta:
+      ai:
+        optional: true
+      zod:
+        optional: true
+
   vitest@4.1.10:
     resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -7021,6 +7072,14 @@ snapshots:
       vite: 7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest-evals/core@0.16.1':
+    dependencies:
+      zod: 4.4.3
+
+  '@vitest-evals/report-ui@0.16.1':
+    dependencies:
+      '@vitest-evals/core': 0.16.1
 
   '@vitest/browser-preview@4.1.10(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -9352,6 +9411,15 @@ snapshots:
       lightningcss: 1.33.0
       terser: 5.49.2
       yaml: 2.9.0
+
+  vitest-evals@0.16.1(tinyrainbow@3.1.1)(vitest@4.1.10)(zod@4.4.3):
+    dependencies:
+      '@vitest-evals/core': 0.16.1
+      '@vitest-evals/report-ui': 0.16.1
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+    optionalDependencies:
+      zod: 4.4.3
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
This PR adds `pnpm evals` on top of `WorkshopAgentSession`. An eval defines one or more prompts and deterministic checks against the Gadget the agent created. The runner starts an isolated Workshop under local workerd, runs each model and trial, calls the generated Gadget through its RPC API, and cleans up the workspace afterward.

The report shows whether the task passed, which checks failed, and the evidence returned by each check. It also records the canonical conversation, timings, model turns, tool calls, tool errors, final-step tokens, observed chat cost, model, trial, Git commit, and prompt hash.

The first eval asks the agent to create a Project Doc. Only model inference leaves the machine. This PR does not add a production target, Braintrust, or an LLM quality judge.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


Wall time: 0.45 seconds


Wall time: 2.19 seconds


Wall time: 0.48 seconds