### PR TITLE
Export mock-model from integration-tests

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./harness": "./src/harness.ts",
+    "./mock-model": "./src/mock-model.ts",
     "./network-interceptor": "./src/network-interceptor.ts",
     "./rpc-client": "./src/rpc-client.ts"
   },


### PR DESCRIPTION
`src/mock-model.ts` arrived with #354 but was not added to `packages/integration-tests/package.json`'s `exports` map, so `@gadgets/integration-tests/mock-model` does not resolve — while `./harness`, `./network-interceptor` and `./rpc-client` all do.

The package README describes the toolkit as *"consumed both by the tests here and by per-vendor suites in repos that vendor this one as a submodule"*. Such a suite can reach the harness and the interceptor by specifier, but has to reach into `src/` by relative path for the scripted model — the piece that makes an agent test deterministic.

One line, no behaviour change. The tests in this package import the module by relative path already, so nothing here depends on the new entry point; it just makes the module reachable the same way its siblings are.

Per CONTRIBUTING, keeping this to the single missing line rather than bundling anything else.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->