### PR TITLE
Fix Google configurator token refresh

### DIFF
--- a/packages/gatekeeper-google/__tests__/workerd/configurators.test.ts
+++ b/packages/gatekeeper-google/__tests__/workerd/configurators.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AccessTokenRequest } from "../../src/auth-retry";
+import { BigQueryConfiguratorUI, CalendarConfiguratorUI } from "../../src/google-configurators";
+import type { GoogleAccessToken } from "../../src/google-api";
+
+const token = (value: string): GoogleAccessToken => ({
+  token: value,
+  expires: new Date(Date.now() + 3600_000),
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Google resource configurator authentication", () => {
+  it("refreshes a rejected Calendar access token", async () => {
+    let getToken = vi.fn(async (opts?: AccessTokenRequest) =>
+      token(opts?.forceRefresh ? "fresh" : "stale"));
+    vi.stubGlobal("fetch", vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      let authorization = new Headers(init?.headers).get("Authorization");
+      if (authorization === "Bearer stale") {
+        return Response.json({ error: { code: 401 } }, { status: 401 });
+      }
+      return Response.json({
+        items: [{ id: "person@example.com", summary: "Primary calendar", primary: true }],
+      });
+    }));
+
+    await expect(new CalendarConfiguratorUI(getToken).listCalendars(""))
+      .resolves.toEqual([{
+        value: "person@example.com",
+        title: "Primary calendar",
+        subtitle: "Primary calendar",
+        meta: undefined,
+      }]);
+    expect(getToken.mock.calls).toEqual([
+      [undefined],
+      [{ forceRefresh: true, staleToken: "stale" }],
+    ]);
+  });
+
+  it("reloads a widened BigQuery access token after a scope 403", async () => {
+    let getToken = vi.fn(async (opts?: AccessTokenRequest) =>
+      token(opts?.reloadStored ? "widened" : "narrow"));
+    vi.stubGlobal("fetch", vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      let authorization = new Headers(init?.headers).get("Authorization");
+      if (authorization === "Bearer narrow") {
+        return Response.json({ error: { code: 403 } }, { status: 403 });
+      }
+      return Response.json({
+        projects: [{
+          id: "project-1",
+          friendlyName: "Project One",
+          projectReference: { projectId: "project-1" },
+        }],
+      });
+    }));
+
+    await expect(new BigQueryConfiguratorUI(getToken).listProjects(""))
+      .resolves.toEqual([{
+        value: "project-1",
+        title: "project-1",
+        subtitle: "Project One",
+      }]);
+    expect(getToken.mock.calls).toEqual([
+      [undefined],
+      [{ reloadStored: true }],
+    ]);
+  });
+});

--- a/packages/gatekeeper-google/src/google-configurators.ts
+++ b/packages/gatekeeper-google/src/google-configurators.ts
@@ -57,17 +57,12 @@ async function withDriveApiEnabled<T>(
   }
 }
 
-// TODO: BigQuery and Calendar freeze one token for the configurator's lifetime, so their clients
-// cannot heal a 401. Give them `googleTokenProvider` too.
-
 async function bigQueryApi(target: object): Promise<BigQueryApi> {
-  let token = await googleToken(target);
-  return new BigQueryApi(() => Promise.resolve(token.token));
+  return new BigQueryApi(googleTokenProvider(target));
 }
 
 async function calendarApi(target: object): Promise<GoogleCalendarApi> {
-  let token = await googleToken(target);
-  return new GoogleCalendarApi(() => Promise.resolve(token.token));
+  return new GoogleCalendarApi(googleTokenProvider(target));
 }
 
 async function cachedBigQueryOptions(

--- a/packages/gatekeeper-google/vitest.worker.config.ts
+++ b/packages/gatekeeper-google/vitest.worker.config.ts
@@ -2,7 +2,7 @@ import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import capnwebValidate from "capnweb-validate/vite";
 import { defineConfig } from "vitest/config";
 
-/** Workerd coverage for Gmail sessions and the Gmail Durable Object. */
+/** Workerd coverage for Google resource configurators, Gmail sessions, and the Gmail Durable Object. */
 export default defineConfig({
   plugins: [
     capnwebValidate(),
@@ -22,6 +22,7 @@ export default defineConfig({
   ],
   test: {
     include: [
+      "__tests__/workerd/configurators.test.ts",
       "__tests__/workerd/gmail-actions.test.ts",
       "__tests__/workerd/gmail-state.test.ts",
     ],


### PR DESCRIPTION
Google Calendar and BigQuery resource pickers kept using the access token captured when they opened, so reconnecting could not recover from a 401 or pick up newly granted scopes after a 403.

They now request the current token through the existing Google retry path.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->