### PR TITLE
Usability - LLAMA: Allow context window and output limit to be set per model

### DIFF
--- a/packages/workshop-backend/__tests__/ai-models.test.ts
+++ b/packages/workshop-backend/__tests__/ai-models.test.ts
@@ -461,6 +461,56 @@ describe("getModel direct routing (no gateway)", () => {
     expect(handle.model.baseUrl).toBe("http://my-ollama:11434/v1");
   });
 
+  it("falls back to default token limits for an uncatalogued Ollama model", () => {
+    // The ollama provider has no pi catalog and no SUGGESTED_MODELS row, so an unconfigured
+    // self-hosted model lands on the generic defaults -- which is exactly why the overrides
+    // below exist.
+    const handle = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "ollama",
+      model: "some-self-hosted-model",
+      apiToken: "",
+      apiUrl: "http://my-ollama:11434",
+    }, INITIATOR);
+
+    expect(handle.model.contextWindow).toBe(128_000);
+    expect(handle.model.maxTokens).toBe(4096);
+  });
+
+  it("honors explicit contextWindow and maxTokens overrides", () => {
+    const handle = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "ollama",
+      model: "some-self-hosted-model",
+      apiToken: "",
+      apiUrl: "http://my-ollama:11434",
+      contextWindow: 262144,
+      maxTokens: 32768,
+    }, INITIATOR);
+
+    expect(handle.model.contextWindow).toBe(262144);
+    expect(handle.model.maxTokens).toBe(32768);
+  });
+
+  it("lets an override win over a catalogued model's own limits", () => {
+    // The override is not ollama-specific: a proxy in front of a known provider may impose
+    // limits that differ from the catalog, and the user's value must take precedence.
+    const catalogued = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      apiToken: "token",
+    }, INITIATOR);
+    const overridden = getModel(env({ CF_AI_GATEWAY: undefined }), {
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      apiToken: "token",
+      contextWindow: 12345,
+      maxTokens: 678,
+    }, INITIATOR);
+
+    expect(overridden.model.contextWindow).toBe(12345);
+    expect(overridden.model.maxTokens).toBe(678);
+    expect(catalogued.model.contextWindow).not.toBe(12345);
+  });
+
   it("sends no Authorization header for an Ollama config without an API key", async () => {
     // An empty token means local auth: a strict local proxy may reject an unexpected bearer
     // token, so no Authorization header is sent at all (matching the pre-pi provider).

--- a/packages/workshop-backend/src/ai-models.ts
+++ b/packages/workshop-backend/src/ai-models.ts
@@ -144,9 +144,14 @@ function catalogModel(provider: AiModelConfig["provider"], modelId: string): Mod
 function modelTokenWindow(config: AiModelConfig, catalog: Model<Api> | undefined)
     : { contextWindow: number, maxTokens: number } {
   const suggested = SUGGESTED_MODELS[config.provider]?.[config.model];
+  // An explicit per-model override wins over every inferred source. Self-hosted models reached
+  // through the ollama provider have no catalog entry and no SUGGESTED_MODELS row, so without
+  // this they always land on the defaults below regardless of what the server really serves.
   return {
-    contextWindow: suggested?.contextWindow ?? catalog?.contextWindow ?? 128_000,
-    maxTokens: suggested?.outputLimit ??
+    contextWindow: config.contextWindow ??
+        suggested?.contextWindow ?? catalog?.contextWindow ?? 128_000,
+    maxTokens: config.maxTokens ??
+        suggested?.outputLimit ??
         (config.provider === "cloudflare" ? WORKERS_AI_OUTPUT_LIMIT : undefined) ??
         catalog?.maxTokens ?? 4096,
   };

--- a/packages/workshop-frontend/src/AddModelModal.tsx
+++ b/packages/workshop-frontend/src/AddModelModal.tsx
@@ -102,6 +102,8 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
   const [apiToken, setApiToken] = useState('')
   const [accountId, setAccountId] = useState('')
   const [apiUrl, setApiUrl] = useState('')
+  const [contextWindow, setContextWindow] = useState('')
+  const [maxTokens, setMaxTokens] = useState('')
 
   // Validation errors
   const [errors, setErrors] = useState<Record<string, string>>({})
@@ -124,6 +126,8 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
       setApiToken('')
       setAccountId('')
       setApiUrl('')
+      setContextWindow('')
+      setMaxTokens('')
       setErrors({})
       setAdvancedOpen(false)
     }
@@ -175,6 +179,16 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
       newErrors.apiUrl = 'Please enter the Ollama API URL'
     }
 
+    // Both overrides are optional, but a supplied value must be a positive integer -- a bad
+    // value here would otherwise surface much later as a confusing provider-side rejection.
+    for (const [field, raw] of [['contextWindow', contextWindow], ['maxTokens', maxTokens]] as const) {
+      if (!raw.trim()) continue
+      const parsed = Number(raw)
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        newErrors[field] = 'Please enter a positive whole number of tokens'
+      }
+    }
+
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
@@ -200,6 +214,8 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
         apiToken: gatewayMode ? '' : apiToken.trim(),
         ...(!gatewayMode && accountId.trim() && { accountId: accountId.trim() }),
         ...(!gatewayMode && apiUrl.trim() && { apiUrl: apiUrl.trim() }),
+        ...(contextWindow.trim() && { contextWindow: Number(contextWindow) }),
+        ...(maxTokens.trim() && { maxTokens: Number(maxTokens) }),
       }
 
       await authenticatedApi.addModel(profile, config)
@@ -340,19 +356,46 @@ export default function AddModelModal({ visible, onCancel, onSuccess, authentica
           )}
 
           {/* Advanced Settings for non-Ollama, non-Cloudflare providers */}
-          {showCredentials && selection && !isOllama && !isCloudflare && (
+          {showCredentials && selection && (
             <Collapsible.Root
               open={advancedOpen}
               onOpenChange={setAdvancedOpen}
             >
               <Collapsible.DefaultTrigger>Advanced Settings</Collapsible.DefaultTrigger>
               <Collapsible.DefaultPanel>
+                {!isOllama && !isCloudflare && (
+                  <Input
+                    label="API URL"
+                    placeholder="https://..."
+                    description="Override the default API endpoint (useful for proxies like Cloudflare AI Gateway)"
+                    value={apiUrl}
+                    onChange={(e) => setApiUrl(e.target.value)}
+                  />
+                )}
                 <Input
-                  label="API URL"
-                  placeholder="https://..."
-                  description="Override the default API endpoint (useful for proxies like Cloudflare AI Gateway)"
-                  value={apiUrl}
-                  onChange={(e) => setApiUrl(e.target.value)}
+                  label="Context Window"
+                  placeholder="e.g., 262144"
+                  description={
+                    'Tokens of context the model supports. Leave blank to infer it. Self-hosted ' +
+                    'models have no catalog entry, so inference falls back to a conservative ' +
+                    'default that rarely matches the server -- set it to what your server serves.'
+                  }
+                  value={contextWindow}
+                  onChange={(e) => { setContextWindow(e.target.value); setErrors(prev => ({ ...prev, contextWindow: '' })) }}
+                  error={errors.contextWindow}
+                  variant={errors.contextWindow ? 'error' : 'default'}
+                />
+                <Input
+                  label="Max Output Tokens"
+                  placeholder="e.g., 32768"
+                  description={
+                    'Most tokens the model may emit per response. Leave blank to infer it. ' +
+                    'Reasoning models need a high limit, because thinking tokens count towards it.'
+                  }
+                  value={maxTokens}
+                  onChange={(e) => { setMaxTokens(e.target.value); setErrors(prev => ({ ...prev, maxTokens: '' })) }}
+                  error={errors.maxTokens}
+                  variant={errors.maxTokens ? 'error' : 'default'}
                 />
               </Collapsible.DefaultPanel>
             </Collapsible.Root>

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -1170,6 +1170,22 @@ export type AiModelConfig = {
    * alternative provider that provides a compatible API.
    */
   apiUrl?: string;
+
+  /**
+   * Context window, in tokens. Optional override for self-hosted models, which have no catalog
+   * entry: without it such models fall back to a conservative default that rarely matches what
+   * the server actually serves. Compaction budgets are computed from this, so a value larger
+   * than the server's real window causes requests to be rejected once history grows, while a
+   * smaller one silently wastes the window.
+   */
+  contextWindow?: number;
+
+  /**
+   * Maximum output tokens per response. Optional override, for the same reason as
+   * `contextWindow`. Reasoning models in particular need far more than the default, since
+   * thinking tokens count against this limit.
+   */
+  maxTokens?: number;
 };
 
 /**


### PR DESCRIPTION
## What does this change?

Self-hosted models reached through the `ollama` provider have no pi catalog entry (`catalogModel` returns undefined for it) and no `SUGGESTED_MODELS` row, so `modelTokenWindow` always falls through to its generic defaults of 128k context and 4096 output tokens regardless of what the server actually serves. The Add Model dialog offers no way to correct this, so the values are unreachable for exactly the models that need them most.



## Why is this obviously correct and trivially verifiable?

Both fields are optional and blank means "infer as before", so existing configurations are unaffected. A supplied value is validated as a positive integer at submit time, since a bad one would otherwise surface much later as a provider-side rejection.

Tests cover the fallback, the override, and an override winning over a catalogued model's own limits. Note that I could not execute the suite in my environment: `vitest run` fails at import for every workshop-backend test file, including on a pristine checkout, so the failure is unrelated to this change. The three affected packages typecheck.


## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [X] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [X] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [X] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->