### PR TITLE
Run Workshop integration files in parallel

### DIFF
--- a/packages/integration-tests/__tests__/network-interceptor.test.ts
+++ b/packages/integration-tests/__tests__/network-interceptor.test.ts
@@ -1,12 +1,8 @@
-// Unit spec for NetworkInterceptor -- the mechanism every suite in two repos leans on for its
-// "nothing reaches the real internet" guarantee. Runs in plain Node against a stubbed real fetch;
-// no Workers are booted. The end-to-end half of the guarantee (Worker subrequests actually route
-// through the patch) is covered by the fetch-probe case in observer-reverification.test.ts.
+// Unit tests for NetworkInterceptor. They run in Node and never start workerd. The fetch-probe case
+// in observer-reverification.test.ts proves that Worker subrequests reach this interceptor.
 //
-// These tests swap globalThis.fetch, so they stay serial (no it.concurrent) within this file. The
-// observer suite is unaffected because `fileParallelism: false` runs the files one at a time rather
-// than side by side, and each swap is undone in afterEach -- not because the files get a process
-// each, which Vitest does not promise.
+// These cases stay serial because they replace globalThis.fetch inside one file process. Vitest's
+// default fork pool gives each parallel test file its own process and global state.
 
 import { afterEach, beforeEach, expect, it } from "vitest";
 import { NetworkInterceptor, type Handler } from "../src/network-interceptor.js";

--- a/packages/integration-tests/__tests__/workshop-sharing.test.ts
+++ b/packages/integration-tests/__tests__/workshop-sharing.test.ts
@@ -6,7 +6,7 @@ import {
 import { type Harness, startHarness } from "../src/harness.js";
 import { mockChatCompletion } from "../src/mock-model.js";
 import { NetworkInterceptor } from "../src/network-interceptor.js";
-import { connect, nextUsernames, signUp } from "../src/rpc-client.js";
+import { connect, logIn, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
 
 let harness: Harness | undefined;
 const network = new NetworkInterceptor([mockChatCompletion("Test chat")]);
@@ -48,10 +48,52 @@ async function expectOpenDenied(
   expect(getOpenGadgetErrorCode(denied)).toBe(OPEN_GADGET_ERROR_CODES.workspaceAccessDenied);
 }
 
+async function withAuthenticated<T>(
+    username: string, body: (authenticated: RpcStub<AuthenticatedApi>) => Promise<T>): Promise<T> {
+  using publicApi = connect(requireHarness().url);
+  using authenticated = await logIn(publicApi, username);
+  const result = await body(authenticated);
+  return result;
+}
+
 async function activate(workspace: RpcStub<Overseer>): Promise<string> {
   const { id } = await workspace.getMetadata();
   await workspace.newChat("Make this workspace visible without an agent", null);
   return id;
+}
+
+async function expectOpenDeniedAfterRestart(
+    username: string, workspaceId: string, shareKey?: string): Promise<void> {
+  const result = await waitFor("revoked workspace access after restart", async () => {
+    try {
+      return await withAuthenticated(username, async authenticated => {
+        try {
+          using _workspace = await authenticated.openGadget(workspaceId, shareKey);
+        } catch (error) {
+          return getOpenGadgetErrorCode(error) === OPEN_GADGET_ERROR_CODES.workspaceAccessDenied
+            ? { denied: true }
+            : null;
+        }
+        return { denied: false };
+      });
+    } catch {
+      return null;
+    }
+  });
+  expect(result.denied).toBe(true);
+}
+
+async function listShareLinksAfterRestart(username: string, workspaceId: string) {
+  return waitFor("owner workspace after revocation restart", async () => {
+    try {
+      return await withAuthenticated(username, async authenticated => {
+        using workspace = await authenticated.openGadget(workspaceId);
+        return workspace.listShareLinks();
+      });
+    } catch {
+      return null;
+    }
+  });
 }
 
 it.concurrent("grants and revokes a use-only collaborator", async () => {
@@ -59,74 +101,85 @@ it.concurrent("grants and revokes a use-only collaborator", async () => {
       "owner", "collaborator", "intruder");
   if (!ownerName || !collaboratorName || !intruderName) throw new Error("Missing test username");
 
-  using ownerPublic = connect(requireHarness().url);
-  using collaboratorPublic = connect(requireHarness().url);
-  using intruderPublic = connect(requireHarness().url);
-  using owner = await signUp(ownerPublic, ownerName);
-  using collaborator = await signUp(collaboratorPublic, collaboratorName);
-  using intruder = await signUp(intruderPublic, intruderName);
-  using workspace = await owner.newGadget();
-  const workspaceId = await activate(workspace);
+  const { workspaceId, affected } = await (async () => {
+    using ownerPublic = connect(requireHarness().url);
+    using collaboratorPublic = connect(requireHarness().url);
+    using intruderPublic = connect(requireHarness().url);
+    using owner = await signUp(ownerPublic, ownerName);
+    using collaborator = await signUp(collaboratorPublic, collaboratorName);
+    using intruder = await signUp(intruderPublic, intruderName);
+    using workspace = await owner.newGadget();
+    const id = await activate(workspace);
 
-  await expectOpenDenied(intruder, workspaceId);
+    await expectOpenDenied(intruder, id);
 
-  const added = await workspace.addCollaborator(collaboratorName, "use", "reviewer");
-  expect(added).toMatchObject({
-    profile: { id: collaboratorName },
-    role: "use",
-  });
-  if (added === null) throw new Error("Collaborator was not added");
+    const added = await workspace.addCollaborator(collaboratorName, "use", "reviewer");
+    expect(added).toMatchObject({
+      profile: { id: collaboratorName },
+      role: "use",
+    });
+    if (added === null) throw new Error("Collaborator was not added");
 
-  using collaboratorWorkspace = await collaborator.openGadget(workspaceId);
-  expect(await collaboratorWorkspace.getMetadata()).toMatchObject({
-    id: workspaceId,
-    role: "use",
-  });
-  await expect(collaboratorWorkspace.setTitle("Forbidden rename")).rejects.toThrow();
+    using collaboratorWorkspace = await collaborator.openGadget(id);
+    expect(await collaboratorWorkspace.getMetadata()).toMatchObject({
+      id,
+      role: "use",
+    });
+    await expect(collaboratorWorkspace.setTitle("Forbidden rename")).rejects.toThrow();
+    return {
+      workspaceId: id,
+      affected: await workspace.removeCollaborator(added.profile.id, []),
+    };
+  })();
 
-  const affected = await workspace.removeCollaborator(added.profile.id, []);
   expect(affected).toContainEqual(expect.objectContaining({
     profile: expect.objectContaining({ id: collaboratorName }),
     oldRole: "use",
     newRole: null,
   }));
-  await expectOpenDenied(collaborator, workspaceId);
-  await workspace.deleteSelf();
+  await expectOpenDeniedAfterRestart(collaboratorName, workspaceId);
 });
 
 it.concurrent("revokes every key and recipient of one share link", async () => {
   const [ownerName, firstName, secondName] = usernames("linkowner", "first", "second");
   if (!ownerName || !firstName || !secondName) throw new Error("Missing test username");
 
-  using ownerPublic = connect(requireHarness().url);
-  using firstPublic = connect(requireHarness().url);
-  using secondPublic = connect(requireHarness().url);
-  using owner = await signUp(ownerPublic, ownerName);
-  using first = await signUp(firstPublic, firstName);
-  using second = await signUp(secondPublic, secondName);
-  using workspace = await owner.newGadget();
-  const workspaceId = await activate(workspace);
+  const { workspaceId, link, copied, affected } = await (async () => {
+    using ownerPublic = connect(requireHarness().url);
+    using firstPublic = connect(requireHarness().url);
+    using secondPublic = connect(requireHarness().url);
+    using owner = await signUp(ownerPublic, ownerName);
+    using first = await signUp(firstPublic, firstName);
+    using second = await signUp(secondPublic, secondName);
+    using workspace = await owner.newGadget();
+    const id = await activate(workspace);
 
-  const link = await workspace.createShareLink("use", "review link");
-  const copied = await workspace.newShareLinkKey(link.linkId);
-  expect(await workspace.listShareLinks()).toContainEqual(expect.objectContaining({
-    linkId: link.linkId,
-    note: "review link",
-    role: "use",
-  }));
+    const shareLink = await workspace.createShareLink("use", "review link");
+    const copiedKey = await workspace.newShareLinkKey(shareLink.linkId);
+    expect(await workspace.listShareLinks()).toContainEqual(expect.objectContaining({
+      linkId: shareLink.linkId,
+      note: "review link",
+      role: "use",
+    }));
 
-  using firstWorkspace = await first.openGadget(workspaceId, link.key);
-  using secondWorkspace = await second.openGadget(workspaceId, copied.key);
-  expect(await firstWorkspace.getMetadata()).toMatchObject({ role: "use" });
-  expect(await secondWorkspace.getMetadata()).toMatchObject({ role: "use" });
+    using firstWorkspace = await first.openGadget(id, shareLink.key);
+    using secondWorkspace = await second.openGadget(id, copiedKey.key);
+    expect(await firstWorkspace.getMetadata()).toMatchObject({ role: "use" });
+    expect(await secondWorkspace.getMetadata()).toMatchObject({ role: "use" });
+    const preview = await workspace.previewRevokeShareLink(shareLink.linkId);
+    expect(preview.map(user => user.profile.id).toSorted()).toEqual([firstName, secondName].toSorted());
+    return {
+      workspaceId: id,
+      link: shareLink,
+      copied: copiedKey,
+      affected: await workspace.revokeShareLink(shareLink.linkId, []),
+    };
+  })();
 
-  const preview = await workspace.previewRevokeShareLink(link.linkId);
-  expect(preview.map(user => user.profile.id).toSorted()).toEqual([firstName, secondName].toSorted());
-  const affected = await workspace.revokeShareLink(link.linkId, []);
   expect(affected.map(user => user.profile.id).toSorted()).toEqual([firstName, secondName].toSorted());
-  expect(await workspace.listShareLinks()).toEqual([]);
-
-  await expectOpenDenied(first, workspaceId, link.key);
-  await expectOpenDenied(second, workspaceId, copied.key);
-  await workspace.deleteSelf();
+  await Promise.all([
+    expectOpenDeniedAfterRestart(firstName, workspaceId, link.key),
+    expectOpenDeniedAfterRestart(secondName, workspaceId, copied.key),
+  ]);
+  expect(await listShareLinksAfterRestart(ownerName, workspaceId)).toEqual([]);
 });

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -10,8 +10,9 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "test:run": "vitest run",
-    "test:watch": "vitest"
+    "test:prebuild": "vp run -F @gadgets/workshop-backend build:integration-worker",
+    "test:run": "pnpm run test:prebuild && vitest run",
+    "test:watch": "pnpm run test:prebuild && vitest"
   },
   "dependencies": {
     "@gadgets/workshop-shared": "workspace:*",

--- a/packages/integration-tests/src/global-setup.ts
+++ b/packages/integration-tests/src/global-setup.ts
@@ -1,0 +1,25 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { TestProject } from "vitest/node";
+import { pnpmCommand } from "../../../scripts/pnpm-command.js";
+
+const PACKAGE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const VALIDATED_ENTRY = join(PACKAGE_DIR, "../workshop-backend/.wrangler/validate/src/server.ts");
+
+function rebuildWorkshopForWatch(): void {
+  const [command, args] = pnpmCommand(["run", "test:prebuild"]);
+  execFileSync(command, args, { cwd: PACKAGE_DIR, stdio: "inherit" });
+}
+
+/** Share one validated Worker build across isolated test-file processes. */
+export default function setup(project: TestProject): () => void {
+  if (!existsSync(VALIDATED_ENTRY)) {
+    throw new Error("The integration-test Workshop build did not produce its validated entrypoint");
+  }
+  process.env.WORKSHOP_INTEGRATION_PREBUILT = "1";
+  // Vite+ owns the initial build. A watch process stays alive, so later reruns invoke that task here.
+  project.onTestsRerun(rebuildWorkshopForWatch);
+  return () => { delete process.env.WORKSHOP_INTEGRATION_PREBUILT; };
+}

--- a/packages/integration-tests/src/harness.ts
+++ b/packages/integration-tests/src/harness.ts
@@ -83,6 +83,9 @@ function workshopConfig(
     gatekeepers: { binding: string; name: string }[],
     patch?: (config: WorkerConfig) => void): WorkerConfig {
   const config = readWorkerConfig(WORKSHOP_DIR);
+  // globalSetup completed the destructive shared `.wrangler/validate` build before file workers
+  // started. Rebuilding it in each fork would race on that directory.
+  if (process.env.WORKSHOP_INTEGRATION_PREBUILT === "1") delete config.build;
 
   // The checked-in config declares no services; run-dev-server.ts adds one per gatekeeper. We add
   // only the ones the suite asked for, so buildGatekeeperVendorMap() discovers exactly those vendors

--- a/packages/integration-tests/src/rpc-client.ts
+++ b/packages/integration-tests/src/rpc-client.ts
@@ -79,6 +79,14 @@ export async function signUp(
   return (await api.authenticate(token)) as unknown as RpcStub<AuthenticatedApi>;
 }
 
+/** Authenticate an existing integration-test account. */
+export async function logIn(
+    api: RpcStub<PublicApi>, username: string): Promise<RpcStub<AuthenticatedApi>> {
+  const token = await api.login(username, passwordHashFor(username));
+  if (token === null) throw new Error(`Login failed for "${username}"`);
+  return (await api.authenticate(token)) as unknown as RpcStub<AuthenticatedApi>;
+}
+
 export type ConnectedAccount = {
   id: number;
   vendorId: string;

--- a/packages/integration-tests/vite.config.ts
+++ b/packages/integration-tests/vite.config.ts
@@ -1,5 +1,17 @@
-// Vite+ per-package settings. The `test` task definition is shared by every package whose tests run
-// under vitest and lives beside the other shared task configs.
 import vitestTaskViteConfig from '../../scripts/vitest-task-vite-config.js'
 
-export default vitestTaskViteConfig('vitest run')
+const config = vitestTaskViteConfig('vitest run')
+
+export default {
+  run: {
+    tasks: {
+      test: {
+        command: config.run.tasks.test.command,
+        // Backend source reaches this task through the gitignored validated entrypoint.
+        // Running the fast suite is safer than maintaining a second source fingerprint.
+        cache: false,
+        dependsOn: ['@gadgets/workshop-backend#build:integration-worker'],
+      },
+    },
+  },
+}

--- a/packages/integration-tests/vitest.config.ts
+++ b/packages/integration-tests/vitest.config.ts
@@ -1,15 +1,65 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const WORKSPACE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const workspacePath = (path: string) =>
+  resolve(WORKSPACE_DIR, path).replaceAll("\\", "/");
+const formatBlueprintsPath = resolve(
+    WORKSPACE_DIR,
+    "packages/workshop-backend",
+    process.env.FORMAT_BLUEPRINTS_DIR ?? "format-blueprints",
+).replaceAll("\\", "/");
+const backendSourceRoot = workspacePath("packages/workshop-backend/src");
+
+// Vite registers literal watch paths. The force-rerun globs below filter events from these roots.
+const WATCH_PATHS = [
+  backendSourceRoot,
+  workspacePath("packages/workshop-backend/browser"),
+  formatBlueprintsPath,
+  workspacePath("packages/workshop-backend/scripts"),
+  workspacePath("packages/workshop-backend/build-browser-runtime.mjs"),
+  workspacePath("packages/workshop-backend/package.json"),
+  workspacePath("packages/workshop-backend/wrangler.jsonc"),
+  workspacePath("packages/workshop-backend/vite.config.ts"),
+  workspacePath("packages/workshop-backend/tsconfig.json"),
+  workspacePath("packages/workshop-backend/tsconfig.browser.json"),
+  workspacePath("packages/workshop-shared/src"),
+  workspacePath("packages/backend-utils/src"),
+  workspacePath("packages/error-reporting/src"),
+  workspacePath("packages/typed-storage/src"),
+  workspacePath("packages/integration-tests/fixtures"),
+  workspacePath("pnpm-lock.yaml"),
+];
+
 export default defineConfig({
+  plugins: [{
+    name: "watch-integration-worker-inputs",
+    configureServer(server) {
+      server.watcher.add(WATCH_PATHS);
+    },
+  }],
   test: {
     include: ["__tests__/**/*.test.ts"],
-    // Each harness boots real workerd instances, so these run far slower than unit tests.
+    globalSetup: ["./src/global-setup.ts"],
+    // Wrangler loads these outside Vitest's module graph. Absolute source paths make watch mode
+    // rebuild before rerunning; generated outputs are omitted so a build cannot trigger itself.
+    forceRerunTriggers: [
+      `${backendSourceRoot}/*`,
+      `${backendSourceRoot}/!(generated)/**`,
+      `${formatBlueprintsPath}/**`,
+      workspacePath("packages/workshop-backend/browser/**"),
+      workspacePath("packages/workshop-backend/scripts/build-format-blueprints.mjs"),
+      workspacePath("packages/workshop-backend/build-browser-runtime.mjs"),
+      workspacePath("packages/workshop-backend/{package.json,wrangler.jsonc,vite.config.ts,tsconfig*.json}"),
+      workspacePath("packages/workshop-shared/src/**"),
+      workspacePath("packages/backend-utils/src/**"),
+      workspacePath("packages/error-reporting/src/**"),
+      workspacePath("packages/typed-storage/src/**"),
+      workspacePath("packages/integration-tests/fixtures/**"),
+      workspacePath("pnpm-lock.yaml"),
+    ],
     testTimeout: 120_000,
     hookTimeout: 120_000,
-    // One harness at a time: the workers bind fixed DO namespaces and KV, so files running together
-    // would race on ports and persisted state. This serialises the files -- one runs to completion
-    // before the next starts, though they may share a worker process -- and leaves what happens
-    // inside a file alone: only the cases written as `it.concurrent` run together.
-    fileParallelism: false,
   },
 });

--- a/packages/workshop-backend/vite.config.ts
+++ b/packages/workshop-backend/vite.config.ts
@@ -1,6 +1,6 @@
 // Vite+ per-package settings. The `test` task definition is shared by every package whose tests run
 // under vitest and lives beside the other shared task configs.
-import { vitestTask } from '../../scripts/vitest-task-vite-config.js'
+import { vitestTask, withTestTimeout } from '../../scripts/vitest-task-vite-config.js'
 
 /**
  * Codegen steps stay separate commands rather than one `&&` string so each caches on its own.
@@ -22,28 +22,29 @@ export default {
         command: 'node scripts/build-format-blueprints.mjs',
         cache: false,
       },
-      /**
-       * A task rather than a package.json script so it can depend on the codegen above; a script
-       * would run it in vp's clean environment. `cache: false` because `build-browser-runtime.mjs`
-       * writes into the same package tracking hashes as its input, which vp declines to cache.
-       */
-      build: {
-        command: ['node build-browser-runtime.mjs', 'tsc --project tsconfig.browser.json', 'tsc'],
-        dependsOn: ['build:format-blueprints'],
+      'build:browser-runtime': {
+        command: withTestTimeout('node build-browser-runtime.mjs'),
         cache: false,
       },
-      /**
-       * The browser-runtime codegen is repeated here rather than shared because tasks are
-       * independent -- `vp run test` never triggers `build` -- and `src/generated/` is gitignored but
-       * imported by `src/`. It caches, unlike the blueprint codegen, because it reads no environment.
-       */
+      /** Builds the validated entrypoint shared by integration-test file workers. */
+      'build:integration-worker': {
+        command: withTestTimeout('capnweb-validate build --out .wrangler/validate'),
+        dependsOn: [
+          '@gadgets/typed-storage#build', 'build:format-blueprints', 'build:browser-runtime',
+        ],
+        cache: false,
+      },
+      build: {
+        command: ['tsc --project tsconfig.browser.json', 'tsc'],
+        dependsOn: ['build:format-blueprints', 'build:browser-runtime'],
+        cache: false,
+      },
       test: {
         ...vitestTask([
-          'node build-browser-runtime.mjs',
           'vitest run',
           'vitest run --config vitest.integration.config.ts',
         ]),
-        dependsOn: ['build:format-blueprints'],
+        dependsOn: ['build:format-blueprints', 'build:browser-runtime'],
       },
     },
   },

--- a/scripts/env-passthrough.test.ts
+++ b/scripts/env-passthrough.test.ts
@@ -49,6 +49,10 @@ const EXPECTED: Record<string, ExpectedArea> = {
     forwarded: ["VITE_FRONTEND_ERROR_REPORTING"],
     injected: ["GATEKEEPER_APP_UNMINIFIED"],
   },
+  "packages/integration-tests": {
+    injected: ["WORKSHOP_INTEGRATION_PREBUILT"],
+    uncached: ["FORMAT_BLUEPRINTS_DIR"],
+  },
   // `env: ['VITE_*']` — vite's `define` inlines any VITE_-prefixed variable, so the set this
   // package can depend on is open-ended and the wildcard is the only honest declaration.
   "packages/workshop-frontend": {

--- a/scripts/vitest-task-vite-config.ts
+++ b/scripts/vitest-task-vite-config.ts
@@ -96,7 +96,7 @@ const TOTAL_TIMEOUT_SECONDS = 600
  * (and would owe `scripts/env-passthrough.test.ts` an entry). Here a policy change is a visible,
  * fingerprinted change.
  */
-const withTimeout = (command: string): string =>
+export const withTestTimeout = (command: string): string =>
   `node ../../scripts/with-timeout.ts` +
   ` --idle ${IDLE_TIMEOUT_SECONDS} --max ${TOTAL_TIMEOUT_SECONDS} -- ${command}`
 
@@ -118,7 +118,7 @@ export function vitestTask(
 ): VitestTask {
   const exclusions = [...VITEST_SCRATCH_EXCLUSIONS, ...extraExclusions]
   return {
-    command: Array.isArray(command) ? command.map(withTimeout) : withTimeout(command),
+    command: Array.isArray(command) ? command.map(withTestTimeout) : withTestTimeout(command),
     input: [{ auto: true }, ...exclusions],
     output: [{ auto: true }, ...exclusions],
   }


### PR DESCRIPTION
The Workshop integration suite grew from two files to six. Five files start a local Workshop, and `fileParallelism: false` made those startup costs add up. The suite took 28–43 seconds on current main and would reach about 50 seconds with the agent-test stack.

The old config comment said parallel files would share ports and storage. They do not. Vitest runs each file in an isolated fork, and every `createTestHarness()` call starts separate workerd processes with dynamic ports and in-memory Durable Object, KV, and R2 state.

The real shared resource is generated code. `capnweb-validate` deletes and rewrites `packages/workshop-backend/.wrangler/validate`, while Wrangler reads its generated `server.ts`. This PR gives the format, browser-runtime, and validated-Worker builds one Vite+ task owner. The integration task builds that entrypoint once, then isolated file processes read it. Direct runs use the same task. Watch mode registers the complete Worker input closure, including a configured external blueprint directory, and rebuilds before each rerun. Generated outputs are excluded so a build cannot trigger itself.

The build steps keep the repository's 60-second idle and 600-second total watchdog. The integration task is uncached because backend source reaches it through the gitignored validated output; running this fast suite is safer than maintaining a second source fingerprint.

Measured locally:

```text
Current main, sequential              28–43s
Current main, default parallel      2.67–3.32s
Expanded stack, default parallel    2.89–3.64s
```

Five repeated runs of both the current and expanded suites passed with Vitest’s default worker count. An explicit cap made both suites slower, so `maxWorkers` remains unset.

Run it with:

```sh
pnpm --filter @gadgets/integration-tests test:run
```
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


Wall time: 0.54 seconds


Wall time: 0.47 seconds