### PR TITLE
Guide Calendar scheduling through one connection

### DIFF
--- a/packages/gatekeeper-google/__tests__/resources.test.ts
+++ b/packages/gatekeeper-google/__tests__/resources.test.ts
@@ -43,6 +43,15 @@ describe("resource declarations", () => {
     );
   });
 
+  it("advertises one batched Calendar connection for scheduling", () => {
+    expect(GOOGLE_CALENDAR_RESOURCE.description).toBe(
+      "Read and manage one selected calendar. For scheduling across people, request one connection " +
+      "using https://calendar.google.com/calendar/primary/?availability=allVisible, then call " +
+      "checkAvailability once with up to 50 attendee email addresses. Do not request each " +
+      "attendee's calendar.",
+    );
+  });
+
   it("has a distinct pattern per resource", () => {
     let patterns = SUPPORTED_RESOURCES.map(r => r.urlPattern);
     expect(new Set(patterns).size).toBe(patterns.length);

--- a/packages/gatekeeper-google/src/resources.ts
+++ b/packages/gatekeeper-google/src/resources.ts
@@ -52,7 +52,11 @@ export const GOOGLE_SHEETS_RESOURCE: SupportedResource = {
 export const GOOGLE_CALENDAR_RESOURCE: SupportedResource = {
   urlPattern: "https://calendar.google.com/calendar/:calendarId/*",
   title: "Google Calendar",
-  description: "Read and manage a Google Calendar.",
+  description:
+      "Read and manage one selected calendar. For scheduling across people, request one connection " +
+      "using https://calendar.google.com/calendar/primary/?availability=allVisible, then call " +
+      "checkAvailability once with up to 50 attendee email addresses. Do not request each " +
+      "attendee's calendar.",
   grantable: true,
 };
 


### PR DESCRIPTION
Scheduling prompts can cause the agent to request a separate Google Calendar connection for each attendee, producing a wall of blocking setup cards. The pre-connection resource description did not explain that one primary-calendar connection with all-visible availability can query up to 50 email addresses at once.

Advertise the exact connection URL and batched `checkAvailability` call so scheduling workflows request one connection. Multiple connection requests remain supported for workflows that genuinely need distinct resources.

Verified with the full Google gatekeeper test suite, package build, and `pnpm lint:check`.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->