### PR TITLE
Resolve Google Calendar primary alias

### DIFF
--- a/packages/gatekeeper-google/__tests__/configurator-url.test.ts
+++ b/packages/gatekeeper-google/__tests__/configurator-url.test.ts
@@ -128,13 +128,14 @@ describe("Calendar configurator URLs", () => {
       listCalendars: vi.fn(),
     } as unknown as CalendarConfiguratorRpc;
 
-    const values = await calendarConfigurator.initialValuesFromResourceUrl!({
-      resourceUrl: "https://calendar.google.com/calendar/primary/",
+    const seeded = await calendarConfigurator.initialValuesFromResourceUrl!({
+      resourceUrl: "https://calendar.google.com/calendar/primary/?availability=allVisible",
       resourceUrlPattern: GOOGLE_CALENDAR_RESOURCE.urlPattern,
       ui,
     });
+    const values = { availabilityMode: "thisCalendar" as const, ...seeded };
     const resourceUrl = calendarConfigurator.resourceUrl!({
-      values: { availabilityMode: "thisCalendar", ...values }, ui,
+      values, ui,
     });
 
     expect(calendarConfigurator.isReady!({ values: { calendarId: "primary" } })).toBe(false);
@@ -143,7 +144,7 @@ describe("Calendar configurator URLs", () => {
     expect(parseResourceUrl(resourceUrl)).toEqual({
       kind: "calendar",
       calendarId: "person@example.com",
-      availabilityMode: "thisCalendar",
+      availabilityMode: "allVisible",
     });
   });
 });

--- a/packages/gatekeeper-google/__tests__/configurator-url.test.ts
+++ b/packages/gatekeeper-google/__tests__/configurator-url.test.ts
@@ -20,11 +20,13 @@ vi.mock("@gadgets/configurator-ui", () => ({
 }));
 import driveAccountConfigurator from "../src/configurator/drive-account-configurator-ui";
 import driveFileConfigurator from "../src/configurator/drive-file-configurator-ui";
+import calendarConfigurator from "../src/configurator/calendar-configurator-ui";
+import type { CalendarConfiguratorRpc } from "../src/configurator/calendar-configurator-types";
 import gmailConfigurator from "../src/configurator/gmail-configurator-ui";
 import sharedDriveConfigurator from "../src/configurator/shared-drive-configurator-ui";
 import {
-  GMAIL_RESOURCE, GOOGLE_DRIVE_FILE_RESOURCE, GOOGLE_DRIVE_RESOURCE, GOOGLE_SHARED_DRIVE_RESOURCE,
-  parseResourceUrl,
+  GMAIL_RESOURCE, GOOGLE_CALENDAR_RESOURCE, GOOGLE_DRIVE_FILE_RESOURCE, GOOGLE_DRIVE_RESOURCE,
+  GOOGLE_SHARED_DRIVE_RESOURCE, parseResourceUrl,
 } from "../src/resources";
 
 // The configurators never call `ui` from these two methods; it is present only to satisfy the
@@ -116,6 +118,33 @@ describe("Gmail configurator URLs", () => {
 
     expect(gmailValues(inbox)).toEqual({ mode: "all" });
     expect(parseResourceUrl(inbox)).toEqual({ kind: "gmail" });
+  });
+});
+
+describe("Calendar configurator URLs", () => {
+  it("resolves an account-relative primary prefill to a stable calendar ID", async () => {
+    const ui = {
+      getPrimaryCalendarId: vi.fn(async () => "person@example.com"),
+      listCalendars: vi.fn(),
+    } as unknown as CalendarConfiguratorRpc;
+
+    const values = await calendarConfigurator.initialValuesFromResourceUrl!({
+      resourceUrl: "https://calendar.google.com/calendar/primary/",
+      resourceUrlPattern: GOOGLE_CALENDAR_RESOURCE.urlPattern,
+      ui,
+    });
+    const resourceUrl = calendarConfigurator.resourceUrl!({
+      values: { availabilityMode: "thisCalendar", ...values }, ui,
+    });
+
+    expect(calendarConfigurator.isReady!({ values: { calendarId: "primary" } })).toBe(false);
+    expect(calendarConfigurator.isReady!({ values })).toBe(true);
+    expect(ui.getPrimaryCalendarId).toHaveBeenCalledOnce();
+    expect(parseResourceUrl(resourceUrl)).toEqual({
+      kind: "calendar",
+      calendarId: "person@example.com",
+      availabilityMode: "thisCalendar",
+    });
   });
 });
 

--- a/packages/gatekeeper-google/__tests__/configurator-url.test.ts
+++ b/packages/gatekeeper-google/__tests__/configurator-url.test.ts
@@ -128,12 +128,11 @@ describe("Calendar configurator URLs", () => {
       listCalendars: vi.fn(),
     } as unknown as CalendarConfiguratorRpc;
 
-    const seeded = await calendarConfigurator.initialValuesFromResourceUrl!({
+    const values = await calendarConfigurator.initialValuesFromResourceUrl!({
       resourceUrl: "https://calendar.google.com/calendar/primary/?availability=allVisible",
       resourceUrlPattern: GOOGLE_CALENDAR_RESOURCE.urlPattern,
       ui,
     });
-    const values = { availabilityMode: "thisCalendar" as const, ...seeded };
     const resourceUrl = calendarConfigurator.resourceUrl!({
       values, ui,
     });

--- a/packages/gatekeeper-google/__tests__/workerd/configurators.test.ts
+++ b/packages/gatekeeper-google/__tests__/workerd/configurators.test.ts
@@ -10,7 +10,19 @@ const token = (value: string): GoogleAccessToken => ({
 
 afterEach(() => vi.unstubAllGlobals());
 
-describe("Google resource configurator authentication", () => {
+describe("Google resource configurators", () => {
+  it("resolves the primary Calendar alias to its stable ID", async () => {
+    let getToken = vi.fn(async () => token("access-token"));
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      id: "person@example.com",
+      summary: "Primary calendar",
+      primary: true,
+    })));
+
+    await expect(new CalendarConfiguratorUI(getToken).getPrimaryCalendarId())
+      .resolves.toBe("person@example.com");
+  });
+
   it("refreshes a rejected Calendar access token", async () => {
     let getToken = vi.fn(async (opts?: AccessTokenRequest) =>
       token(opts?.forceRefresh ? "fresh" : "stale"));

--- a/packages/gatekeeper-google/src/configurator/calendar-configurator-types.d.ts
+++ b/packages/gatekeeper-google/src/configurator/calendar-configurator-types.d.ts
@@ -9,5 +9,9 @@ export type CalendarConfiguratorValues = {
 }
 
 export interface CalendarConfiguratorRpc {
+  /** List writable calendars matching the search query. */
   listCalendars(query: string): Promise<ConfiguratorOption[]>;
+
+  /** Resolve the connected account's primary calendar to its stable calendar ID. */
+  getPrimaryCalendarId(): Promise<string>;
 }

--- a/packages/gatekeeper-google/src/configurator/calendar-configurator-ui.tsx
+++ b/packages/gatekeeper-google/src/configurator/calendar-configurator-ui.tsx
@@ -5,7 +5,15 @@ export default {
   initial: { availabilityMode: "thisCalendar" },
 
   isReady({ values }) {
-    return typeof values.calendarId === "string" && values.calendarId.length > 0;
+    return typeof values.calendarId === "string" &&
+      values.calendarId.length > 0 && values.calendarId !== "primary";
+  },
+
+  async initialValuesFromResourceUrl({ resourceUrl, ui }) {
+    const calendarId = decodeURIComponent(new URL(resourceUrl).pathname.split("/")[2] ?? "");
+    return {
+      calendarId: calendarId === "primary" ? await ui.getPrimaryCalendarId() : calendarId,
+    };
   },
 
   resourceUrl({ values }) {

--- a/packages/gatekeeper-google/src/configurator/calendar-configurator-ui.tsx
+++ b/packages/gatekeeper-google/src/configurator/calendar-configurator-ui.tsx
@@ -10,9 +10,12 @@ export default {
   },
 
   async initialValuesFromResourceUrl({ resourceUrl, ui }) {
-    const calendarId = decodeURIComponent(new URL(resourceUrl).pathname.split("/")[2] ?? "");
+    const parsed = new URL(resourceUrl);
+    const calendarId = decodeURIComponent(parsed.pathname.split("/")[2] ?? "");
     return {
       calendarId: calendarId === "primary" ? await ui.getPrimaryCalendarId() : calendarId,
+      availabilityMode: parsed.searchParams.get("availability") === "allVisible"
+        ? "allVisible" : "thisCalendar",
     };
   },
 

--- a/packages/gatekeeper-google/src/google-configurators.ts
+++ b/packages/gatekeeper-google/src/google-configurators.ts
@@ -128,6 +128,15 @@ export class CalendarConfiguratorUI extends RpcTarget implements CalendarConfigu
     googleTokenGetters.set(this, getToken);
   }
 
+  async getPrimaryCalendarId(): Promise<string> {
+    let api = await calendarApi(this);
+    let calendarId = (await api.getCalendar("primary")).id;
+    if (!calendarId || calendarId === "primary") {
+      throw new Error("Google Calendar did not return a stable primary calendar ID.");
+    }
+    return calendarId;
+  }
+
   async listCalendars(query: string): Promise<ConfiguratorOption[]> {
     let options = calendarConfiguratorCaches.get(this);
     if (!options) {


### PR DESCRIPTION
Agent-requested Google Calendar connections can prefill `primary`, Google’s account-relative alias. The configurator previously treated it as a final value, which the backend then rejected because bindings require a stable calendar ID.

The configurator now resolves `primary` through the selected Google account before submission while keeping the stable-ID requirement intact.

Fixes #315.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->