### PR TITLE
Simplify repository build scripts & make cross platform

### DIFF
--- a/packages/gatekeeper-context/package.json
+++ b/packages/gatekeeper-context/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "echo \"run 'pnpm dev-server' in the root directory instead\" >&2 && exit 1",
     "deploy": "vp run --no-cache build:app && wrangler deploy",
-    "build:app:watch": "node build-app.mjs --watch",
     "typecheck:app": "tsc -p tsconfig.app.json && tsc -p tsconfig.vite.json",
     "build": "pnpm run typecheck:app && vp run --cache build:app && tsc",
     "clean": "rm -rf dist src/generated",

--- a/packages/gatekeeper-scheduler/package.json
+++ b/packages/gatekeeper-scheduler/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "echo \"run 'pnpm dev-server' in the root directory instead\" >&2 && exit 1",
     "deploy": "vp run --no-cache build:app && wrangler deploy",
-    "build:app:watch": "node build-app.mjs --watch",
     "typecheck:app": "tsc -p tsconfig.app.json && tsc -p tsconfig.vite.json",
     "build": "pnpm run typecheck:app && vp run --cache build:app && tsc",
     "clean": "rm -rf dist",

--- a/packages/workshop-frontend/vite.config.ts
+++ b/packages/workshop-frontend/vite.config.ts
@@ -5,16 +5,35 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 import { vitestTask } from '../../scripts/vitest-task-vite-config.js'
 
-// `dist/` is this package's own build output, excluded from the inputs of both tasks: vp declines to
-// cache a task that reads a path it also wrote. Package-relative rather than workspace-wide --
-// `typed-storage` emits, and its `exports` resolves to `dist/index.js`, so a pattern matching every
-// package's `dist` would drop a real input.
+// `dist/` is this package's own build output, excluded from the inputs of the bundle and test
+// tasks: vp declines to cache a task that reads a path it also wrote. Package-relative rather than
+// workspace-wide -- `typed-storage` emits, and its `exports` resolves to `dist/index.js`, so a
+// pattern matching every package's `dist` would drop a real input.
+const frontendBundleTaskOptions = {
+  dependsOn: ['clean:dist'],
+  env: ['VITE_*'],
+  input: [
+    { auto: true },
+    { pattern: '!dist/**', base: 'package' } as const,
+    // Wrangler's scratch bundles are randomly named, and tracking reaches past the package that
+    // owns the task, so any sibling that ran `wrangler dev` guarantees a miss here. Workspace-wide
+    // for that reason; `build:app` and the shared `test` task exclude the same tree.
+    { pattern: '!**/.wrangler/**', base: 'workspace' } as const,
+  ],
+  output: ['dist/**'],
+}
+
 const ownDist = { pattern: '!dist/**', base: 'package' } as const
+const viteBuildCommand =
+  `node --input-type=module -e "process.env.NODE_ENV='production'; await (await import('vite')).build()"`
 
 const runConfig = {
   run: {
     tasks: {
-      'clean:dist': { command: 'rm -rf dist', cache: false },
+      'clean:dist': {
+        command: `node --input-type=module -e "import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })"`,
+        cache: false,
+      },
       /**
        * `build` is a task rather than a package.json script so `env` can declare the `VITE_*` flags
        * it reads: a cached `vp` run executes scripts in a clean environment, and the values would be
@@ -27,27 +46,16 @@ const runConfig = {
        * config-file pass (`vite.config.ts` and the scripts it imports), which the app's own
        * `tsconfig.json` excludes.
        *
-       * `NODE_ENV=production` applies to this command alone and changes nothing in the normal case:
-       * vite already defaults a build to production when `NODE_ENV` is unset. It is here because
-       * vite takes `isProduction` from `NODE_ENV` and not from `--mode`, so an ambient
-       * `NODE_ENV=development` would otherwise ship a development bundle from `--no-cache`, the
-       * path `deploy` uses.
+       * Production mode is set before Vite is imported because Vite snapshots whether `NODE_ENV`
+       * was present before loading this config. The Node launcher is shell-neutral.
        */
       build: {
-        command: ['tsc', 'tsc -p tsconfig.vite.json', 'NODE_ENV=production vite build'],
-        dependsOn: ['clean:dist'],
-        env: ['VITE_*'],
-        input: [
-          { auto: true },
-          ownDist,
-          // Wrangler's scratch bundles are randomly named, and tracking reaches past the package
-          // that owns the task, so any sibling that ran `wrangler dev` guarantees a miss here on the
-          // next run -- vp reported one as `'bundle-1434329262.js' added in
-          // 'packages/workshop-backend/.wrangler/tmp'`. Workspace-wide for that reason; `build:app`
-          // and the shared `test` task exclude the same tree.
-          { pattern: '!**/.wrangler/**', base: 'workspace' } as const,
-        ],
-        output: ['dist/**'],
+        command: ['tsc', 'tsc -p tsconfig.vite.json', viteBuildCommand],
+        ...frontendBundleTaskOptions,
+      },
+      'build:assets': {
+        command: viteBuildCommand,
+        ...frontendBundleTaskOptions,
       },
       test: vitestTask('vitest run', [ownDist]),
     },

--- a/scripts/env-passthrough.test.ts
+++ b/scripts/env-passthrough.test.ts
@@ -23,9 +23,9 @@ import { describe, it } from "node:test";
  *   uncached  — the task that reads it is `cache: false`, so it runs with the full ambient
  *               environment. Used where `env` would be unsound: `FORMAT_BLUEPRINTS_DIR` names a
  *               directory outside the workspace, and `env` fingerprints the value, not the contents.
- *   injected  — set explicitly by the process that spawns the build, never inherited. Stripping is
- *               correct here: `build-app.mjs` always passes `GATEKEEPER_APP_UNMINIFIED` itself
- *               precisely so an inherited value cannot turn a production build unminified.
+ *   injected  — set explicitly by the build setup, never inherited. Stripping is correct here:
+ *               `build-app.mjs` always passes `GATEKEEPER_APP_UNMINIFIED`, and the frontend build
+ *               task sets `NODE_ENV` before importing Vite.
  *   external  — read outside any vp task (release/dev tooling invoked directly), so vp never
  *               filters it.
  */
@@ -60,6 +60,7 @@ const EXPECTED: Record<string, ExpectedArea> = {
       "VITE_DEV_USERNAME",
       "VITE_FRONTEND_ERROR_REPORTING",
     ],
+    injected: ["NODE_ENV"],
   },
   "packages/workshop-backend": {
     uncached: ["FORMAT_BLUEPRINTS_DIR"],

--- a/scripts/oxlint-plugin.mjs
+++ b/scripts/oxlint-plugin.mjs
@@ -1,4 +1,4 @@
-export const preferJsdoc = {
+const preferJsdoc = {
   meta: {
     type: "layout",
     docs: {

--- a/scripts/oxlint-plugin.test.ts
+++ b/scripts/oxlint-plugin.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
-import { preferJsdoc } from "./oxlint-plugin.mjs";
+import plugin from "./oxlint-plugin.mjs";
 
 const require = createRequire(import.meta.url);
 const vitePlusRequire = createRequire(require.resolve("vite-plus/package.json"));
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run("prefer-jsdoc", preferJsdoc, {
+ruleTester.run("prefer-jsdoc", plugin.rules["prefer-jsdoc"], {
   valid: [
     "// Explains an implementation detail.\nconst value = 1;",
     "/** Documents the public value. */\nexport const value = 1;",

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -36,17 +36,17 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawn } from "node:child_process";
 import {
+  gatekeeperShortName, isGatekeeperPackage, type DeployablePackage,
+} from "../release/manifest-lib.ts";
+import {
   ROOT,
   STAGING_CONFIG_NAME,
   backendSecrets,
-  gatekeeperShortName,
   generatePreviewConfigs,
-  isGatekeeper,
   previewPullRequestNumber,
   previewUrlFor,
   resolvePreviewName,
   writePreviewConfig,
-  type DeployablePackage,
   type StagingConfig,
 } from "./staging-config.ts";
 
@@ -561,7 +561,7 @@ function tiers(packages: readonly DeployablePackage[]): {
     return pkg;
   };
   return {
-    gatekeepers: packages.filter((pkg) => isGatekeeper(pkg.name))
+    gatekeepers: packages.filter((pkg) => isGatekeeperPackage(pkg.name))
         .toSorted((a, b) => a.name.localeCompare(b.name)),
     backend: byName("workshop-backend"),
     router: byName("router"),

--- a/scripts/preview/staging-config.test.ts
+++ b/scripts/preview/staging-config.test.ts
@@ -7,17 +7,17 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { BindingDecl } from "../release/manifest-lib.ts";
+import {
+  gatekeeperShortName, isGatekeeperPackage, readDeployablePackages, type BindingDecl,
+} from "../release/manifest-lib.ts";
 import {
   MAX_PREVIEW_NAME_LENGTH,
+  PACKAGES_DIR,
   R2_MAX_BUCKET_NAME_LENGTH,
   backendSecrets,
   buildPreviewConfigs,
   gatekeeperBindingName,
-  gatekeeperShortName,
-  isGatekeeper,
   previewPullRequestNumber,
-  readPackages,
   resolveAccess,
   resolveAiGateway,
   resolvePreviewName,
@@ -96,7 +96,7 @@ function previewsOf(configs: Map<string, StagingConfig>, name: string): PreviewO
 }
 
 function buildAll() {
-  const packages = readPackages();
+  const packages = readDeployablePackages(PACKAGES_DIR);
   const configs = buildPreviewConfigs({
     previewName: PREVIEW_NAME,
     packages,
@@ -369,7 +369,7 @@ test("no generated config carries a secret's value anywhere", () => {
 
 test("every gatekeeper is bound to the backend by RPC and to the router by HTTP", () => {
   const { packages, configs } = buildAll();
-  const gatekeepers = packages.map((pkg) => pkg.name).filter(isGatekeeper).toSorted();
+  const gatekeepers = packages.map((pkg) => pkg.name).filter(isGatekeeperPackage).toSorted();
   assert.ok(gatekeepers.length >= 16, `only found ${gatekeepers.length} gatekeepers`);
 
   // A service binding names a worker, which is the package name; the binding name — what the
@@ -398,7 +398,7 @@ test("every gatekeeper is bound to the backend by RPC and to the router by HTTP"
 test("every gatekeeper is mounted under the router's origin", () => {
   const { packages, configs } = buildAll();
 
-  for (const { name } of packages.filter((pkg) => isGatekeeper(pkg.name))) {
+  for (const { name } of packages.filter((pkg) => isGatekeeperPackage(pkg.name))) {
     assert.equal(previewsOf(configs, name).vars?.BASE_URL,
         `${BASE_URL}/gatekeeper/${gatekeeperShortName(name)}`);
   }

--- a/scripts/preview/staging-config.ts
+++ b/scripts/preview/staging-config.ts
@@ -28,8 +28,9 @@ import { createHash } from "node:crypto";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
-  findDeployablePackages, readWranglerConfig,
-  type BindingDecl, type ObservabilityConfig, type ServiceBinding, type WranglerConfig,
+  gatekeeperShortName, isGatekeeperPackage, readDeployablePackages,
+  type BindingDecl, type DeployablePackage, type ObservabilityConfig, type ServiceBinding,
+  type WranglerConfig,
 } from "../release/manifest-lib.ts";
 
 /**
@@ -92,19 +93,7 @@ export interface StagingConfig extends WranglerConfig {
   previews?: PreviewOverrides;
 }
 
-/** A deployable package as the generator sees it: its name and its parsed wrangler.jsonc. */
-export interface PackageConfig {
-  /** The workspace package directory name, which is also the worker name. */
-  name: string;
-  /** The parsed wrangler.jsonc. */
-  config: WranglerConfig;
-}
-
-/** A deployable package on disk, as {@link readPackages} returns it. */
-export interface DeployablePackage extends PackageConfig {
-  /** Absolute path to the package directory. */
-  dir: string;
-}
+type PackageConfig = Pick<DeployablePackage, "name" | "config">;
 
 /** The values every `apply*` function derives its config from. */
 interface PreviewContext {
@@ -136,20 +125,6 @@ export const R2_MAX_BUCKET_NAME_LENGTH = 63;
 export const MAX_PREVIEW_NAME_LENGTH = 28;
 const PREVIEW_NAME_HASH_LENGTH = 8;
 
-const GATEKEEPER_PREFIX = "gatekeeper-";
-
-/** True for the packages that are gatekeeper workers (as opposed to the router and backend). */
-export function isGatekeeper(pkgName: string): boolean {
-  return pkgName.startsWith(GATEKEEPER_PREFIX);
-}
-
-/**
- * The vendor id a gatekeeper is reached by: `gatekeeper-mcp-portal` -> `mcp-portal`. Matches
- * manifest-lib.ts's shortName, and hence the `/gatekeeper/<short>` path the router serves.
- */
-export function gatekeeperShortName(pkgName: string): string {
-  return pkgName.slice(GATEKEEPER_PREFIX.length);
-}
 
 /**
  * The service binding name a gatekeeper is bound as: `gatekeeper-mcp-portal` ->
@@ -427,7 +402,7 @@ export function buildPreviewConfigs({
     throw new Error("buildPreviewConfigs needs both accountId and workersDevHost");
   }
   const baseUrl = routerPreviewUrl(previewName, workersDevHost);
-  const gatekeepers = packages.map((pkg) => pkg.name).filter(isGatekeeper).toSorted();
+  const gatekeepers = packages.map((pkg) => pkg.name).filter(isGatekeeperPackage).toSorted();
   const context: PreviewContext = { baseUrl, gatekeepers };
   const configs = new Map<string, StagingConfig>();
 
@@ -455,7 +430,7 @@ export function buildPreviewConfigs({
     delete config.routes;
     stripBaselineResources(config);
 
-    if (isGatekeeper(pkg.name)) applyGatekeeper(pkg.name, config, context);
+    if (isGatekeeperPackage(pkg.name)) applyGatekeeper(pkg.name, config, context);
     else if (pkg.name === "workshop-backend") applyBackend(config, context);
     else if (pkg.name === "router") applyRouter(config, context);
     else throw new Error(`cannot build a preview config for package: ${pkg.name}`);
@@ -672,11 +647,6 @@ export function backendSecrets({
   };
 }
 
-/** Read every deployable package's wrangler.jsonc off disk. */
-export function readPackages(): DeployablePackage[] {
-  return findDeployablePackages(PACKAGES_DIR)
-      .map(({ name, dir }) => ({ name, dir, config: readWranglerConfig(dir) }));
-}
 
 /** Write one package's generated preview config to its `wrangler.staging.jsonc`. */
 export function writePreviewConfig(pkgDir: string, config: StagingConfig): void {
@@ -697,7 +667,7 @@ export function generatePreviewConfigs(options: {
 } {
   const previewName = options.previewName ?? resolvePreviewName();
   const { accountId, workersDevHost } = resolveTarget();
-  const packages = readPackages();
+  const packages = readDeployablePackages(PACKAGES_DIR);
   const configs = buildPreviewConfigs({
     previewName,
     packages,

--- a/scripts/release/build-release.ts
+++ b/scripts/release/build-release.ts
@@ -31,8 +31,8 @@ import {
   collectAssets, collectModules, stableStringify, type CollectedAssets,
 } from "./hash-lib.ts";
 import {
-  findDeployablePackages, generateManifest, readDeployInputs, readWranglerConfig,
-  type WorkerBuild, type WranglerConfig,
+  generateManifest, readDeployablePackages, readDeployInputs,
+  type DeployablePackage, type WorkerBuild,
 } from "./manifest-lib.ts";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -82,15 +82,6 @@ class CancelledBySignal extends Error {
   }
 }
 
-/** A deployable package, with its `wrangler.jsonc` read once and carried alongside. */
-interface DeployablePackage {
-  /** Package directory name, which is also the worker name. */
-  name: string;
-  /** Absolute path to the package directory. */
-  dir: string;
-  /** The package's parsed wrangler config. */
-  config: WranglerConfig;
-}
 
 function parseArgs(argv: string[]): {
   out: string;
@@ -365,8 +356,7 @@ async function main() {
   mkdirSync(join(args.out, "modules"), { recursive: true });
   mkdirSync(join(args.out, "assets"), { recursive: true });
 
-  const packages: DeployablePackage[] = findDeployablePackages(PACKAGES_DIR)
-      .map((pkg) => ({ ...pkg, config: readWranglerConfig(pkg.dir) }));
+  const packages = readDeployablePackages(PACKAGES_DIR);
 
   // 1. Every bundle, overlapping.
   const { bundles, assets } = await buildAll(packages, args.concurrency);

--- a/scripts/release/manifest-lib.test.ts
+++ b/scripts/release/manifest-lib.test.ts
@@ -13,7 +13,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { collectAssets, collectModules, stableStringify } from "./hash-lib.ts";
 import {
-  findDeployablePackages, generateManifest, readDeployInputs, readWranglerConfig,
+  generateManifest, readDeployablePackages, readDeployInputs,
 } from "./manifest-lib.ts";
 
 const RELEASE = dirname(fileURLToPath(import.meta.url));
@@ -26,7 +26,7 @@ const PLACEHOLDER_RE =
     /^\$(ACCOUNT_ID|PUBLIC_BASE_URL|KV_[A-Z0-9_]+_ID|R2_[A-Z0-9_]+_NAME|WORKER_NAME\([a-z0-9-]+\)|SECRET\([A-Z0-9_]+\))/;
 
 function buildTestManifest() {
-  const workers = findDeployablePackages(join(ROOT, "packages")).map((pkg) => {
+  const workers = readDeployablePackages(join(ROOT, "packages")).map((pkg) => {
     const bundleDir = join(TESTDATA, "fixture-bundles", pkg.name);
     assert.ok(existsSync(bundleDir),
         `missing fixture bundle for new deployable package: add scripts/release/testdata/` +
@@ -34,7 +34,7 @@ function buildTestManifest() {
     const { mainModule, modules } = collectModules(bundleDir);
     return {
       pkgName: pkg.name,
-      config: readWranglerConfig(pkg.dir),
+      config: pkg.config,
       mainModule,
       modules,
       deployInputs: readDeployInputs(pkg.dir),
@@ -188,7 +188,7 @@ test("worker entries carry the deploy contract", () => {
 
 test("per-package deploy-inputs.json files are well-formed when present", () => {
   const KINDS = new Set(["secret", "var", "workerName"]);
-  for (const pkg of findDeployablePackages(join(ROOT, "packages"))) {
+  for (const pkg of readDeployablePackages(join(ROOT, "packages"))) {
     const inputs = readDeployInputs(pkg.dir);
     if (inputs === undefined) continue;
     assert.ok(Array.isArray(inputs), `${pkg.name}/deploy-inputs.json must be an array`);

--- a/scripts/release/manifest-lib.ts
+++ b/scripts/release/manifest-lib.ts
@@ -133,6 +133,16 @@ export interface WranglerConfig {
   $schema?: string;
 }
 
+/** A deployable workspace package and its parsed Wrangler configuration. */
+export interface DeployablePackage {
+  /** Package directory name, which is also the worker name. */
+  name: string;
+  /** Absolute path to the package directory. */
+  dir: string;
+  /** The package's parsed wrangler.jsonc. */
+  config: WranglerConfig;
+}
+
 /** One user-supplied value the deploy wizard collects before installing a gatekeeper. */
 export interface DeployInput {
   /** Env var / secret name the worker reads. Screaming snake case. */
@@ -287,8 +297,10 @@ export const DEFAULT_CRED_INPUTS: DeployInput[] = [
   },
 ];
 
-/** Discover the deployable set: every public package with a wrangler.jsonc. */
-export function findDeployablePackages(packagesDir: string): { name: string; dir: string }[] {
+const GATEKEEPER_PREFIX = "gatekeeper-";
+
+/** Read every deployable package and its Wrangler configuration, sorted by package name. */
+export function readDeployablePackages(packagesDir: string): DeployablePackage[] {
   return readdirSync(packagesDir)
       .filter((name) => {
     try {
@@ -298,12 +310,21 @@ export function findDeployablePackages(packagesDir: string): { name: string; dir
     }
   })
       .toSorted()
-      .map((name) => ({ name, dir: join(packagesDir, name) }));
+      .map((name) => {
+    const dir = join(packagesDir, name);
+    const config = parse(readFileSync(join(dir, "wrangler.jsonc"), "utf8")) as WranglerConfig;
+    return { name, dir, config };
+  });
 }
 
-/** Parse one package's wrangler.jsonc. */
-export function readWranglerConfig(pkgDir: string): WranglerConfig {
-  return parse(readFileSync(join(pkgDir, "wrangler.jsonc"), "utf8")) as WranglerConfig;
+/** True when a deployable package is a gatekeeper worker. */
+export function isGatekeeperPackage(pkgName: string): boolean {
+  return pkgName.startsWith(GATEKEEPER_PREFIX);
+}
+
+/** Return a gatekeeper package's vendor id used in its routed URL. */
+export function gatekeeperShortName(pkgName: string): string {
+  return pkgName.slice(GATEKEEPER_PREFIX.length);
 }
 
 /** Read a package's `deploy-inputs.json`, or undefined if it declares none. */
@@ -316,12 +337,8 @@ export function readDeployInputs(pkgDir: string): DeployInput[] | undefined {
 function workerKind(pkgName: string): WorkerEntry["kind"] {
   if (pkgName === "workshop-backend") return "backend";
   if (pkgName === "router") return "router";
-  if (pkgName.startsWith("gatekeeper-")) return "gatekeeper";
+  if (isGatekeeperPackage(pkgName)) return "gatekeeper";
   throw new Error(`cannot classify deployable package: ${pkgName}`);
-}
-
-function shortName(pkgName: string): string {
-  return pkgName.slice("gatekeeper-".length);
 }
 
 /**
@@ -422,7 +439,7 @@ export function buildWorkerEntry(
     // (default entrypoint — it forwards whole HTTP requests, not vendor RPC).
     gatekeeperBindingExpansion = { propsByPackage: {} };
   } else {
-    vars.BASE_URL = `$PUBLIC_BASE_URL/gatekeeper/${shortName(pkgName)}`;
+    vars.BASE_URL = `$PUBLIC_BASE_URL/gatekeeper/${gatekeeperShortName(pkgName)}`;
     installable = !NOT_INSTALLABLE.has(pkgName);
     if (installable) {
       inputs = deployInputs ??
@@ -444,7 +461,7 @@ export function buildWorkerEntry(
 
   return {
     kind,
-    ...(kind === "gatekeeper" ? { shortName: shortName(pkgName) } : {}),
+    ...(kind === "gatekeeper" ? { shortName: gatekeeperShortName(pkgName) } : {}),
     installable,
     ...(PREINSTALL.has(pkgName) ? { preinstall: true } : {}),
     ...(SINGLETON.has(pkgName) ? { singleton: true } : {}),

--- a/scripts/run-local.ts
+++ b/scripts/run-local.ts
@@ -10,26 +10,15 @@
 //   3. Launches the local server (run-dev-server.ts --serve-frontend-assets), which serves the
 //      built frontend as static assets on the backend.
 //
-// To keep repeat runs fast, install + build are skipped entirely when nothing has changed. We hash
-// all source files (everything git tracks, plus untracked-but-not-ignored files) and compare
-// against a stored stamp. If the hash matches and the build outputs still exist, we skip straight
-// to serving. Any source change (including dependency changes via pnpm-lock.yaml) flips the hash and
-// triggers a rebuild.
+// Vite+ owns the build cache and restores missing outputs on warm runs.
 
-import { createHash } from "node:crypto";
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, sep } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getDevServerConfig } from "./dev-server-config.ts";
 import { pnpmCommand } from "./pnpm-command.ts";
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const STAMP_PATH = join(ROOT, ".run-local-stamp");
-
-const FRONTEND_DIST = join(ROOT, "packages", "workshop-frontend", "dist");
-const TYPED_STORAGE_DIST = join(ROOT, "packages", "typed-storage", "dist");
-const NODE_MODULES = join(ROOT, "node_modules");
 
 // Forward any extra flags (e.g. --use-workers-ai-binding) on to run-dev-server.ts.
 const passthroughArgs = process.argv.slice(2);
@@ -41,86 +30,6 @@ try {
   process.exit(1);
 }
 
-// ---------------------------------------------------------------------------
-// Enumerate source files and compute a content hash.
-// ---------------------------------------------------------------------------
-
-// Directories that never contribute to a build and should be skipped by the filesystem-walk
-// fallback. (The git-based path already excludes these via .gitignore.)
-const WALK_IGNORE = new Set([".git", "node_modules", "dist", ".wrangler"]);
-
-function listFilesViaGit(): string[] | null {
-  try {
-    const tracked = execFileSync(
-        "git", ["ls-files", "-z"], { cwd: ROOT, maxBuffer: 1024 * 1024 * 64 });
-    const untracked = execFileSync(
-        "git", ["ls-files", "-z", "--others", "--exclude-standard"],
-        { cwd: ROOT, maxBuffer: 1024 * 1024 * 64 });
-    const split = (buf: Buffer) => buf.toString("utf8").split("\0").filter(Boolean);
-    return [...split(tracked), ...split(untracked)];
-  } catch {
-    return null;
-  }
-}
-
-function listFilesViaWalk(dir: string, acc: string[]): string[] {
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.isDirectory()) {
-      if (WALK_IGNORE.has(entry.name)) continue;
-      listFilesViaWalk(join(dir, entry.name), acc);
-    } else if (entry.isFile()) {
-      acc.push(relative(ROOT, join(dir, entry.name)));
-    }
-  }
-  return acc;
-}
-
-function computeSourceHash(): string {
-  let files: string[] | null = listFilesViaGit();
-  if (files === null) {
-    // Not a git checkout (e.g. extracted tarball): walk the filesystem instead.
-    files = listFilesViaWalk(ROOT, []);
-  }
-  // Normalize path separators so the hash is stable across platforms, then sort for determinism.
-  files = files.map(f => f.split(sep).join("/")).toSorted();
-
-  const hash = createHash("sha256");
-  for (const rel of files) {
-    const abs = join(ROOT, rel);
-    let contents: Buffer;
-    try {
-      contents = readFileSync(abs);
-    } catch {
-      // File listed but unreadable/removed between listing and hashing; record its absence.
-      hash.update(`${rel}\0<missing>\0`);
-      continue;
-    }
-    hash.update(rel);
-    hash.update("\0");
-    hash.update(contents);
-    hash.update("\0");
-  }
-  return hash.digest("hex");
-}
-
-function readStamp(): string | null {
-  try {
-    return readFileSync(STAMP_PATH, "utf8").trim();
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Decide what work is needed.
-// ---------------------------------------------------------------------------
-
-const sourceHash = computeSourceHash();
-const stamp = readStamp();
-
-const outputsPresent = existsSync(FRONTEND_DIST) && existsSync(TYPED_STORAGE_DIST);
-const needsBuild = stamp !== sourceHash || !outputsPresent;
-const needsInstall = needsBuild || !existsSync(NODE_MODULES);
 
 function runPnpm(args: string[]): void {
   console.log(`\n> pnpm ${args.join(" ")}`);
@@ -128,22 +37,9 @@ function runPnpm(args: string[]): void {
   execFileSync(command, argv, { stdio: "inherit", cwd: ROOT });
 }
 
-if (needsInstall) {
-  runPnpm(["install"]);
-} else {
-  console.log("Dependencies up to date; skipping install.");
-}
-
-if (needsBuild) {
-  // Build only what's required to run locally (no full-repo type-check / no frontend tsc).
-  runPnpm(["--filter", "@gadgets/typed-storage", "build"]);
-  runPnpm(["--filter", "@gadgets/workshop-frontend", "exec", "vite", "build"]);
-
-  // Record the stamp only after a successful build so an interrupted build retries next time.
-  writeFileSync(STAMP_PATH, sourceHash + "\n");
-} else {
-  console.log("No source changes since last build; skipping build.");
-}
+runPnpm(["install"]);
+runPnpm(["exec", "vp", "run", "--cache", "@gadgets/typed-storage#build"]);
+runPnpm(["exec", "vp", "run", "--cache", "@gadgets/workshop-frontend#build:assets"]);
 
 // ---------------------------------------------------------------------------
 // Launch the local server (serves the built frontend as static assets).


### PR DESCRIPTION
This removes run-local's repository-wide hash and stamp, and uses Vite+'s existing task cache for typed-storage and frontend assets instead. The frontend bundle tasks now share cache metadata, enforce production mode from Vite config, and clean dist without relying on POSIX shell syntax. Release and preview scripts now share one deployable-package reader and gatekeeper naming helpers, while unused app-watch aliases and the test-only oxlint rule export are gone.