### PR TITLE
Keep blueprint modal actions visible for long forms

### DIFF
--- a/packages/workshop-frontend/src/BlueprintModal.tsx
+++ b/packages/workshop-frontend/src/BlueprintModal.tsx
@@ -279,7 +279,7 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
 
   return (
     <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-      <Dialog className="responsive-dialog !z-[1000] !flex !w-[min(640px,calc(100vw-32px))] flex-col overflow-hidden bg-kumo-base p-0 !top-[10%] !-translate-y-0" size="lg">
+      <Dialog className="responsive-dialog !z-[1000] !top-[clamp(24px,10vh,80px)] !flex !max-h-[calc(100vh-clamp(24px,10vh,80px)-24px)] !w-[min(640px,calc(100vw-32px))] !-translate-y-0 flex-col overflow-hidden bg-kumo-base p-0" size="lg">
           <div className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-4 py-5 sm:px-6">
             <div className="flex min-w-0 items-start gap-3">
               <div className="min-w-0">
@@ -307,9 +307,8 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
             />
           </div>
 
-          <div className="min-h-0 flex-1">
-            {formMode !== 'list' ? (
-              <div className="flex h-full min-h-0 flex-col">
+          {formMode !== 'list' ? (
+              <div className="flex min-h-0 flex-1 flex-col">
                 <div className="chat-panel min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-5 sm:px-6">
                   <div className="space-y-3">
                     <WorkshopInput
@@ -452,7 +451,7 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
                 </div>
               </div>
             ) : (
-              <div className="h-full min-h-0 space-y-4 overflow-y-auto px-4 py-5 sm:px-6">
+              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-5 sm:px-6">
               <button
                 type="button"
                 onClick={() => {
@@ -542,7 +541,6 @@ export default function BlueprintModal({ open, onClose, overseer, gadget, metada
             </section>
               </div>
             )}
-          </div>
       </Dialog>
     </Dialog.Root>
   )


### PR DESCRIPTION
The blueprint modal could grow past the viewport when it contained a screenshot or several connections, leaving Create/Save unreachable without zooming out. It now scrolls its content while keeping the header and actions visible.

Verified in Chrome with six connections across desktop, short, mobile, and scaled viewports. All 328 frontend tests, build, and lint pass.

## Screenshot

![Blueprint creation modal with scrollable connections and the Create action visible](https://github.com/user-attachments/assets/dc912b00-2630-4eee-a016-d02c22a2f2ea)
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->