### PR TITLE
Add createExternalResource agent tool

### DIFF
--- a/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
@@ -9,7 +9,7 @@ import type {
   AiChatAuthorInfo, AiModelConfig, AuthenticatedApi, Overseer, PublicApi,
 } from "@gadgets/workshop-shared/api";
 import { startTestGatekeeperHarness, TEST_VENDOR_ID, type Harness } from "../src/harness.js";
-import { scriptedChatCompletions } from "../src/mock-model.js";
+import { scriptedChatCompletions, type ScriptedChatCompletions } from "../src/mock-model.js";
 import { NetworkInterceptor } from "../src/network-interceptor.js";
 import {
   connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
@@ -27,98 +27,12 @@ const MODEL_CONFIG: AiModelConfig = {
 const RESOURCE_URL_PATTERN = "https://gadgets-test.example/things/*";
 
 let harness: Harness;
-const model = scriptedChatCompletions([
-  // --- Test 1, turn 1: a fixable rejection, then a successful creation, used immediately.
-  {
-    toolCall: {
-      id: "create-bad-type",
-      name: "createExternalResource",
-      arguments: {
-        vendorId: TEST_VENDOR_ID,
-        resourceUrlPattern: "https://gadgets-test.example/nope/*",
-        title: "My Thing",
-        bindingName: "NEW_THING",
-      },
-    },
-  },
-  {
-    toolCall: {
-      id: "create-thing",
-      name: "createExternalResource",
-      arguments: {
-        vendorId: TEST_VENDOR_ID,
-        resourceUrlPattern: RESOURCE_URL_PATTERN,
-        title: "My Thing",
-        bindingName: "NEW_THING",
-      },
-    },
-  },
-  {
-    toolCall: {
-      id: "read-new-thing",
-      name: "executeCode",
-      arguments: {
-        code: "export default async function(self, env) { console.log(await env.NEW_THING.readValue()); }",
-      },
-    },
-  },
-  { text: "Created the thing and read 42 from it." },
-  // --- Test 1, turn 2 (after approval): the replayed binding still works, and the write's
-  // action snapshot shows the refreshed (created) resource URL. writeValue awaits a decision,
-  // so this turn deliberately suspends.
-  {
-    toolCall: {
-      id: "write-new-thing",
-      name: "executeCode",
-      arguments: {
-        code: "export default async function(self, env) { console.log(await env.NEW_THING.writeValue(9)); }",
-      },
-    },
-  },
-  // --- Test 2, turn 1: create a thing whose creation the user will reject.
-  {
-    toolCall: {
-      id: "create-doomed",
-      name: "createExternalResource",
-      arguments: {
-        vendorId: TEST_VENDOR_ID,
-        resourceUrlPattern: RESOURCE_URL_PATTERN,
-        title: "Doomed Thing",
-        bindingName: "DOOMED",
-      },
-    },
-  },
-  { text: "Created the doomed thing." },
-  // --- Test 2, turn 2 (after rejection): the binding is dead, with an explanation.
-  {
-    toolCall: {
-      id: "read-doomed",
-      name: "executeCode",
-      arguments: {
-        code: "export default async function(self, env) {" +
-            " try { console.log(await env.DOOMED.readValue()); }" +
-            " catch (err) { console.log('DEAD: ' + (err && err.message)); } }",
-      },
-    },
-  },
-  { text: "The doomed thing is gone." },
-  // --- Test 3: the vendor fails after durably queueing its creation action; the overseer must
-  // settle the orphan instead of leaving it pending against a removed gatekeeper.
-  {
-    toolCall: {
-      id: "create-orphan",
-      name: "createExternalResource",
-      arguments: {
-        vendorId: TEST_VENDOR_ID,
-        resourceUrlPattern: RESOURCE_URL_PATTERN,
-        title: "fail-after-queue",
-        bindingName: "ORPHAN",
-      },
-    },
-  },
-  { text: "The creation failed." },
-]);
-const network = new NetworkInterceptor({ handlers: [model.handler] });
+// Each test owns its script (assigned before its first turn) so tests stay independently
+// runnable; the interceptor delegates to whichever script is current.
+let model: ScriptedChatCompletions;
+const network = new NetworkInterceptor({
+  handlers: [(url, method, headers, request) => model.handler(url, method, headers, request)],
+});
 
 beforeAll(async () => {
   network.install();
@@ -196,6 +110,55 @@ function userMessagesShownToModel(): string[] {
 }
 
 it("creates a resource the agent can use before the user approves it", async () => {
+  model = scriptedChatCompletions([
+    // Turn 1: a fixable rejection, then a successful creation, used immediately.
+    {
+      toolCall: {
+        id: "create-bad-type",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: "https://gadgets-test.example/nope/*",
+          title: "My Thing",
+          bindingName: "NEW_THING",
+        },
+      },
+    },
+    {
+      toolCall: {
+        id: "create-thing",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: RESOURCE_URL_PATTERN,
+          title: "My Thing",
+          bindingName: "NEW_THING",
+        },
+      },
+    },
+    {
+      toolCall: {
+        id: "read-new-thing",
+        name: "executeCode",
+        arguments: {
+          code: "export default async function(self, env) { console.log(await env.NEW_THING.readValue()); }",
+        },
+      },
+    },
+    { text: "Created the thing and read 42 from it." },
+    // Turn 2 (after approval): the replayed binding still works, and the write's action
+    // snapshot shows the refreshed (created) resource URL. writeValue awaits a decision, so
+    // this turn deliberately suspends.
+    {
+      toolCall: {
+        id: "write-new-thing",
+        name: "executeCode",
+        arguments: {
+          code: "export default async function(self, env) { console.log(await env.NEW_THING.writeValue(9)); }",
+        },
+      },
+    },
+  ]);
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createres");
   using workspace = await authenticated.newGadget();
@@ -240,22 +203,81 @@ it("creates a resource the agent can use before the user approves it", async () 
   expect(write.resourceUrl).toContain("/things/created-");
   expect(write.resourceUrl).not.toContain("provisional");
 
-  // Replay told the model about the approval — the recorded tool result permanently says the
-  // resource doesn't exist yet, so without this the model's context never learns it now does.
+  // The creation action itself settled as approved.
+  const all = (await workspace.listActions({ filter: "all" })).entries;
+  expect(all.find(action => action.id === pending.id)?.state).toBe("approved");
+
+  // The decision reached the model as a durable nudge — the recorded tool result permanently
+  // says the resource doesn't exist yet, so without this the model's context never learns it
+  // now does.
   const approval = userMessagesShownToModel().find(message =>
     message.includes("The user approved the creation of env.NEW_THING"));
   expect(approval).toContain(write.resourceUrl);
+  expect(model.remainingSteps()).toBe(0);
 });
 
-it("kills the binding when the user rejects the creation", async () => {
+it("kills the binding and cascades to queued edits when the user rejects the creation",
+    async () => {
+  model = scriptedChatCompletions([
+    // Turn 1: create a thing, queue an edit against it, then suspend on the edit's
+    // awaitDecision. The user rejects the creation, which must cascade to the queued edit.
+    {
+      toolCall: {
+        id: "create-doomed",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: RESOURCE_URL_PATTERN,
+          title: "Doomed Thing",
+          bindingName: "DOOMED",
+        },
+      },
+    },
+    {
+      toolCall: {
+        id: "write-doomed",
+        name: "executeCode",
+        arguments: {
+          code: "export default async function(self, env) { console.log(await env.DOOMED.writeValue(5)); }",
+        },
+      },
+    },
+    // Turn 2 (after rejection): the binding is dead, with an explanation.
+    {
+      toolCall: {
+        id: "read-doomed",
+        name: "executeCode",
+        arguments: {
+          code: "export default async function(self, env) {" +
+              " try { console.log(await env.DOOMED.readValue()); }" +
+              " catch (err) { console.log('DEAD: ' + (err && err.message)); } }",
+        },
+      },
+    },
+    { text: "The doomed thing is gone." },
+  ]);
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createrej");
   using workspace = await authenticated.newGadget();
-  const chatId = await workspace.newChat("Create a doomed test thing.", MODEL_ID);
-  await waitForAgentSays(workspace, chatId, "Created the doomed thing.");
+  const chatId = await workspace.newChat(
+      "Create a doomed test thing and write to it.", MODEL_ID);
 
-  const pending = await onlyPendingAction(workspace, "the creation action to be pending");
-  await workspace.rejectAction(pending.id);
+  // The write awaits a decision, so the turn suspends holding two pending actions: the
+  // creation and an edit that depends on it.
+  const pending = await waitFor("the creation and its edit to be pending", async () => {
+    const entries = (await workspace.listActions({ filter: "pending" })).entries;
+    return entries.length === 2 ? entries : null;
+  });
+  const creation = pending.find(action =>
+    action.description.title.startsWith("Create test thing"));
+  if (creation === undefined) throw new Error("No pending creation action found");
+  await workspace.rejectAction(creation.id);
+
+  // Rejecting the creation settled the dependent edit too — nothing left to decide one by one.
+  const all = (await workspace.listActions({ filter: "all" })).entries;
+  expect(all.filter(action => action.state === "pending")).toEqual([]);
+  expect(all.filter(action => action.type === "action" && action.state === "rejected"))
+      .toHaveLength(2);
 
   // The next turn's use of the binding fails with the gatekeeper's dead-binding explanation
   // rather than silently simulating against nothing.
@@ -264,12 +286,30 @@ it("kills the binding when the user rejects the creation", async () => {
   expect(toolResultShownToModel("read-doomed")).toContain("DEAD:");
   expect(toolResultShownToModel("read-doomed")).toMatch(/rejected/);
 
-  // Replay told the model about the rejection too.
+  // The rejection nudge reached the model.
   expect(userMessagesShownToModel().some(message =>
     message.includes("The user rejected the creation of env.DOOMED"))).toBe(true);
+  expect(model.remainingSteps()).toBe(0);
 });
 
 it("settles the queued action when the vendor fails after queueing it", async () => {
+  model = scriptedChatCompletions([
+    // The vendor fails after durably queueing its creation action; the overseer must settle
+    // the orphan instead of leaving it pending against a removed gatekeeper.
+    {
+      toolCall: {
+        id: "create-orphan",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: RESOURCE_URL_PATTERN,
+          title: "fail-after-queue",
+          bindingName: "ORPHAN",
+        },
+      },
+    },
+    { text: "The creation failed." },
+  ]);
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createfail");
   using workspace = await authenticated.newGadget();
@@ -283,7 +323,9 @@ it("settles the queued action when the vendor fails after queueing it", async ()
   // not left pending forever (approve/reject would both fail on the missing facet).
   const actions = (await workspace.listActions({ filter: "all" })).entries;
   expect(actions.filter(action => action.state === "pending")).toEqual([]);
-  expect(actions.some(action => action.type === "action" && action.state === "rejected"))
-      .toBe(true);
+  const settled = actions.find(action =>
+    action.type === "action" && action.state === "rejected");
+  if (settled?.gatekeeperId === undefined) throw new Error("No settled creation action found");
+  await expect(workspace.getGatekeeperById(settled.gatekeeperId)).rejects.toThrow();
   expect(model.remainingSteps()).toBe(0);
 });

--- a/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
@@ -1,0 +1,289 @@
+// createExternalResource end to end against the fixture gatekeeper: tool → binding → action card
+// → approve → describe refresh, plus the rejection path, replay across turns, and a vendor that
+// fails after queueing its creation action. (Provider depth is covered by per-vendor suites,
+// e.g. gatekeeper-google's workerd tests.)
+
+import { afterAll, beforeAll, expect, it } from "vitest";
+import type { RpcStub } from "capnweb";
+import type {
+  AiChatAuthorInfo, AiModelConfig, AuthenticatedApi, Overseer, PublicApi,
+} from "@gadgets/workshop-shared/api";
+import { startTestGatekeeperHarness, TEST_VENDOR_ID, type Harness } from "../src/harness.js";
+import { scriptedChatCompletions } from "../src/mock-model.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+import {
+  connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
+} from "../src/rpc-client.js";
+
+const MODEL_ID = "@cf/zai-org/glm-5.2";
+const MODEL_PROFILE: AiChatAuthorInfo = { type: "agent", id: MODEL_ID, name: "Scripted model" };
+const MODEL_CONFIG: AiModelConfig = {
+  provider: "cloudflare",
+  model: MODEL_ID,
+  accountId: "test-account",
+  apiToken: "test-token",
+};
+
+const RESOURCE_URL_PATTERN = "https://gadgets-test.example/things/*";
+
+let harness: Harness;
+const model = scriptedChatCompletions([
+  // --- Test 1, turn 1: a fixable rejection, then a successful creation, used immediately.
+  {
+    toolCall: {
+      id: "create-bad-type",
+      name: "createExternalResource",
+      arguments: {
+        vendorId: TEST_VENDOR_ID,
+        resourceUrlPattern: "https://gadgets-test.example/nope/*",
+        title: "My Thing",
+        bindingName: "NEW_THING",
+      },
+    },
+  },
+  {
+    toolCall: {
+      id: "create-thing",
+      name: "createExternalResource",
+      arguments: {
+        vendorId: TEST_VENDOR_ID,
+        resourceUrlPattern: RESOURCE_URL_PATTERN,
+        title: "My Thing",
+        bindingName: "NEW_THING",
+      },
+    },
+  },
+  {
+    toolCall: {
+      id: "read-new-thing",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) { console.log(await env.NEW_THING.readValue()); }",
+      },
+    },
+  },
+  { text: "Created the thing and read 42 from it." },
+  // --- Test 1, turn 2 (after approval): the replayed binding still works, and the write's
+  // action snapshot shows the refreshed (created) resource URL. writeValue awaits a decision,
+  // so this turn deliberately suspends.
+  {
+    toolCall: {
+      id: "write-new-thing",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) { console.log(await env.NEW_THING.writeValue(9)); }",
+      },
+    },
+  },
+  // --- Test 2, turn 1: create a thing whose creation the user will reject.
+  {
+    toolCall: {
+      id: "create-doomed",
+      name: "createExternalResource",
+      arguments: {
+        vendorId: TEST_VENDOR_ID,
+        resourceUrlPattern: RESOURCE_URL_PATTERN,
+        title: "Doomed Thing",
+        bindingName: "DOOMED",
+      },
+    },
+  },
+  { text: "Created the doomed thing." },
+  // --- Test 2, turn 2 (after rejection): the binding is dead, with an explanation.
+  {
+    toolCall: {
+      id: "read-doomed",
+      name: "executeCode",
+      arguments: {
+        code: "export default async function(self, env) {" +
+            " try { console.log(await env.DOOMED.readValue()); }" +
+            " catch (err) { console.log('DEAD: ' + (err && err.message)); } }",
+      },
+    },
+  },
+  { text: "The doomed thing is gone." },
+  // --- Test 3: the vendor fails after durably queueing its creation action; the overseer must
+  // settle the orphan instead of leaving it pending against a removed gatekeeper.
+  {
+    toolCall: {
+      id: "create-orphan",
+      name: "createExternalResource",
+      arguments: {
+        vendorId: TEST_VENDOR_ID,
+        resourceUrlPattern: RESOURCE_URL_PATTERN,
+        title: "fail-after-queue",
+        bindingName: "ORPHAN",
+      },
+    },
+  },
+  { text: "The creation failed." },
+]);
+const network = new NetworkInterceptor({ handlers: [model.handler] });
+
+beforeAll(async () => {
+  network.install();
+  harness = await startTestGatekeeperHarness({ enableGadgetExecution: true });
+});
+
+afterAll(async () => {
+  try {
+    await harness?.server.close();
+    expect(network.getUnmockedCalls()).toEqual([]);
+  } finally {
+    network.uninstall();
+  }
+});
+
+/** Sign up a fresh user configured with the scripted model and an ambient test-vendor account. */
+async function signUpScriptedUser(
+    publicApi: RpcStub<PublicApi>, prefix: string): Promise<RpcStub<AuthenticatedApi>> {
+  const [username] = nextUsernames(prefix);
+  if (username === undefined) throw new Error("Failed to allocate a username");
+  const authenticated = await signUp(publicApi, username);
+  await authenticated.addModel(MODEL_PROFILE, MODEL_CONFIG);
+  await authenticated.setQuickModel(null);
+  await authenticated.setPreferredModel(MODEL_ID);
+  await authenticated.completeOnboarding();
+  await authenticated.provisionAmbientAccount(TEST_VENDOR_ID);
+  await waitFor("the ambient test account to be provisioned", async () =>
+    (await listConnectedAccounts(authenticated)).find(entry => entry.vendorId === TEST_VENDOR_ID)
+      ?? null);
+  return authenticated;
+}
+
+/** Wait for the agent's turn to end with `text` as its closing message, failing fast on errors. */
+async function waitForAgentSays(
+    workspace: RpcStub<Overseer>, chatId: number, text: string): Promise<void> {
+  await waitFor(`the agent to say "${text}"`, async () => {
+    const current = await workspace.getChatHistory(chatId);
+    const error = current.messages.find(message => message.type === "error");
+    if (error !== undefined) throw new Error(`The scripted agent failed: ${error.message}`);
+    return current.messages.some(message =>
+      message.type === "message" && message.author.type === "agent" &&
+      message.message === text) ? current : null;
+  });
+}
+
+/** Wait until exactly one action is pending and return it. */
+function onlyPendingAction(workspace: RpcStub<Overseer>, what: string) {
+  return waitFor(what, async () => {
+    const entries = (await workspace.listActions({ filter: "pending" })).entries;
+    return entries.length === 1 ? entries[0] : null;
+  });
+}
+
+/** The most recent tool result the mock model was shown for `toolCallId`. */
+function toolResultShownToModel(toolCallId: string): string {
+  for (let i = model.requests.length - 1; i >= 0; i--) {
+    const request = model.requests[i] as {
+      messages?: Array<{ role: string; tool_call_id?: string; content?: string }>;
+    };
+    const result = request.messages?.find(
+        message => message.role === "tool" && message.tool_call_id === toolCallId);
+    if (result?.content !== undefined) return result.content;
+  }
+  throw new Error(`The model never saw a tool result for ${toolCallId}`);
+}
+
+/** All user-role message contents in the model's most recent request. */
+function userMessagesShownToModel(): string[] {
+  const request = model.requests[model.requests.length - 1] as {
+    messages?: Array<{ role: string; content?: string }>;
+  };
+  return (request.messages ?? [])
+      .filter(message => message.role === "user")
+      .map(message => message.content ?? "");
+}
+
+it("creates a resource the agent can use before the user approves it", async () => {
+  using publicApi = connect(harness.url);
+  using authenticated = await signUpScriptedUser(publicApi, "createres");
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Create a new test thing and read it.", MODEL_ID);
+
+  // The turn runs to completion: creation does not suspend the agent the way requestConnection
+  // or an awaitDecision action does.
+  await waitForAgentSays(workspace, chatId, "Created the thing and read 42 from it.");
+
+  // The bad resource type was a fixable rejection: the model retried within the same turn.
+  expect(toolResultShownToModel("create-bad-type")).toMatch(/can create/i);
+  // The successful creation told the agent the binding is live and approval is still pending.
+  expect(toolResultShownToModel("create-thing")).toContain("env.NEW_THING");
+  // The binding worked from executeCode before any approval: the read reached the simulated
+  // resource (the fixture session answers 42).
+  expect(toolResultShownToModel("read-new-thing")).toContain("42");
+
+  // The creation action rode the normal approval flow into the chat and the action log.
+  const pending = await onlyPendingAction(workspace, "the creation action to be pending");
+  expect(pending).toMatchObject({
+    type: "action",
+    state: "pending",
+    description: { title: 'Create test thing "My Thing"' },
+  });
+  expect(pending.resourceUrl).toContain("/things/provisional-");
+  const history = await workspace.getChatHistory(chatId);
+  expect(history.messages.some(message =>
+    message.type === "action" && message.actionId === pending.id)).toBe(true);
+
+  await workspace.approveAction(pending.id);
+
+  // A second turn proves both replay (the binding is re-established from the recorded tool
+  // output) and the post-apply describe refresh (the new action's snapshot carries the real,
+  // no-longer-provisional resource URL).
+  await workspace.sendChatMessage(chatId, "Now set its value to 9.", MODEL_ID);
+  const write = await onlyPendingAction(workspace, "the write action to be pending");
+  expect(write).toMatchObject({
+    type: "action",
+    state: "pending",
+    description: { title: "Set the test value to 9" },
+  });
+  expect(write.resourceUrl).toContain("/things/created-");
+  expect(write.resourceUrl).not.toContain("provisional");
+
+  // Replay told the model about the approval — the recorded tool result permanently says the
+  // resource doesn't exist yet, so without this the model's context never learns it now does.
+  const approval = userMessagesShownToModel().find(message =>
+    message.includes("The user approved the creation of env.NEW_THING"));
+  expect(approval).toContain(write.resourceUrl);
+});
+
+it("kills the binding when the user rejects the creation", async () => {
+  using publicApi = connect(harness.url);
+  using authenticated = await signUpScriptedUser(publicApi, "createrej");
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Create a doomed test thing.", MODEL_ID);
+  await waitForAgentSays(workspace, chatId, "Created the doomed thing.");
+
+  const pending = await onlyPendingAction(workspace, "the creation action to be pending");
+  await workspace.rejectAction(pending.id);
+
+  // The next turn's use of the binding fails with the gatekeeper's dead-binding explanation
+  // rather than silently simulating against nothing.
+  await workspace.sendChatMessage(chatId, "Read the doomed thing.", MODEL_ID);
+  await waitForAgentSays(workspace, chatId, "The doomed thing is gone.");
+  expect(toolResultShownToModel("read-doomed")).toContain("DEAD:");
+  expect(toolResultShownToModel("read-doomed")).toMatch(/rejected/);
+
+  // Replay told the model about the rejection too.
+  expect(userMessagesShownToModel().some(message =>
+    message.includes("The user rejected the creation of env.DOOMED"))).toBe(true);
+});
+
+it("settles the queued action when the vendor fails after queueing it", async () => {
+  using publicApi = connect(harness.url);
+  using authenticated = await signUpScriptedUser(publicApi, "createfail");
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Create a failing test thing.", MODEL_ID);
+  await waitForAgentSays(workspace, chatId, "The creation failed.");
+
+  // The tool reported a fixable rejection carrying the vendor's error...
+  expect(toolResultShownToModel("create-orphan")).toContain("Simulated post-queue failure");
+
+  // ...and the action the vendor had already queued was settled with the removed gatekeeper,
+  // not left pending forever (approve/reject would both fail on the missing facet).
+  const actions = (await workspace.listActions({ filter: "all" })).entries;
+  expect(actions.filter(action => action.state === "pending")).toEqual([]);
+  expect(actions.some(action => action.type === "action" && action.state === "rejected"))
+      .toBe(true);
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
@@ -5,26 +5,19 @@
 
 import { afterAll, beforeAll, expect, it } from "vitest";
 import type { RpcStub } from "capnweb";
-import type {
-  AiChatAuthorInfo, AiModelConfig, AuthenticatedApi, Overseer, PublicApi,
-} from "@gadgets/workshop-shared/api";
+import type { AuthenticatedApi, Overseer, PublicApi } from "@gadgets/workshop-shared/api";
 import {
   startTestGatekeeperHarness, TEST_GATEKEEPER_WORKER, TEST_VENDOR_ID, type Harness,
 } from "../src/harness.js";
-import { scriptedChatCompletions, type ScriptedChatCompletions } from "../src/mock-model.js";
+import {
+  scriptedChatCompletions, SCRIPTED_MODEL_CONFIG, SCRIPTED_MODEL_ID, SCRIPTED_MODEL_PROFILE,
+  type ScriptedChatCompletions,
+} from "../src/mock-model.js";
 import { NetworkInterceptor } from "../src/network-interceptor.js";
 import {
   accountLabel, connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
 } from "../src/rpc-client.js";
 
-const MODEL_ID = "@cf/zai-org/glm-5.2";
-const MODEL_PROFILE: AiChatAuthorInfo = { type: "agent", id: MODEL_ID, name: "Scripted model" };
-const MODEL_CONFIG: AiModelConfig = {
-  provider: "cloudflare",
-  model: MODEL_ID,
-  accountId: "test-account",
-  apiToken: "test-token",
-};
 
 const RESOURCE_URL_PATTERN = "https://gadgets-test.example/things/*";
 
@@ -56,9 +49,9 @@ async function signUpScriptedUser(
   const [username] = nextUsernames(prefix);
   if (username === undefined) throw new Error("Failed to allocate a username");
   const authenticated = await signUp(publicApi, username);
-  await authenticated.addModel(MODEL_PROFILE, MODEL_CONFIG);
+  await authenticated.addModel(SCRIPTED_MODEL_PROFILE, SCRIPTED_MODEL_CONFIG);
   await authenticated.setQuickModel(null);
-  await authenticated.setPreferredModel(MODEL_ID);
+  await authenticated.setPreferredModel(SCRIPTED_MODEL_ID);
   await authenticated.completeOnboarding();
   await authenticated.provisionAmbientAccount(TEST_VENDOR_ID);
   await waitFor("the ambient test account to be provisioned", async () =>
@@ -195,7 +188,7 @@ it("creates a resource the agent can use before the user approves it", async () 
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createres");
   using workspace = await authenticated.newGadget();
-  const chatId = await workspace.newChat("Create a new test thing and read it.", MODEL_ID);
+  const chatId = await workspace.newChat("Create a new test thing and read it.", SCRIPTED_MODEL_ID);
 
   // The turn runs to completion: creation does not suspend the agent the way requestConnection
   // or an awaitDecision action does.
@@ -223,7 +216,7 @@ it("creates a resource the agent can use before the user approves it", async () 
 
   // Turn 2: the binding is re-established from the recorded tool output, and the write is
   // queued while the resource is still provisional. The turn suspends holding both actions.
-  await workspace.sendChatMessage(chatId, "Now set its value to 9.", MODEL_ID);
+  await workspace.sendChatMessage(chatId, "Now set its value to 9.", SCRIPTED_MODEL_ID);
   const queued = await waitFor("the creation and the write to be pending", async () => {
     const entries = (await workspace.listActions({ filter: "pending" })).entries;
     return entries.length === 2 ? entries : null;
@@ -324,7 +317,7 @@ it("kills the binding and cascades to queued edits when the user rejects the cre
   using authenticated = await signUpScriptedUser(publicApi, "createrej");
   using workspace = await authenticated.newGadget();
   const chatId = await workspace.newChat(
-      "Create a doomed test thing and write to it.", MODEL_ID);
+      "Create a doomed test thing and write to it.", SCRIPTED_MODEL_ID);
 
   // The write awaits a decision, so the turn suspends holding two pending actions: the
   // creation and an edit that depends on it.
@@ -345,7 +338,7 @@ it("kills the binding and cascades to queued edits when the user rejects the cre
 
   // The next turn's use of the binding fails with the gatekeeper's dead-binding explanation
   // rather than silently simulating against nothing.
-  await workspace.sendChatMessage(chatId, "Read the doomed thing.", MODEL_ID);
+  await workspace.sendChatMessage(chatId, "Read the doomed thing.", SCRIPTED_MODEL_ID);
   await waitForAgentSays(workspace, chatId, "The doomed thing is gone.");
   expect(toolResultShownToModel("read-doomed")).toContain("DEAD:");
   expect(toolResultShownToModel("read-doomed")).toMatch(/rejected/);
@@ -377,7 +370,7 @@ it("settles the queued action when the vendor fails after queueing it", async ()
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createfail");
   using workspace = await authenticated.newGadget();
-  const chatId = await workspace.newChat("Create a failing test thing.", MODEL_ID);
+  const chatId = await workspace.newChat("Create a failing test thing.", SCRIPTED_MODEL_ID);
   await waitForAgentSays(workspace, chatId, "The creation failed.");
 
   // The tool reported a fixable rejection carrying the vendor's error...
@@ -415,7 +408,7 @@ it("fails closed when the vendor never queues its creation action", async () => 
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createnoop");
   using workspace = await authenticated.newGadget();
-  const chatId = await workspace.newChat("Create a never-queued test thing.", MODEL_ID);
+  const chatId = await workspace.newChat("Create a never-queued test thing.", SCRIPTED_MODEL_ID);
   await waitForAgentSays(workspace, chatId, "The creation failed.");
 
   expect(toolResultShownToModel("create-unqueued")).toMatch(/vendor bug/);
@@ -442,7 +435,7 @@ it("settles an undecided creation when its chat is deleted", async () => {
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createdel");
   using workspace = await authenticated.newGadget();
-  const chatId = await workspace.newChat("Create a thing I will abandon.", MODEL_ID);
+  const chatId = await workspace.newChat("Create a thing I will abandon.", SCRIPTED_MODEL_ID);
   await waitForAgentSays(workspace, chatId, "Created the abandoned thing.");
   const pending = await onlyPendingAction(workspace, "the creation action to be pending");
   if (pending.gatekeeperId === undefined) throw new Error("Creation action has no gatekeeper");
@@ -492,7 +485,7 @@ it("threads creation options to the vendor and its approval card", async () => {
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createopts");
   using workspace = await authenticated.newGadget();
-  const chatId = await workspace.newChat("Create a thing on the top shelf.", MODEL_ID);
+  const chatId = await workspace.newChat("Create a thing on the top shelf.", SCRIPTED_MODEL_ID);
   await waitForAgentSays(workspace, chatId, "Created the shelved thing.");
 
   expect(toolResultShownToModel("create-bad-option")).toContain('accept only "shelf"');

--- a/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
@@ -1,18 +1,20 @@
 // createExternalResource end to end against the fixture gatekeeper: tool → binding → action card
-// → approve → describe refresh, plus the rejection path, replay across turns, and a vendor that
-// fails after queueing its creation action. (Provider depth is covered by per-vendor suites,
-// e.g. gatekeeper-google's workerd tests.)
+// → out-of-order refusal → in-order approval → describe refresh, plus the rejection path, replay
+// across turns, and a vendor that fails after queueing its creation action. (Provider depth is
+// covered by per-vendor suites, e.g. gatekeeper-google's workerd tests.)
 
 import { afterAll, beforeAll, expect, it } from "vitest";
 import type { RpcStub } from "capnweb";
 import type {
   AiChatAuthorInfo, AiModelConfig, AuthenticatedApi, Overseer, PublicApi,
 } from "@gadgets/workshop-shared/api";
-import { startTestGatekeeperHarness, TEST_VENDOR_ID, type Harness } from "../src/harness.js";
+import {
+  startTestGatekeeperHarness, TEST_GATEKEEPER_WORKER, TEST_VENDOR_ID, type Harness,
+} from "../src/harness.js";
 import { scriptedChatCompletions, type ScriptedChatCompletions } from "../src/mock-model.js";
 import { NetworkInterceptor } from "../src/network-interceptor.js";
 import {
-  connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
+  accountLabel, connect, listConnectedAccounts, nextUsernames, signUp, waitFor,
 } from "../src/rpc-client.js";
 
 const MODEL_ID = "@cf/zai-org/glm-5.2";
@@ -109,6 +111,27 @@ function userMessagesShownToModel(): string[] {
       .map(message => message.content ?? "");
 }
 
+/** The hydrated action card for `actionId` in the chat history (what the UI renders from). */
+async function actionCard(workspace: RpcStub<Overseer>, chatId: number, actionId: number) {
+  const history = await workspace.getChatHistory(chatId);
+  const message = history.messages.find(entry =>
+    entry.type === "action" && entry.actionId === actionId);
+  if (message?.type !== "action") throw new Error(`No action card for action ${actionId}`);
+  return message;
+}
+
+/** Vendor-side action bookkeeping for `label` (the fixture control DO's view). */
+async function actionState(label: string) {
+  const response = await harness.fetchWorker(
+      TEST_GATEKEEPER_WORKER, "http://gatekeeper-test.test/control/action-state",
+      { method: "POST", body: JSON.stringify({ label }) });
+  if (response.status !== 200) {
+    throw new Error(`Reading test action state failed with ${response.status}`);
+  }
+  // Loose shape: the assertions pin the fields that matter.
+  return await response.json() as { pending: unknown[]; value?: number; applyCount: number };
+}
+
 it("creates a resource the agent can use before the user approves it", async () => {
   model = scriptedChatCompletions([
     // Turn 1: a fixable rejection, then a successful creation, used immediately.
@@ -146,9 +169,8 @@ it("creates a resource the agent can use before the user approves it", async () 
       },
     },
     { text: "Created the thing and read 42 from it." },
-    // Turn 2 (after approval): the replayed binding still works, and the write's action
-    // snapshot shows the refreshed (created) resource URL. writeValue awaits a decision, so
-    // this turn deliberately suspends.
+    // Turn 2: replay re-establishes the binding, and a write is queued against the
+    // still-provisional resource. writeValue awaits a decision, so this turn suspends.
     {
       toolCall: {
         id: "write-new-thing",
@@ -158,6 +180,17 @@ it("creates a resource the agent can use before the user approves it", async () 
         },
       },
     },
+    // Resumed turn (after in-order approval): the write reached the provider path.
+    {
+      toolCall: {
+        id: "read-after-write",
+        name: "executeCode",
+        arguments: {
+          code: "export default async function(self, env) { console.log(await env.NEW_THING.readValue()); }",
+        },
+      },
+    },
+    { text: "The value is now 9." },
   ]);
   using publicApi = connect(harness.url);
   using authenticated = await signUpScriptedUser(publicApi, "createres");
@@ -184,35 +217,66 @@ it("creates a resource the agent can use before the user approves it", async () 
     description: { title: 'Create test thing "My Thing"' },
   });
   expect(pending.resourceUrl).toContain("/things/provisional-");
-  const history = await workspace.getChatHistory(chatId);
-  expect(history.messages.some(message =>
-    message.type === "action" && message.actionId === pending.id)).toBe(true);
+  // The card in the chat history renders from the hydrated actionLog, not just the id.
+  expect((await actionCard(workspace, chatId, pending.id)).actionLog)
+      .toMatchObject({ state: "pending" });
 
-  await workspace.approveAction(pending.id);
-
-  // A second turn proves both replay (the binding is re-established from the recorded tool
-  // output) and the post-apply describe refresh (the new action's snapshot carries the real,
-  // no-longer-provisional resource URL).
+  // Turn 2: the binding is re-established from the recorded tool output, and the write is
+  // queued while the resource is still provisional. The turn suspends holding both actions.
   await workspace.sendChatMessage(chatId, "Now set its value to 9.", MODEL_ID);
-  const write = await onlyPendingAction(workspace, "the write action to be pending");
-  expect(write).toMatchObject({
-    type: "action",
-    state: "pending",
-    description: { title: "Set the test value to 9" },
+  const queued = await waitFor("the creation and the write to be pending", async () => {
+    const entries = (await workspace.listActions({ filter: "pending" })).entries;
+    return entries.length === 2 ? entries : null;
   });
-  expect(write.resourceUrl).toContain("/things/created-");
-  expect(write.resourceUrl).not.toContain("provisional");
+  const write = queued.find(action => action.description.title === "Set the test value to 9");
+  if (write === undefined) throw new Error("No pending write action found");
+  // Queue-time snapshot: the resource was still provisional when the write was queued.
+  expect(write.resourceUrl).toContain("/things/provisional-");
 
-  // The creation action itself settled as approved.
+  // Approving the dependent write before the creation is refused (the gatekeeper's in-order
+  // guard) and the write stays pending.
+  await expect(workspace.approveAction(write.id)).rejects.toThrow(/does not exist yet/);
+  expect((await workspace.listActions({ filter: "pending" })).entries
+      .some(action => action.id === write.id)).toBe(true);
+
+  // In order: creation, then the write. The write approval resolving is the apply proof — the
+  // platform awaits the vendor's applyAction before marking it approved, and the identical call
+  // was just refused. The second approval resumes the suspended turn.
+  await workspace.approveAction(pending.id);
+  await workspace.approveAction(write.id);
+  await waitForAgentSays(workspace, chatId, "The value is now 9.");
+
+  // Both actions settled, and the post-apply describe refresh retired the provisional URL:
+  // the resumed read's observation snapshots the created resource.
   const all = (await workspace.listActions({ filter: "all" })).entries;
   expect(all.find(action => action.id === pending.id)?.state).toBe("approved");
+  expect(all.find(action => action.id === write.id)?.state).toBe("approved");
+  expect(all.some(action =>
+    action.type === "observation" && action.resourceUrl?.includes("/things/created-"))).toBe(true);
+
+  // actionLog hydrates at read time: the same card now carries the decision, and the creation
+  // card's link was refreshed off the dead provisional URL.
+  expect((await actionCard(workspace, chatId, pending.id)).actionLog).toMatchObject({
+    state: "approved",
+    resourceUrl: expect.stringContaining("/things/created-"),
+  });
+
+  // Vendor-side proof the applies really landed: the creation staged value 0, the write 9.
+  const account = (await listConnectedAccounts(authenticated))
+      .find(entry => entry.vendorId === TEST_VENDOR_ID);
+  if (!account) throw new Error("No connected test account");
+  expect(await actionState(accountLabel(account)))
+      .toMatchObject({ pending: [], value: 9, applyCount: 2 });
 
   // The decision reached the model as a durable nudge — the recorded tool result permanently
   // says the resource doesn't exist yet, so without this the model's context never learns it
-  // now does.
-  const approval = userMessagesShownToModel().find(message =>
-    message.includes("The user approved the creation of env.NEW_THING"));
-  expect(approval).toContain(write.resourceUrl);
+  // now does. The verdict lands before the describe refresh (so it carries no URL); the
+  // refresh then delivers the real URL as a follow-up, or the model would only ever hold the
+  // dead provisional one.
+  expect(userMessagesShownToModel().some(message =>
+    message.includes("The user approved the creation of env.NEW_THING"))).toBe(true);
+  expect(userMessagesShownToModel().some(message =>
+    /env\.NEW_THING now exists at .*\/things\/created-/.test(message))).toBe(true);
   expect(model.remainingSteps()).toBe(0);
 });
 
@@ -327,5 +391,68 @@ it("settles the queued action when the vendor fails after queueing it", async ()
     action.type === "action" && action.state === "rejected");
   if (settled?.gatekeeperId === undefined) throw new Error("No settled creation action found");
   await expect(workspace.getGatekeeperById(settled.gatekeeperId)).rejects.toThrow();
+  expect(model.remainingSteps()).toBe(0);
+});
+
+it("fails closed when the vendor never queues its creation action", async () => {
+  model = scriptedChatCompletions([
+    // A contract-breaking vendor returns from submitCreationAction without queueing; the
+    // overseer must surface the bug instead of leaving a permanently provisional binding.
+    {
+      toolCall: {
+        id: "create-unqueued",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: RESOURCE_URL_PATTERN,
+          title: "never-queues",
+          bindingName: "UNQUEUED",
+        },
+      },
+    },
+    { text: "The creation failed." },
+  ]);
+  using publicApi = connect(harness.url);
+  using authenticated = await signUpScriptedUser(publicApi, "createnoop");
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Create a never-queued test thing.", MODEL_ID);
+  await waitForAgentSays(workspace, chatId, "The creation failed.");
+
+  expect(toolResultShownToModel("create-unqueued")).toMatch(/vendor bug/);
+  expect((await workspace.listActions({ filter: "all" })).entries).toEqual([]);
+  expect(model.remainingSteps()).toBe(0);
+});
+
+it("settles an undecided creation when its chat is deleted", async () => {
+  model = scriptedChatCompletions([
+    {
+      toolCall: {
+        id: "create-abandoned",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: RESOURCE_URL_PATTERN,
+          title: "Abandoned Thing",
+          bindingName: "ABANDONED",
+        },
+      },
+    },
+    { text: "Created the abandoned thing." },
+  ]);
+  using publicApi = connect(harness.url);
+  using authenticated = await signUpScriptedUser(publicApi, "createdel");
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Create a thing I will abandon.", MODEL_ID);
+  await waitForAgentSays(workspace, chatId, "Created the abandoned thing.");
+  const pending = await onlyPendingAction(workspace, "the creation action to be pending");
+  if (pending.gatekeeperId === undefined) throw new Error("Creation action has no gatekeeper");
+
+  await workspace.deleteChat(chatId);
+
+  // The deleted log was the only thing that could ever bind the resource, so the card must not
+  // stay approvable: approving it would mint a provider resource nothing can address.
+  const all = (await workspace.listActions({ filter: "all" })).entries;
+  expect(all.find(action => action.id === pending.id)?.state).toBe("rejected");
+  await expect(workspace.getGatekeeperById(pending.gatekeeperId)).rejects.toThrow();
   expect(model.remainingSteps()).toBe(0);
 });

--- a/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
+++ b/packages/integration-tests/__tests__/workshop-agent-create-resource.test.ts
@@ -456,3 +456,48 @@ it("settles an undecided creation when its chat is deleted", async () => {
   await expect(workspace.getGatekeeperById(pending.gatekeeperId)).rejects.toThrow();
   expect(model.remainingSteps()).toBe(0);
 });
+
+it("threads creation options to the vendor and its approval card", async () => {
+  model = scriptedChatCompletions([
+    // An unknown option is an agent-fixable vendor rejection; the retry with the documented
+    // key succeeds and the approval card reflects the placement.
+    {
+      toolCall: {
+        id: "create-bad-option",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: RESOURCE_URL_PATTERN,
+          title: "Shelved Thing",
+          bindingName: "SHELVED",
+          options: { bogus: true },
+        },
+      },
+    },
+    {
+      toolCall: {
+        id: "create-shelved",
+        name: "createExternalResource",
+        arguments: {
+          vendorId: TEST_VENDOR_ID,
+          resourceUrlPattern: RESOURCE_URL_PATTERN,
+          title: "Shelved Thing",
+          bindingName: "SHELVED",
+          options: { shelf: "top" },
+        },
+      },
+    },
+    { text: "Created the shelved thing." },
+  ]);
+  using publicApi = connect(harness.url);
+  using authenticated = await signUpScriptedUser(publicApi, "createopts");
+  using workspace = await authenticated.newGadget();
+  const chatId = await workspace.newChat("Create a thing on the top shelf.", MODEL_ID);
+  await waitForAgentSays(workspace, chatId, "Created the shelved thing.");
+
+  expect(toolResultShownToModel("create-bad-option")).toContain('accept only "shelf"');
+  const pending = await onlyPendingAction(workspace, "the creation action to be pending");
+  if (pending.type !== "action") throw new Error("Expected an action record");
+  expect(pending.description.description).toContain("on shelf top");
+  expect(model.remainingSteps()).toBe(0);
+});

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -39,6 +39,9 @@ const SUPPORTED_RESOURCES: SupportedResource[] = [{
   urlPattern: `https://${VENDOR_HOST}/things/*`,
   title: "Test Thing",
   description: "A resource that exists only so tests can bind something.",
+  creatable: {
+    description: "Creates a new test thing with the given title.",
+  },
 }];
 
 const TYPES_CODE = `
@@ -161,7 +164,12 @@ function control(exports: Cloudflare.Exports): DurableObjectStub<TestControl> {
 // Vendor
 
 type AccountProps = { label: string };
-type BindingProps = AccountProps & { resourceUrl: string; ambient?: true };
+type BindingProps = AccountProps & {
+  resourceUrl: string;
+  ambient?: true;
+  /** Present on bindings minted by createResource(): the thing to create once approved. */
+  creation?: { title: string };
+};
 
 @validateRpc()
 export class GatekeeperVendor extends WorkerEntrypoint<Cloudflare.Env> {
@@ -247,6 +255,31 @@ export class TestAccount
         props: { label: this.ctx.props.label, resourceUrl: url },
       }),
       resource: SUPPORTED_RESOURCES[0],
+    };
+  }
+
+  /**
+   * Mint a NEW test thing (createExternalResource): a provisional resource URL and a gatekeeper
+   * class that simulates the thing until the creation action is approved.
+   */
+  async createResource(resourceUrlPattern: string, options: { title: string }): Promise<{
+    class: DurableObjectClass<Gatekeeper<TestSession>>;
+    resource: SupportedResource;
+    resourceUrl: string;
+  }> {
+    if (resourceUrlPattern !== SUPPORTED_RESOURCES[0].urlPattern) {
+      throw new Error(
+          `The test gatekeeper cannot create resources of type "${resourceUrlPattern}".`);
+    }
+    const resourceUrl = `https://${VENDOR_HOST}/things/provisional-${crypto.randomUUID()}`;
+    return {
+      class: this.ctx.exports.TestGatekeeper({
+        props: {
+          label: this.ctx.props.label, resourceUrl, creation: { title: options.title },
+        },
+      }),
+      resource: SUPPORTED_RESOURCES[0],
+      resourceUrl,
     };
   }
 
@@ -362,6 +395,21 @@ export class TestGatekeeper
         tsType: "TestThing",
       };
     }
+    const creation = this.ctx.props.creation;
+    if (creation) {
+      // Answered locally in both states: a created thing has no provider to describe from, and
+      // before approval there is nothing at the provider at all.
+      const createdUrl = this.ctx.storage.kv.get<string>("createdUrl");
+      return {
+        url: createdUrl ?? this.ctx.props.resourceUrl,
+        title: creation.title,
+        snippet: createdUrl
+          ? `The created test resource ${creation.title}.`
+          : `Test thing (pending creation): ${creation.title}.`,
+        suggestedBindingName: "TEST_THING",
+        tsType: "TestThing",
+      };
+    }
     const name = decodeURIComponent(new URL(this.ctx.props.resourceUrl).pathname.split("/").pop()!);
     return {
       url: this.ctx.props.resourceUrl,
@@ -382,8 +430,40 @@ export class TestGatekeeper
   }
 
   async startSession(approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {
+    if (this.ctx.storage.kv.get<boolean>("creationRejected")) {
+      throw new Error(
+          "The user rejected creating this test thing; the binding is dead.");
+    }
     return new TestSessionTarget(
         approvalQueue, control(this.ctx.exports), this.ctx.props.label);
+  }
+
+  /** Queue the creation of this test thing (createExternalResource). Idempotent. */
+  async submitCreationAction(approvalQueue: RpcStub<ApprovalQueue>): Promise<void> {
+    const creation = this.ctx.props.creation;
+    if (!creation) {
+      throw new Error("This test gatekeeper was not minted by createResource().");
+    }
+    if (this.ctx.storage.kv.get<number>("creationActionId") !== undefined) return;
+    const id = await control(this.ctx.exports).stageAction(this.ctx.props.label, 0);
+    this.ctx.storage.kv.put("creationActionId", id);
+    try {
+      await approvalQueue.submitAction(id, {
+        title: `Create test thing "${creation.title}"`,
+        description: `Create a new test thing titled **${creation.title}**.`,
+        implementsRevert: false,
+        actionKind: { tag: "create-thing", label: "Create thing" },
+      });
+    } catch (error) {
+      this.ctx.storage.kv.delete("creationActionId");
+      await control(this.ctx.exports).discardAction(this.ctx.props.label, id);
+      throw error;
+    }
+    // Test knob: this title makes the call reject only after the action was durably queued,
+    // modeling a vendor that fails post-queue (the overseer must settle the orphaned action).
+    if (creation.title === "fail-after-queue") {
+      throw new Error("Simulated post-queue failure.");
+    }
   }
 
   /**
@@ -413,11 +493,29 @@ export class TestGatekeeper
   }
 
   async applyAction(action: number): Promise<void> {
+    // The in-order guard the submitCreationAction contract requires: manual approval can target
+    // any pending action, so the gatekeeper itself must refuse to apply anything that depends on
+    // the thing existing until the creation has been applied.
+    const creationActionId = this.ctx.storage.kv.get<number>("creationActionId");
+    if (creationActionId !== undefined && action !== creationActionId &&
+        this.ctx.storage.kv.get<string>("createdUrl") === undefined) {
+      throw new Error(
+          "The test thing does not exist yet: approve its creation action before this one.");
+    }
     await control(this.ctx.exports).applyAction(this.ctx.props.label, action);
+    if (action === this.ctx.storage.kv.get<number>("creationActionId")) {
+      // The thing now "exists": describe() flips from the provisional URL to the real one.
+      this.ctx.storage.kv.put(
+          "createdUrl",
+          this.ctx.props.resourceUrl.replace("/things/provisional-", "/things/created-"));
+    }
   }
 
   async rejectAction(action: number): Promise<void> {
     await control(this.ctx.exports).discardAction(this.ctx.props.label, action);
+    if (action === this.ctx.storage.kv.get<number>("creationActionId")) {
+      this.ctx.storage.kv.put("creationRejected", true);
+    }
   }
 
   async revertAction(_action: number): Promise<void> {

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -444,6 +444,8 @@ export class TestGatekeeper
     if (!creation) {
       throw new Error("This test gatekeeper was not minted by createResource().");
     }
+    // Test knob: a contract-breaking vendor that returns without queueing its creation.
+    if (creation.title === "never-queues") return;
     if (this.ctx.storage.kv.get<number>("creationActionId") !== undefined) return;
     const id = await control(this.ctx.exports).stageAction(this.ctx.props.label, 0);
     this.ctx.storage.kv.put("creationActionId", id);

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -24,8 +24,8 @@ import { DurableObject, RpcTarget, WorkerEntrypoint, type RpcStub } from "cloudf
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import type {
   AccountDescription, ActionKind, ApprovalQueue, Gatekeeper, GatekeeperConnectCallback,
-  GatekeeperUser, GatekeeperUserVerifier, ResourceDescription, ResourceConfiguratorFrame,
-  SupportedResource, VendorDescription,
+  GatekeeperUser, GatekeeperUserVerifier, ResourceCreationOptions, ResourceDescription,
+  ResourceConfiguratorFrame, SupportedResource, VendorDescription,
 } from "@gadgets/workshop-shared/gatekeeper";
 import type {
   ChatGatewayRpcTarget, GadgetResponse,
@@ -168,7 +168,7 @@ type BindingProps = AccountProps & {
   resourceUrl: string;
   ambient?: true;
   /** Present on bindings minted by createResource(): the thing to create once approved. */
-  creation?: { title: string };
+  creation?: { title: string, shelf?: string };
 };
 
 @validateRpc()
@@ -262,7 +262,8 @@ export class TestAccount
    * Mint a NEW test thing (createExternalResource): a provisional resource URL and a gatekeeper
    * class that simulates the thing until the creation action is approved.
    */
-  async createResource(resourceUrlPattern: string, options: { title: string }): Promise<{
+  async createResource(resourceUrlPattern: string,
+      input: { title: string, options?: ResourceCreationOptions }): Promise<{
     class: DurableObjectClass<Gatekeeper<TestSession>>;
     resource: SupportedResource;
     resourceUrl: string;
@@ -271,11 +272,24 @@ export class TestAccount
       throw new Error(
           `The test gatekeeper cannot create resources of type "${resourceUrlPattern}".`);
     }
+    // Per the ResourceCreationOptions contract: unknown/invalid options are agent-fixable
+    // rejections, and accepted ones surface on the creation card (see submitCreationAction).
+    const { title, options } = input;
+    const unknown = Object.keys(options ?? {}).filter((key) => key !== "shelf");
+    if (unknown.length > 0) {
+      throw new Error(`Unknown creation option(s): ${unknown.join(", ")}. ` +
+          `Test things accept only "shelf" (a string).`);
+    }
+    const shelf = options?.shelf;
+    if (shelf !== undefined && typeof shelf !== "string") {
+      throw new Error(`The "shelf" creation option must be a string.`);
+    }
     const resourceUrl = `https://${VENDOR_HOST}/things/provisional-${crypto.randomUUID()}`;
     return {
       class: this.ctx.exports.TestGatekeeper({
         props: {
-          label: this.ctx.props.label, resourceUrl, creation: { title: options.title },
+          label: this.ctx.props.label, resourceUrl,
+          creation: { title, ...(shelf !== undefined ? { shelf } : {}) },
         },
       }),
       resource: SUPPORTED_RESOURCES[0],
@@ -452,7 +466,8 @@ export class TestGatekeeper
     try {
       await approvalQueue.submitAction(id, {
         title: `Create test thing "${creation.title}"`,
-        description: `Create a new test thing titled **${creation.title}**.`,
+        description: `Create a new test thing titled **${creation.title}**` +
+            `${creation.shelf !== undefined ? ` on shelf ${creation.shelf}` : ""}.`,
         implementsRevert: false,
         actionKind: { tag: "create-thing", label: "Create thing" },
       });

--- a/packages/workshop-backend/__tests__/agent-compaction.test.ts
+++ b/packages/workshop-backend/__tests__/agent-compaction.test.ts
@@ -361,6 +361,42 @@ describe("compaction checkpoint state", () => {
     expect(state.nextChangeId).toBe(1);
   });
 
+  // Replay re-establishes a created resource's binding from the recorded tool output; once
+  // compaction swallows the creation call, the checkpoint must carry the same binding.
+  it("folds a created external resource's binding into the checkpoint", () => {
+    let state = buildState([
+      {
+        ...message(0, agent, "Creating"),
+        toolCalls: [{
+          toolCallId: "call_1", toolName: "createExternalResource",
+          input: {vendorId: "docs", resourceUrlPattern: "https://example.com/*",
+                  title: "Notes", bindingName: "NOTES"},
+          output: {gatekeeperId: 5, resourceUrl: "https://example.com/prov", message: "Created"},
+        }],
+      },
+    ], 1);
+
+    expect(state.chatBindings).toContainEqual(["NOTES", {type: "workpiece", id: 5}]);
+  });
+
+  // A rejection is recorded as a string output with no `error` set; no binding was made, so none
+  // may be folded.
+  it("does not bind a rejected external-resource creation", () => {
+    let state = buildState([
+      {
+        ...message(0, agent, "Creating"),
+        toolCalls: [{
+          toolCallId: "call_1", toolName: "createExternalResource",
+          input: {vendorId: "docs", resourceUrlPattern: "https://example.com/*",
+                  title: "Notes", bindingName: "NOTES"},
+          output: "Cannot create the resource: no connected account.",
+        }],
+      },
+    ], 1);
+
+    expect(state.chatBindings.map(([name]) => name)).not.toContain("NOTES");
+  });
+
   it("carries a previous checkpoint's proposed state forward", () => {
     let previous = {
       chatId: 1, compactedTo: 3, summary: "earlier",

--- a/packages/workshop-backend/__tests__/chat-changes.test.ts
+++ b/packages/workshop-backend/__tests__/chat-changes.test.ts
@@ -1317,6 +1317,27 @@ describe("reconcilePendingGadgets", () => {
     expect(record.pending).toBeUndefined();
     expect(impl.storage.actions.get(8)!.state).toBe("approved");
   }));
+
+  it("delivers the deferred approval nudge when keeping an approved creation",
+      () => withImpl(async impl => {
+    addChat(impl, 1);
+    impl.storage.gatekeepers.put({
+      id: 502, class: { type: "vendor", vendorId: "test", accountId: 1 },
+      provisional: true, pending: { chatId: 1 }, creation: { bindingName: "THING", actionId: 9 },
+    });
+    impl.storage.actions.put({
+      id: 9, gatekeeperId: 502, caller: { from: "agent", chatId: 1 }, action: 1,
+      createdAt: new Date(), state: "approved", appliedAt: new Date(), type: "action",
+      resolvedBy: { type: "user", id: "u", name: "User" },
+      description: { title: "Create thing" },
+    });
+
+    await impl.reconcilePendingGadgets(1);
+    expect(impl.storage.gatekeepers.get(502)!.pending).toBeUndefined();
+    let nudges = chatMessages(impl, 1).filter(m => m.type === "agentNudge");
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0].text).toContain("The user approved the creation of env.THING");
+  }));
 });
 
 describe("chat content reconstruction", () => {

--- a/packages/workshop-backend/__tests__/chat-changes.test.ts
+++ b/packages/workshop-backend/__tests__/chat-changes.test.ts
@@ -1276,6 +1276,47 @@ describe("reconcilePendingGadgets", () => {
     await impl.reconcilePendingGadgets(1);
     expect(impl.storage.gadgets.get(created.id)).toBeUndefined();
   }));
+
+  // Simulates a createExternalResource mint whose step crashed before the barrier: the
+  // gatekeeper record and its queued creation action are durable, but no tool call backs them.
+  it("reaps a crash-orphaned provisional gatekeeper and settles its creation action",
+      () => withImpl(async impl => {
+    addChat(impl, 1);
+    impl.storage.gatekeepers.put({
+      id: 500, class: { type: "vendor", vendorId: "test", accountId: 1 },
+      provisional: true, pending: { chatId: 1 }, creation: { bindingName: "THING", actionId: 7 },
+    });
+    impl.storage.actions.put({
+      id: 7, gatekeeperId: 500, caller: { from: "agent", chatId: 1 }, action: 1,
+      createdAt: new Date(), state: "pending", type: "action",
+      description: { title: "Create thing" },
+    });
+
+    await impl.reconcilePendingGadgets(1);
+    expect(impl.storage.gatekeepers.get(500)).toBeUndefined();
+    expect(impl.storage.actions.get(7)!.state).toBe("rejected");
+  }));
+
+  it("keeps a pending-marked gatekeeper whose creation action was approved",
+      () => withImpl(async impl => {
+    addChat(impl, 1);
+    impl.storage.gatekeepers.put({
+      id: 501, class: { type: "vendor", vendorId: "test", accountId: 1 },
+      provisional: true, pending: { chatId: 1 }, creation: { bindingName: "THING", actionId: 8 },
+    });
+    impl.storage.actions.put({
+      id: 8, gatekeeperId: 501, caller: { from: "agent", chatId: 1 }, action: 1,
+      createdAt: new Date(), state: "approved", appliedAt: new Date(), type: "action",
+      description: { title: "Create thing" },
+    });
+
+    // The approved creation is proof the resource may exist at the provider: keep the
+    // gatekeeper, clear only the crash marker.
+    await impl.reconcilePendingGadgets(1);
+    let record = impl.storage.gatekeepers.get(501)!;
+    expect(record.pending).toBeUndefined();
+    expect(impl.storage.actions.get(8)!.state).toBe("approved");
+  }));
 });
 
 describe("chat content reconstruction", () => {

--- a/packages/workshop-backend/__tests__/deleted-chat-creation-sweep.test.ts
+++ b/packages/workshop-backend/__tests__/deleted-chat-creation-sweep.test.ts
@@ -1,0 +1,80 @@
+// deleteChat settles an undecided creation only when nothing else binds it: a surviving gadget
+// edge (merged, or another chat's — the deleted chat's own pending edges are severed first)
+// keeps the card approvable, so the sweep must leave the record alone. The unbound case is
+// pinned end-to-end by the integration suite ("settles an undecided creation when its chat is
+// deleted").
+//
+// Runs against a real OverseerDurableObject (the TEST_OVERSEER binding, like
+// observer-rejected-creation-scope.test.ts).
+
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import type { OverseerDurableObject } from "../src/overseer.js";
+
+declare module "cloudflare:workers" {
+  interface ProvidedEnv {
+    TEST_OVERSEER: DurableObjectNamespace<OverseerDurableObject>;
+  }
+}
+
+const CHAT_ID = 9;
+const GATEKEEPER_ID = 1;
+const CREATION_ACTION_ID = 42;
+
+// The slice of OverseerImpl this test touches; records go in as plain literals.
+type TestImpl = {
+  storage: {
+    gatekeepers: { get(id: number): unknown; put(record: unknown): void };
+    actions: { get(id: number): { state: string } | undefined; put(record: unknown): void };
+    gadgets: { put(record: unknown): void };
+  };
+  removeChatWorkpieces(chatId: number): Promise<void>;
+};
+
+async function withImpl(fn: (impl: TestImpl) => Promise<void>): Promise<void> {
+  let stub = env.TEST_OVERSEER.getByName(`deleted-chat-creation-sweep-${crypto.randomUUID()}`);
+  await runInDurableObject(stub, async (instance: OverseerDurableObject) => {
+    // Private member access: tests in this suite reach the impl behind the DO facade.
+    await fn((instance as unknown as { impl: TestImpl }).impl);
+  });
+}
+
+describe("chat deletion and undecided creations", () => {
+  it("spares a creation a surviving gadget edge still binds", () => withImpl(async impl => {
+    impl.storage.gatekeepers.put({
+      id: GATEKEEPER_ID,
+      resourceTitle: "Provisional Doc",
+      class: {},
+      provisional: true,
+      creationSpec: {
+        type: "gatekeeper",
+        vendorId: "testvendor",
+        resourceUrl: "https://example.com/provisional-1",
+        typeUrlPattern: "https://*",
+      },
+      creation: { chatId: CHAT_ID, bindingName: "DOC", actionId: CREATION_ACTION_ID },
+    });
+    impl.storage.actions.put({
+      id: CREATION_ACTION_ID,
+      gatekeeperId: GATEKEEPER_ID,
+      type: "action",
+      state: "pending",
+      caller: { from: "agent", chatId: CHAT_ID },
+      resourceTitle: "Provisional Doc",
+      createdAt: new Date(0),
+      action: {},
+      description: { title: "Create", description: "Create it", implementsRevert: false },
+    });
+    // A permanent (merged) edge from another chat's gadget.
+    impl.storage.gadgets.put({
+      type: "gadget", id: 100, title: "G", created: new Date(0), bindingName: "G",
+      bindings: { DOC: { target: GATEKEEPER_ID } },
+    });
+
+    await impl.removeChatWorkpieces(CHAT_ID);
+
+    expect(impl.storage.gatekeepers.get(GATEKEEPER_ID)).toBeDefined();
+    expect(impl.storage.actions.get(CREATION_ACTION_ID)?.state).toBe("pending");
+  }));
+});

--- a/packages/workshop-backend/__tests__/git-push-actions.test.ts
+++ b/packages/workshop-backend/__tests__/git-push-actions.test.ts
@@ -52,9 +52,12 @@ async function storeLocal(impl: any, type: string, payload: Uint8Array): Promise
   return oid;
 }
 
-// Seeds the standard scenario: the gatekeeper has proven a base commit (empty tree), and a
-// locally-authored commit sits on top of it. Returns both oids.
+// Seeds the standard scenario: the gatekeeper record exists (submitAction refuses to queue
+// against a removed one), it has proven a base commit (empty tree), and a locally-authored
+// commit sits on top of it. Returns both oids.
 async function seedPushableHistory(impl: any): Promise<{ base: string, head: string }> {
+  impl.storage.gatekeepers.put(
+      { id: GATEKEEPER, class: { type: "vendor", vendorId: "test", accountId: 1 } });
   let treeOid = await impl.gitCache.putFromGatekeeper(GATEKEEPER, "tree", new Uint8Array(0));
   let base = await impl.gitCache.putFromGatekeeper(
       GATEKEEPER, "commit", commitPayload(treeOid, [], "base"));

--- a/packages/workshop-backend/__tests__/observer-rejected-creation-scope.test.ts
+++ b/packages/workshop-backend/__tests__/observer-rejected-creation-scope.test.ts
@@ -1,0 +1,79 @@
+// A rejected creation's gatekeeper is retained only to explain its dead binding, so it must not
+// stay an observer requirement: a build collaborator without an account of that vendor would be
+// locked out of the workspace by a resource the user declined.
+//
+// Runs against a real OverseerDurableObject (the TEST_OVERSEER binding, like
+// observer-exclude-scope.test.ts).
+
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import type { OverseerDurableObject } from "../src/overseer.js";
+
+declare module "cloudflare:workers" {
+  interface ProvidedEnv {
+    TEST_OVERSEER: DurableObjectNamespace<OverseerDurableObject>;
+  }
+}
+
+// The slice of OverseerImpl this test touches; records go in as plain literals.
+type TestImpl = {
+  storage: {
+    gatekeepers: { put(record: unknown): void };
+    actions: { put(record: unknown): void };
+  };
+  listObserverRequirements(role: "build" | "use"): Array<{ gatekeeperId: number }>;
+};
+
+const GATEKEEPER_ID = 1;
+const CREATION_ACTION_ID = 42;
+
+let doCounter = 0;
+
+async function withImpl(fn: (impl: TestImpl) => Promise<void>): Promise<void> {
+  let stub = env.TEST_OVERSEER.getByName(`rejected-creation-scope-${++doCounter}`);
+  await runInDurableObject(stub, async (instance: OverseerDurableObject) => {
+    // Private member access: tests in this suite reach the impl behind the DO facade.
+    await fn((instance as unknown as { impl: TestImpl }).impl);
+  });
+}
+
+// A createExternalResource mint whose creation action is in the given state.
+function putCreation(impl: TestImpl, state: "pending" | "rejected"): void {
+  impl.storage.gatekeepers.put({
+    id: GATEKEEPER_ID,
+    resourceTitle: "Provisional Doc",
+    class: {},
+    creationSpec: {
+      type: "gatekeeper",
+      vendorId: "testvendor",
+      resourceUrl: "https://example.com/provisional-1",
+      typeUrlPattern: "https://*",
+    },
+    creation: { chatId: 1, bindingName: "DOC", actionId: CREATION_ACTION_ID },
+  });
+  impl.storage.actions.put({
+    id: CREATION_ACTION_ID,
+    gatekeeperId: GATEKEEPER_ID,
+    type: "action",
+    state,
+    caller: { from: "agent", chatId: 1 },
+    resourceTitle: "Provisional Doc",
+    createdAt: new Date(0),
+    action: {},
+    description: { title: "Create", description: "Create it", implementsRevert: false },
+  });
+}
+
+describe("rejected creations and observer verification scope", () => {
+  it("a pending creation is a build-scope requirement; a rejected one is not",
+      () => withImpl(async impl => {
+    putCreation(impl, "pending");
+    expect(impl.listObserverRequirements("build")).toEqual([
+      expect.objectContaining({ gatekeeperId: GATEKEEPER_ID }),
+    ]);
+
+    putCreation(impl, "rejected");
+    expect(impl.listObserverRequirements("build")).toEqual([]);
+  }));
+});

--- a/packages/workshop-backend/src/agent-compaction.ts
+++ b/packages/workshop-backend/src/agent-compaction.ts
@@ -1,4 +1,5 @@
-import {SUGGESTED_MODELS, WORKERS_AI_OUTPUT_LIMIT, type AiChatMessage, type AiModelConfig}
+import {SUGGESTED_MODELS, WORKERS_AI_OUTPUT_LIMIT, isCreatedResourceSuccess, type AiChatMessage,
+        type AiModelConfig}
   from "@gadgets/workshop-shared/api";
 import {composeCodeChange, type CodeChange} from "@gadgets/workshop-shared/code-change";
 import type {Api, Message, Model} from "@earendil-works/pi-ai";
@@ -201,7 +202,8 @@ export function legacyChatBaseVersion(
  * Earliest turn a checkpoint cannot absorb, or undefined if none. A pending connection request
  * carries live accept/deny state that only its own message can answer, so the boundary stays behind
  * it. Provisional gadget creations and binding additions need no such protection: the checkpoint
- * records them, and the registry rows they name are untouched by compaction.
+ * records them, and the registry rows they name are untouched by compaction. (Nor do pending
+ * creation actions: their decision arrives as a durable agentNudge, an ordinary message.)
  */
 export function findProtectedFromSequence(messages: AiChatMessage[]): number | undefined {
   let protectedIndex = messages.findIndex(
@@ -393,6 +395,11 @@ export function buildCompactionState(
         } else if (call.toolName === "createWorktree" && call.output !== undefined) {
           chatBindings.set(call.input.bindingName,
               {type: "workpiece", id: call.output.worktreeId});
+        } else if (call.toolName === "createExternalResource" &&
+                   isCreatedResourceSuccess(call.output)) {
+          // Mirrors replay's re-establishment of the binding from the recorded output.
+          chatBindings.set(call.input.bindingName,
+              {type: "workpiece", id: call.output.gatekeeperId});
         }
       }
     } else if (message.type === "agentCallback") {

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -3317,6 +3317,9 @@ export async function runAgent(
             nameProblem = `There is already a binding named "${input.bindingName}" in your ` +
                 `env. Choose a different name.`;
           }
+          if (nameProblem === undefined && input.title.trim().length === 0) {
+            nameProblem = `A resource requires a non-empty title.`;
+          }
           if (nameProblem !== undefined) {
             let message = `Cannot create the resource: ${nameProblem}`;
             return toolResult(message, { output: message });

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -1,4 +1,4 @@
-import { AiChatMessage, AiChatAuthorInfo, AiToolCall, AiChatMessageBody, AgentSpawnerConfig, AiChatStreamEvent, BlueprintOutput, ChatGadgetPin, ChatCodeBase, WorkpieceId, type AiModelConfig, isTextLikeAttachmentMimeType, validateBindingName } from '@gadgets/workshop-shared/api';
+import { AiChatMessage, AiChatAuthorInfo, AiToolCall, AiChatMessageBody, AgentSpawnerConfig, AiChatStreamEvent, BlueprintOutput, ChatGadgetPin, ChatCodeBase, WorkpieceId, type AiModelConfig, type CreatedResourceOutput, isCreatedResourceSuccess, isTextLikeAttachmentMimeType, validateBindingName } from '@gadgets/workshop-shared/api';
 import { applyCodeChange, codeChangeSerializedSize, replaceSpanChange, type CodeContent,
   type CodeChange, type FileChange } from '@gadgets/workshop-shared/code-change';
 import { PDF_MIME_TYPE, modelApiSupportsPdfAttachments } from './chat-attachment-pdf';
@@ -386,6 +386,15 @@ export function makeStoredAssistantMessage(message: AssistantMessage): StoredAss
   };
 }
 
+/** Input of the createExternalResource tool (see the AgentHooks member for semantics). */
+export type CreateExternalResourceInput = {
+  vendorId: string;
+  resourceUrlPattern: string;
+  title: string;
+  bindingName: string;
+  accountId?: number;
+};
+
 /**
  * Methods of OverseerImpl that runAgent() needs to call, extracted as an interface to avoid cyclic
  * dependencies.
@@ -631,6 +640,21 @@ export interface AgentHooks {
    * (analogous to consumeCapturedActions).
    */
   consumeCapturedConnectionRequests(chatId: number): AiChatMessageBody[];
+
+  /**
+   * Create a new external resource via a connected account: resolves the vendor + creatable
+   * resource type, mints a provisional gatekeeper workpiece (GatekeeperUser.createResource +
+   * addGatekeeper), and submits the creation action attributed to this chat (its card is spliced
+   * via consumeCapturedActions like any action). Unlike requestConnection, no user action gates
+   * the binding — the gatekeeper simulates the resource until the creation is approved — so the
+   * turn does NOT end. A string result is a fixable rejection (unknown vendor, type not
+   * creatable, no usable account, missing authorization); the agent retries in-turn. Either
+   * shape is recorded verbatim as the tool call's output (see isCreatedResourceSuccess).
+   * `initiator` names whose connected accounts create the resource -- the turn's initiator, not
+   * the workspace owner, so a collaborator-driven turn uses (and enumerates) their own accounts.
+   */
+  createExternalResource(chatId: number, input: CreateExternalResourceInput,
+      initiator: AiChatAuthorInfo): Promise<CreatedResourceOutput | string>;
 
   /**
    * Blueprint hooks for the agent.
@@ -984,6 +1008,12 @@ List the resource types a gatekeeper vendor offers, so you can construct a resou
 
 let REQUEST_CONNECTION_TOOL_DESCRIPTION = `
 Ask the user to connect a gatekeeper resource (e.g. a ClickHouse cluster, a GitHub repo). Pre-configure as much as you can: always pass vendorId, and pass resourceUrl when you can infer it (use listConnectableResources to learn the URL patterns). The request must resolve to a specific resource: if you pass a resourceUrl it must match one of the vendor's patterns, and if the vendor offers multiple resource types with no whole-instance option you MUST pass a matching resourceUrl. Otherwise the call is rejected with guidance and no card is shown — fix the request and try again. You also choose \`bindingName\`: the name the resource will have in your env once connected (you know why you want the resource, so pick a name that reflects its role). On success this shows the user an accept/deny card in the chat. It does NOT block: your turn ends after a successful call, and you will be resumed once the user accepts (the resource becomes available as \`env.<bindingName>\`, which you can describeBinding and use from executeCode; wire it into a Gadget with setGadgetBinding only if the Gadget's code needs it) or denies (your turn simply ends; wait for the user's next message).
+`.trim();
+
+let CREATE_EXTERNAL_RESOURCE_TOOL_DESCRIPTION = `
+Create a brand-new external resource (e.g. a new Google Doc) through an already-connected account. Only resource types marked "Creatable" by listConnectableResources support this; requestConnection is for binding a resource that already EXISTS. Pass the vendor id, the creatable type's urlPattern, a human-readable title for the new resource, and a bindingName (a JavaScript identifier not already in use; style: ALL_CAPS_WITH_UNDERSCORES).
+
+This does NOT block: on success the resource is immediately available as \`env.<bindingName>\` (describeBinding it, use it from executeCode) and your turn continues. The resource does not exist at the provider yet — the creation is submitted for the user's approval like any other action, and the gatekeeper simulates it locally until then, so edits you queue apply after the creation is approved, in order. If the call is rejected with guidance (bad name, unknown type, no connected account), fix the request and try again; if multiple accounts are connected the rejection lists their ids so you can retry with accountId or ask the user.
 `.trim();
 
 let GIVE_UP_TOOL_DESCRIPTION = `
@@ -1926,6 +1956,22 @@ export async function runAgent(
                 case "requestConnection":
                   toolOutput = {text: toolCall.output ?? ""};
                   break;
+                case "createExternalResource": {
+                  // Like createGadget: a creation tool can't re-run, so replay re-establishes
+                  // the binding from the recorded output.
+                  if (toolCall.output === undefined) {
+                    throw new Error(
+                        "createExternalResource tool call in log is missing its result");
+                  }
+                  if (isCreatedResourceSuccess(toolCall.output)) {
+                    chatBindings.set(toolCall.input.bindingName,
+                        {type: "workpiece", id: toolCall.output.gatekeeperId});
+                    toolOutput = {text: jsonToolResultText(toolCall.output)};
+                  } else {
+                    toolOutput = {text: toolCall.output};
+                  }
+                  break;
+                }
                 default:
                   toolCall satisfies never;
                   throw new Error("Unknown tool.");
@@ -2204,7 +2250,8 @@ export async function runAgent(
       case "action":
       case "useGadget":
       case "error":
-        // No need to tell the agent about this.
+        // No need to tell the agent about this. (A creation action's decision reaches the model
+        // as a durable agentNudge appended when the user decides — see nudgeCreationDecision.)
         break;
 
       default:
@@ -2473,7 +2520,10 @@ export async function runAgent(
           `can; use listConnectableResources to learn a vendor's resource URL patterns first). The ` +
           `user accepts or denies in the chat. If they accept, you'll be resumed and the resource ` +
           `becomes available as a binding in your env; if they deny, your turn ends and you wait ` +
-          `for the user's next message.\n` +
+          `for the user's next message. Resource types listConnectableResources marks "Creatable" ` +
+          `can instead be created brand-new with createExternalResource through an ` +
+          `already-connected account — that binding is usable immediately (the user approves the ` +
+          `creation as a normal action while you keep working).\n` +
           `If one of these services likely holds information relevant to the task, consider ` +
           `requesting a connection and reading from it before you answer, instead of answering from ` +
           `guesswork — a connection often gives you the real information. Connectable vendors:\n` +
@@ -3216,6 +3266,76 @@ export async function runAgent(
             claimedNames.add(input.bindingName);
           }
           return toolResult(result.message, { output: result.message });
+        } catch (error) {
+          toolCallNotes.set(toolCallId, { error: toolErrorText(error) });
+          throw error;
+        }
+      }
+    }),
+
+    createExternalResource: defineTool({
+      name: "createExternalResource",
+      label: "Create external resource",
+      description: CREATE_EXTERNAL_RESOURCE_TOOL_DESCRIPTION,
+      parameters: Type.Object({
+        vendorId: Type.String({
+          description: "Vendor id, as listed in the system prompt (e.g. 'google').",
+        }),
+        resourceUrlPattern: Type.String({
+          description:
+              "The urlPattern of the resource type to create, exactly as listed by " +
+              "listConnectableResources. Only types marked Creatable can be created.",
+        }),
+        title: Type.String({
+          description:
+              "Human-readable title for the new resource (e.g. the document title). Shown to " +
+              "the user on the approval card.",
+        }),
+        bindingName: Type.String({
+          description:
+              "Name under which the new resource appears in your env immediately. Must be a " +
+              "JavaScript identifier not already in use; pick a name reflecting the resource's " +
+              "role. Style: ALL_CAPS_WITH_UNDERSCORES.",
+        }),
+        accountId: Type.Optional(Type.Number({
+          description:
+              "Which connected account creates the resource. Only needed when several accounts " +
+              "of the vendor are connected (a rejection will list the candidate ids).",
+        })),
+      }),
+      execute: async (toolCallId, input) => {
+        try {
+          // Validate the chosen name before creating anything; like requestConnection, a bad
+          // name is a fixable message (not an error) so the agent retries within the same turn.
+          let nameProblem: string | undefined;
+          try {
+            validateBindingName(input.bindingName);
+          } catch (err) {
+            nameProblem = `${err instanceof Error ? err.message : err}`;
+          }
+          if (nameProblem === undefined && isNameInScope(input.bindingName)) {
+            nameProblem = `There is already a binding named "${input.bindingName}" in your ` +
+                `env. Choose a different name.`;
+          }
+          if (nameProblem !== undefined) {
+            let message = `Cannot create the resource: ${nameProblem}`;
+            return toolResult(message, { output: message });
+          }
+
+          let output = await hooks.createExternalResource(chatId, input, initiator);
+          if (!isCreatedResourceSuccess(output)) {
+            // Fixable rejection: recorded as the string output, no binding was made.
+            return toolResult(output, { output });
+          }
+
+          // The binding is live immediately — no user gate (contrast requestConnection). The
+          // creation action's card rides the step's captured actions like any other action.
+          chatBindings.set(input.bindingName, {type: "workpiece", id: output.gatekeeperId});
+
+          // Persist the full result as the tool's recorded output: replay can't re-run a
+          // creation tool, so it re-establishes the binding (and the exact text the model saw)
+          // from this recorded value instead.
+          return toolResult(jsonToolResultText(output), {output} as Partial<AiToolCall>);
         } catch (error) {
           toolCallNotes.set(toolCallId, { error: toolErrorText(error) });
           throw error;

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -2,7 +2,7 @@ import { AiChatMessage, AiChatAuthorInfo, AiToolCall, AiChatMessageBody, AgentSp
 import { applyCodeChange, codeChangeSerializedSize, replaceSpanChange, type CodeContent,
   type CodeChange, type FileChange } from '@gadgets/workshop-shared/code-change';
 import { PDF_MIME_TYPE, modelApiSupportsPdfAttachments } from './chat-attachment-pdf';
-import { AgentCatalog, ObservationDescription } from '@gadgets/workshop-shared/gatekeeper';
+import { AgentCatalog, ObservationDescription, type ResourceCreationOptions } from '@gadgets/workshop-shared/gatekeeper';
 import { createWorkshopLogger } from "./observability";
 import { Type } from "@earendil-works/pi-ai";
 import type {
@@ -393,6 +393,7 @@ export type CreateExternalResourceInput = {
   title: string;
   bindingName: string;
   accountId?: number;
+  options?: ResourceCreationOptions;
 };
 
 /**
@@ -3305,6 +3306,13 @@ export async function runAgent(
           description:
               "Which connected account creates the resource. Only needed when several accounts " +
               "of the vendor are connected (a rejection will list the candidate ids).",
+        })),
+        options: Type.Optional(Type.Record(
+            Type.String(), Type.Union([Type.String(), Type.Number(), Type.Boolean()]), {
+          description:
+              "Vendor-specific creation parameters (flat scalars), e.g. a parent folder id. " +
+              "The creatable type's description lists the accepted keys; omit unless it names " +
+              "some. Unknown keys are rejected with guidance.",
         })),
       }),
       execute: async (toolCallId, input) => {

--- a/packages/workshop-backend/src/agent.ts
+++ b/packages/workshop-backend/src/agent.ts
@@ -2520,10 +2520,14 @@ export async function runAgent(
           `can; use listConnectableResources to learn a vendor's resource URL patterns first). The ` +
           `user accepts or denies in the chat. If they accept, you'll be resumed and the resource ` +
           `becomes available as a binding in your env; if they deny, your turn ends and you wait ` +
-          `for the user's next message. Resource types listConnectableResources marks "Creatable" ` +
-          `can instead be created brand-new with createExternalResource through an ` +
-          `already-connected account — that binding is usable immediately (the user approves the ` +
-          `creation as a normal action while you keep working).\n` +
+          `for the user's next message.\n` +
+          `If you need a brand-new resource instead (a new document, for example), resource types ` +
+          `listConnectableResources marks "Creatable" can be created with createExternalResource ` +
+          `through an already-connected account. This applies even when your existing binding for ` +
+          `that vendor is read-only: creation goes through the account, not the binding. Don't ` +
+          `assume a type isn't creatable — listConnectableResources answers in one call, no ` +
+          `connected account required. The new binding is usable immediately (the user approves ` +
+          `the creation as a normal action while you keep working).\n` +
           `If one of these services likely holds information relevant to the task, consider ` +
           `requesting a connection and reading from it before you answer, instead of answering from ` +
           `guesswork — a connection often gives you the real information. Connectable vendors:\n` +

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -1,6 +1,6 @@
 import { RpcCompatible, RpcStub, RpcTarget } from "capnweb";
 import { validateRpc } from "capnweb-validate";
-import { Overseer, GadgetMetadata, UiBundle, WorkpieceId, WorkpieceSummary, WorkpiecesSubscriber, GadgetClient, GadgetBindingInfo, GatekeeperClient, ActionState, ActionLogEntry, ActionsSubscriber, ActionHistoryFilter, ActionHistoryPage, ChatGadgetPin, ChatCodeBase, ChatGadgetPinState, CodeChangeSubmission, CommitIdentity, CommitInfo, MergeChangesResult, AiChatMetadata, AiChatMessage, AiChatHistoryPage, AiChatSubscriber, AiChatAuthorInfo, AiModelConfig, AiChatMessageBody, AgentSpawnerConfig, ConsoleLogSubscriber, ConsoleLogEvent, CapsuleSpecifier, CollaboratorInfo, CollaboratorRole, AffectedCollaborator, ShareLinkInfo, GatekeeperCreationSpec, ObserverConfigCallback, ObserverBindingNeed, ObserverBindingFailure, BlueprintBindingAnnotation, BlueprintBinding, BlueprintMetadata, BlueprintOutput, MessageFormatRef, isOutputIcon, SpawnerEnvTarget, BlueprintGadgetSummary, AiChatStreamEvent, BlueprintScreenshotUpload, BLUEPRINT_SCREENSHOT_R2_PREFIX, blueprintScreenshotUrl, ChatAttachmentUpload, ChatAttachmentHandle, ChatAttachmentRef, BoundHookInfo, PreApprovableAction, PresenceParticipant, PresenceSubscriber, SlashCommandChoice, SlashCommandRequest, validateBindingName, createOpenGadgetError, OPEN_GADGET_ERROR_CODES, resolveSiteName, actionChangeTime } from '@gadgets/workshop-shared/api';
+import { Overseer, GadgetMetadata, UiBundle, WorkpieceId, WorkpieceSummary, WorkpiecesSubscriber, GadgetClient, GadgetBindingInfo, GatekeeperClient, ActionState, ActionLogEntry, ActionsSubscriber, ActionHistoryFilter, ActionHistoryPage, ChatGadgetPin, ChatCodeBase, ChatGadgetPinState, CodeChangeSubmission, CommitIdentity, CommitInfo, MergeChangesResult, AiChatMetadata, AiChatMessage, AiChatHistoryPage, AiChatSubscriber, AiChatAuthorInfo, AiModelConfig, AiChatMessageBody, AgentSpawnerConfig, ConsoleLogSubscriber, ConsoleLogEvent, CapsuleSpecifier, CollaboratorInfo, CollaboratorRole, AffectedCollaborator, ShareLinkInfo, GatekeeperCreationSpec, ObserverConfigCallback, ObserverBindingNeed, ObserverBindingFailure, BlueprintBindingAnnotation, BlueprintBinding, BlueprintMetadata, BlueprintOutput, MessageFormatRef, isOutputIcon, SpawnerEnvTarget, BlueprintGadgetSummary, AiChatStreamEvent, BlueprintScreenshotUpload, BLUEPRINT_SCREENSHOT_R2_PREFIX, blueprintScreenshotUrl, ChatAttachmentUpload, ChatAttachmentHandle, ChatAttachmentRef, BoundHookInfo, PreApprovableAction, PresenceParticipant, PresenceSubscriber, SlashCommandChoice, SlashCommandRequest, type CreatedResourceOutput, isCreatedResourceSuccess, validateBindingName, createOpenGadgetError, OPEN_GADGET_ERROR_CODES, resolveSiteName, actionChangeTime } from '@gadgets/workshop-shared/api';
 import { applyCodeChange, changedGadgets, codeChangeSerializedSize, composeCodeChange, diffFiles,
   transformCodeChange, validateCodeChangeContent, validateCodeChangeSchema,
   type CodeContent, type CodeChange } from "@gadgets/workshop-shared/code-change";
@@ -30,7 +30,7 @@ import {
   getAiGatewayLogCost,
   type AiGatewayLogRoute,
 } from "./ai-gateway";
-import { AgentGadgetInfo, AgentHooks, AiChatAgentContext, CHAT_CHANGE_MESSAGE_BUDGET, ChatBindingEntry, SeedBindingInfo, runAgent, makeStorableArgs, summarizeArgs, type AgentStepChange, type AiChatMessageBodyWithModelData, type CompactionCheckpoint, type StoredAssistantMessage, type WorktreeTurnAccess } from "./agent";
+import { AgentGadgetInfo, AgentHooks, AiChatAgentContext, CHAT_CHANGE_MESSAGE_BUDGET, ChatBindingEntry, SeedBindingInfo, runAgent, makeStorableArgs, summarizeArgs, type AgentStepChange, type AiChatMessageBodyWithModelData, type CompactionCheckpoint, type CreateExternalResourceInput, type StoredAssistantMessage, type WorktreeTurnAccess } from "./agent";
 import { WorktreeSessionImpl } from "./worktree-session";
 import WORKTREE_BINDING_TYPES from "./worktree-binding.txt";
 import { deploymentOutputForBlueprint, FormatOffer, listFormatOffers, readAdminConfig } from "./admin-config";
@@ -285,6 +285,28 @@ type GatekeeperRecord = {
   hasSlashCommands?: true;  // denormalized from ResourceDescription
   class: GatekeeperClass,
   hook?: string,  // export name to which the gatekeeper's hook is connected
+
+  // Present while a createExternalResource-minted gatekeeper's resource exists only locally:
+  // describe() reports a provisional URL until the creation action (queued first, applied first)
+  // is applied, after which applyPendingAction re-denormalizes the real description and clears
+  // this marker.
+  provisional?: true;
+
+  // Present while a createExternalResource mint is not yet backed by the chat log: set in the
+  // same put as `provisional`, cleared at the step barrier that records the tool call (see
+  // addChatMessages). An unstamped marker with no active turn is a mid-step crash orphan --
+  // #reapPendingGatekeepers rejects its queued actions and removes it, mirroring
+  // GadgetRecord.pending's lifecycle (no sequence: creations ride an ordinary message, with no
+  // merge/revert to compare against). Distinct from `provisional`, which means "URL not real
+  // yet" and outlives the barrier.
+  pending?: {chatId: number};
+
+  // Present on a createExternalResource mint: the agent's env name for the resource (stamped at
+  // the mint) and the creation action's id (stamped by submitAction on the first queued action --
+  // the vendor queues the creation first, and this makes that ordering the definition). Never
+  // cleared; drives the post-apply describe refresh, the crash reap's keep check, and the
+  // decision nudges.
+  creation?: {bindingName: string, actionId?: number};
 
   // Records how this gatekeeper was originally created, enabling blueprint metadata derivation.
   creationSpec?: GatekeeperCreationSpec;
@@ -2456,6 +2478,44 @@ class OverseerImpl implements AgentHooks {
       let meta = this.storage.chatMeta.get(chatId);
       if (meta) this.storage.chatMeta.put(meta);
     }
+
+    // Gatekeepers minted by createExternalResource follow the same barrier lifecycle and are
+    // swept on the same schedule. (No chatMeta re-put: gatekeepers don't participate in the
+    // derived proposedChangeWorkpieces.)
+    this.#reapPendingGatekeepers(chatId);
+  }
+
+  // Reap crash-orphaned provisional gatekeepers minted by createExternalResource for the given
+  // chat (see GatekeeperRecord.pending: set durably at the mint, cleared at the step barrier that
+  // records the tool call). Runs on reconcilePendingGadgets' schedule -- never mid-step, when an
+  // unstamped marker legitimately exists -- and on chat deletion. Best-effort per gatekeeper,
+  // like the gadget sweep.
+  #reapPendingGatekeepers(chatId: number): void {
+    for (let record of Array.from(this.storage.gatekeepers.list())) {
+      if (record.pending?.chatId !== chatId) continue;
+      try {
+        // Keep the gatekeeper iff its creation action was actually applied: `provisional` clears
+        // on the post-apply describe refresh, but that refresh is best-effort, so accept an
+        // approved creation action as proof too -- reaping on `provisional` alone could sever a
+        // real provider resource.
+        let creationId = record.creation?.actionId;
+        let created = !record.provisional || (creationId !== undefined &&
+            this.storage.actions.get(creationId)?.state === "approved");
+        if (created) {
+          delete record.pending;
+          this.storage.gatekeepers.put(record);
+          continue;
+        }
+
+        // A crash orphan: its step's message is by construction lost, so nothing in the log
+        // backs the creation (and the resumed turn may have minted a replacement).
+        this.#rejectPendingActionsAndRemoveGatekeeper(record.id);
+      } catch (err) {
+        this.logger.warn("failed to reap pending gatekeeper", {
+          event: "gatekeeper.pending.reconcile.failed", chatId, error: err,
+        });
+      }
+    }
   }
 
   // Auto-create the workspace's single gadget and record it as the default gadget. New workspaces
@@ -2661,6 +2721,7 @@ class OverseerImpl implements AgentHooks {
         this.bumpVersion([gadget.id]);
       }
     }
+    this.#reapPendingGatekeepers(chatId);
   }
 
   // Disable (if needed) and delete a bound hook, updating its action-log record to match.
@@ -5255,6 +5316,62 @@ class OverseerImpl implements AgentHooks {
       this.gitCache.convertPushMarksToOnRemote(record.id);
       this.storage.actions.put(record);
     });
+
+    // A gatekeeper minted by createExternalResource was described with a provisional URL; once
+    // its creation action is approved (this action, or an earlier one whose refresh failed),
+    // describe() reports the real resource, so refresh the denormalized copy and retire the
+    // marker. The point read keeps an invalidated edit that applies before the creation from
+    // clearing the marker early. Best-effort: on failure the marker stays set and the next
+    // applied action retries.
+    let gatekeeperRecord = this.storage.gatekeepers.get(record.gatekeeperId);
+    let creationId = gatekeeperRecord?.creation?.actionId;
+    if (gatekeeperRecord?.provisional && creationId !== undefined &&
+        this.storage.actions.get(creationId)?.state === "approved") {
+      try {
+        let description = await gatekeeper.describe();
+        // Re-read after the await: a concurrent removeGatekeeper during the describe() would
+        // otherwise be resurrected by putting the stale record back.
+        gatekeeperRecord = this.storage.gatekeepers.get(record.gatekeeperId);
+        if (gatekeeperRecord?.provisional) {
+          gatekeeperRecord.resourceTitle = description.title;
+          gatekeeperRecord.resourceUrl = description.url;
+          gatekeeperRecord.hasSlashCommands = description.hasSlashCommands;
+          // Blueprint export's suggestValue reads creationSpec.resourceUrl; retire the
+          // provisional URL there too or exported blueprints would suggest a dead resource.
+          if (gatekeeperRecord.creationSpec?.type === "gatekeeper") {
+            gatekeeperRecord.creationSpec.resourceUrl = description.url;
+          }
+          delete gatekeeperRecord.provisional;
+          this.storage.gatekeepers.put(gatekeeperRecord);
+        }
+      } catch (error) {
+        this.logger.warn("failed to refresh created resource description after apply", {
+          event: "gatekeeper.created.describe.refresh.failed",
+          gatekeeperId: record.gatekeeperId, error,
+        });
+      }
+    }
+
+    if (record.id === creationId && record.caller.from === "agent" &&
+        gatekeeperRecord !== undefined) {
+      this.nudgeCreationDecision(record.caller.chatId, gatekeeperRecord, "approved", resolvedBy);
+    }
+  }
+
+  // Record the user's verdict on a created resource in its chat's log: the creation tool's
+  // recorded result permanently says the resource doesn't exist yet, so the model only learns
+  // the decision from this durable nudge (replayed as a user message, invisible in the UI).
+  nudgeCreationDecision(chatId: number, gatekeeper: GatekeeperRecord,
+                        decision: "approved" | "rejected", author: AiChatAuthorInfo) {
+    if (gatekeeper.creation === undefined) return;
+    if (this.storage.chatMeta.get(chatId) === undefined) return;  // Chat since deleted.
+    let name = `env.${gatekeeper.creation.bindingName}`;
+    let text = decision === "approved"
+        ? `The user approved the creation of ${name}.` + (gatekeeper.provisional ? `` :
+            ` The resource now exists at ${gatekeeper.resourceUrl}.`)
+        : `The user rejected the creation of ${name}; it will not be created at the provider. ` +
+            `Do not retry; wait for the user to tell you how to proceed.`;
+    this.addChatMessages(chatId, author, [{type: "agentNudge", text}]);
   }
 
   // Apply all currently-eligible pending actions of the given gatekeeper, in ascending id order.
@@ -5356,6 +5473,26 @@ class OverseerImpl implements AgentHooks {
     }
 
     return new GatekeeperClientImpl<any>(this, id, facet, undefined, joinAs);
+  }
+
+  // Reject a gatekeeper's still-pending actions, then remove it, in one durable step -- so no
+  // pending record survives pointing at a dead gatekeeper (approve/reject would fail forever on
+  // the missing facet). appliedAt is required (the byLastChanged resume-replay index keys on it);
+  // clearPushMarks matches rejectAction (a no-op for pushless actions). Rejecting first empties
+  // the queue, so removeGatekeeper's own push-mark loop is a no-op. No gatekeeper-side
+  // rejectAction RPC: the facet is deleted outright and nothing observes its internal pending
+  // state after removal.
+  #rejectPendingActionsAndRemoveGatekeeper(id: number) {
+    this.storage.transaction(() => {
+      for (let action of Array.from(this.storage.actions.pendingByGatekeeper.get(id))) {
+        if (action.type !== "action") continue;
+        action.state = "rejected";
+        action.appliedAt = new Date();
+        this.gitCache.clearPushMarks(action.id);
+        this.storage.actions.put(action);
+      }
+      this.removeGatekeeper(id);
+    });
   }
 
   // Destroy a gatekeeper (connection) workpiece. Any binding edges pointing at it are severed so
@@ -5821,6 +5958,12 @@ class OverseerImpl implements AgentHooks {
     this.storage.transaction(() => {
       if (description.pushedCommits !== undefined && description.pushedCommits.length > 0) {
         this.gitCache.markPushClosure(gatekeeperId, actionId, description.pushedCommits);
+      }
+      // The first action queued against a createExternalResource mint IS the creation; stamp
+      // its identity in the same durable step as the action itself.
+      if (gatekeeper?.creation !== undefined && gatekeeper.creation.actionId === undefined) {
+        gatekeeper.creation.actionId = actionId;
+        this.storage.gatekeepers.put(gatekeeper);
       }
       this.storage.actions.put(record);
     });
@@ -7555,6 +7698,12 @@ class OverseerImpl implements AgentHooks {
           if ((call.toolName === "createGadget" || call.toolName === "createWorktree") &&
               call.input.bindingName !== undefined) {
             taken.add(call.input.bindingName);
+          } else if (call.toolName === "createExternalResource" &&
+                     isCreatedResourceSuccess(call.output)) {
+            // Success-only, matching runAgent's replay: a rejected creation binds nothing,
+            // and claiming its name would desync the PARAMS_<n> simulation from the
+            // authoritative allocation (see agent.ts).
+            taken.add(call.input.bindingName);
           }
         }
       } else if (msg.type === "connectionRequest") {
@@ -7778,6 +7927,13 @@ class OverseerImpl implements AgentHooks {
             taken.add(call.input.bindingName);
             if (call.output && !nameByTarget.has(call.output.worktreeId)) {
               nameByTarget.set(call.output.worktreeId, call.input.bindingName);
+            }
+          } else if (call.toolName === "createExternalResource" &&
+                     isCreatedResourceSuccess(call.output)) {
+            // Success-only, like chatScopeNames: a rejected creation binds nothing in replay.
+            taken.add(call.input.bindingName);
+            if (!nameByTarget.has(call.output.gatekeeperId)) {
+              nameByTarget.set(call.output.gatekeeperId, call.input.bindingName);
             }
           }
         }
@@ -8452,6 +8608,23 @@ class OverseerImpl implements AgentHooks {
         }
       }
 
+      // Clear the crash-orphan marker of any gatekeeper whose createExternalResource call this
+      // message records: the log now backs the creation (see GatekeeperRecord.pending). Same
+      // synchronous step as the message write, so the log and the registry can never disagree.
+      // A rejected creation left no gatekeeper to unstamp.
+      if (msg.type === "message") {
+        for (let call of msg.toolCalls ?? []) {
+          if (call.toolName === "createExternalResource" &&
+              isCreatedResourceSuccess(call.output)) {
+            let gatekeeper = this.storage.gatekeepers.get(call.output.gatekeeperId);
+            if (gatekeeper?.pending?.chatId === chatId) {
+              delete gatekeeper.pending;
+              this.storage.gatekeepers.put(gatekeeper);
+            }
+          }
+        }
+      }
+
       this.storage.chats.put({
         chatId,
         sequence,
@@ -8760,10 +8933,16 @@ class OverseerImpl implements AgentHooks {
     let lines = [`Resource types offered by "${vendorId}" (${vendor.description.displayName}):`];
     for (let r of vendor.supportedResources) {
       lines.push(`* ${r.title} — urlPattern: ${r.urlPattern}\n  ${r.description}`);
+      if (r.creatable) lines.push(`  Creatable: ${r.creatable.description}`);
     }
     lines.push(
         `\nTo request one, call requestConnection with vendorId="${vendorId}" and a resourceUrl ` +
         `matching one of the patterns above (or omit resourceUrl to let the user pick).`);
+    if (vendor.supportedResources.some(r => r.creatable)) {
+      lines.push(
+          `Types marked "Creatable" can also be created brand-new with createExternalResource ` +
+          `(requires an already-connected "${vendorId}" account).`);
+    }
     return lines.join("\n");
   }
 
@@ -8833,6 +9012,103 @@ class OverseerImpl implements AgentHooks {
     let result = this.#capturedConnectionRequests.get(chatId) ?? [];
     this.#capturedConnectionRequests.delete(chatId);
     return result;
+  }
+
+  // Create a brand-new external resource (createExternalResource tool). Unlike requestConnection,
+  // no user action gates the binding: the gatekeeper simulates the resource locally, and the
+  // provider-side creation is an ordinary pending action (captured for this chat, so its card
+  // lands in the transcript at the step barrier). `created: false` is a fixable rejection — the
+  // agent should adjust and retry in the same turn.
+  async createExternalResource(chatId: number, input: CreateExternalResourceInput,
+      initiator: AiChatAuthorInfo): Promise<CreatedResourceOutput | string> {
+    let vendors = await this.#listGatekeeperVendorsCached();
+    let vendor = vendors.find(v => v.id === input.vendorId);
+    if (!vendor) {
+      return `Cannot create a resource: unknown vendor "${input.vendorId}". ` +
+          `Available vendors: ${vendors.map(v => v.id).join(", ") || "(none)"}.`;
+    }
+
+    let resource = vendor.supportedResources.find(
+        r => r.urlPattern === input.resourceUrlPattern);
+    if (!resource?.creatable) {
+      let creatable = vendor.supportedResources.filter(r => r.creatable);
+      return creatable.length === 0
+          ? `"${vendor.description.displayName}" does not support creating new resources.`
+          : `Cannot create a resource of type "${input.resourceUrlPattern}". ` +
+            `"${vendor.description.displayName}" can create: ` +
+            creatable.map(r => `${r.title} (${r.urlPattern})`).join(", ") + `.`;
+    }
+
+    // Mint the provisional gatekeeper class through the *initiator's* user DO (the admin-check
+    // chokepoint) -- connected accounts are per-user, so a collaborator-driven turn creates the
+    // resource under (and enumerates) the collaborator's accounts, not the owner's. The same
+    // initiator.id resolution as listAvailableBlueprints. Its failures are agent-readable by
+    // contract: no usable account, ambiguous accounts, missing authorization.
+    let minted;
+    try {
+      let userStub = wrapDoStubForTelemetry(
+          this.users.get(this.users.idFromName(initiator.id)), this.logger);
+      minted = await userStub.createResourceGatekeeper(
+          input.vendorId, input.accountId, input.resourceUrlPattern, {title: input.title});
+    } catch (error) {
+      return `Cannot create the resource: ${stringifyError(error)}`;
+    }
+
+    let client = await this.addGatekeeper(minted.class, {
+      type: "gatekeeper",
+      vendorId: minted.vendorId,
+      resourceUrl: minted.resourceUrl,
+      typeUrlPattern: minted.typeUrlPattern,
+    });
+    let gatekeeperId = await client.getId();
+
+    // Mark the record provisional so the post-apply describe refresh (applyPendingAction) knows
+    // to re-denormalize once the resource really exists, pending so a mid-step crash before the
+    // tool call reaches the log leaves a reapable orphan rather than a live duplicate (see
+    // GatekeeperRecord.pending), and stamp the creation identity for the decision nudges.
+    // (addGatekeeper just created the record.)
+    let record = this.storage.gatekeepers.get(gatekeeperId)!;
+    record.provisional = true;
+    record.pending = {chatId};
+    record.creation = {bindingName: input.bindingName};
+    this.storage.gatekeepers.put(record);
+
+    // Have the facet queue its creation action, attributed to this chat so the approval card is
+    // spliced into the transcript. On failure, no half-created workpiece survives.
+    // (submitCreationAction is optional on Gatekeeper; a creatable-advertising vendor must
+    // implement it, so view the facet through the usual Required<Pick<...>> stub shape.)
+    let capturedBefore = this.#capturedActions.get(chatId);
+    let awaitDecisionBefore = capturedBefore?.awaitDecision ?? false;
+    let capturedCountBefore = capturedBefore?.actions.length ?? 0;
+    try {
+      let facet = this.getGatekeeperFacet(gatekeeperId) as unknown as
+          Fetcher<Gatekeeper<any> & Required<Pick<Gatekeeper<any>, "submitCreationAction">>>;
+      using queue = new RpcStub<ApprovalQueue>(
+          new ApprovalQueueImpl(this, gatekeeperId, {from: "agent", chatId}));
+      await facet.submitCreationAction(queue as unknown as ApprovalQueue);
+    } catch (error) {
+      // The facet may have queued its action durably before the RPC failed; settle it with the
+      // gatekeeper or the pending record would be unresolvable (its facet is gone). Any
+      // awaitDecision latch it set must unwind with it -- the settled action can never be
+      // decided, and suspending the turn would hide the rejection from the model.
+      this.#rejectPendingActionsAndRemoveGatekeeper(gatekeeperId);
+      let captured = this.#capturedActions.get(chatId);
+      if (captured) {
+        captured.awaitDecision = awaitDecisionBefore;
+        // Drop the settled creation's captured cards too: spliced into the turn, a rejected
+        // awaitDecision card would trip the resume gate's "denial ends the turn" rule (see
+        // #maybeResumeAfterActionDecision).
+        captured.actions.length = capturedCountBefore;
+      }
+      return `Cannot create the resource: ${stringifyError(error)}`;
+    }
+
+    return { gatekeeperId, resourceUrl: minted.resourceUrl, message:
+        `Created "${input.title}" (${resource.title}), available as env.${input.bindingName} ` +
+        `in executeCode immediately — use describeBinding to learn its API. The resource ` +
+        `does not exist at ${vendor.description.displayName} yet: the user must approve the ` +
+        `creation action (and any edits you queue) before anything reaches the provider, but ` +
+        `you can keep working against the simulated resource without waiting.` };
   }
 
   // --- Blueprint hooks for the agent ---
@@ -9174,6 +9450,16 @@ class OverseerImpl implements AgentHooks {
     for (let gk of this.storage.gatekeepers.list()) {
       if (boundIds && !boundIds.has(gk.id)) continue;
       if (!observerVendorId(gk)) continue;
+      // A rejected creation is retained only to explain its dead binding: no provider resource
+      // ever existed, so there is nothing to verify observers against -- and requiring an
+      // account choice would lock out any collaborator without one, over a resource the user
+      // declined. (Its simulated state derives from the chat; anything copied there from other
+      // bindings is still guarded by those gatekeepers' own verification.)
+      let creationId = gk.creation?.actionId;
+      if (creationId !== undefined &&
+          this.storage.actions.get(creationId)?.state === "rejected") {
+        continue;
+      }
       result.push(gk);
     }
     return result;
@@ -11226,17 +11512,34 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     // can't leave the action rejected with the gatekeeper but still "pending" in storage.
     let profile = await this.#getClientProfile();
 
-    await gatekeeper.rejectAction(action.action);
+    // Rejecting a creation dooms the gatekeeper's other queued actions (in-order application
+    // means they could only ever apply after a creation that now never will), so settle them too
+    // rather than stranding cards the user would have to reject one by one.
+    let record = this.impl.storage.gatekeepers.get(action.gatekeeperId);
+    let rejectsCreation = record?.creation?.actionId === id;
+    let doomed = rejectsCreation
+        ? Array.from(this.impl.storage.actions.pendingByGatekeeper.get(action.gatekeeperId))
+            .filter((a): a is ActionRecord & {type: "action"} =>
+                a.type === "action" && a.id !== id)
+        : [];
 
-    action.state = "rejected";
-    action.appliedAt = new Date();
-    action.resolvedBy = profile;
-    // A rejected push's pending-push marks are removed in the same durable step as the state
-    // change (nothing was transmitted, so nothing became proven). No-op for pushless actions.
-    this.impl.storage.transaction(() => {
-      this.impl.gitCache.clearPushMarks(action.id);
-      this.impl.storage.actions.put(action);
-    });
+    for (let target of [action, ...doomed]) {
+      await gatekeeper.rejectAction(target.action);
+
+      target.state = "rejected";
+      target.appliedAt = new Date();
+      target.resolvedBy = profile;
+      // A rejected push's pending-push marks are removed in the same durable step as the state
+      // change (nothing was transmitted, so nothing became proven). No-op for pushless actions.
+      this.impl.storage.transaction(() => {
+        this.impl.gitCache.clearPushMarks(target.id);
+        this.impl.storage.actions.put(target);
+      });
+    }
+
+    if (rejectsCreation && action.caller.from === "agent") {
+      this.impl.nudgeCreationDecision(action.caller.chatId, record!, "rejected", profile);
+    }
 
     // Deny leaves the turn ended, like denyConnectionRequest. The rejected record also prevents a
     // sibling approval from resuming this turn.

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -2506,6 +2506,13 @@ class OverseerImpl implements AgentHooks {
         if (!record.provisional || approvedBy !== undefined) {
           delete record.pending;
           this.storage.gatekeepers.put(record);
+          // If the mint quarantined sessions (see addGatekeeper), the deferred restart must
+          // still fire: nothing else removes the mark, and a marked id blocks every
+          // openSession for the life of this DO instance. The kept record is durable now, so
+          // restarting cannot recreate the remint loop the barrier deferral prevents.
+          if (this.#gatekeepersPendingRestart.has(record.id)) {
+            this.scheduleAccessRestart("Gadget restarted because a new connection was added.");
+          }
           // The crashed step's barrier would have delivered the deferred decision nudge (see
           // addChatMessages); emit it here so the resumed turn learns the resource is real.
           if (approvedBy !== undefined) {
@@ -5431,9 +5438,11 @@ class OverseerImpl implements AgentHooks {
 
   // `joinAs` counts the returned client toward #hasCollaboratorSession for its lifetime; passed by
   // the collaborator-facing mints, omitted for the owner's and for internal callers (see
-  // GadgetClientImpl).
+  // GadgetClientImpl). `deferRestart` is for the one mid-turn mint (createExternalResource):
+  // quarantine instead of aborting, and restart at the step barrier -- see the restart block below.
   async addGatekeeper(
-      cls: GatekeeperClass, creationSpec?: GatekeeperCreationSpec, joinAs?: SessionKind)
+      cls: GatekeeperClass, creationSpec?: GatekeeperCreationSpec, joinAs?: SessionKind,
+      options?: {deferRestart?: boolean})
       : Promise<GatekeeperClient<any>> {
     let id = this.allocateWorkpieceId();
     let gatekeeperRecord: GatekeeperRecord = {
@@ -5478,7 +5487,16 @@ class OverseerImpl implements AgentHooks {
     // window. Publish, restart-check, and mark share one synchronous block, so no request can
     // interleave between the record appearing and the block taking effect.
     if (creationSpec && "vendorId" in creationSpec) {
-      if (this.#restartIfSessionsAffected(
+      if (options?.deferRestart) {
+        // Deferred: an immediate abort would kill the minting turn before its barrier records
+        // the tool call, and the resumed replay would re-issue the mint -- an abort/resume loop
+        // for as long as the collaborator keeps reconnecting. Quarantine in the same synchronous
+        // block instead (unverified sessions can't reach the id, see assertGatekeeperUsable) and
+        // restart once the log backs the creation (addChatMessages' unstamp branch).
+        if (this.#hasCollaboratorSession("build")) {
+          this.#gatekeepersPendingRestart.add(id);
+        }
+      } else if (this.#restartIfSessionsAffected(
           "Gadget restarted because a new connection was added.", "build")) {
         this.#gatekeepersPendingRestart.add(id);
       }
@@ -6307,9 +6325,11 @@ class OverseerImpl implements AgentHooks {
   // session can even guess a brand-new one; a "use" session's gadget reload mints fresh binding
   // loopbacks). Every client-reachable route to the connection checks this set
   // (assertGatekeeperUsable/gatekeeperUsable). In-memory and never cleared: the scheduled reset
-  // is what clears it, by destroying this object. Only ever populated when a restart really was
-  // scheduled -- marking without one would brick the connection until some unrelated restart came
-  // along.
+  // is what clears it, by destroying this object. Populated only when a restart was scheduled --
+  // or, for a deferred creation mint (addGatekeeper), committed to fire at the step barrier;
+  // marking with no restart coming would brick the connection until some unrelated restart came
+  // along. A deferred mark whose creation never reaches the log stays behind on a reaped,
+  // never-reused id -- inert until the next restart.
   #gatekeepersPendingRestart = new Set<number>();
 
   // Whether `id` is NOT blocked pending a scheduled restart (see #gatekeepersPendingRestart).
@@ -8638,6 +8658,12 @@ class OverseerImpl implements AgentHooks {
             if (gatekeeper?.pending?.chatId === chatId) {
               delete gatekeeper.pending;
               this.storage.gatekeepers.put(gatekeeper);
+              // A deferred mint-time restart (see addGatekeeper) fires now that the log backs
+              // the creation: the resumed turn replays this call instead of re-issuing it.
+              if (this.#gatekeepersPendingRestart.has(gatekeeper.id)) {
+                this.scheduleAccessRestart(
+                    "Gadget restarted because a new connection was added.");
+              }
               // A decision made before this barrier deferred its nudge (see
               // nudgeCreationDecision); deliver it now that the call is in the log.
               let creation = gatekeeper.creation?.actionId !== undefined
@@ -9090,7 +9116,7 @@ class OverseerImpl implements AgentHooks {
       vendorId: minted.vendorId,
       resourceUrl: minted.resourceUrl,
       typeUrlPattern: minted.typeUrlPattern,
-    });
+    }, undefined, {deferRestart: true});
     let gatekeeperId = await client.getId();
 
     // Mark the record provisional so the post-apply describe refresh (applyPendingAction) knows

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -2499,11 +2499,18 @@ class OverseerImpl implements AgentHooks {
         // approved creation action as proof too -- reaping on `provisional` alone could sever a
         // real provider resource.
         let creationId = record.creation?.actionId;
-        let created = !record.provisional || (creationId !== undefined &&
-            this.storage.actions.get(creationId)?.state === "approved");
-        if (created) {
+        let creation = creationId !== undefined
+            ? this.storage.actions.get(creationId) : undefined;
+        let approvedBy = creation?.type === "action" && creation.state === "approved"
+            ? creation.resolvedBy : undefined;
+        if (!record.provisional || approvedBy !== undefined) {
           delete record.pending;
           this.storage.gatekeepers.put(record);
+          // The crashed step's barrier would have delivered the deferred decision nudge (see
+          // addChatMessages); emit it here so the resumed turn learns the resource is real.
+          if (approvedBy !== undefined) {
+            this.nudgeCreationDecision(chatId, record, "approved", approvedBy);
+          }
           continue;
         }
 
@@ -5321,14 +5328,15 @@ class OverseerImpl implements AgentHooks {
     // its creation action is approved (this action, or an earlier one whose refresh failed),
     // describe() reports the real resource, so refresh the denormalized copy and retire the
     // marker. The point read keeps an invalidated edit that applies before the creation from
-    // clearing the marker early. Best-effort: on failure the marker stays set and the next
-    // applied action retries.
+    // clearing the marker early. Best-effort with one retry (a lone approved creation has no
+    // later apply to retry on): on failure the marker stays set and the next applied action,
+    // if any, retries.
     let gatekeeperRecord = this.storage.gatekeepers.get(record.gatekeeperId);
     let creationId = gatekeeperRecord?.creation?.actionId;
     if (gatekeeperRecord?.provisional && creationId !== undefined &&
         this.storage.actions.get(creationId)?.state === "approved") {
       try {
-        let description = await gatekeeper.describe();
+        let description = await gatekeeper.describe().catch(() => gatekeeper.describe());
         // Re-read after the await: a concurrent removeGatekeeper during the describe() would
         // otherwise be resurrected by putting the stale record back.
         gatekeeperRecord = this.storage.gatekeepers.get(record.gatekeeperId);
@@ -5364,6 +5372,10 @@ class OverseerImpl implements AgentHooks {
   nudgeCreationDecision(chatId: number, gatekeeper: GatekeeperRecord,
                         decision: "approved" | "rejected", author: AiChatAuthorInfo) {
     if (gatekeeper.creation === undefined) return;
+    // A mid-step decision precedes the mint's own tool call in the log, so a nudge now would
+    // replay before the call it answers; the step barrier re-emits it once the call is recorded
+    // (see addChatMessages' unstamp branch).
+    if (gatekeeper.pending !== undefined) return;
     if (this.storage.chatMeta.get(chatId) === undefined) return;  // Chat since deleted.
     let name = `env.${gatekeeper.creation.bindingName}`;
     let text = decision === "approved"
@@ -5480,8 +5492,9 @@ class OverseerImpl implements AgentHooks {
   // the missing facet). appliedAt is required (the byLastChanged resume-replay index keys on it);
   // clearPushMarks matches rejectAction (a no-op for pushless actions). Rejecting first empties
   // the queue, so removeGatekeeper's own push-mark loop is a no-op. No gatekeeper-side
-  // rejectAction RPC: the facet is deleted outright and nothing observes its internal pending
-  // state after removal.
+  // rejectAction RPC: on these paths the facet just failed or its step vanished, and removal
+  // destroys its storage -- vendor state staged elsewhere must tolerate orphaned entries (a
+  // documented submitCreationAction contract clause).
   #rejectPendingActionsAndRemoveGatekeeper(id: number) {
     this.storage.transaction(() => {
       for (let action of Array.from(this.storage.actions.pendingByGatekeeper.get(id))) {
@@ -8546,6 +8559,11 @@ class OverseerImpl implements AgentHooks {
       return;
     }
 
+    // Creation decisions deferred by nudgeCreationDecision while the mint was un-barriered;
+    // emitted after the loop so their nudges sequence after the tool calls they answer.
+    let decidedCreations: {gatekeeper: GatekeeperRecord, decision: "approved" | "rejected",
+                           author: AiChatAuthorInfo}[] = [];
+
     for (let {modelData, ...msg} of msgs) {
       if (msg.type === "changes") {
         // (A message's `pins` need no validation or mirroring here: pins are validated and
@@ -8620,6 +8638,15 @@ class OverseerImpl implements AgentHooks {
             if (gatekeeper?.pending?.chatId === chatId) {
               delete gatekeeper.pending;
               this.storage.gatekeepers.put(gatekeeper);
+              // A decision made before this barrier deferred its nudge (see
+              // nudgeCreationDecision); deliver it now that the call is in the log.
+              let creation = gatekeeper.creation?.actionId !== undefined
+                  ? this.storage.actions.get(gatekeeper.creation.actionId) : undefined;
+              if (creation?.type === "action" && creation.resolvedBy !== undefined &&
+                  (creation.state === "approved" || creation.state === "rejected")) {
+                decidedCreations.push(
+                    {gatekeeper, decision: creation.state, author: creation.resolvedBy});
+              }
             }
           }
         }
@@ -8647,6 +8674,10 @@ class OverseerImpl implements AgentHooks {
 
     meta.lastActive = this.getChatTimestamp();
     this.storage.chatMeta.put(meta);
+
+    for (let {gatekeeper, decision, author} of decidedCreations) {
+      this.nudgeCreationDecision(chatId, gatekeeper, decision, author);
+    }
 
     if (aiGatewayLogId && aiGatewayLogRoute) {
       // Best-effort UI accounting only. The log ID is not persisted, so a DO restart can lose
@@ -11512,37 +11543,50 @@ class OverseerClientInterface extends RpcTarget implements Overseer {
     // can't leave the action rejected with the gatekeeper but still "pending" in storage.
     let profile = await this.#getClientProfile();
 
+    await gatekeeper.rejectAction(action.action);
+    this.#markActionRejected(action, profile);
+
     // Rejecting a creation dooms the gatekeeper's other queued actions (in-order application
     // means they could only ever apply after a creation that now never will), so settle them too
-    // rather than stranding cards the user would have to reject one by one.
+    // rather than stranding cards the user would have to reject one by one. The marks and the
+    // nudge land in one synchronous step -- a crash mid-cascade must not strand half of it --
+    // ahead of the best-effort gatekeeper notifies. The record itself survives: replay
+    // re-establishes the chat binding from the recorded tool call (see agent.ts), and the
+    // vendor's dead-session error explains the rejection better than a missing binding would.
     let record = this.impl.storage.gatekeepers.get(action.gatekeeperId);
-    let rejectsCreation = record?.creation?.actionId === id;
-    let doomed = rejectsCreation
-        ? Array.from(this.impl.storage.actions.pendingByGatekeeper.get(action.gatekeeperId))
-            .filter((a): a is ActionRecord & {type: "action"} =>
-                a.type === "action" && a.id !== id)
-        : [];
-
-    for (let target of [action, ...doomed]) {
-      await gatekeeper.rejectAction(target.action);
-
-      target.state = "rejected";
-      target.appliedAt = new Date();
-      target.resolvedBy = profile;
-      // A rejected push's pending-push marks are removed in the same durable step as the state
-      // change (nothing was transmitted, so nothing became proven). No-op for pushless actions.
-      this.impl.storage.transaction(() => {
-        this.impl.gitCache.clearPushMarks(target.id);
-        this.impl.storage.actions.put(target);
-      });
-    }
-
-    if (rejectsCreation && action.caller.from === "agent") {
-      this.impl.nudgeCreationDecision(action.caller.chatId, record!, "rejected", profile);
+    if (record?.creation?.actionId === id) {
+      let siblings = Array.from(
+          this.impl.storage.actions.pendingByGatekeeper.get(action.gatekeeperId))
+          .filter(sibling => sibling.type === "action");
+      for (let sibling of siblings) this.#markActionRejected(sibling, profile);
+      if (action.caller.from === "agent") {
+        this.impl.nudgeCreationDecision(action.caller.chatId, record, "rejected", profile);
+      }
+      for (let sibling of siblings) {
+        try {
+          await gatekeeper.rejectAction(sibling.action);
+        } catch (error) {
+          this.impl.logger.warn("failed to notify gatekeeper of cascaded rejection", {
+            event: "gatekeeper.creation.cascade.reject.failed", actionId: sibling.id, error,
+          });
+        }
+      }
     }
 
     // Deny leaves the turn ended, like denyConnectionRequest. The rejected record also prevents a
     // sibling approval from resuming this turn.
+  }
+
+  // A rejected push's pending-push marks are removed in the same durable step as the state
+  // change (nothing was transmitted, so nothing became proven). No-op for pushless actions.
+  #markActionRejected(action: ActionRecord & {type: "action"}, resolvedBy: AiChatAuthorInfo) {
+    action.state = "rejected";
+    action.appliedAt = new Date();
+    action.resolvedBy = resolvedBy;
+    this.impl.storage.transaction(() => {
+      this.impl.gitCache.clearPushMarks(action.id);
+      this.impl.storage.actions.put(action);
+    });
   }
 
   // Enable auto-approval of actions carrying `actionKind` on the given gatekeeper. Stores the

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -9195,7 +9195,8 @@ class OverseerImpl implements AgentHooks {
       let userStub = wrapDoStubForTelemetry(
           this.users.get(this.users.idFromName(initiator.id)), this.logger);
       minted = await userStub.createResourceGatekeeper(
-          input.vendorId, input.accountId, input.resourceUrlPattern, {title: input.title});
+          input.vendorId, input.accountId, input.resourceUrlPattern,
+          {title: input.title, options: input.options});
     } catch (error) {
       return `Cannot create the resource: ${stringifyError(error)}`;
     }

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -301,12 +301,13 @@ type GatekeeperRecord = {
   // yet" and outlives the barrier.
   pending?: {chatId: number};
 
-  // Present on a createExternalResource mint: the agent's env name for the resource (stamped at
-  // the mint) and the creation action's id (stamped by submitAction on the first queued action --
-  // the vendor queues the creation first, and this makes that ordering the definition). Never
-  // cleared; drives the post-apply describe refresh, the crash reap's keep check, and the
-  // decision nudges.
-  creation?: {bindingName: string, actionId?: number};
+  // Present on a createExternalResource mint: the creating chat (drives chat deletion's sweep
+  // of undecided creations), the agent's env name for the resource (stamped at the mint), and
+  // the creation action's id (stamped by submitAction on the first queued action -- the vendor
+  // queues the creation first, and this makes that ordering the definition). Never cleared;
+  // also drives the post-apply describe refresh, the crash reap's keep check, and the decision
+  // nudges. Records minted before chatId existed lack it and are simply not swept.
+  creation?: {chatId?: number, bindingName: string, actionId?: number};
 
   // Records how this gatekeeper was originally created, enabling blueprint metadata derivation.
   creationSpec?: GatekeeperCreationSpec;
@@ -2501,9 +2502,9 @@ class OverseerImpl implements AgentHooks {
         let creationId = record.creation?.actionId;
         let creation = creationId !== undefined
             ? this.storage.actions.get(creationId) : undefined;
-        let approvedBy = creation?.type === "action" && creation.state === "approved"
-            ? creation.resolvedBy : undefined;
-        if (!record.provisional || approvedBy !== undefined) {
+        let approval = creation?.type === "action" && creation.state === "approved"
+            ? creation : undefined;
+        if (!record.provisional || approval !== undefined) {
           delete record.pending;
           this.storage.gatekeepers.put(record);
           // If the mint quarantined sessions (see addGatekeeper), the deferred restart must
@@ -2515,8 +2516,8 @@ class OverseerImpl implements AgentHooks {
           }
           // The crashed step's barrier would have delivered the deferred decision nudge (see
           // addChatMessages); emit it here so the resumed turn learns the resource is real.
-          if (approvedBy !== undefined) {
-            this.nudgeCreationDecision(chatId, record, "approved", approvedBy);
+          if (approval?.resolvedBy !== undefined) {
+            this.nudgeCreationDecision(chatId, record, "approved", approval.resolvedBy);
           }
           continue;
         }
@@ -2736,6 +2737,25 @@ class OverseerImpl implements AgentHooks {
       }
     }
     this.#reapPendingGatekeepers(chatId);
+
+    // Undecided creations barriered to this chat outlive the pending marker, and once the log
+    // is deleted an approvable card would mint a provider resource nothing can address -- so
+    // settle them, unless a surviving gadget edge still binds the resource (merged or another
+    // chat's; this chat's pending edges were severed above), which keeps the card meaningful.
+    // Approved creations stay -- the provider resource is real.
+    for (let record of Array.from(this.storage.gatekeepers.list())) {
+      if (record.creation?.chatId !== chatId) continue;
+      let bound = [...this.storage.gadgets.list()].some(gadget =>
+          gadget.type === "gadget" &&
+          Object.values(gadget.bindings).some(edge => edge.target === record.id));
+      if (bound) continue;
+      let actionId = record.creation.actionId;
+      if (actionId !== undefined &&
+          this.storage.actions.get(actionId)?.state === "approved") {
+        continue;
+      }
+      this.#rejectPendingActionsAndRemoveGatekeeper(record.id);
+    }
   }
 
   // Disable (if needed) and delete a bound hook, updating its action-log record to match.
@@ -3750,7 +3770,8 @@ class OverseerImpl implements AgentHooks {
     }
 
     try {
-      return this.storage.transaction(() => {
+      let changesWritten = false;
+      let committed = this.storage.transaction(() => {
         let fresh = this.storage.chatMeta.get(chatId);
         if (!fresh) return false;  // chat deleted during the prefetches
 
@@ -3819,7 +3840,7 @@ class OverseerImpl implements AgentHooks {
 
         this.addChatMessages(chatId, author, msgs, totalTokens, aiGatewayLogId,
                              aiGatewayLogRoute, estimatedCost);
-        return this.materializeChatChanges(chatId, undefined, {
+        changesWritten = this.materializeChatChanges(chatId, undefined, {
           author,
           allowDuringTurn: true,
           createdGadgets: step.createdGadgets,
@@ -3827,7 +3848,27 @@ class OverseerImpl implements AgentHooks {
           addedBindings: step.addedBindings,
           worktreeCommits: step.worktreeCommits,
         }) !== undefined;
+        return true;
       });
+      // The deferred creation-mint restart (see addGatekeeper) fires only after the barrier
+      // committed: launched inside the transaction, the abort would survive a rollback and
+      // restart with the tool call unrecorded -- the remint loop the deferral prevents. An
+      // uncommitted step (chat deleted) records no call, so there is nothing to restart for.
+      // `committed` is not the return value: the contract's boolean is "changes message
+      // written", false for an ordinary creation-only step whose barrier fully committed.
+      if (committed) {
+        for (let msg of msgs) {
+          if (msg.type !== "message") continue;
+          for (let call of msg.toolCalls ?? []) {
+            if (call.toolName === "createExternalResource" &&
+                isCreatedResourceSuccess(call.output) &&
+                this.#gatekeepersPendingRestart.has(call.output.gatekeeperId)) {
+              this.scheduleAccessRestart("Gadget restarted because a new connection was added.");
+            }
+          }
+        }
+      }
+      return changesWritten;
     } catch (err) {
       // The transaction rolled the rows back, but the append path already advanced the
       // in-memory caches to reflect them; drop both so later reads rebuild from storage.
@@ -5331,6 +5372,16 @@ class OverseerImpl implements AgentHooks {
       this.storage.actions.put(record);
     });
 
+    // The decision nudge precedes the best-effort refresh below: a reset during describe() must
+    // not cost the model the verdict -- the recorded tool result permanently says the resource
+    // doesn't exist yet, and nothing later re-emits the decision.
+    let gatekeeperRecord = this.storage.gatekeepers.get(record.gatekeeperId);
+    let creationId = gatekeeperRecord?.creation?.actionId;
+    if (record.id === creationId && record.caller.from === "agent" &&
+        gatekeeperRecord !== undefined) {
+      this.nudgeCreationDecision(record.caller.chatId, gatekeeperRecord, "approved", resolvedBy);
+    }
+
     // A gatekeeper minted by createExternalResource was described with a provisional URL; once
     // its creation action is approved (this action, or an earlier one whose refresh failed),
     // describe() reports the real resource, so refresh the denormalized copy and retire the
@@ -5338,8 +5389,6 @@ class OverseerImpl implements AgentHooks {
     // clearing the marker early. Best-effort with one retry (a lone approved creation has no
     // later apply to retry on): on failure the marker stays set and the next applied action,
     // if any, retries.
-    let gatekeeperRecord = this.storage.gatekeepers.get(record.gatekeeperId);
-    let creationId = gatekeeperRecord?.creation?.actionId;
     if (gatekeeperRecord?.provisional && creationId !== undefined &&
         this.storage.actions.get(creationId)?.state === "approved") {
       try {
@@ -5358,6 +5407,39 @@ class OverseerImpl implements AgentHooks {
           }
           delete gatekeeperRecord.provisional;
           this.storage.gatekeepers.put(gatekeeperRecord);
+          // The creation card's link renders from the action's own snapshot (actionLog), so
+          // retire its provisional URL too. Point-write only: edit cards keep their queue-time
+          // snapshots (audit semantics; no settled-by-gatekeeper index to rewrite them).
+          let creationRecord = this.storage.actions.get(creationId);
+          if (creationRecord?.type === "action") {
+            creationRecord.resourceTitle = description.title;
+            creationRecord.resourceUrl = description.url;
+            this.storage.actions.put(creationRecord);
+            // The verdict nudge fired before this refresh (verdict durability first), so on
+            // this path it carried no URL; deliver the real one now that it is known. Two
+            // adjacent nudges are the price of that ordering -- do not fold them into one
+            // pre-refresh message. A mid-step decision (pending set) skips: the barrier's
+            // deferred verdict re-reads this record and carries the URL itself.
+            if (gatekeeperRecord.pending === undefined &&
+                gatekeeperRecord.creation !== undefined &&
+                creationRecord.caller.from === "agent" &&
+                this.storage.chatMeta.get(creationRecord.caller.chatId) !== undefined) {
+              this.addChatMessages(creationRecord.caller.chatId, resolvedBy, [{
+                type: "agentNudge",
+                text: `env.${gatekeeperRecord.creation.bindingName} now exists at ` +
+                    `${description.url}.`,
+              }]);
+            }
+          }
+          // The mint's restart verified observers against the *simulated* resource (the
+          // contract tells vendors to admit on its policy); now that the real one exists,
+          // their admission must be re-asked -- the next open re-runs addObserver against the
+          // provider's actual ACL. A pre-barrier approval defers to the barrier's quarantine
+          // restart instead: aborting here would lose the mint's unrecorded tool call.
+          if (gatekeeperRecord.pending === undefined) {
+            this.#restartIfSessionsAffected(
+                "Gadget restarted because a created resource now exists at the provider.");
+          }
         }
       } catch (error) {
         this.logger.warn("failed to refresh created resource description after apply", {
@@ -5365,11 +5447,6 @@ class OverseerImpl implements AgentHooks {
           gatekeeperId: record.gatekeeperId, error,
         });
       }
-    }
-
-    if (record.id === creationId && record.caller.from === "agent" &&
-        gatekeeperRecord !== undefined) {
-      this.nudgeCreationDecision(record.caller.chatId, gatekeeperRecord, "approved", resolvedBy);
     }
   }
 
@@ -5438,11 +5515,12 @@ class OverseerImpl implements AgentHooks {
 
   // `joinAs` counts the returned client toward #hasCollaboratorSession for its lifetime; passed by
   // the collaborator-facing mints, omitted for the owner's and for internal callers (see
-  // GadgetClientImpl). `deferRestart` is for the one mid-turn mint (createExternalResource):
-  // quarantine instead of aborting, and restart at the step barrier -- see the restart block below.
+  // GadgetClientImpl). `creation` marks a createExternalResource mint: its recovery markers ride
+  // the initial record put (no window where the record exists unmarked), and the access restart
+  // is deferred to the step barrier -- see the restart block below.
   async addGatekeeper(
       cls: GatekeeperClass, creationSpec?: GatekeeperCreationSpec, joinAs?: SessionKind,
-      options?: {deferRestart?: boolean})
+      creation?: {chatId: number, bindingName: string})
       : Promise<GatekeeperClient<any>> {
     let id = this.allocateWorkpieceId();
     let gatekeeperRecord: GatekeeperRecord = {
@@ -5450,6 +5528,11 @@ class OverseerImpl implements AgentHooks {
       class: cls,
       creationSpec,
     };
+    if (creation) {
+      gatekeeperRecord.provisional = true;
+      gatekeeperRecord.pending = {chatId: creation.chatId};
+      gatekeeperRecord.creation = {chatId: creation.chatId, bindingName: creation.bindingName};
+    }
 
     // The record is published only once, below, after describe() resolves -- the facet takes the
     // class directly so it needs no record to exist yet. Publishing it before the await instead
@@ -5464,6 +5547,12 @@ class OverseerImpl implements AgentHooks {
       gatekeeperRecord.resourceTitle = description.title;
       gatekeeperRecord.resourceUrl = description.url;
       gatekeeperRecord.hasSlashCommands = description.hasSlashCommands;
+      // A creation mint whose chat was deleted during the awaits must not publish: the chat's
+      // sweep already ran and its aborted turn abandons this continuation, so nothing would ever
+      // reap the record. Check-and-put share one synchronous block.
+      if (creation && !this.storage.chatMeta.get(creation.chatId)) {
+        throw new Error("The chat was deleted while the resource was being created.");
+      }
       this.storage.gatekeepers.put(gatekeeperRecord);
     } catch (error) {
       // Still the right teardown with nothing published: it deletes the facet we just created, and
@@ -5487,7 +5576,7 @@ class OverseerImpl implements AgentHooks {
     // window. Publish, restart-check, and mark share one synchronous block, so no request can
     // interleave between the record appearing and the block taking effect.
     if (creationSpec && "vendorId" in creationSpec) {
-      if (options?.deferRestart) {
+      if (creation) {
         // Deferred: an immediate abort would kill the minting turn before its barrier records
         // the tool call, and the resumed replay would re-issue the mint -- an abort/resume loop
         // for as long as the collaborator keeps reconnecting. Quarantine in the same synchronous
@@ -5965,17 +6054,23 @@ class OverseerImpl implements AgentHooks {
       this.gitCache.verifyPushAncestry(gatekeeperId, description.pushedCommits);
     }
 
+    // A pending action against a removed gatekeeper would be permanently undecidable (approve
+    // and reject both need the facet), so a submit racing removal -- deleteChat's reap can pull
+    // the record while the facet's call is in flight -- fails here instead.
+    let gatekeeper = this.storage.gatekeepers.get(gatekeeperId);
+    if (!gatekeeper) {
+      throw new Error("The connection this action targets has been removed.");
+    }
+
     let actionId = this.storage.nextActionId.get();
     this.storage.nextActionId.put(actionId + 1);
-
-    let gatekeeper = this.storage.gatekeepers.get(gatekeeperId);
 
     let record: ActionRecord = {
       id: actionId,
       gatekeeperId,
       caller,
-      resourceTitle: gatekeeper?.resourceTitle,
-      resourceUrl: gatekeeper?.resourceUrl,
+      resourceTitle: gatekeeper.resourceTitle,
+      resourceUrl: gatekeeper.resourceUrl,
       action,
       createdAt: new Date(),
       state: "pending",
@@ -5992,7 +6087,7 @@ class OverseerImpl implements AgentHooks {
       }
       // The first action queued against a createExternalResource mint IS the creation; stamp
       // its identity in the same durable step as the action itself.
-      if (gatekeeper?.creation !== undefined && gatekeeper.creation.actionId === undefined) {
+      if (gatekeeper.creation !== undefined && gatekeeper.creation.actionId === undefined) {
         gatekeeper.creation.actionId = actionId;
         this.storage.gatekeepers.put(gatekeeper);
       }
@@ -8658,12 +8753,6 @@ class OverseerImpl implements AgentHooks {
             if (gatekeeper?.pending?.chatId === chatId) {
               delete gatekeeper.pending;
               this.storage.gatekeepers.put(gatekeeper);
-              // A deferred mint-time restart (see addGatekeeper) fires now that the log backs
-              // the creation: the resumed turn replays this call instead of re-issuing it.
-              if (this.#gatekeepersPendingRestart.has(gatekeeper.id)) {
-                this.scheduleAccessRestart(
-                    "Gadget restarted because a new connection was added.");
-              }
               // A decision made before this barrier deferred its nudge (see
               // nudgeCreationDecision); deliver it now that the call is in the log.
               let creation = gatekeeper.creation?.actionId !== undefined
@@ -9116,19 +9205,8 @@ class OverseerImpl implements AgentHooks {
       vendorId: minted.vendorId,
       resourceUrl: minted.resourceUrl,
       typeUrlPattern: minted.typeUrlPattern,
-    }, undefined, {deferRestart: true});
+    }, undefined, {chatId, bindingName: input.bindingName});
     let gatekeeperId = await client.getId();
-
-    // Mark the record provisional so the post-apply describe refresh (applyPendingAction) knows
-    // to re-denormalize once the resource really exists, pending so a mid-step crash before the
-    // tool call reaches the log leaves a reapable orphan rather than a live duplicate (see
-    // GatekeeperRecord.pending), and stamp the creation identity for the decision nudges.
-    // (addGatekeeper just created the record.)
-    let record = this.storage.gatekeepers.get(gatekeeperId)!;
-    record.provisional = true;
-    record.pending = {chatId};
-    record.creation = {bindingName: input.bindingName};
-    this.storage.gatekeepers.put(record);
 
     // Have the facet queue its creation action, attributed to this chat so the approval card is
     // spliced into the transcript. On failure, no half-created workpiece survives.
@@ -9158,6 +9236,15 @@ class OverseerImpl implements AgentHooks {
         captured.actions.length = capturedCountBefore;
       }
       return `Cannot create the resource: ${stringifyError(error)}`;
+    }
+
+    // Fail closed on the vendor contract: submitCreationAction must queue the creation, which
+    // stamps creation.actionId (see submitAction). A vendor returning without queueing would
+    // otherwise leave a permanently provisional binding with no approval card and no error.
+    if (this.storage.gatekeepers.get(gatekeeperId)?.creation?.actionId === undefined) {
+      this.removeGatekeeper(gatekeeperId);
+      return `Cannot create the resource: the "${input.vendorId}" gatekeeper returned without ` +
+          `submitting its creation action. This is a vendor bug; do not retry.`;
     }
 
     return { gatekeeperId, resourceUrl: minted.resourceUrl, message:

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -1710,6 +1710,10 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
       if (!record || record.vendorId !== vendorId) {
         throw new Error(`There is no connected "${vendorId}" account with id ${accountId}.`);
       }
+      if (!areCredentialsValid(record)) {
+        throw new Error(`The connected "${vendorId}" account ${accountId} has expired ` +
+            `credentials. Ask the user to reconnect it, then retry.`);
+      }
       account = record;
     } else {
       let candidates = [...this.#connectedAccountRecords()]

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -53,6 +53,7 @@ export type ProvidedAccountInfo = {
 // usable directly, the way the runtime stub actually behaves.
 type AccountCreatorStub = Required<Pick<GatekeeperVendor, "createAccount">>;
 type SingletonAccountStub = Required<Pick<GatekeeperUser, "getSingletonGatekeeperClass" | "startAppUi">>;
+type ResourceCreatorStub = Required<Pick<GatekeeperUser, "createResource">>;
 
 function areCredentialsValid(record: ConnectedAccountRecord): boolean {
   if (record.credentialsExpired) return false;
@@ -1688,6 +1689,72 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     }
 
     return {class: cls, vendorId: account.vendorId, typeUrlPattern: resource.urlPattern};
+  }
+
+  /**
+   * Mint a gatekeeper for a NEW resource of type `resourceUrlPattern` via
+   * GatekeeperUser.createResource() — the urlPattern→capability chokepoint for creations, applying
+   * the same admin disable-set checks as getGatekeeperClassFor(). When `accountId` is omitted and
+   * exactly one usable account is connected for the vendor, that account is used; otherwise the
+   * error enumerates the candidates so the agent can retry with an accountId or ask the user.
+   * Every thrown message here is agent-readable: the overseer surfaces it as a fixable tool result.
+   */
+  async createResourceGatekeeper(
+      vendorId: string, accountId: number | undefined, resourceUrlPattern: string,
+      options: {title: string})
+      : Promise<{class: DurableObjectClass<Gatekeeper<any>>, vendorId: string,
+                  typeUrlPattern: string, resourceUrl: string}> {
+    let account: ConnectedAccountRecord;
+    if (accountId !== undefined) {
+      let record = this.storage.connectedAccounts.get(accountId);
+      if (!record || record.vendorId !== vendorId) {
+        throw new Error(`There is no connected "${vendorId}" account with id ${accountId}.`);
+      }
+      account = record;
+    } else {
+      let candidates = [...this.#connectedAccountRecords()]
+          .filter(rec => rec.vendorId === vendorId && areCredentialsValid(rec));
+      if (candidates.length === 0) {
+        throw new Error(
+            `No connected "${vendorId}" account is available. Use requestConnection to ask the ` +
+            `user to connect one first.`);
+      }
+      if (candidates.length > 1) {
+        let names = candidates.map(rec =>
+            `${rec.id} (${rec.description.uniqueName ?? rec.description.displayName ?? "unnamed"})`);
+        throw new Error(
+            `Multiple "${vendorId}" accounts are connected: ${names.join(", ")}. Retry with the ` +
+            `accountId of the one to use, or ask the user which they prefer.`);
+      }
+      account = candidates[0];
+    }
+
+    // No stub-side probe for the optional method: RPC stubs cannot reliably report whether an
+    // optional method exists (see the note on GatekeeperUser's singleton section), so we view the
+    // stub through the Required<Pick<...>> shape. The caller gates on SupportedResource.creatable;
+    // a vendor that advertised it without implementing createResource() surfaces here as an RPC
+    // error, which the overseer relays to the agent.
+    let {class: cls, resource, resourceUrl} =
+        await (account.account as unknown as ResourceCreatorStub)
+            .createResource(resourceUrlPattern, options);
+
+    // Check the admin disable-set against the pattern the vendor actually resolved, after the
+    // RPC, exactly like getGatekeeperClassFor -- the vendor is the authority on which resource
+    // type a request maps to. (createResource mints only the class and a provisional URL; the
+    // provider-side creation is a separate pending action, so nothing external happened yet.)
+    let config = await readAdminConfig(this.env);
+    let vendorIdLower = account.vendorId.toLowerCase();
+    if (config.disabledGatekeepers.includes(vendorIdLower)) {
+      throw new Error(
+          `The "${account.vendorId}" gatekeeper is disabled on this deployment by an administrator.`);
+    }
+    if (isResourceDisabled(config, vendorIdLower, resource.urlPattern)) {
+      throw new Error(
+          `The "${resource.title}" resource is disabled on this deployment by an administrator.`);
+    }
+
+    return {class: cls, vendorId: account.vendorId, typeUrlPattern: resource.urlPattern,
+            resourceUrl};
   }
 
   /**

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -1746,9 +1746,12 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     // RPC, exactly like getGatekeeperClassFor -- the vendor is the authority on which resource
     // type a request maps to. (createResource mints only the class and a provisional URL; the
     // provider-side creation is a separate pending action, so nothing external happened yet.)
+    // A dormant auto-provisioning vendor (ambient mode "disabled") blocks here too: existing
+    // accounts stay unusable, matching startHook's use-time check.
     let config = await readAdminConfig(this.env);
     let vendorIdLower = account.vendorId.toLowerCase();
-    if (config.disabledGatekeepers.includes(vendorIdLower)) {
+    if (config.disabledGatekeepers.includes(vendorIdLower) ||
+        ambientGatekeeperMode(config, vendorIdLower) === "disabled") {
       throw new Error(
           `The "${account.vendorId}" gatekeeper is disabled on this deployment by an administrator.`);
     }

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -1,6 +1,6 @@
 import { RpcStub } from "capnweb";
 import { GadgetMetadataWithTimestamps, AiChatAuthorInfo, AiModelConfig, SUGGESTED_MODELS, CollaboratorRole, ConnectedAccountsSubscriber, ConnectedAccountsFilter, GatekeeperVendorFilter, GadgetMetadata, BlueprintMetadata, BlueprintLibrarySummary, BlueprintSource, BlueprintUserSummary, BLUEPRINT_SCREENSHOT_R2_PREFIX, GatekeeperVendorInfo, BlueprintOutput, OutputSummary, WorkpieceId, ListOutputsResult, AUTH_ERROR_CODES, createAuthError } from '@gadgets/workshop-shared/api';
-import { Gatekeeper, GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor, AccountDescription, VendorDescription, GatekeeperConnectCallback, SupportedResource, ResourceConfiguratorFrame, AppUiContext, GatekeeperUiFrame } from "@gadgets/workshop-shared/gatekeeper";
+import { Gatekeeper, GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor, AccountDescription, VendorDescription, GatekeeperConnectCallback, SupportedResource, ResourceConfiguratorFrame, ResourceCreationOptions, AppUiContext, GatekeeperUiFrame } from "@gadgets/workshop-shared/gatekeeper";
 import { shouldAutoProvisionAccount, ambientGatekeeperMode } from "./provisioning-policy.js";
 import { CloudflareGatekeeperUser } from "@gadgets/workshop-shared/cloudflare-gatekeeper";
 import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
@@ -1701,7 +1701,7 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
    */
   async createResourceGatekeeper(
       vendorId: string, accountId: number | undefined, resourceUrlPattern: string,
-      options: {title: string})
+      input: {title: string, options?: ResourceCreationOptions})
       : Promise<{class: DurableObjectClass<Gatekeeper<any>>, vendorId: string,
                   typeUrlPattern: string, resourceUrl: string}> {
     let account: ConnectedAccountRecord;
@@ -1740,7 +1740,7 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
     // error, which the overseer relays to the agent.
     let {class: cls, resource, resourceUrl} =
         await (account.account as unknown as ResourceCreatorStub)
-            .createResource(resourceUrlPattern, options);
+            .createResource(resourceUrlPattern, input);
 
     // Check the admin disable-set against the pattern the vendor actually resolved, after the
     // RPC, exactly like getGatekeeperClassFor -- the vendor is the authority on which resource

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -82,6 +82,7 @@ import {
   WorkpieceId,
   BlueprintOutput,
   MessageFormatRef,
+  isCreatedResourceSuccess,
 } from "@gadgets/workshop-shared/api";
 import { composeCodeChange, type CodeChange } from "@gadgets/workshop-shared/code-change";
 import type { ChatChangeRow } from "./otClient";
@@ -619,6 +620,10 @@ function getToolCallSummary(
       return { verb: "Listed connectable resources", target: tc.input.vendorId };
     case "requestConnection":
       return { verb: "Requested connection", target: tc.input.vendorId };
+    case "createExternalResource":
+      return isCreatedResourceSuccess(tc.output)
+        ? { verb: "Created external resource", target: tc.input.title }
+        : { verb: "Tried to create external resource", target: tc.input.title };
   }
   // Compile-time exhaustiveness check.
   const _exhaustive: never = tc;
@@ -700,6 +705,8 @@ function describeToolCallCount(toolName: AiToolCall["toolName"], count: number):
       return `Listed connectable resources`;
     case "requestConnection":
       return count === 1 ? "Requested a connection" : `Requested ${count} connections`;
+    case "createExternalResource":
+      return `Created ${pluralize(count, "external resource")}`;
   }
   const _exhaustive: never = toolName;
   return _exhaustive;
@@ -728,6 +735,7 @@ function getToolIcon(
     case "saveCapsuleAsBinding":
       return LinkSimple;
     case "createGadget":
+    case "createExternalResource":
       return Plus;
     case "createWorktree":
       return GitBranch;
@@ -762,6 +770,8 @@ function getProvisionalToolLabel(toolName: AiToolCall["toolName"] | null | undef
       return "Creating gadget";
     case "createWorktree":
       return "Creating worktree";
+    case "createExternalResource":
+      return "Creating external resource";
     case "executeCode":
       return "Running code";
     case "webFetch":
@@ -798,6 +808,7 @@ function getProvisionalToolVerb(toolName: AiToolCall["toolName"]): string {
     case "listBlueprints": return "Listing blueprints";
     case "listConnectableResources": return "Listing connectable resources";
     case "requestConnection": return "Requesting a connection";
+    case "createExternalResource": return "Creating external resource";
   }
   const _exhaustive: never = toolName;
   return _exhaustive;
@@ -823,6 +834,7 @@ function describeProvisionalToolCount(toolName: AiToolCall["toolName"], count: n
     case "listBlueprints": return "Listing blueprints";
     case "listConnectableResources": return "Listing connectable resources";
     case "requestConnection": return `Requesting ${pluralize(count, "connection")}`;
+    case "createExternalResource": return `Creating ${pluralize(count, "external resource")}`;
   }
   const _exhaustive: never = toolName;
   return _exhaustive;

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -671,7 +671,9 @@ function describeObservationCount(count: number): string {
   return count === 1 ? "Read 1 resource" : `${count} resource reads`;
 }
 
-function describeToolCallCount(toolName: AiToolCall["toolName"], count: number): string {
+function describeToolCallCount(calls: AiToolCall[]): string {
+  const toolName = calls[0].toolName;
+  const count = calls.length;
   switch (toolName) {
     case "readFile":
       return `Read ${pluralize(count, "file")}`;
@@ -705,8 +707,13 @@ function describeToolCallCount(toolName: AiToolCall["toolName"], count: number):
       return `Listed connectable resources`;
     case "requestConnection":
       return count === 1 ? "Requested a connection" : `Requested ${count} connections`;
-    case "createExternalResource":
-      return `Created ${pluralize(count, "external resource")}`;
+    case "createExternalResource": {
+      const created = calls.filter((tc) =>
+        tc.toolName === "createExternalResource" && isCreatedResourceSuccess(tc.output)).length;
+      return created === 0
+        ? `Tried to create ${pluralize(count, "external resource")}`
+        : `Created ${pluralize(created, "external resource")}`;
+    }
   }
   const _exhaustive: never = toolName;
   return _exhaustive;
@@ -912,12 +919,10 @@ function buildToolCallGroups(
     const summary = getToolCallSummary(toolCalls[0], outputOf);
     labelParts.push(detailLines.length === 1 && summary.target && observations.length === 0
       ? `${summary.verb} ${summary.target}`
-      : describeToolCallCount(toolCalls[0].toolName, toolCalls.length));
+      : describeToolCallCount(toolCalls));
   } else if (toolCalls.length > 1 && distinctToolNames.length <= 3) {
-    labelParts.push(...distinctToolNames.map((toolName) => {
-      const count = toolCalls.filter((tc) => tc.toolName === toolName).length;
-      return describeToolCallCount(toolName, count);
-    }));
+    labelParts.push(...distinctToolNames.map((toolName) =>
+      describeToolCallCount(toolCalls.filter((tc) => tc.toolName === toolName))));
   } else if (toolCalls.length > 0) {
     labelParts.push(`${toolCalls.length} tool calls`);
   }

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -916,7 +916,9 @@ function buildToolCallGroups(
     const summary = getToolCallSummary(toolCalls[0], outputOf);
     labelParts.push(`${summary.verb}${summary.target ? ` ${summary.target}` : ""}`);
   } else if (toolCalls.length > 1 && distinctToolNames.length === 1) {
-    const summary = getToolCallSummary(toolCalls[0], outputOf);
+    // Label by the last call: for same-target retries the final outcome wins (a failed create
+    // retried successfully is "Created", not "Tried").
+    const summary = getToolCallSummary(toolCalls[toolCalls.length - 1], outputOf);
     labelParts.push(detailLines.length === 1 && summary.target && observations.length === 0
       ? `${summary.verb} ${summary.target}`
       : describeToolCallCount(toolCalls));
@@ -1451,9 +1453,21 @@ const ToolCallDetails = memo(function ToolCallDetails(
           )}
         </>
       ) : (
-        <pre className="max-h-56 overflow-auto rounded-xl border border-kumo-line/70 bg-kumo-base p-3 font-mono text-[12px] leading-[18px] text-kumo-subtle whitespace-pre-wrap">
-          {JSON.stringify(tc.input, null, 2)}
-        </pre>
+        <>
+          <pre className="max-h-56 overflow-auto rounded-xl border border-kumo-line/70 bg-kumo-base p-3 font-mono text-[12px] leading-[18px] text-kumo-subtle whitespace-pre-wrap">
+            {JSON.stringify(tc.input, null, 2)}
+          </pre>
+          {tc.toolName === "createExternalResource" && typeof tc.output === "string" && (
+            <>
+              <span className="font-mono text-[11px] leading-4 text-kumo-inactive uppercase tracking-[0.08em]">
+                Output
+              </span>
+              <pre className="max-h-56 overflow-auto rounded-xl border border-kumo-line/70 bg-kumo-base p-3 font-mono text-[12px] leading-[18px] text-kumo-subtle whitespace-pre-wrap">
+                {tc.output}
+              </pre>
+            </>
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -3233,7 +3233,52 @@ export type AiToolCall = {
     bindingName?: string;
   };
   output?: string;
+} | {
+  /**
+   * Create a brand-new external resource through an already-connected account (contrast
+   * requestConnection, which binds an EXISTING resource and requires user acceptance before the
+   * agent proceeds). Non-blocking: the gatekeeper simulates the resource until the user approves
+   * the creation action (a normal action card), so the binding is usable immediately.
+   */
+  toolName: "createExternalResource";
+  input: {
+    vendorId: string;
+
+    /** urlPattern of the resource type to create (one whose SupportedResource is creatable). */
+    resourceUrlPattern: string;
+
+    /** Human-readable title for the new resource (e.g. the document title). */
+    title: string;
+
+    /** Name under which the resource appears in the chat's env (see validateBindingName()). */
+    bindingName: string;
+
+    /** Which connected account creates the resource; required only when several match. */
+    accountId?: number;
+  };
+
+  /**
+   * On success, the full tool result: the created gatekeeper workpiece, its provisional
+   * resourceUrl, and the message shown to the model — replay re-binds and re-renders from it
+   * instead of re-creating, like createGadget. A string output is a fixable rejection returned
+   * to the model (no binding was made), like requestConnection's output.
+   */
+  output?: CreatedResourceOutput | string;
 });
+
+/** Success output of a createExternalResource call (see the AiToolCall member). */
+export type CreatedResourceOutput = {gatekeeperId: WorkpieceId, resourceUrl: string, message: string};
+
+/**
+ * True iff a createExternalResource output is the structured success shape — the only shape under
+ * which a binding was made. A string output is a fixable rejection; it is not an error (no
+ * `error` is set on the call), so error-based filters do not catch it. Every consumer that scans
+ * recorded tool calls must gate on this, not on `output !== undefined`.
+ */
+export function isCreatedResourceSuccess(output: CreatedResourceOutput | string | undefined)
+    : output is CreatedResourceOutput {
+  return typeof output === "object";
+}
 
 // TODO: Extend AiToolCall for code-mode tool calls.
 // - Includes inline audit logs from the action.

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -24,7 +24,7 @@
 // Gadget a stub pointing to the Gadget's server-side Durable Object interface.
 
 import { RpcCompatible, RpcStub, RpcTarget } from "capnweb";
-import { AccountDescription, ActionKind, ActionDescription, AvatarImage, GatekeeperUiFrame, ObservationDescription, ResourceDescription, ResourceConfiguratorFrame, SupportedResource, VendorDescription, HookDescription } from "./gatekeeper.js";
+import { AccountDescription, ActionKind, ActionDescription, AvatarImage, GatekeeperUiFrame, ObservationDescription, ResourceDescription, ResourceConfiguratorFrame, ResourceCreationOptions, SupportedResource, VendorDescription, HookDescription } from "./gatekeeper.js";
 import type { CodeChange } from "./code-change.js";
 import type { UiFeatureFlags } from "./feature-flags.js";
 
@@ -3255,6 +3255,12 @@ export type AiToolCall = {
 
     /** Which connected account creates the resource; required only when several match. */
     accountId?: number;
+
+    /**
+     * Vendor-specific creation parameters (flat scalars), as documented by the creatable
+     * type's description; see ResourceCreationOptions.
+     */
+    options?: ResourceCreationOptions;
   };
 
   /**

--- a/packages/workshop-shared/src/gatekeeper.ts
+++ b/packages/workshop-shared/src/gatekeeper.ts
@@ -785,6 +785,10 @@ export interface Gatekeeper<Session> extends DurableObject {
    * but a manual approval can target any pending action, so the gatekeeper must itself reject
    * applyAction() of any action that depends on the resource existing until the creation has
    * been applied. Only gatekeepers reachable via createResource() need implement this.
+   *
+   * If this call fails, or a crash orphans the mint, the platform settles the queued actions
+   * and removes the gatekeeper WITHOUT delivering rejectAction(): the facet's storage is
+   * destroyed with it, and any state staged outside the facet must tolerate orphaned entries.
    */
   submitCreationAction?(approvalQueue: RpcStub<ApprovalQueue>): Promise<void>;
 

--- a/packages/workshop-shared/src/gatekeeper.ts
+++ b/packages/workshop-shared/src/gatekeeper.ts
@@ -569,6 +569,15 @@ export interface GatekeeperConnectCallback extends WorkerEntrypoint {
 }
 
 /**
+ * Vendor-specific creation parameters for GatekeeperUser.createResource(), authored by the agent
+ * and untrusted like `title`. Flat bounded scalars only (e.g. a parent folder id). The resource's
+ * `creatable.description` documents the accepted keys; the vendor MUST reject unknown or invalid
+ * entries with an agent-readable message, and MUST reflect consequential entries (e.g. placement)
+ * in the creation action's description so the user approves what will actually happen.
+ */
+export type ResourceCreationOptions = Record<string, string | number | boolean>;
+
+/**
  * RPC interface to an Adapter. This is a privileged interface exposed to the Gadget Workshop UI
  * itself, not to Gadgets nor AI agents.
  *
@@ -620,9 +629,11 @@ export interface GatekeeperUser extends WorkerEntrypoint {
    * state's own policy.
    *
    * Throws with an agent-readable message when the account cannot create this resource type
-   * (e.g. its authorization does not cover the needed scopes); callers surface the message.
+   * (e.g. its authorization does not cover the needed scopes) or when `input.options` carries
+   * unknown or invalid entries (see ResourceCreationOptions); callers surface the message.
    */
-  createResource?(resourceUrlPattern: string, options: {title: string}): Promise<{
+  createResource?(resourceUrlPattern: string,
+                  input: {title: string, options?: ResourceCreationOptions}): Promise<{
     class: DurableObjectClass<Gatekeeper<any>>;
     resource: SupportedResource;
     /** Provisional URL of the new resource; replaced by the real URL once created. */

--- a/packages/workshop-shared/src/gatekeeper.ts
+++ b/packages/workshop-shared/src/gatekeeper.ts
@@ -255,6 +255,18 @@ export type SupportedResource = {
    * If omitted/false, the resource type is not separately grantable.
    */
   grantable?: boolean;
+
+  /**
+   * Present when an agent may create a brand-new resource of this type via the
+   * createExternalResource tool, without user pre-approval. The vendor's GatekeeperUser must
+   * implement createResource() for this urlPattern, and the gatekeeper class it returns must
+   * implement submitCreationAction(). The gatekeeper simulates the new resource locally until
+   * the user approves the creation action.
+   */
+  creatable?: {
+    /** What creation does, e.g. "Creates a new, empty Google Doc with the given title." */
+    description: string;
+  };
 }
 
 /** Removes every trailing slash from a string in linear time. */
@@ -594,6 +606,30 @@ export interface GatekeeperUser extends WorkerEntrypoint {
   }>;
 
   /**
+   * Create a NEW resource of the type identified by `resourceUrlPattern` (a urlPattern from
+   * getSupportedResources() whose `creatable` is set). Mints a provisional identity for the
+   * resource — no provider API call, no user interaction — and returns a gatekeeper class imbued
+   * with it (via `ctx.props`), exactly as getGatekeeperClassFor() does for existing resources,
+   * plus the provisional `resourceUrl` that names the resource until it really exists.
+   *
+   * The returned class MUST implement Gatekeeper.submitCreationAction(). The provider-side
+   * creation happens only when the user approves that action; until then the gatekeeper simulates
+   * the resource locally, and describe() must not call the provider. addObserver() likewise
+   * MUST NOT require the provider resource to exist: build collaborators are verified against
+   * the binding while the creation is still pending, so admit observers on the simulated
+   * state's own policy.
+   *
+   * Throws with an agent-readable message when the account cannot create this resource type
+   * (e.g. its authorization does not cover the needed scopes); callers surface the message.
+   */
+  createResource?(resourceUrlPattern: string, options: {title: string}): Promise<{
+    class: DurableObjectClass<Gatekeeper<any>>;
+    resource: SupportedResource;
+    /** Provisional URL of the new resource; replaced by the real URL once created. */
+    resourceUrl: string;
+  }>;
+
+  /**
    * Get the UI used to choose a specific resource.
    * `resourceUrlPattern` is the `urlPattern` associated with the supported resource.
    */
@@ -737,6 +773,20 @@ export interface Gatekeeper<Session> extends DurableObject {
    * particular API.
    */
   startSession(approvalQueue: RpcStub<ApprovalQueue>): Promise<Session>;
+
+  /**
+   * For gatekeepers minted by GatekeeperUser.createResource(): submit the pending "create this
+   * resource" action to the given approval queue. The Overseer calls this exactly once,
+   * immediately after adding the workpiece, with a queue scoped to it and attributed to the
+   * creating agent's chat (so the approval card lands there). Implementations must be idempotent
+   * (a retried call must not queue a second creation) and must queue the creation FIRST.
+   *
+   * Ordering is the gatekeeper's responsibility: the platform applies auto-approvals in order,
+   * but a manual approval can target any pending action, so the gatekeeper must itself reject
+   * applyAction() of any action that depends on the resource existing until the creation has
+   * been applied. Only gatekeepers reachable via createResource() need implement this.
+   */
+  submitCreationAction?(approvalQueue: RpcStub<ApprovalQueue>): Promise<void>;
 
   /**
    * Bounded, user-specific metadata the agent uses to discover entries reachable through this


### PR DESCRIPTION
Adds the `createExternalResource` tool as discussed with respect to Google Drive: rather than granting whole-Drive access so the agent can make one document, the agent creates a new resource of a creatable type through an already-connected account.

This adds the other half of `requestConnection`: the agent mints a brand-new resource of a type the vendor marks creatable, through an account the user already connected.  The binding is live immediately (simliar to what `createGadget` does), the turn continues, and the gatekeeper simulates the resource until the user approves the creation, which queues first and applies first, so dependent edits are safe to stack behind it.

:lock_with_ink_pen:   One thing worth noting: thus far we have been following that we use the minting account's credentials, and for creations that account is the turn initiator's. This means a collaborator-driven creation lands in the collaborator's provider account. If we want this to be the gadget owner's we can make that swap.

Auto approval is not supported yet.

<img width="1154" height="1201" alt="Screenshot from 2026-09-07 16-50-55" src="https://github.com/user-attachments/assets/d57fcce6-6d6d-44cb-ac35-3e48b2b93836" />
<img width="896" height="658" alt="Screenshot from 2026-09-07 16-53-21" src="https://github.com/user-attachments/assets/94ad348d-8307-4fec-b6cb-c5bce1f7b9ba" />


First consumer is Google Doc creation, stacked as #428 