### PR TITLE
Add functional eval scenarios and CI reporting

### DIFF
--- a/.github/workflows/workshop-evals.yml
+++ b/.github/workflows/workshop-evals.yml
@@ -1,0 +1,74 @@
+name: Workshop evals
+
+on:
+  workflow_dispatch:
+    inputs:
+      models:
+        description: Comma-separated model IDs; blank uses DeepSeek V4 Pro
+      trials:
+        description: Repetitions per task and model
+        default: "1"
+        required: true
+      reportOnly:
+        description: Report failed trials without failing the workflow
+        type: boolean
+        default: false
+        required: true
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Vite+, Node.js and dependencies
+        uses: voidzero-dev/setup-vp@313600b80b104eadebb9111787d37a2e83e014ca # v1.17.0
+        with:
+          node-version: "24.19.0"
+          cache: true
+          run-install: true
+
+      - name: Run local workerd evals
+        continue-on-error: true
+        env:
+          CF_AI_GATEWAY: ${{ secrets.CF_AI_GATEWAY_NAME }}
+          CF_AI_GATEWAY_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
+          CF_AI_GATEWAY_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          WORKSHOP_EVAL_MODELS: ${{ inputs.models }}
+          WORKSHOP_EVAL_TRIALS: ${{ inputs.trials }}
+          WORKSHOP_EVAL_COMMIT: ${{ github.sha }}
+        run: pnpm evals
+
+      - name: Require eval results
+        run: test -f packages/workshop-evals/.wrangler/evals/results.json
+
+      - name: Upload eval results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: workshop-evals
+          path: packages/workshop-evals/.wrangler/evals/results.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 30
+
+      # The zero floor keeps report validation active without rejecting task misses in report-only mode.
+      - name: Publish eval report
+        uses: getsentry/vitest-evals@d37153f06d7d086393927c57a2faaeff464a55e2 # v0
+        with:
+          results: packages/workshop-evals/.wrangler/evals/results.json
+          publish-check: true
+          check-name: Workshop evals
+          fail-on-failures: ${{ !inputs.reportOnly }}
+          min-pass-rate: 0
+          soft-fail: false

--- a/packages/integration-tests/src/agent-session.ts
+++ b/packages/integration-tests/src/agent-session.ts
@@ -70,6 +70,7 @@ export interface WorkshopAgentSession extends AsyncDisposable {
   listActions(options?: ActionListOptions): Promise<ActionHistoryPage>;
   connectedAccount(vendorId: string): ConnectedAccount;
   openGadget(id: WorkpieceId): Promise<ProvisionalGadget>;
+  acceptChanges(): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -453,6 +454,14 @@ class WorkshopAgentSessionImpl implements WorkshopAgentSession {
     const chatId = this.#chatId;
     if (chatId === undefined) throw new Error("The session has no chat branch");
     return { client: await this.#workspace.getGadget(id), chatId };
+  }
+
+  async acceptChanges(): Promise<void> {
+    this.#assertOpen();
+    const chatId = this.#chatId;
+    if (chatId === undefined) throw new Error("The session has no chat changes to accept");
+    const result = await this.#workspace.mergeChanges(chatId);
+    if (result.outcome !== "merged") throw new Error("The agent changes are stale");
   }
 
   close(): Promise<void> {

--- a/packages/workshop-evals/evals/appointment-desk.eval.ts
+++ b/packages/workshop-evals/evals/appointment-desk.eval.ts
@@ -1,0 +1,242 @@
+import { z } from "zod";
+import { defineTaskEval } from "../src/eval.js";
+import { defineEvalTask } from "../src/task.js";
+
+const OkSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), error: z.string().min(1) }),
+]);
+
+const StatusSchema = z.object({
+  capacity: z.number().int().nonnegative(),
+  bookedCount: z.number().int().nonnegative(),
+  personIds: z.array(z.string()),
+});
+
+interface DeskApi {
+  defineSlot(input: { slotId: string; startIso: string; capacity: number }):
+    Promise<z.infer<typeof OkSchema>>;
+  book(input: { bookingId: string; slotId: string; personId: string }):
+    Promise<z.infer<typeof OkSchema>>;
+  cancel(input: { bookingId: string }): Promise<z.infer<typeof OkSchema>>;
+  slotStatus(input: { slotId: string }): Promise<z.infer<typeof StatusSchema>>;
+}
+
+/** Settles a batch of concurrent results into counts of accepted and each rejection code. */
+function tally(results: readonly z.infer<typeof OkSchema>[]) {
+  const accepted = results.filter(result => result.ok).length;
+  const errors: Record<string, number> = {};
+  for (const result of results) {
+    if (result.ok) continue;
+    errors[result.error] = (errors[result.error] ?? 0) + 1;
+  }
+  return { accepted, errors };
+}
+
+/** Whether two personId lists name exactly the same people, in any order. */
+function samePeople(left: readonly string[], right: readonly string[]): boolean {
+  return JSON.stringify([...left].toSorted()) === JSON.stringify([...right].toSorted());
+}
+
+/**
+ * Durable Object RPC calls can interleave at each `await`. A count check followed by an awaited
+ * insert can therefore oversell. Both shipped format blueprints guard this race, so the task probes
+ * a platform-relevant capability rather than prompt recall.
+ *
+ * The prompt states the capacity invariant without prescribing synchronization. In a measured GLM
+ * 5.2 run, synchronous SQL plus a BEFORE INSERT trigger passed. Requiring a mutation queue would
+ * have rejected that correct implementation.
+ */
+const task = defineEvalTask({
+  id: "appointment-desk",
+  turns: [{
+    prompt: `Build a Gadget named exactly "Desk" for booking appointment slots at a small clinic.
+Reception shares the link, so several people book at the same moment from their own phones. A slot
+must never be oversold: if it has three places, exactly three bookings can ever succeed, no matter
+how many arrive at once. Getting this wrong is the one failure I cannot live with, so make it
+impossible rather than unlikely. Store everything in the Gadget's own storage.
+
+It needs a stable server RPC taking and returning plain data, so I can verify it:
+
+- defineSlot({ slotId: string, startIso: string, capacity: integer > 0 })
+  -> { ok: true } | { ok: false, error: string }
+  Rejects "DUPLICATE_SLOT" if that slotId already exists.
+
+- book({ bookingId: string, slotId: string, personId: string })
+  -> { ok: true } | { ok: false, error: string }
+  Reject these, changing nothing, with exactly these error codes:
+    "UNKNOWN_SLOT"      - no slot with that id
+    "SLOT_FULL"         - the slot already holds its capacity in bookings
+    "DUPLICATE_BOOKING" - a booking with that bookingId already exists
+
+- cancel({ bookingId: string }) -> { ok: true } | { ok: false, error: string }
+  Rejects "UNKNOWN_BOOKING". A cancelled booking frees its place for someone else.
+
+- slotStatus({ slotId: string })
+  -> { capacity: integer, bookedCount: integer, personIds: string[] }
+  personIds lists the people currently holding a place, and its length always equals bookedCount.`,
+    verify: async verifier => {
+      await verifier.check("sequential-booking-respects-capacity", async () => {
+        using api = await verifier.connect<DeskApi>("Desk");
+        const defined = OkSchema.parse(await api.defineSlot({
+          slotId: "seq", startIso: "2026-07-01T09:00:00Z", capacity: 2,
+        }));
+        const duplicate = OkSchema.parse(await api.defineSlot({
+          slotId: "seq", startIso: "2026-07-01T10:00:00Z", capacity: 3,
+        }));
+        const results = [
+          OkSchema.parse(await api.book({ bookingId: "seq-1", slotId: "seq", personId: "ana" })),
+          OkSchema.parse(await api.book({ bookingId: "seq-2", slotId: "seq", personId: "ben" })),
+          OkSchema.parse(await api.book({ bookingId: "seq-3", slotId: "seq", personId: "cy" })),
+        ];
+        const status = StatusSchema.parse(await api.slotStatus({ slotId: "seq" }));
+        return {
+          pass: defined.ok && !duplicate.ok && duplicate.error === "DUPLICATE_SLOT" &&
+            results[0]?.ok === true && results[1]?.ok === true &&
+            results[2]?.ok === false && results[2].error === "SLOT_FULL" &&
+            status.capacity === 2 && status.bookedCount === 2 &&
+            samePeople(status.personIds, ["ana", "ben"]),
+          evidence: { defined, duplicate, results, status },
+        };
+      });
+
+      await verifier.check("cancelling-frees-a-place", async () => {
+        using api = await verifier.connect<DeskApi>("Desk");
+        await api.defineSlot({ slotId: "cancel", startIso: "2026-07-02T09:00:00Z", capacity: 1 });
+        await api.book({ bookingId: "cancel-1", slotId: "cancel", personId: "ana" });
+        const blocked = OkSchema.parse(
+            await api.book({ bookingId: "cancel-2", slotId: "cancel", personId: "ben" }));
+        const cancelled = OkSchema.parse(await api.cancel({ bookingId: "cancel-1" }));
+        const unknown = OkSchema.parse(await api.cancel({ bookingId: "cancel-nope" }));
+        // Retrying the exact ID that was refused with SLOT_FULL proves the rejection changed
+        // nothing: reserving booking IDs before checking capacity would leave cancel-2 consumed.
+        const retried = OkSchema.parse(
+            await api.book({ bookingId: "cancel-2", slotId: "cancel", personId: "ben" }));
+        const status = StatusSchema.parse(await api.slotStatus({ slotId: "cancel" }));
+        return {
+          pass: !blocked.ok && blocked.error === "SLOT_FULL" && cancelled.ok &&
+            !unknown.ok && unknown.error === "UNKNOWN_BOOKING" && retried.ok &&
+            status.capacity === 1 && status.bookedCount === 1 && status.personIds.join() === "ben",
+          evidence: { blocked, cancelled, unknown, retried, status },
+        };
+      });
+
+      await verifier.check("rejects-unknown-slot", async () => {
+        using api = await verifier.connect<DeskApi>("Desk");
+        const result = OkSchema.parse(
+            await api.book({ bookingId: "ghost", slotId: "no-such-slot", personId: "ana" }));
+        const defined = OkSchema.parse(await api.defineSlot({
+          slotId: "no-such-slot", startIso: "2026-07-02T10:00:00Z", capacity: 1,
+        }));
+        const retried = OkSchema.parse(
+            await api.book({ bookingId: "ghost", slotId: "no-such-slot", personId: "ana" }));
+        const status = StatusSchema.parse(await api.slotStatus({ slotId: "no-such-slot" }));
+        return {
+          pass: !result.ok && result.error === "UNKNOWN_SLOT" && defined.ok && retried.ok &&
+            status.bookedCount === 1 && status.personIds.join() === "ana",
+          evidence: { result, defined, retried, status },
+        };
+      });
+
+      // Ten bookings dispatched without awaiting arrive as ten interleaved RPC calls, so a
+      // check-then-write implementation oversells the slot.
+      await verifier.check("concurrent-booking-never-oversells", async () => {
+        using api = await verifier.connect<DeskApi>("Desk");
+        const capacity = 3;
+        await api.defineSlot({ slotId: "race", startIso: "2026-07-03T09:00:00Z", capacity });
+        const results = (await Promise.all(Array.from({ length: 10 }, (_unused, index) =>
+          api.book({
+            bookingId: `race-${index}`, slotId: "race", personId: `person-${index}`,
+          })))).map(result => OkSchema.parse(result));
+        const status = StatusSchema.parse(await api.slotStatus({ slotId: "race" }));
+        const { accepted, errors } = tally(results);
+        // The stored holders must be exactly the callers whose requests succeeded; counting
+        // successes and holders separately would let them describe different bookings.
+        const succeeded = results.flatMap((result, index) => result.ok ? [`person-${index}`] : []);
+        return {
+          pass: accepted === capacity && status.capacity === capacity &&
+            status.bookedCount === capacity && status.personIds.length === capacity &&
+            new Set(status.personIds).size === capacity &&
+            samePeople(status.personIds, succeeded) &&
+            errors.SLOT_FULL === 10 - capacity,
+          evidence: { accepted, errors, status, succeeded },
+        };
+      });
+
+      await verifier.check("concurrent-duplicate-booking-ids-collapse-to-one", async () => {
+        using api = await verifier.connect<DeskApi>("Desk");
+        await api.defineSlot({ slotId: "dupe", startIso: "2026-07-04T09:00:00Z", capacity: 8 });
+        // Two definitions of the same slotId race: a check-then-insert defineSlot lets both
+        // succeed, so exactly one may win and the stored capacity must be the winner's.
+        const [racedLow, racedHigh] = (await Promise.all([
+          api.defineSlot({ slotId: "dupe-other", startIso: "2026-07-04T10:00:00Z", capacity: 2 }),
+          api.defineSlot({ slotId: "dupe-other", startIso: "2026-07-04T11:00:00Z", capacity: 7 }),
+        ])).map(result => OkSchema.parse(result));
+        const winnerCapacity = racedLow.ok ? 2 : racedHigh.ok ? 7 : null;
+        const defineRejections = [racedLow, racedHigh]
+          .map(result => result.ok ? null : result.error);
+        const results = (await Promise.all(Array.from({ length: 6 }, () =>
+          api.book({ bookingId: "dupe-same", slotId: "dupe", personId: "ana" }))))
+            .map(result => OkSchema.parse(result));
+        const crossSlot = OkSchema.parse(
+            await api.book({ bookingId: "dupe-same", slotId: "dupe-other", personId: "ben" }));
+        // Reading both slots only after the rejected cross-slot attempt proves the rejection
+        // changed nothing, including the raced definition's stored capacity.
+        const dupeStatus = StatusSchema.parse(await api.slotStatus({ slotId: "dupe" }));
+        const otherStatus = StatusSchema.parse(await api.slotStatus({ slotId: "dupe-other" }));
+        const { accepted, errors } = tally(results);
+        // Capacity 8 must admit five further distinct bookings; an implementation capping unique
+        // bookings at three would refuse the fourth.
+        const extras = (await Promise.all(Array.from({ length: 5 }, (_unused, index) =>
+          api.book({
+            bookingId: `dupe-extra-${index}`, slotId: "dupe", personId: `extra-${index}`,
+          })))).map(result => OkSchema.parse(result));
+        const finalStatus = StatusSchema.parse(await api.slotStatus({ slotId: "dupe" }));
+        return {
+          pass: accepted === 1 && errors.DUPLICATE_BOOKING === 5 &&
+            racedLow.ok !== racedHigh.ok &&
+            defineRejections.every(code => code === null || code === "DUPLICATE_SLOT") &&
+            otherStatus.capacity === winnerCapacity &&
+            !crossSlot.ok && crossSlot.error === "DUPLICATE_BOOKING" &&
+            dupeStatus.capacity === 8 && dupeStatus.bookedCount === 1 &&
+            dupeStatus.personIds.join() === "ana" &&
+            otherStatus.bookedCount === 0 && otherStatus.personIds.length === 0 &&
+            extras.every(result => result.ok) &&
+            finalStatus.capacity === 8 && finalStatus.bookedCount === 6 &&
+            samePeople(finalStatus.personIds,
+                ["ana", "extra-0", "extra-1", "extra-2", "extra-3", "extra-4"]),
+          evidence: {
+            accepted, errors, racedLow, racedHigh, winnerCapacity, crossSlot,
+            dupeStatus, otherStatus, extras, finalStatus,
+          },
+        };
+      });
+    },
+    verifyAfterAccept: async verifier => {
+      await verifier.check("bookings-survive-code-reload", async () => {
+        using api = await verifier.connect<DeskApi>("Desk");
+        const status = StatusSchema.parse(await api.slotStatus({ slotId: "seq" }));
+        // The cancel slot must reload with exactly its post-cancellation state: a cancelled
+        // booking restored from memory would oversell this capacity-1 slot.
+        const cancelStatus = StatusSchema.parse(await api.slotStatus({ slotId: "cancel" }));
+        const cancelledAgain = OkSchema.parse(await api.cancel({ bookingId: "cancel-2" }));
+        const rebooked = OkSchema.parse(
+            await api.book({ bookingId: "cancel-4", slotId: "cancel", personId: "dee" }));
+        const rebookedStatus = StatusSchema.parse(await api.slotStatus({ slotId: "cancel" }));
+        return {
+          pass: status.capacity === 2 && status.bookedCount === 2 &&
+            status.personIds.length === 2 && status.personIds.includes("ana") &&
+            status.personIds.includes("ben") &&
+            cancelStatus.capacity === 1 && cancelStatus.bookedCount === 1 &&
+            cancelStatus.personIds.join() === "ben" &&
+            cancelledAgain.ok && rebooked.ok &&
+            rebookedStatus.capacity === 1 && rebookedStatus.bookedCount === 1 &&
+            rebookedStatus.personIds.join() === "dee",
+          evidence: { status, cancelStatus, cancelledAgain, rebooked, rebookedStatus },
+        };
+      });
+    },
+  }],
+});
+
+defineTaskEval(task);

--- a/packages/workshop-evals/evals/expense-ledger.eval.ts
+++ b/packages/workshop-evals/evals/expense-ledger.eval.ts
@@ -1,0 +1,594 @@
+import { z } from "zod";
+import { defineTaskEval } from "../src/eval.js";
+import { defineEvalTask } from "../src/task.js";
+
+const OkSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), error: z.string().min(1) }),
+]);
+
+const BudgetResultSchema = z.object({ ok: z.boolean() });
+
+const BalancesSchema = z.object({
+  perPerson: z.array(z.object({ personId: z.string(), netCents: z.number().int() })),
+});
+
+const SettlementSchema = z.object({
+  transfers: z.array(z.object({
+    fromId: z.string(),
+    toId: z.string(),
+    amountCents: z.number().int().positive(),
+  })),
+});
+
+const MonthlySchema = z.object({
+  totalCents: z.number().int(),
+  byPayer: z.array(z.object({
+    personId: z.string(),
+    paidCents: z.number().int(),
+  })),
+});
+
+const BudgetStatusSchema = z.object({
+  byCategory: z.array(z.object({
+    category: z.string(),
+    limitCents: z.number().int().nullable(),
+    spentCents: z.number().int(),
+    remainingCents: z.number().int().nullable(),
+  })),
+});
+
+type Expense = {
+  id: string;
+  description: string;
+  payerId: string;
+  amountCents: number;
+  splitBetween: string[];
+  dateIso: string;
+  category?: string;
+};
+
+interface LedgerApi {
+  addExpense(input: Expense): Promise<z.infer<typeof OkSchema>>;
+  balances(): Promise<z.infer<typeof BalancesSchema>>;
+  settlement(): Promise<z.infer<typeof SettlementSchema>>;
+  monthlyTotals(input: { month: string }): Promise<z.infer<typeof MonthlySchema>>;
+}
+
+interface BudgetedLedgerApi extends LedgerApi {
+  setBudget(input: { category: string; month: string; limitCents: number }): Promise<{ ok: boolean }>;
+  budgetStatus(input: { month: string }): Promise<z.infer<typeof BudgetStatusSchema>>;
+}
+
+/** Net balance for one person, or null when the ledger does not know them. */
+function net(balances: z.infer<typeof BalancesSchema>, personId: string): number | null {
+  return balances.perPerson.find(entry => entry.personId === personId)?.netCents ?? null;
+}
+
+function analyzeSettlement(
+    balances: z.infer<typeof BalancesSchema>, settlement: z.infer<typeof SettlementSchema>) {
+  const remaining = new Map(balances.perPerson.map(entry => [entry.personId, entry.netCents]));
+  const knownEndpoints = settlement.transfers.every(
+      transfer => remaining.has(transfer.fromId) && remaining.has(transfer.toId));
+  for (const transfer of settlement.transfers) {
+    remaining.set(transfer.fromId, (remaining.get(transfer.fromId) ?? 0) + transfer.amountCents);
+    remaining.set(transfer.toId, (remaining.get(transfer.toId) ?? 0) - transfer.amountCents);
+  }
+  return {
+    knownEndpoints,
+    owing: balances.perPerson.filter(entry => entry.netCents !== 0).length,
+    unsettled: [...remaining].filter(([, value]) => value !== 0),
+  };
+}
+
+function canonicalBalances(balances: z.infer<typeof BalancesSchema>) {
+  return balances.perPerson
+      .map(entry => ({ personId: entry.personId, netCents: entry.netCents }))
+      .toSorted((left, right) => left.personId.localeCompare(right.personId));
+}
+
+function canonicalMonthly(monthly: z.infer<typeof MonthlySchema>) {
+  return {
+    totalCents: monthly.totalCents,
+    byPayer: monthly.byPayer.toSorted((left, right) =>
+      left.personId.localeCompare(right.personId)),
+  };
+}
+
+function canonicalBudgetStatus(status: z.infer<typeof BudgetStatusSchema>) {
+  return status.byCategory.toSorted((left, right) =>
+    left.category.localeCompare(right.category));
+}
+
+const TURN_ONE_MONTH = "2026-03";
+const TURN_ONE_IDS = ["survive-1", "survive-2"];
+
+/**
+ * A shared-expense ledger, which is the archetypal thing people build on a platform like this.
+ *
+ * Most checks assert an invariant rather than a hand-computed constant: balances sum to zero,
+ * transfers clear them, and split shares total the expense exactly. An invariant survives an
+ * arithmetic slip in the task and still catches the bug it describes, such as per-share rounding that
+ * loses a cent.
+ */
+const task = defineEvalTask({
+  id: "expense-ledger",
+  turns: [{
+    prompt: `Build a Gadget named exactly "Ledger" for tracking shared household expenses between
+flatmates and working out who owes whom. I want to add an expense, see everyone's running balance,
+and get a short list of payments that settles us up.
+
+Store all money as integer cents. Never use floating point. Keep everything in the Gadget's own
+storage so nothing is lost when the server restarts.
+
+It also needs a stable server RPC taking and returning plain data, so I can verify it:
+
+- addExpense({ id: string, description: string, payerId: string, amountCents: integer > 0,
+  splitBetween: string[], dateIso: "YYYY-MM-DD" }) -> { ok: true } | { ok: false, error: string }
+  The payer paid amountCents on behalf of everyone in splitBetween, split as evenly as integer
+  cents allow. When it does not divide evenly, give the leftover cents to the earliest people in
+  splitBetween order, so the shares always sum to exactly amountCents.
+  Reject these, changing nothing, with exactly these error codes:
+    "DUPLICATE_ID"   - an expense with that id already exists
+    "INVALID_AMOUNT" - amountCents is not a positive integer
+    "EMPTY_SPLIT"    - splitBetween is empty
+    "BAD_DATE"       - dateIso is not a YYYY-MM-DD calendar date
+
+- balances() -> { perPerson: Array<{ personId: string, netCents: integer }> }
+  netCents is positive when that person is owed money, negative when they owe it. Include everyone
+  who appears in any expense as a payer or in a split.
+
+- settlement() -> { transfers: Array<{ fromId: string, toId: string, amountCents: integer > 0 }> }
+  Payments that bring every balance to zero. Keep it short: never more transfers than one fewer
+  than the number of people with a non-zero balance.
+
+- monthlyTotals({ month: "YYYY-MM" }) -> { totalCents: integer,
+  byPayer: Array<{ personId: string, paidCents: integer }> }
+  Counting only expenses whose dateIso falls inside that month.`,
+    verify: async verifier => {
+      await verifier.check("splits-leftover-cents-without-losing-any", async () => {
+        using api = await verifier.connect<LedgerApi>("Ledger");
+        const emptySettlement = SettlementSchema.parse(await api.settlement());
+        // 100 split three ways cannot divide evenly; flooring each share would lose a cent.
+        const added = await api.addExpense({
+          id: "cents-1",
+          description: "Milk",
+          payerId: "cents-ana",
+          amountCents: 100,
+          splitBetween: ["cents-ana", "cents-ben", "cents-cy"],
+          dateIso: "2026-05-04",
+        });
+        const nonLexical = OkSchema.parse(await api.addExpense({
+          id: "cents-order",
+          description: "Order-sensitive split",
+          payerId: "order-z",
+          amountCents: 5,
+          splitBetween: ["order-z", "order-a"],
+          dateIso: "2026-05-04",
+        }));
+        const balances = BalancesSchema.parse(await api.balances());
+        const trio = ["cents-ana", "cents-ben", "cents-cy"].map(id => net(balances, id));
+        const [ana, ben, cy] = trio;
+        return {
+          pass: emptySettlement.transfers.length === 0 && OkSchema.parse(added).ok &&
+            nonLexical.ok &&
+            // Ana paid 100 and owes the first, largest share of 34, leaving her owed 66. Flooring
+            // every share to 33 would lose a cent and show up as a 65/-33/-33 that does not balance.
+            ana === 66 && ben === -33 && cy === -33 &&
+            trio.reduce((sum, value) => (sum ?? 0) + (value ?? 0), 0) === 0 &&
+            net(balances, "order-z") === 2 && net(balances, "order-a") === -2,
+          evidence: { emptySettlement, ana, ben, cy, nonLexical },
+        };
+      });
+
+      await verifier.check("balances-always-sum-to-zero", async () => {
+        using api = await verifier.connect<LedgerApi>("Ledger");
+        const added = [
+          await api.addExpense({
+            id: "sum-1",
+            description: "Rent",
+            payerId: "sum-ana",
+            amountCents: 133_337,
+            splitBetween: ["sum-ana", "sum-ben", "sum-cy", "sum-dee"],
+            dateIso: "2026-05-01",
+          }),
+          await api.addExpense({
+            id: "sum-2",
+            description: "Wifi",
+            payerId: "sum-ben",
+            amountCents: 4_999,
+            splitBetween: ["sum-ben", "sum-cy"],
+            dateIso: "2026-05-02",
+          }),
+          await api.addExpense({
+            id: "sum-3",
+            description: "Cleaner",
+            payerId: "sum-cy",
+            amountCents: 7,
+            splitBetween: ["sum-ana", "sum-ben", "sum-cy", "sum-dee"],
+            dateIso: "2026-05-03",
+          }),
+          await api.addExpense({
+            id: "sum-outside-payer",
+            description: "Shared supplies",
+            payerId: "outside-payer",
+            amountCents: 101,
+            splitBetween: ["outside-ana", "outside-ben"],
+            dateIso: "2026-05-03",
+          }),
+        ];
+        const balances = BalancesSchema.parse(await api.balances());
+        const expectedPeople = [
+          "sum-ana", "sum-ben", "sum-cy", "sum-dee",
+          "outside-payer", "outside-ana", "outside-ben",
+        ];
+        const missingPeople = expectedPeople.filter(personId => net(balances, personId) === null);
+        const expectedBalances = {
+          "sum-ana": 100_000,
+          "sum-ben": -30_837,
+          "sum-cy": -35_828,
+          "sum-dee": -33_335,
+        };
+        const wrongBalances = Object.entries(expectedBalances)
+          .filter(([personId, expected]) => net(balances, personId) !== expected);
+        const total = balances.perPerson.reduce((sum, entry) => sum + entry.netCents, 0);
+        return {
+          pass: added.every(result => OkSchema.parse(result).ok) &&
+            missingPeople.length === 0 && wrongBalances.length === 0 && total === 0 &&
+            net(balances, "outside-payer") === 101 &&
+            net(balances, "outside-ana") === -51 && net(balances, "outside-ben") === -50 &&
+            balances.perPerson.every(entry => Number.isInteger(entry.netCents)),
+          evidence: { total, missingPeople, wrongBalances, perPerson: balances.perPerson },
+        };
+      });
+
+      await verifier.check("settlement-clears-every-balance-and-stays-short", async () => {
+        using api = await verifier.connect<LedgerApi>("Ledger");
+        const balances = BalancesSchema.parse(await api.balances());
+        const mayBefore = MonthlySchema.parse(await api.monthlyTotals({ month: "2026-05" }));
+        const settlement = SettlementSchema.parse(await api.settlement());
+        const analysis = analyzeSettlement(balances, settlement);
+        const balancesAfter = BalancesSchema.parse(await api.balances());
+        const mayAfter = MonthlySchema.parse(await api.monthlyTotals({ month: "2026-05" }));
+        const unchanged = JSON.stringify(canonicalBalances(balances)) ===
+            JSON.stringify(canonicalBalances(balancesAfter)) &&
+          JSON.stringify(canonicalMonthly(mayBefore)) === JSON.stringify(canonicalMonthly(mayAfter));
+        return {
+          pass: analysis.owing >= 2 && settlement.transfers.length >= 1 &&
+            analysis.knownEndpoints && analysis.unsettled.length === 0 && unchanged &&
+            settlement.transfers.length <= analysis.owing - 1 &&
+            settlement.transfers.every(transfer => transfer.fromId !== transfer.toId),
+          evidence: {
+            transfers: settlement.transfers.length,
+            owing: analysis.owing,
+            knownEndpoints: analysis.knownEndpoints,
+            unsettled: Object.fromEntries(analysis.unsettled),
+            unchanged,
+          },
+        };
+      });
+
+      await verifier.check("rejects-bad-input-with-named-codes", async () => {
+        using api = await verifier.connect<LedgerApi>("Ledger");
+        const valid: Expense = {
+          id: "reject-1",
+          description: "Beer",
+          payerId: "reject-ana",
+          amountCents: 500,
+          splitBetween: ["reject-ana", "reject-ben"],
+          dateIso: "2026-05-05",
+        };
+        const accepted = OkSchema.parse(await api.addExpense(valid));
+        const before = BalancesSchema.parse(await api.balances());
+        const rejections = [
+          { expected: "DUPLICATE_ID", result: OkSchema.parse(
+            await api.addExpense({ ...valid, amountCents: 999 })) },
+          { expected: "INVALID_AMOUNT", result: OkSchema.parse(
+            await api.addExpense({ ...valid, id: "reject-2", amountCents: 0 })) },
+          { expected: "INVALID_AMOUNT", result: OkSchema.parse(
+            await api.addExpense({ ...valid, id: "reject-5", amountCents: 1.5 })) },
+          { expected: "EMPTY_SPLIT", result: OkSchema.parse(
+            await api.addExpense({ ...valid, id: "reject-3", splitBetween: [] })) },
+          { expected: "BAD_DATE", result: OkSchema.parse(
+            await api.addExpense({ ...valid, id: "reject-4", dateIso: "2026-02-31" })) },
+        ];
+        const afterRejections = BalancesSchema.parse(await api.balances());
+        const corrected = (await Promise.all([
+          api.addExpense({ ...valid, id: "reject-2", amountCents: 200 }),
+          api.addExpense({ ...valid, id: "reject-3" }),
+          api.addExpense({ ...valid, id: "reject-4" }),
+          api.addExpense({ ...valid, id: "reject-5", amountCents: 1 }),
+        ])).map(result => OkSchema.parse(result));
+        const wrong = rejections.filter(
+            ({ expected, result }) => result.ok || result.error !== expected);
+        const unchanged = JSON.stringify(canonicalBalances(before)) ===
+          JSON.stringify(canonicalBalances(afterRejections));
+        return {
+          pass: accepted.ok && wrong.length === 0 && unchanged &&
+            corrected.every(result => result.ok),
+          evidence: { wrong, unchanged, corrected },
+        };
+      });
+
+      await verifier.check("monthly-totals-count-only-that-month", async () => {
+        using api = await verifier.connect<LedgerApi>("Ledger");
+        const added = [
+          await api.addExpense({
+            id: TURN_ONE_IDS[0] ?? "survive-1",
+            description: "March groceries",
+            payerId: "month-ana",
+            amountCents: 2_500,
+            splitBetween: ["month-ana", "month-ben"],
+            dateIso: `${TURN_ONE_MONTH}-05`,
+          }),
+          await api.addExpense({
+            id: TURN_ONE_IDS[1] ?? "survive-2",
+            description: "March taxi",
+            payerId: "month-ben",
+            amountCents: 1_200,
+            splitBetween: ["month-ana", "month-ben"],
+            dateIso: `${TURN_ONE_MONTH}-31`,
+          }),
+          await api.addExpense({
+            id: "month-outside",
+            description: "April rent",
+            payerId: "month-ana",
+            amountCents: 90_000,
+            splitBetween: ["month-ana", "month-ben"],
+            dateIso: "2026-04-01",
+          }),
+        ];
+        const duplicateInputs: Expense[] = [{
+          id: "month-race",
+          description: "April supplies",
+          payerId: "race-ana",
+          amountCents: 1_000,
+          splitBetween: ["race-ana", "race-ben"],
+          dateIso: "2026-04-02",
+        }, {
+          id: "month-race",
+          description: "April replacement",
+          payerId: "race-ben",
+          amountCents: 2_000,
+          splitBetween: ["race-ana", "race-ben"],
+          dateIso: "2026-04-03",
+        }];
+        const duplicateRace = (await Promise.all(
+            duplicateInputs.map(input => api.addExpense(input))))
+          .map(result => OkSchema.parse(result));
+        const winnerIndex = duplicateRace.findIndex(result => result.ok);
+        const winner = duplicateInputs.at(winnerIndex);
+        const march = MonthlySchema.parse(await api.monthlyTotals({ month: TURN_ONE_MONTH }));
+        const april = MonthlySchema.parse(await api.monthlyTotals({ month: "2026-04" }));
+        const empty = MonthlySchema.parse(await api.monthlyTotals({ month: "2025-12" }));
+        const marchPaid = (personId: string) =>
+          march.byPayer.find(entry => entry.personId === personId)?.paidCents ?? null;
+        const aprilPaid = (personId: string) =>
+          april.byPayer.find(entry => entry.personId === personId)?.paidCents ?? null;
+        return {
+          pass: added.every(result => OkSchema.parse(result).ok) &&
+            duplicateRace.filter(result => result.ok).length === 1 &&
+            duplicateRace.filter(result => !result.ok && result.error === "DUPLICATE_ID").length === 1 &&
+            march.totalCents === 3_700 &&
+            marchPaid("month-ana") === 2_500 && marchPaid("month-ben") === 1_200 &&
+            winner !== undefined && april.totalCents === 90_000 + winner.amountCents &&
+            aprilPaid("month-ana") === 90_000 &&
+            aprilPaid(winner.payerId) === winner.amountCents &&
+            empty.totalCents === 0 && empty.byPayer.length === 0,
+          evidence: { march, april, empty, duplicateRace, winner: winner ?? null },
+        };
+      });
+    },
+    verifyAfterAccept: async verifier => {
+      await verifier.check("turn-one-state-survives-code-reload", async () => {
+        using api = await verifier.connect<LedgerApi>("Ledger");
+        const march = MonthlySchema.parse(await api.monthlyTotals({ month: TURN_ONE_MONTH }));
+        const duplicate = OkSchema.parse(await api.addExpense({
+          id: TURN_ONE_IDS[0] ?? "survive-1",
+          description: "Replay after reload",
+          payerId: "month-ana",
+          amountCents: 1,
+          splitBetween: ["month-ana"],
+          dateIso: `${TURN_ONE_MONTH}-05`,
+        }));
+        const balances = BalancesSchema.parse(await api.balances());
+        const settlement = SettlementSchema.parse(await api.settlement());
+        const analysis = analyzeSettlement(balances, settlement);
+        return {
+          pass: march.totalCents === 3_700 && !duplicate.ok &&
+            duplicate.error === "DUPLICATE_ID" &&
+            net(balances, "month-ana") === 45_650 && net(balances, "month-ben") === -45_650 &&
+            settlement.transfers.length > 0 && analysis.knownEndpoints &&
+            analysis.unsettled.length === 0,
+          evidence: { march, duplicate, balances, settlement, analysis },
+        };
+      });
+    },
+  }, {
+    prompt: `Now I want to see where the money actually goes. Add to the same Gadget:
+
+- addExpense takes an optional category: string. Expenses recorded before this change, and any
+  added without one, count as "uncategorized".
+- setBudget({ category: string, month: "YYYY-MM", limitCents: integer >= 0 }) -> { ok: boolean }.
+  Setting the same category and month again replaces the previous limit.
+- budgetStatus({ month: "YYYY-MM" }) -> { byCategory: Array<{ category: string,
+  limitCents: integer | null, spentCents: integer, remainingCents: integer | null }> }
+  One row per category that either has a budget for that month or had spending in it. Spending
+  counts the full expense amount against the month its dateIso falls in. limitCents and
+  remainingCents are null when no budget is set. remainingCents is limitCents - spentCents and is
+  allowed to go negative.
+
+Everything that already worked must keep working, including the expenses I have already recorded.`,
+    verify: async verifier => {
+      // Accepting turn one bumps the loader version before this prompt. Missing March rows were not
+      // stored durably.
+      await verifier.check("expenses-recorded-before-the-change-survive", async () => {
+        using api = await verifier.connect<BudgetedLedgerApi>("Ledger");
+        const march = MonthlySchema.parse(await api.monthlyTotals({ month: TURN_ONE_MONTH }));
+        return {
+          pass: march.totalCents === 3_700,
+          evidence: march,
+        };
+      });
+
+      await verifier.check("pre-existing-spending-counts-as-uncategorized", async () => {
+        using api = await verifier.connect<BudgetedLedgerApi>("Ledger");
+        const status = BudgetStatusSchema.parse(await api.budgetStatus({ month: TURN_ONE_MONTH }));
+        const uncategorized = status.byCategory.find(row => row.category === "uncategorized");
+        return {
+          pass: uncategorized?.spentCents === 3_700 && uncategorized.limitCents === null &&
+            uncategorized.remainingCents === null,
+          evidence: status,
+        };
+      });
+
+      await verifier.check("budget-remaining-tracks-spending-and-can-go-negative", async () => {
+        using api = await verifier.connect<BudgetedLedgerApi>("Ledger");
+        const initialFood = BudgetResultSchema.parse(
+            await api.setBudget({ category: "food", month: "2026-06", limitCents: 10_000 }));
+        const budgets = [initialFood, ...(await Promise.all([
+          api.setBudget({ category: "food", month: "2026-06", limitCents: 5_000 }),
+          api.setBudget({ category: "food", month: "2026-07", limitCents: 8_000 }),
+          api.setBudget({ category: "travel", month: "2026-06", limitCents: 20_000 }),
+          api.setBudget({ category: "savings", month: "2026-06", limitCents: 30_000 }),
+        ])).map(result => BudgetResultSchema.parse(result))];
+        const added = (await Promise.all([
+          api.addExpense({
+            id: "budget-1", description: "Market", payerId: "budget-ana",
+            amountCents: 6_500, splitBetween: ["budget-ana", "budget-ben"],
+            dateIso: "2026-06-02", category: "food",
+          }),
+          api.addExpense({
+            id: "budget-2", description: "Train", payerId: "budget-ben",
+            amountCents: 4_000, splitBetween: ["budget-ana", "budget-ben"],
+            dateIso: "2026-06-03", category: "travel",
+          }),
+          api.addExpense({
+            id: "budget-3", description: "Soap", payerId: "budget-ana",
+            amountCents: 100, splitBetween: ["budget-ana", "budget-ben"],
+            dateIso: "2026-06-04",
+          }),
+        ])).map(result => OkSchema.parse(result));
+        const june = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-06" }));
+        const july = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-07" }));
+        const monthlyBefore = MonthlySchema.parse(await api.monthlyTotals({ month: "2026-06" }));
+        const balancesBefore = BalancesSchema.parse(await api.balances());
+        const settlement = SettlementSchema.parse(await api.settlement());
+        const analysis = analyzeSettlement(balancesBefore, settlement);
+        const monthlyAfter = MonthlySchema.parse(await api.monthlyTotals({ month: "2026-06" }));
+        const balancesAfter = BalancesSchema.parse(await api.balances());
+        const juneAfter = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-06" }));
+        const julyAfter = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-07" }));
+        const juneRow = (category: string) =>
+          june.byCategory.find(entry => entry.category === category);
+        const julyFood = july.byCategory.find(entry => entry.category === "food");
+        const junePaid = (personId: string) =>
+          monthlyBefore.byPayer.find(entry => entry.personId === personId)?.paidCents ?? null;
+        const uniqueCategories = june.byCategory.length === 4 && july.byCategory.length === 1 &&
+          new Set(june.byCategory.map(entry => entry.category)).size === june.byCategory.length &&
+          new Set(july.byCategory.map(entry => entry.category)).size === july.byCategory.length;
+        const unchanged = JSON.stringify(canonicalMonthly(monthlyBefore)) ===
+            JSON.stringify(canonicalMonthly(monthlyAfter)) &&
+          JSON.stringify(canonicalBalances(balancesBefore)) ===
+            JSON.stringify(canonicalBalances(balancesAfter)) &&
+          JSON.stringify(canonicalBudgetStatus(june)) ===
+            JSON.stringify(canonicalBudgetStatus(juneAfter)) &&
+          JSON.stringify(canonicalBudgetStatus(july)) ===
+            JSON.stringify(canonicalBudgetStatus(julyAfter));
+        return {
+          pass: budgets.every(result => result.ok) && added.every(result => result.ok) &&
+            uniqueCategories &&
+            juneRow("food")?.limitCents === 5_000 && juneRow("food")?.spentCents === 6_500 &&
+            juneRow("food")?.remainingCents === -1_500 &&
+            juneRow("travel")?.limitCents === 20_000 && juneRow("travel")?.spentCents === 4_000 &&
+            juneRow("travel")?.remainingCents === 16_000 &&
+            juneRow("savings")?.limitCents === 30_000 && juneRow("savings")?.spentCents === 0 &&
+            juneRow("savings")?.remainingCents === 30_000 &&
+            juneRow("uncategorized")?.limitCents === null &&
+            juneRow("uncategorized")?.spentCents === 100 &&
+            julyFood?.limitCents === 8_000 && julyFood.spentCents === 0 &&
+            julyFood.remainingCents === 8_000 &&
+            monthlyBefore.totalCents === 10_600 &&
+            junePaid("budget-ana") === 6_600 && junePaid("budget-ben") === 4_000 &&
+            net(balancesBefore, "budget-ana") === 1_300 &&
+            net(balancesBefore, "budget-ben") === -1_300 &&
+            analysis.knownEndpoints && analysis.unsettled.length === 0 && unchanged,
+          evidence: {
+            budgets, added, june, july, monthlyBefore, balancesBefore, settlement,
+            juneAfter, julyAfter, uniqueCategories, unchanged,
+          },
+        };
+      });
+
+      await verifier.check("turn-one-contract-still-holds", async () => {
+        using api = await verifier.connect<BudgetedLedgerApi>("Ledger");
+        const duplicate = OkSchema.parse(await api.addExpense({
+          id: TURN_ONE_IDS[0] ?? "survive-1",
+          description: "Replay",
+          payerId: "after-ana",
+          amountCents: 111,
+          splitBetween: ["after-ana", "after-ben"],
+          dateIso: "2026-06-09",
+        }));
+        const balances = BalancesSchema.parse(await api.balances());
+        const settlement = SettlementSchema.parse(await api.settlement());
+        const analysis = analyzeSettlement(balances, settlement);
+        const total = balances.perPerson.reduce((sum, entry) => sum + entry.netCents, 0);
+        return {
+          pass: !duplicate.ok && duplicate.error === "DUPLICATE_ID" &&
+            net(balances, "month-ana") === 45_650 && net(balances, "month-ben") === -45_650 &&
+            total === 0 && settlement.transfers.length > 0 &&
+            analysis.knownEndpoints && analysis.unsettled.length === 0,
+          evidence: { duplicate, total, balances, settlement, analysis },
+        };
+      });
+    },
+    verifyAfterAccept: async verifier => {
+      await verifier.check("turn-two-state-survives-code-reload", async () => {
+        using api = await verifier.connect<BudgetedLedgerApi>("Ledger");
+        const june = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-06" }));
+        const july = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-07" }));
+        const juneTotals = MonthlySchema.parse(await api.monthlyTotals({ month: "2026-06" }));
+        const marchTotals = MonthlySchema.parse(await api.monthlyTotals({ month: TURN_ONE_MONTH }));
+        const balances = BalancesSchema.parse(await api.balances());
+        const settlement = SettlementSchema.parse(await api.settlement());
+        const analysis = analyzeSettlement(balances, settlement);
+        const juneAfter = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-06" }));
+        const julyAfter = BudgetStatusSchema.parse(await api.budgetStatus({ month: "2026-07" }));
+        const juneTotalsAfter = MonthlySchema.parse(await api.monthlyTotals({ month: "2026-06" }));
+        const balancesAfter = BalancesSchema.parse(await api.balances());
+        const unchanged = JSON.stringify(canonicalBudgetStatus(june)) ===
+            JSON.stringify(canonicalBudgetStatus(juneAfter)) &&
+          JSON.stringify(canonicalBudgetStatus(july)) ===
+            JSON.stringify(canonicalBudgetStatus(julyAfter)) &&
+          JSON.stringify(canonicalMonthly(juneTotals)) ===
+            JSON.stringify(canonicalMonthly(juneTotalsAfter)) &&
+          JSON.stringify(canonicalBalances(balances)) ===
+            JSON.stringify(canonicalBalances(balancesAfter));
+        const uniqueCategories = june.byCategory.length === 4 && july.byCategory.length === 1 &&
+          new Set(june.byCategory.map(entry => entry.category)).size === june.byCategory.length &&
+          new Set(july.byCategory.map(entry => entry.category)).size === july.byCategory.length;
+        const juneRow = (category: string) =>
+          june.byCategory.find(entry => entry.category === category);
+        const julyFood = july.byCategory.find(entry => entry.category === "food");
+        return {
+          pass: uniqueCategories &&
+            juneRow("food")?.limitCents === 5_000 && juneRow("food")?.spentCents === 6_500 &&
+            juneRow("travel")?.limitCents === 20_000 && juneRow("travel")?.spentCents === 4_000 &&
+            juneRow("savings")?.limitCents === 30_000 && juneRow("savings")?.spentCents === 0 &&
+            juneRow("uncategorized")?.spentCents === 100 &&
+            julyFood?.limitCents === 8_000 && julyFood.spentCents === 0 &&
+            juneTotals.totalCents === 10_600 && marchTotals.totalCents === 3_700 &&
+            net(balances, "budget-ana") === 1_300 && net(balances, "budget-ben") === -1_300 &&
+            analysis.knownEndpoints && analysis.unsettled.length === 0 && unchanged,
+          evidence: {
+            june, july, juneTotals, marchTotals, balances, settlement,
+            juneAfter, julyAfter, juneTotalsAfter, balancesAfter, uniqueCategories, unchanged,
+          },
+        };
+      });
+    },
+  }],
+});
+
+defineTaskEval(task);

--- a/packages/workshop-evals/src/harness.test.ts
+++ b/packages/workshop-evals/src/harness.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, expect, it, vi } from "vitest";
+import type {
+  AgentTurnOutcome, AgentTurnResult, WorkshopAgentSession,
+} from "@gadgets/integration-tests/agent-session";
+import type { AiChatMessage, WorkpieceSummary } from "@gadgets/workshop-shared/api";
+import { EVAL_VERIFICATION_BUDGET_MS } from "./config.js";
+import { createWorkshopHarness } from "./harness.js";
+import type { LocalEvalTarget, LocalModelAccess } from "./target.js";
+import type { EvalTask } from "./task.js";
+
+const fakes = vi.hoisted(() => {
+  let phaseDelayMs = 0;
+  const outcome: AgentTurnOutcome = { status: "completed" };
+  const workpieces: WorkpieceSummary[] = [{ id: 1, type: "gadget", title: "Gadget" }];
+  const history: AiChatMessage[] = [{
+    chatId: 1,
+    sequence: 1,
+    timestamp: new Date(),
+    author: { type: "agent", id: "agent", name: "agent" },
+    type: "message",
+    message: "done",
+  }, {
+    chatId: 1,
+    sequence: 2,
+    timestamp: new Date(),
+    author: { type: "agent", id: "agent", name: "agent" },
+    type: "changes",
+  }];
+  const result: AgentTurnResult = { outcome, history, workpieces, usage: {} };
+  const session: WorkshopAgentSession = {
+    username: "agent",
+    runTurn: async () => result,
+    approveActionsAndWait: async () => result,
+    listActions: async () => ({ entries: [] }),
+    connectedAccount: () => { throw new Error("connectedAccount is not used by this test"); },
+    openGadget: async () => { throw new Error("openGadget is not used by this test"); },
+    acceptChanges: vi.fn(async () => {
+      await new Promise(resolve => setTimeout(resolve, phaseDelayMs));
+    }),
+    close: async () => {},
+    [Symbol.asyncDispose]: async () => {},
+  };
+  const target: LocalEvalTarget = {
+    session,
+    [Symbol.asyncDispose]: async () => {},
+  };
+  return { target, setPhaseDelay: (ms: number) => { phaseDelayMs = ms; } };
+});
+
+vi.mock("./target.js", () => ({
+  openLocalEvalTarget: vi.fn(() => Promise.resolve(fakes.target)),
+}));
+
+const ACCESS: LocalModelAccess = {
+  kind: "direct",
+  accountId: "account",
+  apiToken: "token",
+};
+const IDENTITY = { gitCommit: "a".repeat(40), taskVersion: "v1" };
+const MODEL = "@cf/zai-org/glm-5.2";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+it("shares one deadline across verification, acceptance, and post-accept checks", async () => {
+  vi.useFakeTimers();
+  const phaseDelay = Math.floor(EVAL_VERIFICATION_BUDGET_MS * 0.4);
+  fakes.setPhaseDelay(phaseDelay);
+  const task: EvalTask = {
+    id: "deadline",
+    turns: [{
+      prompt: "Build it",
+      verify: async () => {
+        await new Promise(resolve => setTimeout(resolve, phaseDelay));
+      },
+      verifyAfterAccept: async () => {
+        await new Promise(resolve => setTimeout(resolve, phaseDelay));
+      },
+    }],
+  };
+  const harness = createWorkshopHarness(task, ACCESS, IDENTITY);
+  const running = harness.run({ model: MODEL, trial: 1 }, {
+    signal: undefined,
+    artifacts: {},
+    setArtifact: () => {},
+  });
+  const failure = expect(running)
+    .rejects.toThrow("Post-accept verification exceeded its time budget");
+
+  await vi.advanceTimersByTimeAsync(EVAL_VERIFICATION_BUDGET_MS + 1);
+  await failure;
+});
+
+it("does not accept changes after a failed verification", async () => {
+  fakes.setPhaseDelay(0);
+  const task: EvalTask = {
+    id: "failed-check",
+    turns: [{
+      prompt: "Build it",
+      verify: async verifier => {
+        await verifier.check("failed", () => Promise.resolve({ pass: false }));
+      },
+      verifyAfterAccept: async () => {},
+    }],
+  };
+  const harness = createWorkshopHarness(task, ACCESS, IDENTITY);
+
+  const result = await harness.run({ model: MODEL, trial: 1 }, {
+    signal: undefined,
+    artifacts: {},
+    setArtifact: () => {},
+  });
+
+  expect(result.output.success).toBe(false);
+  expect(fakes.target.session.acceptChanges).not.toHaveBeenCalled();
+});

--- a/packages/workshop-evals/src/harness.ts
+++ b/packages/workshop-evals/src/harness.ts
@@ -28,6 +28,25 @@ async function withTimeout<T>(operation: Promise<T>, timeoutMs: number, message:
   }
 }
 
+async function beforeDeadline<T>(
+    start: () => Promise<T>, deadline: number, message: string,
+    signal?: AbortSignal): Promise<T> {
+  if (signal?.aborted) throw new EvalDeadlineError("Eval run was cancelled");
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw new EvalDeadlineError(message);
+  const operation = withTimeout(start(), remaining, message);
+  if (signal === undefined) return operation;
+  const aborted = Promise.withResolvers<never>();
+  const onAbort = () => aborted.reject(new EvalDeadlineError("Eval run was cancelled"));
+  signal.addEventListener("abort", onAbort, { once: true });
+  aborted.promise.catch(() => {});
+  try {
+    return await Promise.race([operation, aborted.promise]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
 /** Run one real Workshop task and retain its functional result and trajectory. */
 export function createWorkshopHarness(
     task: EvalTask, access: LocalModelAccess, identity: EvalIdentity) {
@@ -76,12 +95,26 @@ export function createWorkshopHarness(
             usage.observedCumulativeChatCostUsd = cumulativeCost;
           }
           const verificationStartedAt = Date.now();
+          const verificationDeadline = verificationStartedAt + verificationBudget;
+          if (result.outcome.status !== "completed" || signal?.aborted) {
+            runError = new EvalDeadlineError(
+                result.outcome.status === "completed"
+                  ? "Eval run was cancelled"
+                  : result.outcome.message);
+            turns.push({
+              outcome: result.outcome,
+              checks: [],
+              turnWallMs,
+              verificationWallMs: 0,
+            });
+            break;
+          }
           const verifier = new EvalVerifier(opened.session, result.workpieces);
           let checks: EvalCheck[];
           try {
-            checks = await withTimeout(
-                verifier.collect(turn.verify), verificationBudget,
-                "Eval verification exceeded its time budget");
+            checks = await beforeDeadline(
+                () => verifier.collect(turn.verify), verificationDeadline,
+                "Eval verification exceeded its time budget", signal);
           } catch (error) {
             checks = [...verifier.results(), {
               id: "verifier.timeout",
@@ -96,6 +129,76 @@ export function createWorkshopHarness(
             });
             throw error;
           }
+
+          if (checks.some(check => !check.pass)) {
+            turns.push({
+              outcome: result.outcome,
+              checks,
+              turnWallMs,
+              verificationWallMs: Date.now() - verificationStartedAt,
+            });
+            break;
+          }
+
+          const verifyAfterAccept = turn.verifyAfterAccept;
+          if (result.outcome.status === "completed" && verifyAfterAccept !== undefined) {
+            const hasChangesToReload = result.history.some(message =>
+              message.sequence > previousSequence && message.type === "changes");
+            if (!hasChangesToReload) {
+              checks.push({
+                id: "accept.no-changes",
+                pass: false,
+                evidence: "Post-accept verification requires a new code change to reload.",
+              });
+              turns.push({
+                outcome: result.outcome,
+                checks,
+                turnWallMs,
+                verificationWallMs: Date.now() - verificationStartedAt,
+              });
+              break;
+            }
+            const session = opened.session;
+            try {
+              await beforeDeadline(
+                  () => session.acceptChanges(), verificationDeadline,
+                  "Accepting verified agent changes exceeded its time budget", signal);
+            } catch (error) {
+              checks.push({
+                id: "accept.failed",
+                pass: false,
+                evidence: error instanceof Error ? error.message : String(error),
+              });
+              turns.push({
+                outcome: result.outcome,
+                checks,
+                turnWallMs,
+                verificationWallMs: Date.now() - verificationStartedAt,
+              });
+              throw error;
+            }
+
+            const afterAccept = new EvalVerifier(session, result.workpieces);
+            try {
+              checks.push(...await beforeDeadline(
+                  () => afterAccept.collect(verifyAfterAccept), verificationDeadline,
+                  "Post-accept verification exceeded its time budget", signal));
+            } catch (error) {
+              checks.push(...afterAccept.results(), {
+                id: "post-accept-verifier.timeout",
+                pass: false,
+                evidence: error instanceof Error ? error.message : String(error),
+              });
+              turns.push({
+                outcome: result.outcome,
+                checks,
+                turnWallMs,
+                verificationWallMs: Date.now() - verificationStartedAt,
+              });
+              throw error;
+            }
+          }
+
           turns.push({
             outcome: result.outcome,
             checks,

--- a/packages/workshop-evals/src/task.ts
+++ b/packages/workshop-evals/src/task.ts
@@ -17,6 +17,8 @@ export type EvalCheck = {
 export type EvalTurn = {
   prompt: string;
   verify(verifier: EvalVerifier): Promise<void>;
+  /** Commit this turn, reload its Gadgets, then run these checks. */
+  verifyAfterAccept?(verifier: EvalVerifier): Promise<void>;
 };
 
 export type EvalTask = {


### PR DESCRIPTION
This PR adds two more evals and a manual GitHub Actions workflow. The appointment eval checks booking limits, concurrent requests, duplicate IDs, cancellation, and persistence after the agent's changes are accepted. The expense eval uses two prompts in the same workspace to check cents-based splitting, balances, settlements, input errors, monthly totals, budgets, and whether the second code change preserves the first turn's data.

It also adds post-accept checks, so an eval can verify provisional Gadget code, accept the changes, reload the Gadget, and confirm that its behavior and stored data survive.

The workflow runs `pnpm evals` against local workerd, uploads `results.json`, and publishes one GitHub check. It accepts model and trial inputs, plus a report-only mode for collecting scores without requiring every task to pass.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


Wall time: 1.78 seconds


Wall time: 0.45 seconds