### PR TITLE
Fix stale chat metadata rebuild race

### DIFF
--- a/packages/workshop-frontend/src/otClient.test.ts
+++ b/packages/workshop-frontend/src/otClient.test.ts
@@ -569,4 +569,33 @@ describe('ChatOtClient', () => {
     await flush()
     expect(filesOf(h.client.getContent(), 1)).toEqual({ 'a.txt': 'abc!' })
   })
+  it('waits for metadata that covers a materialized change before rebuilding', async () => {
+    const h = new TestHarness()
+    h.commits.set('c1', new Map([['a.txt', 'abc']]))
+    h.client.setDurableState({ rowsThrough: 0 })
+    await flush()
+
+    // Subscription replay delivers the durable message before its metadata. Without the pin from
+    // that metadata, applying the message's edit would rebuild the gadget from an empty tree.
+    h.client.setDurableState({
+      codeBase: { pins: [], generation: 0, revision: 0 },
+      epochChange: { 1: [['a.txt', { edit: [3, [0, '!']] }]] },
+      rowsThrough: 1,
+    })
+    await flush()
+    expect(h.fatal).toBe(null)
+    expect(h.client.hasGadget(1)).toBe(false)
+
+    h.client.setDurableState({
+      codeBase: {
+        pins: [{ gadgetId: 1, baseCommit: 'c1', mergedCommit: 'c1' }],
+        generation: 0, revision: 1,
+      },
+      epochChange: { 1: [['a.txt', { edit: [3, [0, '!']] }]] },
+      rowsThrough: 1,
+    })
+    await flush()
+    expect(h.fatal).toBe(null)
+    expect(filesOf(h.client.getContent(), 1)).toEqual({ 'a.txt': 'abc!' })
+  })
 })

--- a/packages/workshop-frontend/src/otClient.ts
+++ b/packages/workshop-frontend/src/otClient.ts
@@ -259,6 +259,8 @@ export class ChatOtClient {
   setDurableState(durable: ChatDurableCode): void {
     this.#enqueue(async () => {
       const codeBase = durable.codeBase ?? { pins: [], generation: 0, revision: 0 }
+      // Messages can arrive before the metadata that covers their materialization watermark.
+      if (durable.rowsThrough > codeBase.revision) return
       this.#latestDurable = durable
 
       if (!this.#ready) {


### PR DESCRIPTION
We've seen  a few sentry errors in production where a chat change message can arrive before metadata containing its pin, causing the OT client to rebuild from an empty file map and throw `edit of absent file`.

Currently the `ChatOtClient` latches the exception as fatal. When the matching metadata arrives moments later, that client does not retry; the error remains until it is recreated.

This defers snapshots whose materialization watermark is ahead of metadata; the matching metadata update then recomputes and applies the change.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->