### PR TITLE
Re-enable Bonk

### DIFF
--- a/.github/workflows/bonk-pr.yml
+++ b/.github/workflows/bonk-pr.yml
@@ -1,12 +1,10 @@
 name: Bonk PR Review
 
 on:
-  # Emergency shutoff: restore the PR and comment triggers when Bonk is confirmed working.
-  workflow_dispatch:
-  # pull_request:
-  #   types: [opened, synchronize, unlabeled]
-  # issue_comment:
-  #   types: [created]
+  pull_request:
+    types: [opened, synchronize, unlabeled]
+  issue_comment:
+    types: [created]
 
 jobs:
   # Break-glass invariants:
@@ -112,7 +110,9 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id &&
-      github.event.sender.type != 'Bot'
+      github.event.sender.type != 'Bot' &&
+      (github.event.action != 'unlabeled' ||
+       github.event.label.name == 'bonk-break-glass')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
@@ -164,4 +164,4 @@ jobs:
           permissions: write
           token_permissions: NO_PUSH
           agent: bonk
-          opencode_version: 1.18.18
+          opencode_version: 1.18.24

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -1,12 +1,10 @@
 name: Bonk
 
 on:
-  # Emergency shutoff: restore the comment triggers when Bonk is confirmed working.
-  workflow_dispatch:
-  # issue_comment:
-  #   types: [created]
-  # pull_request_review_comment:
-  #   types: [created]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
   # This `if:` is a prefilter, not the authorization: it only keeps the job from starting a runner
@@ -68,4 +66,4 @@ jobs:
           permissions: write
           token_permissions: NO_PUSH
           agent: bonk
-          opencode_version: 1.18.18
+          opencode_version: 1.18.24


### PR DESCRIPTION
Reverts the emergency shutoff from #258, restoring the original triggers on both Bonk workflows.