### PR TITLE
add gatekeeper kit helper class for preview oauth

### DIFF
--- a/packages/gatekeeper-google/__tests__/oauth.test.ts
+++ b/packages/gatekeeper-google/__tests__/oauth.test.ts
@@ -1,139 +1,11 @@
-import { SignJWT } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { exchangeAuthCode } from "../src/google-api";
-import {
-  decodeGoogleOAuthState,
-  decodeLegacyGoogleOAuthState,
-  encodeGoogleOAuthState,
-  encodeLegacyGoogleOAuthState,
-  getDynamicGoogleOAuthReturnUrl,
-  getRegisteredGoogleOAuthRedirectUri,
-  isCurrentGoogleOAuthCallback,
-  isGoogleOAuthPreviewRedirectEnabled,
-  redirectToGoogleOAuthReturnUrl,
-  validateGoogleOAuthReturnUrl,
-  type GoogleOAuthState,
-} from "../src/oauth";
 
-const STATE_SECRET = "test-state-secret";
-const STATE_KEY = new TextEncoder().encode(STATE_SECRET);
-const PREVIEW_RETURN_URL =
-  "https://preview-gatekeeper-google.gadgets-staging.workers.dev/oauth";
-const DOT_PREVIEW_RETURN_URL =
-  "https://preview.gatekeeper-google.gadgets-staging.workers.dev/oauth";
-const STATE: GoogleOAuthState = {
-  userObjectId: "0".repeat(64),
-  oauthNonce: "1".repeat(64),
-  returnUrl: PREVIEW_RETURN_URL,
-};
-const STABLE_ENV = {
-  BASE_URL: "https://gatekeeper-google.gadgets-staging.workers.dev",
-  OAUTH_ALLOW_PREVIEW_REDIRECTS: "true",
-};
-const PREVIEW_ENV = {
-  ...STABLE_ENV,
-  BASE_URL: "https://preview-gatekeeper-google.gadgets-staging.workers.dev",
-  OAUTH_REDIRECT_URI: "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
-};
+const OAUTH_REDIRECT_URI = "https://gatekeeper-google.gadgets-staging.workers.dev/oauth";
 
 afterEach(() => vi.unstubAllGlobals());
 
-describe("Google OAuth callback relay", () => {
-  it("round-trips signed and legacy OAuth state", async () => {
-    const signed = await encodeGoogleOAuthState(STATE, STATE_SECRET);
-    await expect(decodeGoogleOAuthState(signed, STATE_SECRET)).resolves.toEqual(STATE);
-
-    const directState = { userObjectId: STATE.userObjectId, oauthNonce: STATE.oauthNonce };
-    expect(decodeLegacyGoogleOAuthState(encodeLegacyGoogleOAuthState(directState)))
-      .toEqual(directState);
-  });
-
-  it("rejects tampered, expired, and malformed OAuth state", async () => {
-    const encoded = await encodeGoogleOAuthState(STATE, STATE_SECRET);
-    const segments = encoded.split(".");
-    if (segments.length !== 3 || !segments[1]) throw new Error("Expected a three-segment JWT");
-    segments[1] = `${segments[1].startsWith("A") ? "B" : "A"}${segments[1].slice(1)}`;
-    await expect(decodeGoogleOAuthState(segments.join("."), STATE_SECRET)).rejects.toThrow();
-
-    const now = Math.floor(Date.now() / 1000);
-    const expired = await new SignJWT(STATE)
-      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
-      .setIssuedAt(now - 120)
-      .setExpirationTime(now - 60)
-      .sign(STATE_KEY);
-    await expect(decodeGoogleOAuthState(expired, STATE_SECRET)).rejects.toThrow();
-    expect(() => decodeLegacyGoogleOAuthState("not-valid-state")).toThrow(/invalid/i);
-  });
-
-  it("uses a direct callback unless a preview has a registered stable redirect", () => {
-    expect(isGoogleOAuthPreviewRedirectEnabled(STABLE_ENV)).toBe(true);
-    expect(isGoogleOAuthPreviewRedirectEnabled({
-      ...STABLE_ENV,
-      OAUTH_ALLOW_PREVIEW_REDIRECTS: true,
-    })).toBe(true);
-    expect(isGoogleOAuthPreviewRedirectEnabled({
-      ...STABLE_ENV,
-      OAUTH_ALLOW_PREVIEW_REDIRECTS: "false",
-    })).toBe(false);
-    expect(isGoogleOAuthPreviewRedirectEnabled({
-      ...STABLE_ENV,
-      OAUTH_ALLOW_PREVIEW_REDIRECTS: "TRUE",
-    })).toBe(false);
-    expect(getRegisteredGoogleOAuthRedirectUri(STABLE_ENV)).toBe(
-      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
-    );
-    expect(getDynamicGoogleOAuthReturnUrl(STABLE_ENV)).toBeUndefined();
-    expect(getRegisteredGoogleOAuthRedirectUri(PREVIEW_ENV)).toBe(
-      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
-    );
-    expect(getDynamicGoogleOAuthReturnUrl(PREVIEW_ENV)).toBe(STATE.returnUrl);
-    expect(() => getDynamicGoogleOAuthReturnUrl({
-      ...PREVIEW_ENV,
-      OAUTH_ALLOW_PREVIEW_REDIRECTS: "false",
-    })).toThrow(/OAUTH_ALLOW_PREVIEW_REDIRECTS/);
-  });
-
-  it("accepts only the stable callback and its Worker Preview hosts", () => {
-    expect(validateGoogleOAuthReturnUrl(
-      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth",
-      STABLE_ENV,
-    ).hostname).toBe("gatekeeper-google.gadgets-staging.workers.dev");
-    expect(validateGoogleOAuthReturnUrl(PREVIEW_RETURN_URL, STABLE_ENV).hostname)
-      .toBe("preview-gatekeeper-google.gadgets-staging.workers.dev");
-    expect(validateGoogleOAuthReturnUrl(DOT_PREVIEW_RETURN_URL, STABLE_ENV).hostname)
-      .toBe("preview.gatekeeper-google.gadgets-staging.workers.dev");
-    expect(() => validateGoogleOAuthReturnUrl(PREVIEW_RETURN_URL, {
-      ...STABLE_ENV,
-      OAUTH_ALLOW_PREVIEW_REDIRECTS: "false",
-    })).toThrow(/host/);
-    expect(() => validateGoogleOAuthReturnUrl("https://attacker.example/oauth", STABLE_ENV))
-      .toThrow(/host/);
-    expect(() => validateGoogleOAuthReturnUrl(
-      "https://preview-gatekeeper-google.gadgets-staging.workers.dev/not-oauth",
-      STABLE_ENV,
-    )).toThrow(/path/);
-    expect(() => validateGoogleOAuthReturnUrl(`${PREVIEW_RETURN_URL}?next=bad`, STABLE_ENV))
-      .toThrow(/path/);
-  });
-
-  it("relays only the provider result and unchanged signed state", () => {
-    const target = validateGoogleOAuthReturnUrl(PREVIEW_RETURN_URL, STABLE_ENV);
-    const callback = new URL(
-      "https://gatekeeper-google.gadgets-staging.workers.dev/oauth" +
-      "?error=access_denied&error_description=provider-secret",
-    );
-    const response = redirectToGoogleOAuthReturnUrl(target, callback, "signed-state");
-    const location = new URL(response.headers.get("location") ?? "");
-
-    expect(response.status).toBe(302);
-    expect(location.origin + location.pathname).toBe(STATE.returnUrl);
-    expect(location.searchParams.get("error")).toBe("access_denied");
-    expect(location.searchParams.get("state")).toBe("signed-state");
-    expect(location.searchParams.has("error_description")).toBe(false);
-    expect(isCurrentGoogleOAuthCallback(location, STABLE_ENV)).toBe(false);
-    expect(isCurrentGoogleOAuthCallback(location, PREVIEW_ENV)).toBe(true);
-  });
-
+describe("Google OAuth callback", () => {
   it("sends the selected redirect URI unchanged during code exchange", async () => {
     const calls: RequestInit[] = [];
     vi.stubGlobal("fetch", vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -150,11 +22,11 @@ describe("Google OAuth callback relay", () => {
       "code",
       "client-id",
       "client-secret",
-      PREVIEW_ENV.OAUTH_REDIRECT_URI,
+      OAUTH_REDIRECT_URI,
     );
 
     const body = calls[0]?.body;
     expect(body).toBeInstanceOf(URLSearchParams);
-    expect((body as URLSearchParams).get("redirect_uri")).toBe(PREVIEW_ENV.OAUTH_REDIRECT_URI);
+    expect((body as URLSearchParams).get("redirect_uri")).toBe(OAUTH_REDIRECT_URI);
   });
 });

--- a/packages/gatekeeper-google/package.json
+++ b/packages/gatekeeper-google/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@gadgets/backend-utils": "workspace:*",
     "@gadgets/configurator-ui": "workspace:*",
+    "@gadgets/gatekeeper-kit": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
     "capnweb": "catalog:",
     "capnweb-validate": "catalog:",
-    "jose": "^6.2.8",
     "mimetext": "^3.0.28",
     "postal-mime": "^2.7.6"
   },

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -1,6 +1,11 @@
 import { WorkerEntrypoint, DurableObject, RpcTarget, RpcStub } from "cloudflare:workers";
 import { skipRpcValidation, validateRpc } from "capnweb-validate";
 import { GatekeeperUser, GatekeeperUserVerifier, GatekeeperVendor as GatekeeperVendorIface, Gatekeeper, ResourceDescription, ApprovalQueue, ObservationDescription, VendorDescription, GatekeeperConnectCallback, GatekeeperConnectOptions, AccountDescription, SupportedResource, ResourceConfiguratorFrame, Cursor, ActionKind } from '@gadgets/workshop-shared/gatekeeper';
+import {
+  PreviewOAuth,
+  PreviewOAuthConfigurationError,
+  type PreviewOAuthState,
+} from "@gadgets/gatekeeper-kit/preview-oauth";
 import { exchangeAuthCode, getAccessToken, getGoogleAccountDescription, getGoogleVerifiedEmail, GoogleAccessToken, revokeGoogleToken } from "./google-api";
 import { GoogleDocSession, DocMetadata, type GoogleDocReadSession } from "./docs-types";
 import { GoogleDocsApi, type GoogleDocsDocument } from "./docs-api";
@@ -73,21 +78,10 @@ import {
 import { type ObserverBatchResult, type ObserverCheck, ObserverTracker } from "./observers";
 import type {Pager} from "./cursor";
 import {
-  decodeGoogleOAuthState,
-  decodeLegacyGoogleOAuthState,
-  encodeGoogleOAuthState,
-  encodeLegacyGoogleOAuthState,
   getBasePath,
   getBaseUrl,
-  getDynamicGoogleOAuthReturnUrl,
-  getRegisteredGoogleOAuthRedirectUri,
-  isCurrentGoogleOAuthCallback,
-  isGoogleOAuthPreviewRedirectEnabled,
-  isSignedGoogleOAuthState,
-  redirectToGoogleOAuthReturnUrl,
-  validateGoogleOAuthReturnUrl,
+  getGoogleOAuthCallbackUri,
   type GoogleOAuthEnv,
-  type GoogleOAuthState,
 } from "./oauth";
 import {
   DOCS_TYPES_MODULE_PREFIX, DRIVE_TYPES_MODULE_PREFIX, stripTypeModulePrefix,
@@ -222,21 +216,19 @@ export default {
       let doId = path[0];
       let initiationNonce = path[1];
       let stub = ctx.exports.UserAccount.get(ctx.exports.UserAccount.idFromString(doId));
-      let oauthRedirectUri: string;
-      let returnUrl: string | undefined;
+      let previewOAuth: PreviewOAuth;
       try {
-        oauthRedirectUri = getRegisteredGoogleOAuthRedirectUri(env);
-        returnUrl = getDynamicGoogleOAuthReturnUrl(env);
-        if (returnUrl && !env.OAUTH_STATE_SIGNING_SECRET) {
-          throw new Error("Google OAuth state signing secret is not configured.");
-        }
+        previewOAuth = new PreviewOAuth({
+          callbackUri: getGoogleOAuthCallbackUri(env),
+          env,
+        });
       } catch (error) {
         return new Response(
           error instanceof Error ? error.message : "Google OAuth callback is not configured.",
           { status: 503 },
         );
       }
-      const begun = await stub.beginOAuthFlow(initiationNonce, oauthRedirectUri);
+      const begun = await stub.beginOAuthFlow(initiationNonce, previewOAuth.redirectUri);
       if (begun === null) {
         return new Response(INVALID_LINK_HTML, {
           headers: { "Content-Type": "text/html; charset=utf-8" }
@@ -245,24 +237,17 @@ export default {
 
       let newUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
       newUrl.searchParams.set("client_id", env.CLIENT_ID);
-      newUrl.searchParams.set("redirect_uri", oauthRedirectUri);
+      newUrl.searchParams.set("redirect_uri", previewOAuth.redirectUri);
       newUrl.searchParams.set("response_type", "code");
       newUrl.searchParams.set("scope", begun.scopes.join(" "));
       newUrl.searchParams.set("access_type", "offline");
       newUrl.searchParams.set("prompt", "consent");
       // Add newly-requested scopes to any the user already granted, rather than replacing them.
       newUrl.searchParams.set("include_granted_scopes", "true");
-      let oauthState: GoogleOAuthState = {
+      const encodedState = await previewOAuth.createAuthorizationState({
         userObjectId: doId,
         oauthNonce: begun.oauthNonce,
-        ...(returnUrl ? { returnUrl } : {}),
-      };
-      let encodedState = encodeLegacyGoogleOAuthState(oauthState);
-      if (returnUrl) {
-        let signingSecret = env.OAUTH_STATE_SIGNING_SECRET;
-        if (!signingSecret) throw new Error("Google OAuth state signing secret is not configured.");
-        encodedState = await encodeGoogleOAuthState(oauthState, signingSecret);
-      }
+      });
       newUrl.searchParams.set("state", encodedState);
 
       return Response.redirect(newUrl.toString(), 302);
@@ -272,38 +257,22 @@ export default {
       let state = url.searchParams.get("state");
       if (!state) return new Response("Error: no 'state' provided", { status: 400 });
 
-      let oauthState: GoogleOAuthState;
+      let oauthState: PreviewOAuthState;
       try {
-        if (isSignedGoogleOAuthState(state)) {
-          if (!env.OAUTH_STATE_SIGNING_SECRET) {
-            return new Response("Google OAuth state signing secret is not configured.", { status: 500 });
-          }
-          oauthState = await decodeGoogleOAuthState(state, env.OAUTH_STATE_SIGNING_SECRET);
-        } else {
-          oauthState = decodeLegacyGoogleOAuthState(state);
-        }
-      } catch (error) {
-        return new Response(error instanceof Error ? error.message : "Invalid Google OAuth state", {
-          status: 400,
+        const previewOAuth = new PreviewOAuth({
+          callbackUri: getGoogleOAuthCallbackUri(env),
+          env,
         });
-      }
-
-      if (oauthState.returnUrl) {
-        if (!isGoogleOAuthPreviewRedirectEnabled(env)) {
-          return new Response("Google OAuth return URLs are not allowed.", { status: 400 });
+        const result = await previewOAuth.handleCallback(url);
+        if (result.kind === "relay") {
+          return result.response;
         }
-        let returnUrl: URL;
-        try {
-          returnUrl = validateGoogleOAuthReturnUrl(oauthState.returnUrl, env);
-        } catch (error) {
-          return new Response(
-            error instanceof Error ? error.message : "Invalid Google OAuth return URL",
-            { status: 400 },
-          );
-        }
-        if (!isCurrentGoogleOAuthCallback(returnUrl, env)) {
-          return redirectToGoogleOAuthReturnUrl(returnUrl, url, state);
-        }
+        oauthState = result.state;
+      } catch (error) {
+        const configurationError = error instanceof PreviewOAuthConfigurationError;
+        return new Response(error instanceof Error ? error.message : "Invalid Google OAuth state", {
+          status: configurationError ? 500 : 400,
+        });
       }
 
       let userObjectId;

--- a/packages/gatekeeper-google/src/oauth.ts
+++ b/packages/gatekeeper-google/src/oauth.ts
@@ -1,21 +1,10 @@
-import { SignJWT, jwtVerify, type JWTPayload } from "jose";
 import { stripTrailingSlashes } from "@gadgets/workshop-shared/gatekeeper";
+import type { PreviewOAuthEnv } from "@gadgets/gatekeeper-kit/preview-oauth";
 
 const OAUTH_CALLBACK_PATH = "/oauth";
-const OAUTH_STATE_MAX_AGE = "10m";
-const HEX_64 = /^[0-9a-f]{64}$/i;
 
-export type GoogleOAuthEnv = {
+export type GoogleOAuthEnv = PreviewOAuthEnv & {
   BASE_URL?: string;
-  OAUTH_ALLOW_PREVIEW_REDIRECTS?: boolean | string;
-  OAUTH_REDIRECT_URI?: string;
-  OAUTH_STATE_SIGNING_SECRET?: string;
-};
-
-export type GoogleOAuthState = {
-  userObjectId: string;
-  oauthNonce: string;
-  returnUrl?: string;
 };
 
 export function getBaseUrl(env: GoogleOAuthEnv): string {
@@ -29,115 +18,4 @@ export function getBasePath(env: GoogleOAuthEnv): string {
 
 export function getGoogleOAuthCallbackUri(env: GoogleOAuthEnv): string {
   return `${getBaseUrl(env)}${OAUTH_CALLBACK_PATH}`;
-}
-
-export function getRegisteredGoogleOAuthRedirectUri(env: GoogleOAuthEnv): string {
-  return env.OAUTH_REDIRECT_URI || getGoogleOAuthCallbackUri(env);
-}
-
-export function isGoogleOAuthPreviewRedirectEnabled(env: GoogleOAuthEnv): boolean {
-  const value = env.OAUTH_ALLOW_PREVIEW_REDIRECTS;
-  return value === true || value === "true";
-}
-
-export function getDynamicGoogleOAuthReturnUrl(env: GoogleOAuthEnv): string | undefined {
-  if (!env.OAUTH_REDIRECT_URI) return undefined;
-  const callback = getGoogleOAuthCallbackUri(env);
-  if (new URL(callback).href === new URL(env.OAUTH_REDIRECT_URI).href) return undefined;
-  if (!isGoogleOAuthPreviewRedirectEnabled(env)) {
-    throw new Error(
-      "OAUTH_ALLOW_PREVIEW_REDIRECTS must be enabled when OAUTH_REDIRECT_URI differs from BASE_URL",
-    );
-  }
-  return callback;
-}
-
-function oauthStateKey(secret: string): Uint8Array {
-  return new TextEncoder().encode(secret);
-}
-
-function parseGoogleOAuthState(payload: JWTPayload): GoogleOAuthState {
-  const allowedKeys = new Set(["userObjectId", "oauthNonce", "returnUrl", "iat", "exp"]);
-  if (Object.keys(payload).some((key) => !allowedKeys.has(key)) ||
-      typeof payload.userObjectId !== "string" || !HEX_64.test(payload.userObjectId) ||
-      typeof payload.oauthNonce !== "string" || !HEX_64.test(payload.oauthNonce) ||
-      (payload.returnUrl !== undefined && typeof payload.returnUrl !== "string")) {
-    throw new Error("Invalid Google OAuth state");
-  }
-  return {
-    userObjectId: payload.userObjectId,
-    oauthNonce: payload.oauthNonce,
-    ...(payload.returnUrl === undefined ? {} : { returnUrl: payload.returnUrl }),
-  };
-}
-
-export async function encodeGoogleOAuthState(
-    state: GoogleOAuthState, secret: string): Promise<string> {
-  const payload = parseGoogleOAuthState(state);
-  return new SignJWT(payload)
-    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
-    .setIssuedAt()
-    .setExpirationTime(OAUTH_STATE_MAX_AGE)
-    .sign(oauthStateKey(secret));
-}
-
-export async function decodeGoogleOAuthState(
-    state: string, secret: string): Promise<GoogleOAuthState> {
-  const { payload } = await jwtVerify(state, oauthStateKey(secret), {
-    algorithms: ["HS256"],
-    requiredClaims: ["iat", "exp"],
-  });
-  return parseGoogleOAuthState(payload);
-}
-
-export function encodeLegacyGoogleOAuthState(state: GoogleOAuthState): string {
-  return `${state.userObjectId}:${state.oauthNonce}`;
-}
-
-export function decodeLegacyGoogleOAuthState(state: string): GoogleOAuthState {
-  const match = /^([0-9a-f]{64}):([0-9a-f]{64})$/i.exec(state);
-  if (!match?.[1] || !match[2]) throw new Error("Invalid Google OAuth state");
-  return { userObjectId: match[1], oauthNonce: match[2] };
-}
-
-export function isSignedGoogleOAuthState(state: string): boolean {
-  return state.split(".").length === 3;
-}
-
-export function validateGoogleOAuthReturnUrl(returnUrl: string, env: GoogleOAuthEnv): URL {
-  const url = new URL(returnUrl);
-  const callback = new URL(getGoogleOAuthCallbackUri(env));
-  if (url.protocol !== "https:" && !(url.protocol === "http:" && url.hostname === "localhost")) {
-    throw new Error("Invalid Google OAuth return URL protocol");
-  }
-  if (url.pathname !== callback.pathname || url.search || url.hash || url.username || url.password) {
-    throw new Error("Invalid Google OAuth return URL path");
-  }
-
-  // Worker Preview hosts use either <preview-slug>-<deployed-host> or
-  // <preview-slug>.<deployed-host>.
-  const allowed = url.origin === callback.origin || Boolean(
-    isGoogleOAuthPreviewRedirectEnabled(env) &&
-    url.protocol === callback.protocol &&
-    url.port === callback.port &&
-    (url.hostname.endsWith(`-${callback.hostname}`) ||
-      url.hostname.endsWith(`.${callback.hostname}`)),
-  );
-  if (!allowed) throw new Error("Invalid Google OAuth return URL host");
-  return url;
-}
-
-export function isCurrentGoogleOAuthCallback(url: URL, env: GoogleOAuthEnv): boolean {
-  const callback = new URL(getGoogleOAuthCallbackUri(env));
-  return url.origin === callback.origin && url.pathname === callback.pathname;
-}
-
-export function redirectToGoogleOAuthReturnUrl(
-    target: URL, callbackUrl: URL, state: string): Response {
-  for (const key of ["code", "error"]) {
-    const value = callbackUrl.searchParams.get(key);
-    if (value) target.searchParams.set(key, value);
-  }
-  target.searchParams.set("state", state);
-  return Response.redirect(target.toString(), 302);
 }

--- a/packages/gatekeeper-kit/__tests__/preview-oauth.test.ts
+++ b/packages/gatekeeper-kit/__tests__/preview-oauth.test.ts
@@ -1,0 +1,253 @@
+import { decodeJwt, SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import {
+  PreviewOAuth,
+  PreviewOAuthConfigurationError,
+  type PreviewOAuthEnv,
+  type PreviewOAuthState,
+} from "../src/preview-oauth";
+
+const STATE_SECRET = "test-state-secret";
+const STATE_KEY = new TextEncoder().encode(STATE_SECRET);
+const STABLE_CALLBACK = "https://gatekeeper.example.workers.dev/oauth";
+const PREVIEW_CALLBACK = "https://preview-gatekeeper.example.workers.dev/oauth";
+const DOT_PREVIEW_CALLBACK = "https://preview.gatekeeper.example.workers.dev/oauth";
+const STATE: PreviewOAuthState = {
+  userObjectId: "0".repeat(64),
+  oauthNonce: "1".repeat(64),
+};
+const STABLE_ENV: PreviewOAuthEnv = {
+  OAUTH_ALLOW_PREVIEW_REDIRECTS: "true",
+  OAUTH_STATE_SIGNING_SECRET: STATE_SECRET,
+};
+const PREVIEW_ENV: PreviewOAuthEnv = {
+  ...STABLE_ENV,
+  OAUTH_REDIRECT_URI: STABLE_CALLBACK,
+};
+
+async function signedState(returnUrl: string, extra: Record<string, unknown> = {}): Promise<string> {
+  return new SignJWT({ ...STATE, returnUrl, ...extra })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt()
+    .setExpirationTime("10m")
+    .sign(STATE_KEY);
+}
+
+describe("PreviewOAuth", () => {
+  it("keeps direct callbacks on the legacy state wire format", async () => {
+    const oauth = new PreviewOAuth({ callbackUri: STABLE_CALLBACK, env: {} });
+    const encoded = await oauth.createAuthorizationState(STATE);
+
+    expect(oauth.redirectUri).toBe(STABLE_CALLBACK);
+    expect(encoded).toBe(`${STATE.userObjectId}:${STATE.oauthNonce}`);
+    await expect(oauth.handleCallback(new URL(`${STABLE_CALLBACK}?state=${encoded}`)))
+      .resolves.toEqual({ kind: "local", state: STATE });
+  });
+
+  it("creates Google's compatible short-lived HS256 state for a preview", async () => {
+    const oauth = new PreviewOAuth({ callbackUri: PREVIEW_CALLBACK, env: PREVIEW_ENV });
+    const encoded = await oauth.createAuthorizationState(STATE);
+    const payload = decodeJwt(encoded);
+
+    expect(oauth.redirectUri).toBe(STABLE_CALLBACK);
+    expect(encoded.split(".")).toHaveLength(3);
+    expect(payload).toMatchObject({ ...STATE, returnUrl: PREVIEW_CALLBACK });
+    expect(typeof payload.iat).toBe("number");
+    expect(typeof payload.exp).toBe("number");
+    expect((payload.exp ?? 0) - (payload.iat ?? 0)).toBe(10 * 60);
+
+    await expect(oauth.handleCallback(
+      new URL(`${PREVIEW_CALLBACK}?code=code&state=${encodeURIComponent(encoded)}`),
+    )).resolves.toEqual({ kind: "local", state: STATE });
+  });
+
+  it("requires the exact enable value and a signing secret for dynamic callbacks", () => {
+    for (const value of [undefined, false, "false", "TRUE"]) {
+      expect(() => new PreviewOAuth({
+        callbackUri: PREVIEW_CALLBACK,
+        env: { ...PREVIEW_ENV, OAUTH_ALLOW_PREVIEW_REDIRECTS: value },
+      })).toThrow(PreviewOAuthConfigurationError);
+    }
+
+    expect(() => new PreviewOAuth({
+      callbackUri: PREVIEW_CALLBACK,
+      env: { ...PREVIEW_ENV, OAUTH_ALLOW_PREVIEW_REDIRECTS: true },
+    })).not.toThrow();
+    expect(() => new PreviewOAuth({
+      callbackUri: PREVIEW_CALLBACK,
+      env: { ...PREVIEW_ENV, OAUTH_STATE_SIGNING_SECRET: undefined },
+    })).toThrow(/signing secret/i);
+  });
+
+  it("returns OAUTH_REDIRECT_URI byte-for-byte", () => {
+    const redirectUri = "https://gatekeeper.example.workers.dev:443/oauth";
+    const oauth = new PreviewOAuth({
+      callbackUri: PREVIEW_CALLBACK,
+      env: { ...PREVIEW_ENV, OAUTH_REDIRECT_URI: redirectUri },
+    });
+
+    expect(oauth.redirectUri).toBe(redirectUri);
+  });
+
+  it("rejects unsafe or unrelated callback configuration before authorization", () => {
+    for (const callbackUri of [
+      "http://preview-gatekeeper.example.workers.dev/oauth",
+      "https://user:pass@preview-gatekeeper.example.workers.dev/oauth",
+      `${PREVIEW_CALLBACK}?next=bad`,
+      `${PREVIEW_CALLBACK}#fragment`,
+      "https://unrelated.example.workers.dev/oauth",
+      "https://preview-gatekeeper.example.workers.dev/not-oauth",
+    ]) {
+      expect(() => new PreviewOAuth({ callbackUri, env: PREVIEW_ENV }))
+        .toThrow(PreviewOAuthConfigurationError);
+    }
+    expect(() => new PreviewOAuth({
+      callbackUri: PREVIEW_CALLBACK,
+      env: { ...PREVIEW_ENV, OAUTH_REDIRECT_URI: "http://gatekeeper.example.workers.dev/oauth" },
+    })).toThrow(PreviewOAuthConfigurationError);
+  });
+
+  it("rejects tampered, expired, malformed, and non-HS256 state", async () => {
+    const oauth = new PreviewOAuth({ callbackUri: STABLE_CALLBACK, env: STABLE_ENV });
+    const valid = await signedState(PREVIEW_CALLBACK);
+    const segments = valid.split(".");
+    if (!segments[1]) throw new Error("Expected a three-segment JWT");
+    segments[1] = `${segments[1].startsWith("A") ? "B" : "A"}${segments[1].slice(1)}`;
+    await expect(oauth.handleCallback(
+      new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(segments.join("."))}`),
+    )).rejects.toThrow();
+
+    const now = Math.floor(Date.now() / 1000);
+    const expired = await new SignJWT({ ...STATE, returnUrl: PREVIEW_CALLBACK })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt(now - 120)
+      .setExpirationTime(now - 60)
+      .sign(STATE_KEY);
+    await expect(oauth.handleCallback(
+      new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(expired)}`),
+    )).rejects.toThrow();
+
+    const wrongAlgorithm = await new SignJWT({ ...STATE, returnUrl: PREVIEW_CALLBACK })
+      .setProtectedHeader({ alg: "HS384", typ: "JWT" })
+      .setIssuedAt()
+      .setExpirationTime("10m")
+      .sign(STATE_KEY);
+    await expect(oauth.handleCallback(
+      new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(wrongAlgorithm)}`),
+    )).rejects.toThrow();
+    await expect(oauth.handleCallback(new URL(`${STABLE_CALLBACK}?state=not-valid-state`)))
+      .rejects.toThrow(/invalid/i);
+  });
+
+  it("requires exact signed claims and well-formed local identifiers", async () => {
+    const oauth = new PreviewOAuth({ callbackUri: STABLE_CALLBACK, env: STABLE_ENV });
+    const unexpected = await signedState(PREVIEW_CALLBACK, { unexpected: true });
+    await expect(oauth.handleCallback(
+      new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(unexpected)}`),
+    )).rejects.toThrow(/invalid/i);
+
+    const missingTimes = await new SignJWT({ ...STATE, returnUrl: PREVIEW_CALLBACK })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .sign(STATE_KEY);
+    await expect(oauth.handleCallback(
+      new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(missingTimes)}`),
+    )).rejects.toThrow();
+
+    await expect(new PreviewOAuth({ callbackUri: STABLE_CALLBACK, env: {} })
+      .createAuthorizationState({ ...STATE, userObjectId: "not-an-id" }))
+      .rejects.toThrow(/invalid/i);
+    await expect(oauth.handleCallback(new URL(STABLE_CALLBACK))).rejects.toThrow(/state/i);
+  });
+
+  it("accepts only the stable callback and its Worker Preview hosts", async () => {
+    const oauth = new PreviewOAuth({ callbackUri: STABLE_CALLBACK, env: STABLE_ENV });
+    for (const returnUrl of [STABLE_CALLBACK, PREVIEW_CALLBACK, DOT_PREVIEW_CALLBACK]) {
+      const encoded = await signedState(returnUrl);
+      await expect(oauth.handleCallback(
+        new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(encoded)}`),
+      )).resolves.toMatchObject(returnUrl === STABLE_CALLBACK
+        ? { kind: "local", state: STATE }
+        : { kind: "relay" });
+    }
+
+    for (const returnUrl of [
+      "https://attacker.example/oauth",
+      "https://gatekeeper.example.workers.dev.attacker.example/oauth",
+      "https://preview-gatekeeper.example.workers.dev/not-oauth",
+      `${PREVIEW_CALLBACK}?next=bad`,
+      `${PREVIEW_CALLBACK}#fragment`,
+      "https://user:pass@preview-gatekeeper.example.workers.dev/oauth",
+      "http://preview-gatekeeper.example.workers.dev/oauth",
+      "https://preview-gatekeeper.example.workers.dev:8443/oauth",
+    ]) {
+      const encoded = await signedState(returnUrl);
+      await expect(oauth.handleCallback(
+        new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(encoded)}`),
+      )).rejects.toThrow(/return URL/i);
+    }
+  });
+
+  it("does not accept a signed return URL when preview redirects are disabled", async () => {
+    const oauth = new PreviewOAuth({
+      callbackUri: STABLE_CALLBACK,
+      env: { OAUTH_STATE_SIGNING_SECRET: STATE_SECRET },
+    });
+    const encoded = await signedState(PREVIEW_CALLBACK);
+
+    await expect(oauth.handleCallback(
+      new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(encoded)}`),
+    )).rejects.toThrow(/not allowed/i);
+  });
+
+  it("requires the shared secret when a stable Worker receives signed state", async () => {
+    const oauth = new PreviewOAuth({
+      callbackUri: STABLE_CALLBACK,
+      env: { OAUTH_ALLOW_PREVIEW_REDIRECTS: "true" },
+    });
+    const encoded = await signedState(PREVIEW_CALLBACK);
+
+    await expect(oauth.handleCallback(
+      new URL(`${STABLE_CALLBACK}?state=${encodeURIComponent(encoded)}`),
+    )).rejects.toBeInstanceOf(PreviewOAuthConfigurationError);
+  });
+
+  it("relays only the provider result and unchanged signed state", async () => {
+    const oauth = new PreviewOAuth({ callbackUri: STABLE_CALLBACK, env: STABLE_ENV });
+    const encoded = await signedState(PREVIEW_CALLBACK);
+    const callback = new URL(STABLE_CALLBACK);
+    callback.searchParams.set("error", "access_denied");
+    callback.searchParams.set("error_description", "provider-secret");
+    callback.searchParams.set("scope", "private-scope");
+    callback.searchParams.set("state", encoded);
+    const result = await oauth.handleCallback(callback);
+    if (result.kind !== "relay") throw new Error("Expected a relay response");
+    const location = new URL(result.response.headers.get("location") ?? "");
+
+    expect(result.response.status).toBe(302);
+    expect(location.origin + location.pathname).toBe(PREVIEW_CALLBACK);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+    expect(location.searchParams.get("state")).toBe(encoded);
+    expect(location.searchParams.has("error_description")).toBe(false);
+    expect(location.searchParams.has("scope")).toBe(false);
+  });
+
+  it("relays successful callbacks behind a shared router path", async () => {
+    const stableCallback = "https://router.example.workers.dev/gatekeeper/google/oauth";
+    const previewCallback = "https://preview-router.example.workers.dev/gatekeeper/google/oauth";
+    const preview = new PreviewOAuth({
+      callbackUri: previewCallback,
+      env: { ...PREVIEW_ENV, OAUTH_REDIRECT_URI: stableCallback },
+    });
+    const encoded = await preview.createAuthorizationState(STATE);
+    const stable = new PreviewOAuth({ callbackUri: stableCallback, env: STABLE_ENV });
+    const result = await stable.handleCallback(
+      new URL(`${stableCallback}?code=authorization-code&state=${encodeURIComponent(encoded)}`),
+    );
+    if (result.kind !== "relay") throw new Error("Expected a relay response");
+    const location = new URL(result.response.headers.get("location") ?? "");
+
+    expect(location.origin + location.pathname).toBe(previewCallback);
+    expect(location.searchParams.get("code")).toBe("authorization-code");
+    expect(location.searchParams.get("state")).toBe(encoded);
+  });
+});

--- a/packages/gatekeeper-kit/package.json
+++ b/packages/gatekeeper-kit/package.json
@@ -17,6 +17,7 @@
     "./endpoint": "./src/endpoint.ts",
     "./http-errors": "./src/http-errors.ts",
     "./observers": "./src/observers.ts",
+    "./preview-oauth": "./src/preview-oauth.ts",
     "./response-body": "./src/response-body.ts",
     "./simulation": "./src/simulation.ts"
   },
@@ -27,7 +28,8 @@
   },
   "dependencies": {
     "@gadgets/backend-utils": "workspace:*",
-    "@gadgets/workshop-shared": "workspace:*"
+    "@gadgets/workshop-shared": "workspace:*",
+    "jose": "^6.2.8"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "catalog:",

--- a/packages/gatekeeper-kit/src/preview-oauth.ts
+++ b/packages/gatekeeper-kit/src/preview-oauth.ts
@@ -1,0 +1,270 @@
+import { SignJWT, jwtVerify, type JWTPayload } from "jose";
+
+const OAUTH_STATE_MAX_AGE = "10m";
+const HEX_64 = /^[0-9a-f]{64}$/i;
+
+type AuthorizationMode =
+  | { kind: "direct" }
+  | { kind: "preview"; returnUrl: string; signingSecret: string };
+
+/** Runtime configuration shared by stable and preview OAuth gatekeepers. */
+export type PreviewOAuthEnv = Readonly<{
+  /** Whether callbacks may be relayed to Worker Preview hostnames. */
+  OAUTH_ALLOW_PREVIEW_REDIRECTS?: boolean | string;
+  /** Stable callback URI registered with the OAuth provider. Set only on previews. */
+  OAUTH_REDIRECT_URI?: string;
+  /** HMAC secret shared by the stable Worker and its previews. */
+  OAUTH_STATE_SIGNING_SECRET?: string;
+}>;
+
+/** Gatekeeper-owned identifiers carried through an OAuth authorization round trip. */
+export type PreviewOAuthState = Readonly<{
+  /** Durable Object ID for the account completing authorization. */
+  userObjectId: string;
+  /** Single-use nonce for the OAuth callback stage. */
+  oauthNonce: string;
+}>;
+
+/** Result of verifying an OAuth callback and applying preview relay policy. */
+export type PreviewOAuthCallbackResult =
+  | Readonly<{
+    /** Indicates that this Worker owns the callback. */
+    kind: "local";
+    /** Verified account and nonce identifiers. */
+    state: PreviewOAuthState;
+  }>
+  | Readonly<{
+    /** Indicates that the stable Worker must relay the callback to its preview. */
+    kind: "relay";
+    /** Redirect containing only the provider result and unchanged signed state. */
+    response: Response;
+  }>;
+
+/** Thrown when preview OAuth runtime configuration is incomplete or invalid. */
+export class PreviewOAuthConfigurationError extends Error {
+  /**
+   * @param message Display-safe configuration failure.
+   * @param options Optional error cause.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PreviewOAuthConfigurationError";
+  }
+}
+
+function configurationUrl(value: string, label: string): URL {
+  try {
+    return new URL(value);
+  } catch (error) {
+    throw new PreviewOAuthConfigurationError(`${label} must be a valid absolute URL.`, {
+      cause: error,
+    });
+  }
+}
+
+function validatePreviewConfigurationUrl(url: URL, label: string): void {
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && url.hostname === "localhost")) {
+    throw new PreviewOAuthConfigurationError(`${label} must use HTTPS or HTTP on localhost.`);
+  }
+  if (url.search || url.hash || url.username || url.password) {
+    throw new PreviewOAuthConfigurationError(
+      `${label} must not include credentials, a query, or a fragment.`,
+    );
+  }
+}
+
+function stateKey(secret: string): Uint8Array {
+  return new TextEncoder().encode(secret);
+}
+
+function previewRedirectsEnabled(env: PreviewOAuthEnv): boolean {
+  const value = env.OAUTH_ALLOW_PREVIEW_REDIRECTS;
+  return value === true || value === "true";
+}
+
+function parseLocalState(state: object): PreviewOAuthState {
+  const allowedKeys = new Set(["userObjectId", "oauthNonce"]);
+  const value = state as Record<string, unknown>;
+  if (Object.keys(value).some(key => !allowedKeys.has(key)) ||
+      typeof value.userObjectId !== "string" || !HEX_64.test(value.userObjectId) ||
+      typeof value.oauthNonce !== "string" || !HEX_64.test(value.oauthNonce)) {
+    throw new Error("Invalid OAuth state");
+  }
+  return { userObjectId: value.userObjectId, oauthNonce: value.oauthNonce };
+}
+
+function parseSignedState(payload: JWTPayload): PreviewOAuthState & { returnUrl?: string } {
+  const allowedKeys = new Set(["userObjectId", "oauthNonce", "returnUrl", "iat", "exp"]);
+  if (Object.keys(payload).some(key => !allowedKeys.has(key)) ||
+      typeof payload.userObjectId !== "string" || !HEX_64.test(payload.userObjectId) ||
+      typeof payload.oauthNonce !== "string" || !HEX_64.test(payload.oauthNonce) ||
+      (payload.returnUrl !== undefined && typeof payload.returnUrl !== "string")) {
+    throw new Error("Invalid OAuth state");
+  }
+  return {
+    userObjectId: payload.userObjectId,
+    oauthNonce: payload.oauthNonce,
+    ...(payload.returnUrl === undefined ? {} : { returnUrl: payload.returnUrl }),
+  };
+}
+
+function encodeLegacyState(state: PreviewOAuthState): string {
+  return `${state.userObjectId}:${state.oauthNonce}`;
+}
+
+function decodeLegacyState(state: string): PreviewOAuthState {
+  const match = /^([0-9a-f]{64}):([0-9a-f]{64})$/i.exec(state);
+  if (!match?.[1] || !match[2]) throw new Error("Invalid OAuth state");
+  return { userObjectId: match[1], oauthNonce: match[2] };
+}
+
+function isSignedState(state: string): boolean {
+  return state.split(".").length === 3;
+}
+
+function validateReturnUrl(returnUrl: string, callback: URL, enabled: boolean): URL {
+  const url = new URL(returnUrl);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && url.hostname === "localhost")) {
+    throw new Error("Invalid OAuth return URL protocol");
+  }
+  if (url.pathname !== callback.pathname || url.search || url.hash || url.username || url.password) {
+    throw new Error("Invalid OAuth return URL path");
+  }
+
+  // Worker Preview hosts use either <preview-slug>-<deployed-host> or
+  // <preview-slug>.<deployed-host>.
+  const allowed = url.origin === callback.origin || Boolean(
+    enabled &&
+    url.protocol === callback.protocol &&
+    url.port === callback.port &&
+    (url.hostname.endsWith(`-${callback.hostname}`) ||
+      url.hostname.endsWith(`.${callback.hostname}`)),
+  );
+  if (!allowed) throw new Error("Invalid OAuth return URL host");
+  return url;
+}
+
+function isCurrentCallback(url: URL, callback: URL): boolean {
+  return url.origin === callback.origin && url.pathname === callback.pathname;
+}
+
+function relayCallback(target: URL, callbackUrl: URL, state: string): Response {
+  for (const key of ["code", "error"]) {
+    const value = callbackUrl.searchParams.get(key);
+    if (value) target.searchParams.set(key, value);
+  }
+  target.searchParams.set("state", state);
+  return Response.redirect(target.toString(), 302);
+}
+
+/** Preview-safe OAuth state and callback handling for one gatekeeper deployment. */
+export class PreviewOAuth {
+  readonly #authorizationMode: AuthorizationMode;
+  readonly #callback: URL;
+  readonly #enabled: boolean;
+  readonly #signingSecret: string | undefined;
+
+  /** Exact callback URI to send to the provider and retain for the code exchange. */
+  readonly redirectUri: string;
+
+  /**
+   * Validates the current callback and stable/preview configuration. The `redirectUri` property must
+   * be retained with the OAuth nonce and reused unchanged during authorization-code exchange.
+   * @param options Current callback URI and the shared preview OAuth environment.
+   */
+  constructor(options: {
+    /** Exact callback URI served by the current Worker. */
+    callbackUri: string;
+    /** Stable/preview runtime variables and signing secret. */
+    env: PreviewOAuthEnv;
+  }) {
+    this.#callback = configurationUrl(options.callbackUri, "OAuth callback URI");
+    const configuredRedirect = options.env.OAUTH_REDIRECT_URI;
+    this.redirectUri = configuredRedirect || options.callbackUri;
+    const redirect = configurationUrl(this.redirectUri, "OAUTH_REDIRECT_URI");
+    this.#enabled = previewRedirectsEnabled(options.env);
+    const returnUrl = configuredRedirect && this.#callback.href !== redirect.href
+      ? options.callbackUri
+      : undefined;
+    const signingSecret = options.env.OAUTH_STATE_SIGNING_SECRET;
+
+    if (returnUrl) {
+      if (!this.#enabled) {
+        throw new PreviewOAuthConfigurationError(
+          "OAUTH_ALLOW_PREVIEW_REDIRECTS must be enabled when OAUTH_REDIRECT_URI differs from the callback URI",
+        );
+      }
+      if (!signingSecret) {
+        throw new PreviewOAuthConfigurationError("OAuth state signing secret is not configured.");
+      }
+      validatePreviewConfigurationUrl(this.#callback, "OAuth callback URI");
+      validatePreviewConfigurationUrl(redirect, "OAUTH_REDIRECT_URI");
+      try {
+        validateReturnUrl(returnUrl, redirect, this.#enabled);
+      } catch (error) {
+        throw new PreviewOAuthConfigurationError(
+          "OAuth callback URI must be an allowed Worker Preview callback for OAUTH_REDIRECT_URI.",
+          { cause: error },
+        );
+      }
+      this.#authorizationMode = { kind: "preview", returnUrl, signingSecret };
+    } else {
+      this.#authorizationMode = { kind: "direct" };
+    }
+    this.#signingSecret = signingSecret;
+  }
+
+  /**
+   * Encodes authorization state, using the legacy direct form for a local callback and a signed JWT
+   * when the result must return through a stable Worker.
+   * @param state Durable Object ID and one-time OAuth nonce.
+   * @returns Provider-facing OAuth state.
+   */
+  async createAuthorizationState(state: PreviewOAuthState): Promise<string> {
+    const parsed = parseLocalState(state);
+    if (this.#authorizationMode.kind === "direct") return encodeLegacyState(parsed);
+
+    return new SignJWT({ ...parsed, returnUrl: this.#authorizationMode.returnUrl })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuedAt()
+      .setExpirationTime(OAUTH_STATE_MAX_AGE)
+      .sign(stateKey(this.#authorizationMode.signingSecret));
+  }
+
+  /**
+   * Verifies a callback and either returns local state or a validated relay response.
+   * @param callbackUrl Provider callback URL received by the Worker.
+   * @returns A local callback or completed relay result.
+   */
+  async handleCallback(callbackUrl: URL): Promise<PreviewOAuthCallbackResult> {
+    const encodedState = callbackUrl.searchParams.get("state");
+    if (!encodedState) throw new Error("No OAuth state was provided");
+
+    let state: PreviewOAuthState & { returnUrl?: string };
+    if (isSignedState(encodedState)) {
+      if (!this.#signingSecret) {
+        throw new PreviewOAuthConfigurationError("OAuth state signing secret is not configured.");
+      }
+      const { payload } = await jwtVerify(encodedState, stateKey(this.#signingSecret), {
+        algorithms: ["HS256"],
+        requiredClaims: ["iat", "exp"],
+      });
+      state = parseSignedState(payload);
+    } else {
+      state = decodeLegacyState(encodedState);
+    }
+
+    if (state.returnUrl) {
+      if (!this.#enabled) throw new Error("OAuth return URLs are not allowed.");
+      const target = validateReturnUrl(state.returnUrl, this.#callback, this.#enabled);
+      if (!isCurrentCallback(target, this.#callback)) {
+        return { kind: "relay", response: relayCallback(target, callbackUrl, encodedState) };
+      }
+    }
+
+    return {
+      kind: "local",
+      state: { userObjectId: state.userObjectId, oauthNonce: state.oauthNonce },
+    };
+  }
+}

--- a/plans/gatekeeper-kit.md
+++ b/plans/gatekeeper-kit.md
@@ -6,10 +6,10 @@ lines of hand-copied plumbing.
 
 **Status.** Layer 1 (§4, the leaf modules) has landed and has been through a review pass against
 both corpora. The §4 sections are reconciled against the shipped signatures — where the two ever
-disagree, the code and its tests win. Layer 2 (§5, the assembly) and §7 steps 8–16 are still
-proposal: nothing consumes the kit yet, so no gatekeeper has been ported and none of §5's
-ergonomics have met a real consumer. Findings that review raised and declined are recorded in the
-obligations table (§4.8), each with the trigger that would revive it.
+disagree, the code and its tests win. Google consumes the preview OAuth leaf; Layer 2 (§5, the
+assembly) and §7 steps 8–16 are still proposal, so no gatekeeper has been ported to the assembly and
+none of §5's ergonomics have met a real consumer. Findings that review raised and declined are
+recorded in the obligations table (§4.8), each with the trigger that would revive it.
 
 ## 1. Introduction & high-level intent
 
@@ -27,10 +27,10 @@ The kit is one new workspace package, `packages/gatekeeper-kit`, with **two stri
 layers**:
 
 - **Layer 1 — leaf modules.** Small, standalone primitives behind per-file subpath exports:
-  connect nonces and the two-stage handshake, browser status pages, a credential-expiry latch,
-  HTTP error classification, credential storage with refresh coalescing, observer strategies, a
-  durable action journal, pure simulation helpers, a TTL cache, and RPC cursors. Each is usable on
-  its own; none requires the assembly layer.
+  connect nonces and the two-stage handshake, preview OAuth callback relaying, browser status pages,
+  a credential-expiry latch, HTTP error classification, credential storage with refresh
+  coalescing, observer strategies, a durable action journal, pure simulation helpers, a TTL cache,
+  and RPC cursors. Each is usable on its own; none requires the assembly layer.
 - **Layer 2 — the assembly.** A `gatekeeperKit<Env, Grant, Exports, Public>()` factory producing a
   typed spec (`define`, `resource`), pluggable auth strategies (`oauth2`, `tokenAuth`, or a
   hand-written `AuthStrategy`), an HTTP handler, and four abstract base classes (`KitVendorBase`,
@@ -1624,6 +1624,29 @@ origin-scoped headers when one crosses origins (`fetch.ts:142-209`), the factory
 refuses any redirect leaving its declared origin, and `normalizeVendorEndpoint` (§4.14) admits an
 operator-pasted vendor host. Those are three different trust boundaries, and a helper spanning them
 would have to expose knobs for exactly the policy it claims to centralize.
+
+### 4.16 `./preview-oauth`
+
+```ts
+export type PreviewOAuthEnv = {
+  OAUTH_ALLOW_PREVIEW_REDIRECTS?: boolean | string;
+  OAUTH_REDIRECT_URI?: string;
+  OAUTH_STATE_SIGNING_SECRET?: string;
+};
+export type PreviewOAuthState = { userObjectId: string; oauthNonce: string };
+export class PreviewOAuth {
+  constructor(options: { callbackUri: string; env: PreviewOAuthEnv });
+}
+```
+
+This is Google's preview callback relay generalized without changing its wire format: direct flows
+retain the `64hex:64hex` state, while preview flows use a ten-minute HS256 JWT carrying the same two
+identifiers and the preview return URL. The factory returns the exact redirect URI to persist through
+the code exchange, creates provider-facing state, and handles callbacks atomically — callers receive
+either verified local state or an already-filtered relay `Response`. Return URLs are limited to the
+stable callback's exact path and Worker Preview host suffixes; only `code`, `error`, and unchanged
+state cross the relay. Google is the first consumer. Other gatekeepers can adopt the leaf without
+porting to the assembly.
 
 ## 5. Layer 2: the assembly
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       '@gadgets/configurator-ui':
         specifier: workspace:*
         version: link:../configurator-ui
+      '@gadgets/gatekeeper-kit':
+        specifier: workspace:*
+        version: link:../gatekeeper-kit
       '@gadgets/workshop-shared':
         specifier: workspace:*
         version: link:../workshop-shared
@@ -361,9 +364,6 @@ importers:
       capnweb-validate:
         specifier: 'catalog:'
         version: 0.3.0(capnweb@0.12.0)(esbuild@0.28.1)(rollup@4.62.3)(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
-      jose:
-        specifier: ^6.2.8
-        version: 6.2.8
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -420,6 +420,9 @@ importers:
       '@gadgets/workshop-shared':
         specifier: workspace:*
         version: link:../workshop-shared
+      jose:
+        specifier: ^6.2.8
+        version: 6.2.8
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'


### PR DESCRIPTION
- pulls the preview oauth implementation added in #331 out of the google gatekeeper and into the shared gatekeeper-kit package
- google gatekeeper is cut over to using the gatekeeper-kit package
