### PR TITLE
Upgrade the GLM Workers AI model from 5.2 to 5.3 Flash

### DIFF
--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -1192,8 +1192,9 @@ export const SUGGESTED_MODELS: Record<
       name: "Kimi K2.7 Code (Workers AI)", contextWindow: 262144,
       outputLimit: WORKERS_AI_OUTPUT_LIMIT,
     },
-    "@cf/zai-org/glm-5.2": {
-      name: "GLM 5.2 (Workers AI)", contextWindow: 262144, outputLimit: WORKERS_AI_OUTPUT_LIMIT,
+    "@cf/zai-org/glm-5.3-flash": {
+      name: "GLM 5.3 Flash (Workers AI)", contextWindow: 1048576,
+      outputLimit: WORKERS_AI_OUTPUT_LIMIT,
     },
     "@cf/deepseek-ai/deepseek-v4-pro-0813": {
       name: "DeepSeek V4 Pro 0813 (Workers AI)", contextWindow: 1048576,


### PR DESCRIPTION
Swaps `@cf/zai-org/glm-5.2` for `@cf/zai-org/glm-5.3-flash` in `SUGGESTED_MODELS`, with the 1M context window from the [model card](https://developers.cloudflare.com/workers-ai/models/glm-5.3-flash/).