### PR TITLE
feat: add GLM 5.3 Flash to the model catalog

### DIFF
--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -1195,6 +1195,10 @@ export const SUGGESTED_MODELS: Record<
     "@cf/zai-org/glm-5.2": {
       name: "GLM 5.2 (Workers AI)", contextWindow: 262144, outputLimit: WORKERS_AI_OUTPUT_LIMIT,
     },
+    "@cf/zai-org/glm-5.3-flash": {
+      name: "GLM 5.3 Flash (Workers AI)", contextWindow: 1048576,
+      outputLimit: WORKERS_AI_OUTPUT_LIMIT,
+    },
   },
   "anthropic": {
     // TODO: Include Fable -- but we need an admin option to disable it, since many orgs don't


### PR DESCRIPTION
## What does this change?

Cloudflare released `@cf/zai-org/glm-5.3-flash` on August 26, 2026. This adds the model to the existing curated Workers AI picker with the documented 1,048,576-token context window and the shared Workers AI output cap.

The model is Cloudflare-hosted, paid-only, and supports function calling, reasoning, and vision:
https://developers.cloudflare.com/workers-ai/models/glm-5.3-flash/

The smaller documented context value is intentional. The account catalog currently reports 1,310,720, but the public model page reports 1,048,576, so the picker uses the conservative published limit for compaction.

## Why is this obviously correct and trivially verifiable?

The complete patch is one four-line catalog entry. Its identifier and public limits can be compared directly with Cloudflare's model page, and the existing shared Workers AI output-limit constant is reused without changing runtime code.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
