### PR TITLE
Keep tool picker position when selecting tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/node": "26.1.0",
     "aws4fetch": "^1.0.20",
+    "jsdom": "^26.1.0",
     "jsonc-parser": "^3.3.1",
     "typescript": "catalog:",
     "typescript6": "npm:typescript@6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       aws4fetch:
         specifier: ^1.0.20
         version: 1.0.20
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0(supports-color@10.2.2)
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1

--- a/scripts/build-gatekeeper-configurator.test.ts
+++ b/scripts/build-gatekeeper-configurator.test.ts
@@ -1,28 +1,45 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { access, mkdtemp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { after, before, describe, it } from "node:test";
 import ts from "typescript6"; // JS compiler API (decodeMappings); see build-gatekeeper-configurator.ts
 
+const { JSDOM } = createRequire(import.meta.url)("jsdom");
+
 const execFileAsync = promisify(execFile);
 const builder = resolve("scripts/build-gatekeeper-configurator.ts");
 const configuratorSource =
   'import { h } from "@gadgets/configurator-ui";\n' +
   'export default { render() { throw new Error("mapped configurator failure"); return <div />; } };\n';
+const checkboxConfiguratorSource =
+  'import { CheckboxList, h } from "@gadgets/configurator-ui";\n' +
+  'const options = Array.from({ length: 12 }, (_, index) => ({\n' +
+  '  value: `tool-${index}`, title: `Tool ${index}`,\n' +
+  '}));\n' +
+  'export default {\n' +
+  '  initial: { tools: null },\n' +
+  '  render({ values, setValues }) {\n' +
+  '    return <CheckboxList name="tools" value={values.tools} loadOptions={async () => options}\n' +
+  '      onChange={tools => setValues({ tools })} />;\n' +
+  '  },\n' +
+  '};\n';
 let fixtureDir: string;
 let disabledFixtureDir: string;
 let devModeFixtureDir: string;
 let devEnvWithoutDevFlagFixtureDir: string;
+let checkboxFixtureDir: string;
 
 // `envFile` is the `.env.*` file that enables reporting, so which one is written decides which build
 // mode picks it up. `staleArtifacts` pre-seeds the outputs a reporting-disabled build must remove.
-async function createFixture(prefix: string, { envFile, builderArgs = [], staleArtifacts = false }: {
+async function createFixture(prefix: string, { envFile, builderArgs = [], staleArtifacts = false, source }: {
   envFile?: string;
   builderArgs?: string[];
   staleArtifacts?: boolean;
+  source?: string;
 } = {}): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), prefix));
   await mkdir(join(directory, "src", "configurator"), { recursive: true });
@@ -37,7 +54,7 @@ async function createFixture(prefix: string, { envFile, builderArgs = [], staleA
   }
   await writeFile(join(directory, "node_modules", "capnweb", "dist", "index.js"),
     "export class RpcTarget {}\nexport function newMessagePortRpcSession() {}\n");
-  await writeFile(join(directory, "src", "configurator", "test-ui.tsx"), configuratorSource);
+  await writeFile(join(directory, "src", "configurator", "test-ui.tsx"), source ?? configuratorSource);
   await execFileAsync(process.execPath, [builder, directory, ...builderArgs]);
   return directory;
 }
@@ -48,6 +65,44 @@ async function readRuntime(directory: string): Promise<string> {
     /<script type="module" src="data:text\/javascript;charset=utf-8,([^"]+)"/);
   assert.ok(match, "generated HTML should contain its runtime module");
   return decodeURIComponent(match[1]);
+}
+
+async function runConfiguratorRuntime(directory: string) {
+  const dom = new JSDOM("<!DOCTYPE html><div id=\"root\"></div>", {
+    pretendToBeVisual: true,
+    runScripts: "outside-only",
+  });
+  const runtime = (await readRuntime(directory)).replace(/^import .*;\n/gm, "");
+  Object.defineProperty(dom.window, "postMessage", { value: () => {} });
+  dom.window.eval(`
+    class MessageChannel {
+      constructor() { this.port1 = {}; this.port2 = {}; }
+    }
+    class ResizeObserver {
+      observe() {}
+      disconnect() {}
+    }
+    class RpcTarget {}
+    const CSS = { escape: value => String(value) };
+    function newMessagePortRpcSession() {
+      return {
+        gatekeeper: {},
+        getInitialResource: async () => null,
+        setSelectionReady() {},
+        resize() {},
+        forwardScroll() {},
+      };
+    }
+    ${runtime}
+  `);
+
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (dom.window.document.querySelector(".checkbox-rows")) return dom;
+    await new Promise(done => setTimeout(done, 0));
+  }
+  const error = dom.window.document.getElementById("root")?.textContent;
+  dom.window.close();
+  throw new Error(`Configurator did not render its checkbox list: ${error}`);
 }
 
 function readConfiguratorModule(runtime: string): string {
@@ -127,6 +182,8 @@ before(async () => {
     { envFile: ".env.development", builderArgs: ["--dev"] });
   devEnvWithoutDevFlagFixtureDir = await createFixture("configurator-dev-env-oneshot-",
     { envFile: ".env.development", staleArtifacts: true });
+  checkboxFixtureDir = await createFixture(
+    "configurator-checkbox-", { source: checkboxConfiguratorSource });
 });
 
 after(async () => {
@@ -134,6 +191,7 @@ after(async () => {
   await rm(disabledFixtureDir, { recursive: true, force: true });
   await rm(devModeFixtureDir, { recursive: true, force: true });
   await rm(devEnvWithoutDevFlagFixtureDir, { recursive: true, force: true });
+  await rm(checkboxFixtureDir, { recursive: true, force: true });
 });
 
 describe("generated configurator error reporting", () => {
@@ -297,6 +355,37 @@ describe("generated configurator option sanitizing", () => {
     };
     pruneCheckboxEntries(entries, new Set(["tools:new"]));
     assert.deepEqual(entries, { "tools:new": { status: "ready", disabled: false } });
+  });
+});
+
+describe("generated configurator checkbox behavior", () => {
+  it("keeps the tool list in place on selection and resets it when filtering", async () => {
+    const dom = await runConfiguratorRuntime(checkboxFixtureDir);
+    try {
+      const root = dom.window.document.getElementById("root");
+      const rows = root.querySelector(".checkbox-rows");
+      const checkbox = root.querySelectorAll('input[type="checkbox"]')[8];
+      assert.ok(rows);
+      assert.ok(checkbox);
+      rows.scrollTop = 176;
+
+      checkbox.click();
+
+      const rowsAfterSelection = root.querySelector(".checkbox-rows");
+      assert.notEqual(rowsAfterSelection, rows);
+      assert.equal(rowsAfterSelection?.scrollTop, 176);
+      assert.match(root.textContent, /1 of 12 selected/);
+
+      const filter = root.querySelector('input[type="search"]');
+      assert.ok(filter);
+      rowsAfterSelection.scrollTop = 176;
+      filter.value = "tool";
+      filter.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+      assert.equal(root.querySelector(".checkbox-rows")?.scrollTop, 0);
+    } finally {
+      dom.window.close();
+    }
   });
 });
 

--- a/scripts/build-gatekeeper-configurator.ts
+++ b/scripts/build-gatekeeper-configurator.ts
@@ -208,7 +208,7 @@ function setValues(patch) {
   const active = getFocusState();
   values = { ...values, ...patch };
   postSelectionState();
-  render(active);
+  render(active, true);
 }
 
 function clearFields(...names) {
@@ -648,9 +648,14 @@ RadioCards = components.RadioCards;
 CheckboxList = components.CheckboxList;
 Autocomplete = components.Autocomplete;
 
-function render(focusState = undefined) {
+function render(focusState = undefined, preserveCheckboxScroll = false) {
   if (!root || !spec) return;
   if (focusState === undefined) focusState = getFocusState();
+  const checkboxScrollOffsets = preserveCheckboxScroll
+    ? new Map(Array.from(root.querySelectorAll(".checkbox-list[data-name]"), list => [
+        list.getAttribute("data-name"), list.querySelector(".checkbox-rows")?.scrollTop,
+      ]))
+    : null;
   renderGeneration++;
   renderedCheckboxNames = new Set();
   isRendering = true;
@@ -658,6 +663,13 @@ function render(focusState = undefined) {
     spec.render({ ui, values, setValues, clearFields, components }),
   ]));
   isRendering = false;
+  if (checkboxScrollOffsets) {
+    for (const list of root.querySelectorAll(".checkbox-list[data-name]")) {
+      const offset = checkboxScrollOffsets.get(list.getAttribute("data-name"));
+      const rows = list.querySelector(".checkbox-rows");
+      if (rows && offset !== undefined) rows.scrollTop = offset;
+    }
+  }
   pruneCheckboxEntries(checkboxOptionsByName, renderedCheckboxNames);
   if (focusState?.name) {
     const input = root.querySelector('[data-configurator-input="' + CSS.escape(focusState.name) + '"]');


### PR DESCRIPTION
Selecting a tool rebuilt the configurator form and reset the nested tool list to the top. Preserve each checkbox list's position across selection-driven rerenders; changing the filter still starts the filtered results at the top.

The regression test executes the generated configurator runtime and exercises both interactions against real DOM elements.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->