### PR TITLE
Pilot semantic skill catalog retrieval

### DIFF
--- a/packages/workshop-backend/__tests__/skill-retrieval.test.ts
+++ b/packages/workshop-backend/__tests__/skill-retrieval.test.ts
@@ -1,0 +1,228 @@
+import {describe, expect, it, vi} from "vitest";
+import type {AiChatMessage} from "@gadgets/workshop-shared/api";
+import type {AgentCatalog} from "@gadgets/workshop-shared/gatekeeper";
+import {
+  rankSkillsWithWorkersAi, retrieveContextSkillsForPrompt, retrieveSkillCatalog,
+  semanticSkillRetrievalEnabled, skillRetrievalQuery,
+} from "../src/skill-retrieval";
+
+const SKILL_PREFIX = "Agent Skill. Read with env[N].read(id) and " +
+  "console.log(document.content). ";
+
+function catalog(): AgentCatalog {
+  return {
+    entries: [
+      {id: "collection", title: "Cloudflare", description: "Shared context"},
+      {id: "collection/skills/account-plan/SKILL.md", title: "account-plan",
+        description: `${SKILL_PREFIX}Build a strategic customer account plan.`},
+      {id: "collection/skills/battlecard/SKILL.md", title: "battlecard",
+        description: `${SKILL_PREFIX}Prepare competitive positioning against a named vendor.`},
+      {id: "collection/skills/briefing/SKILL.md", title: "briefing",
+        description: `${SKILL_PREFIX}Prepare an executive customer meeting brief.`},
+      {id: "collection/skills/customer-call/SKILL.md", title: "customer-call",
+        description: `${SKILL_PREFIX}Turn customer notes into a call report.`},
+    ],
+  };
+}
+
+function userMessage(message: string, slash = false): AiChatMessage {
+  return {
+    chatId: 1,
+    sequence: 1,
+    timestamp: new Date(0),
+    author: {type: "user", id: "user", name: "User"},
+    type: "message",
+    message,
+    ...(slash ? {generatedBySlashCommandSequence: 0} : {}),
+  };
+}
+
+describe("skillRetrievalQuery", () => {
+  it("uses the latest direct user request", () => {
+    expect(skillRetrievalQuery([
+      userMessage("first"),
+      {...userMessage("latest"), sequence: 2},
+    ])).toBe("latest");
+  });
+
+  it("bypasses generated slash-command messages", () => {
+    expect(skillRetrievalQuery([userMessage("<agent_skill>...</agent_skill>", true)]))
+        .toBeUndefined();
+  });
+
+  it("does not reuse a previous query for a built-in slash command", () => {
+    expect(skillRetrievalQuery([
+      userMessage("previous request"),
+      {
+        chatId: 1,
+        sequence: 2,
+        timestamp: new Date(1),
+        author: {type: "user", id: "user", name: "User"},
+        type: "slashCommand",
+        request: {commandId: "compact", args: "", selection: {builtin: true, commandId: "compact"}},
+      },
+    ])).toBeUndefined();
+  });
+});
+
+describe("semanticSkillRetrievalEnabled", () => {
+  it("requires the exact opt-in value", () => {
+    expect(semanticSkillRetrievalEnabled(undefined)).toBe(false);
+    expect(semanticSkillRetrievalEnabled("false")).toBe(false);
+    expect(semanticSkillRetrievalEnabled("True")).toBe(false);
+    expect(semanticSkillRetrievalEnabled("true")).toBe(true);
+  });
+});
+
+describe("retrieveContextSkillsForPrompt", () => {
+  it("leaves the catalog untouched and never calls AI when disabled", async () => {
+    let original = catalog();
+    let ranker = vi.fn(async () => [0]);
+    let result = await retrieveContextSkillsForPrompt(
+      undefined, "context", original, [userMessage("prepare a briefing")], ranker);
+
+    expect(result).toEqual({catalog: original});
+    expect(ranker).not.toHaveBeenCalled();
+  });
+
+  it("leaves non-Context and slash-command catalogs untouched", async () => {
+    let original = catalog();
+    let ranker = vi.fn(async () => [0]);
+
+    await expect(retrieveContextSkillsForPrompt(
+      "true", "scheduler", original, [userMessage("prepare a briefing")], ranker))
+        .resolves.toEqual({catalog: original});
+    await expect(retrieveContextSkillsForPrompt(
+      "true", "context", original, [userMessage("/briefing", true)], ranker))
+        .resolves.toEqual({catalog: original});
+    expect(ranker).not.toHaveBeenCalled();
+  });
+
+  it("retrieves from the supplied authorized Context catalog when enabled", async () => {
+    let original = catalog();
+    original.entries.push(...Array.from({length: 6}, (_, index) => ({
+      id: `collection/skills/extra-${index}/SKILL.md`,
+      title: `extra-${index}`,
+      description: `${SKILL_PREFIX}Handle specialist workflow ${index}.`,
+    })));
+    let ranker = vi.fn(async (_query: string, entries: unknown[]) =>
+      entries.map((_, index) => index));
+    let result = await retrieveContextSkillsForPrompt(
+      "true", "context", original, [userMessage("what should I do next")],
+      ranker);
+
+    expect(result.retrieval?.strategy).toBe("hybrid");
+    expect(result.catalog?.entries).toHaveLength(9);
+    expect(ranker).toHaveBeenCalledOnce();
+  });
+});
+
+describe("retrieveSkillCatalog", () => {
+  it("preserves collection entries and combines lexical and semantic ranks", async () => {
+    let ranker = vi.fn(async () => [0, 2, 1, 3]);
+    let result = await retrieveSkillCatalog(catalog(), "what should I do next", ranker, 2);
+
+    expect(result.strategy).toBe("hybrid");
+    expect(result.catalog.entries.map(entry => entry.title)).toEqual([
+      "Cloudflare", "account-plan", "briefing",
+    ]);
+    expect(result.catalog.truncated).toBe(true);
+    expect(ranker).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an explicitly named skill ahead of conflicting semantic ranks", async () => {
+    let ranker = vi.fn(async () => [1, 2, 3, 0]);
+    let result = await retrieveSkillCatalog(
+      catalog(), "use account-plan", ranker, 1);
+
+    expect(result.catalog.entries.map(entry => entry.title)).toEqual([
+      "Cloudflare", "account-plan",
+    ]);
+    expect(ranker).not.toHaveBeenCalled();
+  });
+
+  it("uses lexical results when semantic ranking fails", async () => {
+    let failure = new Error("AI unavailable");
+    let result = await retrieveSkillCatalog(
+      catalog(), "competitive positioning against vendor", async () => { throw failure; }, 2);
+
+    expect(result.strategy).toBe("lexical");
+    expect(result.semanticFailure).toBe("provider_error");
+    expect(result.catalog.entries.map(entry => entry.title)).toEqual([
+      "Cloudflare", "battlecard",
+    ]);
+  });
+
+  it("returns the unchanged full catalog when semantic and lexical retrieval fail", async () => {
+    let original = catalog();
+    let result = await retrieveSkillCatalog(
+      original, "unrelated vocabulary", async () => { throw new Error("AI unavailable"); }, 2);
+
+    expect(result.strategy).toBe("full");
+    expect(result.catalog).toBe(original);
+  });
+
+  it("does not treat generated catalog instructions as lexical relevance", async () => {
+    let original = catalog();
+    let result = await retrieveSkillCatalog(
+      original, "read the agent skill document", async () => { throw new Error("AI unavailable"); }, 2);
+
+    expect(result.strategy).toBe("full");
+    expect(result.catalog).toBe(original);
+  });
+
+  it("reports bounded semantic failure categories without returning provider errors", async () => {
+    let result = await retrieveSkillCatalog(
+      catalog(), "unrelated vocabulary", async () => {
+        throw new DOMException("request included private prompt text", "TimeoutError");
+      }, 2);
+
+    expect(result.semanticFailure).toBe("timeout");
+    expect(result).not.toHaveProperty("semanticError");
+  });
+
+  it("does not rank catalogs already within the result limit", async () => {
+    let original = catalog();
+    let ranker = vi.fn(async () => [0]);
+    let result = await retrieveSkillCatalog(original, "account", ranker, 10);
+
+    expect(result.catalog).toBe(original);
+    expect(ranker).not.toHaveBeenCalled();
+  });
+});
+
+describe("rankSkillsWithWorkersAi", () => {
+  it("sorts a complete valid response by score", async () => {
+    let ai = {
+      run: vi.fn(async () => ({
+        response: [
+          {id: 2, score: 0.9}, {id: 1, score: 0.2},
+          {id: 3, score: 0.1}, {id: 0, score: 0.8},
+        ],
+      })),
+    } as unknown as Ai;
+    let entries = catalog().entries.slice(1);
+
+    await expect(rankSkillsWithWorkersAi(ai, "meeting prep", entries))
+        .resolves.toEqual([2, 0, 1, 3]);
+    expect(ai.run).toHaveBeenCalledWith("@cf/baai/bge-m3", {
+      query: "meeting prep",
+      contexts: entries.map(entry => ({
+        text: `${entry.title.replaceAll("-", " ")}. ` + entry.description.slice(SKILL_PREFIX.length),
+      })),
+      truncate_inputs: true,
+    }, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("rejects malformed or incomplete rankings", async () => {
+    let entries = catalog().entries.slice(1);
+    let ai = {
+      run: vi.fn(async () => ({response: [{id: 0, score: 1}]})),
+    } as unknown as Ai;
+
+    await expect(rankSkillsWithWorkersAi(ai, "meeting prep", entries))
+        .rejects.toThrow("incomplete skill ranking");
+  });
+});

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -148,6 +148,9 @@ export type SeedBindingInfo = {
    * when the gatekeeper provides none). Such entries get their own system-prompt section.
    */
   catalog?: AgentCatalog | null;
+
+  /** True when the catalog depends on the current turn and cannot reuse prior token measurements. */
+  dynamicCatalog?: boolean;
 };
 
 /**
@@ -2214,7 +2217,9 @@ export async function runAgent(
   // `measuredTokens` covers the prompt and response of the last model step, so estimate only what
   // was added after it. A tool result carries the call's sequence but wasn't in that usage.
   // (The system prompt is not part of the projection, so the pure estimate adds it separately.)
-  let contextTokens = compaction.measuredTokens > 0 && lastMeasuredSequence !== undefined
+  let dynamicCatalog = seedBindings.some(seed => seed.dynamicCatalog === true);
+  let contextTokens = !dynamicCatalog && compaction.measuredTokens > 0 &&
+      lastMeasuredSequence !== undefined
     ? compaction.measuredTokens + estimateProjectionTokens(
         projection.filter(({message, sequence}) => sequence !== undefined &&
           (sequence > lastMeasuredSequence ||

--- a/packages/workshop-backend/src/env.d.ts
+++ b/packages/workshop-backend/src/env.d.ts
@@ -13,6 +13,10 @@ declare global {
       // Workers AI binding (injected by generate-wrangler-prod / run-dev-server; not in base wrangler.jsonc).
       WORKERS_AI: Ai;
 
+      // Experimental prompt-time semantic ranking for authorized Context skill catalog entries.
+      // Disabled unless explicitly set to "true" by a deployment.
+      ENABLE_SEMANTIC_SKILL_RETRIEVAL?: string;
+
       // AI Gateway mode: when CF_AI_GATEWAY is set, supported providers are routed through
       // Cloudflare AI Gateway with server-managed keys. Users don't need their own keys.
       CF_AI_GATEWAY?: string;            // Gateway name (enables gateway mode)

--- a/packages/workshop-backend/src/observability.ts
+++ b/packages/workshop-backend/src/observability.ts
@@ -8,12 +8,14 @@ export type WorkshopObservabilityFields = {
   autoProvisioned: boolean;
   blueprintId: string;
   callbackInitiated: boolean;
+  candidateCount: number;
   chatId: number;
   commitCount: number;
   durableObjectId: string;
   durationMs: number;
   eventName: string;
   executionId: string;
+  failureType: "invalid_response" | "provider_error" | "timeout";
   failureCount: number;
   gadgetId: string;
   gatekeeperId: number | string;
@@ -24,7 +26,9 @@ export type WorkshopObservabilityFields = {
   outcome: "ok" | "error" | "usage_limit" | "callbacks_stalled" | "no_email" | "signups_disabled";
   path: string;
   resourceTitle: string;
+  retrievalStrategy: "full" | "hybrid" | "lexical";
   sequence: number;
+  selectedCount: number;
   size: number;
   status: number;
   statusCode: number;

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -41,6 +41,9 @@ import { reportIssue } from "@gadgets/backend-utils/error-reporting";
 import type { ProductAnalyticsConnectionType, ProductAnalyticsGadgetInput } from "./analytics";
 import { checkUsageAndBalance } from "./ai-gateway-billing/limits/usage-checker";
 import { completeAgentCatalogSnapshot, normalizeAgentCatalog } from "./agent-catalog";
+import {
+  rankSkillsWithWorkersAi, retrieveContextSkillsForPrompt,
+} from "./skill-retrieval";
 import { refreshCachedBalance } from "./ai-gateway-billing/cloudflare/connection-service";
 import { SharingManager, SharingCaller, CollaboratorRecord, ShareKeyRecord } from "./sharing";
 import { AutoApprovalDrainer } from "./auto-approval";
@@ -6659,7 +6662,35 @@ class OverseerImpl implements AgentHooks {
       if (!gk) continue;
       let info: SeedBindingInfo =
           {name, target, title: gk.resourceTitle || "(untitled resource)", isGadget: false};
-      if (ambientSet.has(target)) info.catalog = catalogs.get(target) ?? null;
+      if (ambientSet.has(target)) {
+        let catalog = catalogs.get(target) ?? null;
+        let started = Date.now();
+        let promptCatalog = await retrieveContextSkillsForPrompt(
+            this.env.ENABLE_SEMANTIC_SKILL_RETRIEVAL,
+            gk.creationSpec?.type === "ambient" ? gk.creationSpec.vendorId : undefined,
+            catalog,
+            chatMessages,
+            (query, entries) => rankSkillsWithWorkersAi(this.env.WORKERS_AI, query, entries));
+        if (promptCatalog.retrieval) {
+          let retrieval = promptCatalog.retrieval;
+          if (retrieval.semanticFailure) {
+            this.logger.warn("semantic skill ranking failed", {
+              event: "agent.skill.retrieval.semantic.failed",
+              failureType: retrieval.semanticFailure,
+            });
+          }
+          this.logger.info("ranked agent skills for prompt", {
+            event: "agent.skill.retrieval.completed",
+            retrievalStrategy: retrieval.strategy,
+            candidateCount: retrieval.skillCount,
+            selectedCount: retrieval.selectedSkillCount,
+            durationMs: Date.now() - started,
+          });
+          catalog = promptCatalog.catalog;
+          info.dynamicCatalog = true;
+        }
+        info.catalog = catalog;
+      }
       result.push(info);
     }
     return result;

--- a/packages/workshop-backend/src/skill-retrieval.ts
+++ b/packages/workshop-backend/src/skill-retrieval.ts
@@ -1,0 +1,293 @@
+import type {AiChatMessage} from "@gadgets/workshop-shared/api";
+import type {AgentCatalog, AgentCatalogEntry} from "@gadgets/workshop-shared/gatekeeper";
+
+const AGENT_SKILL_DESCRIPTION_PREFIX = "Agent Skill.";
+const AGENT_SKILL_INSTRUCTION_END = "console.log(document.content). ";
+const AGENT_SKILL_PATH_SUFFIX = "/SKILL.md";
+const DEFAULT_SKILL_RESULT_LIMIT = 8;
+const MAX_RETRIEVAL_QUERY_LENGTH = 4000;
+const RRF_RANK_OFFSET = 60;
+const SEMANTIC_RANKING_TIMEOUT_MS = 3000;
+const LEXICAL_STOP_WORDS = new Set([
+  "and", "are", "for", "from", "into", "the", "this", "that", "with", "you", "your",
+]);
+
+export type SkillRetrievalStrategy = "full" | "hybrid" | "lexical";
+export type SemanticFailure = "invalid_response" | "provider_error" | "timeout";
+
+export type SkillCatalogRetrievalResult = {
+  catalog: AgentCatalog;
+  strategy: SkillRetrievalStrategy;
+  skillCount: number;
+  selectedSkillCount: number;
+  semanticFailure?: SemanticFailure;
+};
+
+export type PromptSkillRetrievalResult = {
+  catalog: AgentCatalog | null;
+  retrieval?: SkillCatalogRetrievalResult;
+};
+
+type SemanticRanker = (
+  query: string,
+  entries: AgentCatalogEntry[],
+) => Promise<number[]>;
+
+class InvalidSemanticRankingError extends Error {}
+
+function isAgentSkill(entry: AgentCatalogEntry): boolean {
+  return entry.id.endsWith(AGENT_SKILL_PATH_SUFFIX) &&
+    entry.description.startsWith(AGENT_SKILL_DESCRIPTION_PREFIX);
+}
+
+function normalizeWords(text: string): string[] {
+  return text.toLowerCase().split(/[^a-z0-9]+/)
+      .filter(word => word.length > 1 && !LEXICAL_STOP_WORDS.has(word));
+}
+
+function skillPurpose(entry: AgentCatalogEntry): string {
+  let instructionEnd = entry.description.indexOf(AGENT_SKILL_INSTRUCTION_END);
+  return instructionEnd < 0
+    ? entry.description.slice(AGENT_SKILL_DESCRIPTION_PREFIX.length).trim()
+    : entry.description.slice(instructionEnd + AGENT_SKILL_INSTRUCTION_END.length);
+}
+
+function isExactMention(entry: AgentCatalogEntry, query: string): boolean {
+  let title = normalizeWords(entry.title).join(" ");
+  let normalizedQuery = normalizeWords(query).join(" ");
+  return Boolean(title && ` ${normalizedQuery} `.includes(` ${title} `));
+}
+
+function lexicalScore(entry: AgentCatalogEntry, query: string, queryWords: Set<string>): number {
+  let descriptionWords = new Set(normalizeWords(skillPurpose(entry)));
+  let score = isExactMention(entry, query) ? 100 : 0;
+  let titleWords = new Set(normalizeWords(entry.title));
+  for (let word of queryWords) {
+    if (titleWords.has(word)) {
+      score += 10;
+    } else if (descriptionWords.has(word)) {
+      score += 1;
+    }
+  }
+  return score;
+}
+
+function uniqueIndices(...rankings: number[][]): number[] {
+  let seen = new Set<number>();
+  return rankings.flat().filter(index => {
+    if (seen.has(index)) return false;
+    seen.add(index);
+    return true;
+  });
+}
+
+function semanticFailure(error: unknown): SemanticFailure {
+  if (error instanceof InvalidSemanticRankingError) return "invalid_response";
+  if (error instanceof Error && ["AbortError", "TimeoutError"].includes(error.name)) {
+    return "timeout";
+  }
+  return "provider_error";
+}
+
+function rankLexically(entries: AgentCatalogEntry[], query: string): number[] {
+  let queryWords = new Set(normalizeWords(query));
+  return entries
+      .map((entry, index) => ({index, score: lexicalScore(entry, query, queryWords)}))
+      .filter(result => result.score > 0)
+      .toSorted((left, right) => right.score - left.score || left.index - right.index)
+      .map(result => result.index);
+}
+
+function reciprocalRankFusion(rankings: Array<{indices: number[], weight: number}>): number[] {
+  let scores = new Map<number, number>();
+  for (let {indices, weight} of rankings) {
+    for (let rank = 0; rank < indices.length; rank++) {
+      let index = indices[rank];
+      scores.set(index, (scores.get(index) ?? 0) + weight / (RRF_RANK_OFFSET + rank + 1));
+    }
+  }
+  return [...scores]
+      .toSorted(([leftIndex, leftScore], [rightIndex, rightScore]) =>
+        rightScore - leftScore || leftIndex - rightIndex)
+      .map(([index]) => index);
+}
+
+function filteredCatalog(
+    catalog: AgentCatalog,
+    collectionEntries: AgentCatalogEntry[],
+    skillEntries: AgentCatalogEntry[],
+    rankedIndices: number[],
+    limit: number): AgentCatalog {
+  let selected = rankedIndices.slice(0, limit).map(index => skillEntries[index]);
+  return {
+    entries: [...collectionEntries, ...selected],
+    ...(catalog.truncated || selected.length < skillEntries.length ? {truncated: true} : {}),
+  };
+}
+
+/**
+ * Return the latest direct user request for skill retrieval. Slash-command expansions already
+ * selected and loaded an exact skill, so reranking their generated message would be redundant.
+ */
+export function skillRetrievalQuery(messages: AiChatMessage[]): string | undefined {
+  for (let message of messages.toReversed()) {
+    if (message.author.type !== "user") continue;
+    if (message.type !== "message") return undefined;
+    if (message.generatedBySlashCommandSequence !== undefined) return undefined;
+    let query = message.message.trim();
+    return query ? query.slice(0, MAX_RETRIEVAL_QUERY_LENGTH) : undefined;
+  }
+  return undefined;
+}
+
+/** Whether a deployment explicitly enabled the experimental retrieval path. */
+export function semanticSkillRetrievalEnabled(value: string | undefined): boolean {
+  return value === "true";
+}
+
+/** Apply the pilot only to direct user turns against the authorized Context catalog. */
+export async function retrieveContextSkillsForPrompt(
+    enabled: string | undefined,
+    vendorId: string | undefined,
+    catalog: AgentCatalog | null,
+    messages: AiChatMessage[],
+    semanticRanker: SemanticRanker): Promise<PromptSkillRetrievalResult> {
+  if (!semanticSkillRetrievalEnabled(enabled) || vendorId?.toLowerCase() !== "context" || !catalog) {
+    return {catalog};
+  }
+  let query = skillRetrievalQuery(messages);
+  if (!query) return {catalog};
+  let retrieval = await retrieveSkillCatalog(catalog, query, semanticRanker);
+  return {catalog: retrieval.catalog, retrieval};
+}
+
+/**
+ * Reduce an authorized Context catalog to the skills most relevant to this turn. The caller owns
+ * authorization; this function only ranks entries it was given and never resolves additional IDs.
+ */
+export async function retrieveSkillCatalog(
+    catalog: AgentCatalog,
+    query: string,
+    semanticRanker: SemanticRanker,
+    limit = DEFAULT_SKILL_RESULT_LIMIT): Promise<SkillCatalogRetrievalResult> {
+  let collectionEntries = catalog.entries.filter(entry => !isAgentSkill(entry));
+  let skillEntries = catalog.entries.filter(isAgentSkill);
+  if (skillEntries.length <= limit) {
+    return {
+      catalog,
+      strategy: "full",
+      skillCount: skillEntries.length,
+      selectedSkillCount: skillEntries.length,
+    };
+  }
+
+  let lexical = rankLexically(skillEntries, query);
+  let exact = skillEntries
+      .map((entry, index) => ({entry, index}))
+      .filter(({entry}) => isExactMention(entry, query))
+      .map(({index}) => index);
+  if (exact.length > 0) {
+    let ranked = uniqueIndices(exact, lexical);
+    let reduced = filteredCatalog(catalog, collectionEntries, skillEntries, ranked, limit);
+    return {
+      catalog: reduced,
+      strategy: "lexical",
+      skillCount: skillEntries.length,
+      selectedSkillCount: reduced.entries.length - collectionEntries.length,
+    };
+  }
+  try {
+    let semantic = await semanticRanker(query, skillEntries);
+    if (semantic.length === 0 && lexical.length > 0) {
+      let reduced = filteredCatalog(
+        catalog, collectionEntries, skillEntries, lexical, limit);
+      return {
+        catalog: reduced,
+        strategy: "lexical",
+        skillCount: skillEntries.length,
+        selectedSkillCount: reduced.entries.length - collectionEntries.length,
+      };
+    }
+    let fused = reciprocalRankFusion([
+      {indices: lexical, weight: 1},
+      {indices: semantic, weight: 2},
+    ]);
+    let exactSet = new Set(exact);
+    let ranked = [...exact, ...fused.filter(index => !exactSet.has(index))];
+    if (ranked.length > 0) {
+      let reduced = filteredCatalog(
+        catalog, collectionEntries, skillEntries, ranked, limit);
+      return {
+        catalog: reduced,
+        strategy: "hybrid",
+        skillCount: skillEntries.length,
+        selectedSkillCount: reduced.entries.length - collectionEntries.length,
+      };
+    }
+  } catch (error) {
+    if (lexical.length > 0) {
+      let reduced = filteredCatalog(
+        catalog, collectionEntries, skillEntries, lexical, limit);
+      return {
+        catalog: reduced,
+        strategy: "lexical",
+        skillCount: skillEntries.length,
+        selectedSkillCount: reduced.entries.length - collectionEntries.length,
+        semanticFailure: semanticFailure(error),
+      };
+    }
+    return {
+      catalog,
+      strategy: "full",
+      skillCount: skillEntries.length,
+      selectedSkillCount: skillEntries.length,
+      semanticFailure: semanticFailure(error),
+    };
+  }
+
+  return {
+    catalog,
+    strategy: "full",
+    skillCount: skillEntries.length,
+    selectedSkillCount: skillEntries.length,
+  };
+}
+
+/** Rank catalog entries with Workers AI's query/context semantic scorer. */
+export async function rankSkillsWithWorkersAi(
+    ai: Ai,
+    query: string,
+    entries: AgentCatalogEntry[]): Promise<number[]> {
+  let result = await ai.run("@cf/baai/bge-m3", {
+    query,
+    contexts: entries.map(entry => ({
+      text: `${entry.title.replaceAll("-", " ")}. ${skillPurpose(entry)}`,
+    })),
+    truncate_inputs: true,
+  }, {
+    signal: AbortSignal.timeout(SEMANTIC_RANKING_TIMEOUT_MS),
+  });
+  if (!("response" in result) || !Array.isArray(result.response)) {
+    throw new InvalidSemanticRankingError("Workers AI returned no semantic skill ranking.");
+  }
+
+  let seen = new Set<number>();
+  let ranked = result.response.map(item => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new InvalidSemanticRankingError("Workers AI returned a malformed skill ranking.");
+    }
+    let id = item.id;
+    if (!Number.isInteger(id) || id! < 0 || id! >= entries.length || seen.has(id!) ||
+        !Number.isFinite(item.score)) {
+      throw new InvalidSemanticRankingError("Workers AI returned a malformed skill ranking.");
+    }
+    seen.add(id!);
+    return {id: id!, score: item.score!};
+  });
+  if (ranked.length !== entries.length) {
+    throw new InvalidSemanticRankingError("Workers AI returned an incomplete skill ranking.");
+  }
+  return ranked
+      .toSorted((left, right) => right.score - left.score || left.id - right.id)
+      .map(item => item.id);
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This is a non-trivial experimental feature and likely falls outside the normal contribution policy. 
It supports a preview only. This draft is not requesting review or merge.

## What does this change?

This adds a default-off experiment for reducing the Agent Skill catalog included in the agent prompt.

When `ENABLE_SEMANTIC_SKILL_RETRIEVAL` is exactly `true`, the Workshop:

- Operates only on the Context catalog already returned through the existing authorization path.
- Preserves collection entries.
- Bypasses inference for explicitly named skills.
- Bypasses retrieval for generated and built-in slash-command turns.
- Sends the latest direct user request and authorized skill titles/descriptions to Cloudflare Workers AI BGE-M3.
- Combines semantic and whole-token lexical rankings, returning up to eight skills.
- Applies a three-second inference timeout.
- Falls back to lexical results or the unchanged full authorized catalog.
- Continues loading selected skills through the existing exact, authorized `read(id)` path.
- Recalculates prompt size when query-specific catalog contents are used.
- Emits bounded strategy, candidate-count, selection-count, duration, and failure-category telemetry without logging prompts or provider errors.

The feature is absent from the default configuration. A separate wrapper change enables it only for a preview.

This pilot evaluates the current catalog visible through the existing 150-skill cap. It does not implement the future architecture needed to retrieve across skills excluded by that cap.

## Why is this obviously correct and trivially verifiable?

It is not a small, obviously correct, trivially verifiable change. It alters prompt construction and adds an inference dependency, ranking behavior, fallbacks, and telemetry.

The implementation is deliberately default-off and isolated for a preview so its selection quality, latency, prompt-token impact, and fallback behavior can be measured before any production proposal.

If maintainers prefer that an experiment of this scope begin as a Discussion or issue, please say so or close this draft. I will move the proposal there rather than request review or merge.

## Testing

- Workshop backend unit suite: 37 files, 533 tests passed.
- Workshop backend integration suite: 3 passed, 4 skipped.
- Focused catalog and retrieval suite: 26 tests passed.
- Workshop backend build and TypeScript checks passed.
- Repository lint completed with zero errors; existing warnings remain.
- Three independent review passes and a fourth adjudication pass were completed. Findings covering timeout behavior, exact-match bypass, lexical boilerplate, malformed model output, slash commands, token estimation, telemetry safety, and preview-only gating were addressed.

## Known pilot caveats

- Query-specific catalog contents reduce system-prompt cache stability.
- Preview participants’ latest direct request and authorized skill metadata are processed by Cloudflare Workers AI.
- Retrieval currently operates after the existing Context catalog cap, so it cannot recover skills omitted beyond 150.
- Production-quality retrieval beyond 150 should occur inside the Context authorization boundary before catalog truncation.

## Checklist

- [ ] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [ ] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->