### PR TITLE
Make release manifest shortNames legal install slugs

### DIFF
--- a/scripts/release/manifest-lib.test.ts
+++ b/scripts/release/manifest-lib.test.ts
@@ -178,6 +178,12 @@ test("worker entries carry the deploy contract", () => {
     }
   }
 
+  // The MCP connectors are install-once for SINGLETON's second reason: they take no inputs, so a
+  // second install could not differ from the first — it would only mint a second vendor id.
+  assert.equal(workers["gatekeeper-mcp"].singleton, true);
+  assert.equal(workers["gatekeeper-mcp-portal"].singleton, true);
+  assert.equal(workers["gatekeeper-homeassistant"].singleton, true);
+
   // Module blobs are content-addressed.
   for (const [name, entry] of Object.entries(workers)) {
     assert.ok(entry.modules.some((m) => m.name === entry.mainModule),
@@ -211,6 +217,22 @@ test("every gatekeeper shortName is a legal deploy slug", () => {
         `${name}: shortName ${entry.shortName} exceeds ${MAX_SLUG_LEN} chars`);
     assert.equal(entry.vars.BASE_URL, `$PUBLIC_BASE_URL/gatekeeper/${entry.shortName}`,
         `${name}: BASE_URL path must match shortName`);
+  }
+});
+
+// SINGLETON's second reason, as an invariant rather than a list: an installable gatekeeper that
+// collects nothing from the wizard is configured identically on every install, so a second one
+// adds no capability while splitting the vendor id its connections are recorded under
+// (GATEKEEPER_<SLUG> -> `mcp2`). A new zero-input gatekeeper that genuinely wants two installs is
+// a deliberate decision — make it here and in SINGLETON, not by accident.
+test("installable gatekeepers that take no inputs are install-once", () => {
+  for (const [name, entry] of Object.entries(buildTestManifest().workers)) {
+    if (entry.kind !== "gatekeeper" || !entry.installable) continue;
+    if ((entry.inputs ?? []).length > 0) continue;
+    assert.equal(entry.singleton, true,
+        `${name}: takes no deploy inputs, so a second install would be identical to the first ` +
+        `except for its slug — add it to SINGLETON, or give it an input that distinguishes ` +
+        `installs`);
   }
 });
 

--- a/scripts/release/manifest-lib.test.ts
+++ b/scripts/release/manifest-lib.test.ts
@@ -13,7 +13,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { collectAssets, collectModules, stableStringify } from "./hash-lib.ts";
 import {
-  generateManifest, readDeployablePackages, readDeployInputs,
+  generateManifest, readDeployablePackages, readDeployInputs, releaseShortName,
 } from "./manifest-lib.ts";
 
 const RELEASE = dirname(fileURLToPath(import.meta.url));
@@ -25,8 +25,8 @@ const GOLDEN_PATH = join(TESTDATA, "golden-manifest.json");
 const PLACEHOLDER_RE =
     /^\$(ACCOUNT_ID|PUBLIC_BASE_URL|KV_[A-Z0-9_]+_ID|R2_[A-Z0-9_]+_NAME|WORKER_NAME\([a-z0-9-]+\)|SECRET\([A-Z0-9_]+\))/;
 
-function buildTestManifest() {
-  const workers = readDeployablePackages(join(ROOT, "packages")).map((pkg) => {
+function readTestWorkerBuilds() {
+  return readDeployablePackages(join(ROOT, "packages")).map((pkg) => {
     const bundleDir = join(TESTDATA, "fixture-bundles", pkg.name);
     assert.ok(existsSync(bundleDir),
         `missing fixture bundle for new deployable package: add scripts/release/testdata/` +
@@ -40,7 +40,9 @@ function buildTestManifest() {
       deployInputs: readDeployInputs(pkg.dir),
     };
   });
+}
 
+function buildTestManifest(workers = readTestWorkerBuilds()) {
   return generateManifest({
     releaseId: "r000000-fixture",
     commit: "0000000000000000000000000000000000000000",
@@ -184,6 +186,79 @@ test("worker entries carry the deploy contract", () => {
       assert.equal(mod.r2Key, `blobs/modules/${mod.sha256}`);
     }
   }
+});
+
+// The deploy wizard sends a gatekeeper's manifest shortName as the install slug verbatim, and
+// the slug becomes a GATEKEEPER_<SLUG> binding name, so the deploy service rejects anything
+// outside this charset (packages/deploy/src/naming.ts). A shortName that fails here reaches
+// customers as a redacted 500 on install with no workflow logs — fail the release build instead.
+//
+// releaseShortName() now throws on the same rule, so a bad package name fails inside
+// generateManifest before it reaches these assertions. Deliberately restated rather than
+// imported: this copy is the independent oracle that catches the constants there drifting from
+// the deploy service's, which is the failure the generator's own check cannot see.
+const SLUG_RE = /^[a-z][a-z0-9]*$/;
+const MAX_SLUG_LEN = 20;
+
+test("every gatekeeper shortName is a legal deploy slug", () => {
+  const { workers } = buildTestManifest();
+  for (const [name, entry] of Object.entries(workers)) {
+    if (entry.kind !== "gatekeeper") continue;
+    assert.match(entry.shortName ?? "", SLUG_RE,
+        `${name}: shortName ${entry.shortName} is not a legal install slug; it must be ` +
+        `lowercase letters and digits starting with a letter (it becomes GATEKEEPER_<SLUG>)`);
+    assert.ok((entry.shortName ?? "").length <= MAX_SLUG_LEN,
+        `${name}: shortName ${entry.shortName} exceeds ${MAX_SLUG_LEN} chars`);
+    assert.equal(entry.vars.BASE_URL, `$PUBLIC_BASE_URL/gatekeeper/${entry.shortName}`,
+        `${name}: BASE_URL path must match shortName`);
+  }
+});
+
+test("releaseShortName folds package names into the slug charset", () => {
+  assert.equal(releaseShortName("gatekeeper-mcp-portal"), "mcpportal");
+  // No-op for names that already conform.
+  assert.equal(releaseShortName("gatekeeper-google"), "google");
+});
+
+// The fold only removes characters, so a name can fold to a remnant the charset still rejects.
+// The deploy service would reject the install; the release build has to reject it first.
+test("releaseShortName rejects names that don't fold to a legal slug", () => {
+  for (const pkgName of [
+    "gatekeeper-",                        // nothing left
+    "gatekeeper---",                      // nothing left after the fold
+    "gatekeeper-1password",               // digit-leading
+    `gatekeeper-${"a".repeat(21)}`,       // over the 20-char cap
+  ]) {
+    assert.throws(() => releaseShortName(pkgName), /is not a legal install slug/,
+        `expected ${pkgName} to be rejected`);
+  }
+  // The cap itself is inclusive.
+  assert.equal(releaseShortName(`gatekeeper-${"a".repeat(20)}`), "a".repeat(20));
+});
+
+test("every gatekeeper shortName is unique", () => {
+  const owners = new Map<string, string>();
+  for (const [name, entry] of Object.entries(buildTestManifest().workers)) {
+    if (entry.shortName === undefined) continue;
+    const owner = owners.get(entry.shortName);
+    assert.equal(owner, undefined,
+        `${owner} and ${name} both emit shortName ${entry.shortName}`);
+    owners.set(entry.shortName, name);
+  }
+});
+
+// The fold is lossy — gatekeeper-foo-bar and gatekeeper-foobar both emit `foobar` — and two
+// gatekeepers with the same slug would contend for one GATEKEEPER_<SLUG> binding and one
+// /gatekeeper/<slug> route on every customer instance. Per-entry validity can't catch that.
+test("generateManifest rejects gatekeepers whose folded shortNames collide", () => {
+  const builds = readTestWorkerBuilds();
+  const google = builds.find((w) => w.pkgName === "gatekeeper-google");
+  assert.ok(google, "expected gatekeeper-google among the deployable packages");
+  // Folds to "google" too, so it collides with gatekeeper-google.
+  const collider = { ...google, pkgName: "gatekeeper-goo-gle" };
+
+  assert.throws(() => buildTestManifest([...builds, collider]),
+      /gatekeeper-google and gatekeeper-goo-gle both emit shortName "google"/);
 });
 
 test("per-package deploy-inputs.json files are well-formed when present", () => {

--- a/scripts/release/manifest-lib.ts
+++ b/scripts/release/manifest-lib.ts
@@ -327,6 +327,41 @@ export function gatekeeperShortName(pkgName: string): string {
   return pkgName.slice(GATEKEEPER_PREFIX.length);
 }
 
+/**
+ * The install-slug charset, mirroring the deploy service's own rule (its `validateSlug`). It is
+ * the fixed point of every runtime transform a slug passes through — the router lowercases and
+ * maps _ -> -, and the backend's inverse GATEKEEPER_ + `toUpperCase()` breaks on anything else —
+ * so a slug outside it does not survive the round trip through binding names.
+ */
+const SLUG_RE = /^[a-z][a-z0-9]*$/;
+/** The deploy service's install-slug length cap. */
+const MAX_SLUG_LEN = 20;
+
+/**
+ * The release manifest's shortName. Deployed instances bind gatekeepers as GATEKEEPER_<SLUG> and
+ * the router recovers the path from that binding name, so a slug must survive `toUpperCase()` and
+ * back — the deploy wizard restricts it to SLUG_RE and sends the manifest shortName as the install
+ * slug verbatim. Package names are not so restricted (gatekeeper-mcp-portal), so fold here.
+ * Distinct from gatekeeperShortName(), which staging/preview use with GATEKEEPER_<PKG_NAME>
+ * bindings (underscores, router maps _ -> -) where a hyphen does round-trip.
+ *
+ * The fold only removes characters, so it can leave a remnant the charset still rejects: empty
+ * (gatekeeper---), digit-leading (gatekeeper-1password), or over the cap. Throw rather than emit
+ * one — the release build runs without this repo's test suite (the internal pipeline builds a
+ * pinned submodule), and a shortName that reaches the wizard illegal makes the gatekeeper
+ * uninstallable on every customer instance.
+ */
+export function releaseShortName(pkgName: string): string {
+  const shortName = gatekeeperShortName(pkgName).replace(/[^a-z0-9]/g, "");
+  if (!SLUG_RE.test(shortName) || shortName.length > MAX_SLUG_LEN) {
+    throw new Error(`${pkgName} folds to "${shortName}", which is not a legal install slug: ` +
+        `it must be 1-${MAX_SLUG_LEN} lowercase letters and digits starting with a letter ` +
+        `(it becomes a GATEKEEPER_<SLUG> binding and a /gatekeeper/<slug> route). Rename the ` +
+        `package so its name folds to one.`);
+  }
+  return shortName;
+}
+
 /** Read a package's `deploy-inputs.json`, or undefined if it declares none. */
 export function readDeployInputs(pkgDir: string): DeployInput[] | undefined {
   const path = join(pkgDir, "deploy-inputs.json");
@@ -439,7 +474,7 @@ export function buildWorkerEntry(
     // (default entrypoint — it forwards whole HTTP requests, not vendor RPC).
     gatekeeperBindingExpansion = { propsByPackage: {} };
   } else {
-    vars.BASE_URL = `$PUBLIC_BASE_URL/gatekeeper/${gatekeeperShortName(pkgName)}`;
+    vars.BASE_URL = `$PUBLIC_BASE_URL/gatekeeper/${releaseShortName(pkgName)}`;
     installable = !NOT_INSTALLABLE.has(pkgName);
     if (installable) {
       inputs = deployInputs ??
@@ -461,7 +496,7 @@ export function buildWorkerEntry(
 
   return {
     kind,
-    ...(kind === "gatekeeper" ? { shortName: gatekeeperShortName(pkgName) } : {}),
+    ...(kind === "gatekeeper" ? { shortName: releaseShortName(pkgName) } : {}),
     installable,
     ...(PREINSTALL.has(pkgName) ? { preinstall: true } : {}),
     ...(SINGLETON.has(pkgName) ? { singleton: true } : {}),
@@ -510,8 +545,24 @@ export function generateManifest({
   assetVariants?: Record<string, CollectedAssets>;
 }): ReleaseManifest {
   const workerEntries: Record<string, WorkerEntry> = {};
+  // releaseShortName() folds the package name into the install-slug charset, and that fold is
+  // lossy: gatekeeper-foo-bar and gatekeeper-foobar both emit `foobar`. Two gatekeepers sharing a
+  // slug would want the same GATEKEEPER_FOOBAR binding and the same /gatekeeper/foobar route, so
+  // one would silently shadow the other on every customer instance. Fail the release build here —
+  // the per-entry slug check can't see the collision, only the assembled set can.
+  const shortNameOwner = new Map<string, string>();
   for (const w of workers) {
-    workerEntries[w.pkgName] = buildWorkerEntry(w);
+    const entry = buildWorkerEntry(w);
+    if (entry.shortName !== undefined) {
+      const owner = shortNameOwner.get(entry.shortName);
+      if (owner !== undefined) {
+        throw new Error(`${owner} and ${w.pkgName} both emit shortName "${entry.shortName}"; ` +
+            `install slugs must be unique (each becomes a GATEKEEPER_<SLUG> binding and a ` +
+            `/gatekeeper/<slug> route). Rename one package so the slugs differ.`);
+      }
+      shortNameOwner.set(entry.shortName, w.pkgName);
+    }
+    workerEntries[w.pkgName] = entry;
   }
 
   const assets: ReleaseManifest["assets"] = {};

--- a/scripts/release/manifest-lib.ts
+++ b/scripts/release/manifest-lib.ts
@@ -275,13 +275,30 @@ const NOT_INSTALLABLE = new Set(["gatekeeper-email"]);
 const PREINSTALL = new Set(["gatekeeper-context", "gatekeeper-scheduler"]);
 
 // Gatekeepers that may be installed at most once per instance; the deploy service enforces this
-// at install time. The giveaway is the account declaring an agent singleton
-// (`AccountDescription.singleton` — context's `ContextLibrary`, scheduler's `ScheduleSession`):
-// the Workshop auto-provisions those accounts and folds the singleton into every workspace as an
-// ambient gatekeeper, so a second install would hand every user a duplicate ambient capsule.
-// Independent of PREINSTALL in principle; the two sets coincide today only because every ambient
-// gatekeeper we ship is also preinstalled.
-const SINGLETON = new Set(["gatekeeper-context", "gatekeeper-scheduler"]);
+// at install time. Two independent reasons to be here:
+//
+//  1. The account declares an agent singleton (`AccountDescription.singleton` — context's
+//     `ContextLibrary`, scheduler's `ScheduleSession`). The Workshop auto-provisions those
+//     accounts and folds the singleton into every workspace as an ambient gatekeeper, so a second
+//     install would hand every user a duplicate ambient capsule.
+//  2. Nothing could distinguish two installs. A gatekeeper taking no inputs (see
+//     NO_DEFAULT_CRED_INPUTS and the absence of a deploy-inputs.json) is configured identically on
+//     every install, so a second one is a byte-identical worker — it adds no capability, and it
+//     costs: the install slug is what the GATEKEEPER_<SLUG> binding, and hence the Workshop's
+//     vendor id, is derived from, so a duplicate installs as `mcp2` and its connections stop
+//     matching blueprints written against `mcp`.
+//
+// Reason 2 turns on inputs, not on the vendor: google/github/slack take per-install
+// CLIENT_ID/CLIENT_SECRET, so two installs can front two different OAuth apps and must stay
+// multi-install. Independent of PREINSTALL in principle; the ambient two coincide with it today
+// only because every ambient gatekeeper we ship is also preinstalled.
+const SINGLETON = new Set([
+  "gatekeeper-context",       // (1) ambient ContextLibrary
+  "gatekeeper-scheduler",     // (1) ambient ScheduleSession
+  "gatekeeper-homeassistant", // (2) no inputs; users connect their own URL + token in-app
+  "gatekeeper-mcp",           // (2) no inputs; users paste their own endpoints in-app
+  "gatekeeper-mcp-portal",    // (2) no inputs; the one portal comes from the deployment's vars
+]);
 
 /** Default wizard inputs for an installable gatekeeper that fronts a third-party OAuth app. */
 export const DEFAULT_CRED_INPUTS: DeployInput[] = [

--- a/scripts/release/testdata/golden-manifest.json
+++ b/scripts/release/testdata/golden-manifest.json
@@ -599,9 +599,9 @@
           "invocation_logs": false
         }
       },
-      "shortName": "mcp-portal",
+      "shortName": "mcpportal",
       "vars": {
-        "BASE_URL": "$PUBLIC_BASE_URL/gatekeeper/mcp-portal",
+        "BASE_URL": "$PUBLIC_BASE_URL/gatekeeper/mcpportal",
         "MCP_ALLOW_INSECURE": "false"
       }
     },

--- a/scripts/release/testdata/golden-manifest.json
+++ b/scripts/release/testdata/golden-manifest.json
@@ -454,6 +454,7 @@
         }
       },
       "shortName": "homeassistant",
+      "singleton": true,
       "vars": {
         "BASE_URL": "$PUBLIC_BASE_URL/gatekeeper/homeassistant"
       }
@@ -558,6 +559,7 @@
         }
       },
       "shortName": "mcp",
+      "singleton": true,
       "vars": {
         "BASE_URL": "$PUBLIC_BASE_URL/gatekeeper/mcp",
         "MCP_ALLOW_INSECURE": "false"
@@ -600,6 +602,7 @@
         }
       },
       "shortName": "mcpportal",
+      "singleton": true,
       "vars": {
         "BASE_URL": "$PUBLIC_BASE_URL/gatekeeper/mcpportal",
         "MCP_ALLOW_INSECURE": "false"


### PR DESCRIPTION
The deploy wizard sends a gatekeeper's manifest shortName to the deploy service as the install slug verbatim, and the service turns that slug into a GATEKEEPER_<SLUG> binding name - so it validates against `/^[a-z][a-z0-9]*$/`. gatekeeper-mcp-portal was the only installable gatekeeper whose derived shortName carried a hyphen, so mcp-portal failed zod validation on the first line of install(), before the workflow was ever created. Users saw a redacted "Something unexpected went wrong on our side." with no workflow logs to debug from.

- Adds releaseShortName() (manifest-lib.ts:338), which folds the package name into the slug charset by stripping everything outside [a-z0-9]. ( illegal characters as they're not supported in binding name for router worker )
- Adds collision guard in generateManifest() throwing if two gatekeepers fold to the same slug.

Also added tests for `shortName is a legal slug and matches its BASE_URL path`, `releaseShortName() folds correctly and no-ops on conforming names`, `shortNames are unique across the real manifest`

Also made mcp-portal and cf-portal singleton gatekeepers in the manifest