### PR TITLE
add gatekeeper-kit helper for pending action file storage

### DIFF
--- a/packages/gatekeeper-confluence/__tests__/apply.test.ts
+++ b/packages/gatekeeper-confluence/__tests__/apply.test.ts
@@ -2,34 +2,46 @@ import { describe, expect, it } from "vitest";
 import {
   ConfluenceStore,
   applyStoredAction,
+  rejectStoredAction,
   revertStoredAction,
+  stageAction,
   type ConfluenceAction,
+  type UploadAttachmentAction,
 } from "../src/confluence-actions";
 import type { ConfluenceApi } from "../src/confluence-api";
 
-type Kv = ConstructorParameters<typeof ConfluenceStore>[0];
+type Storage = ConstructorParameters<typeof ConfluenceStore>[0];
 
-// Minimal in-memory KV matching the slice of the DO storage API the store uses.
-function makeKv(): Kv {
+// Minimal in-memory storage matching the slice of the DO storage API the store uses.
+function makeStorage(): Storage {
   const map = new Map<string, unknown>();
-  return {
-    get: <T>(k: string) => map.get(k) as T | undefined,
-    put: (k: string, v: unknown) => void map.set(k, v),
+  const kv = {
+    get: <T>(k: string) => {
+      const value = map.get(k);
+      return value === undefined ? undefined : structuredClone(value) as T;
+    },
+    put: (k: string, v: unknown) => void map.set(k, structuredClone(v)),
     delete: (k: string) => void map.delete(k),
     list: <T>({ prefix }: { prefix: string }) =>
-      [...map.entries()].filter(([k]) => k.startsWith(prefix)) as [string, T][],
-  } as unknown as Kv;
+      [...map.entries()].filter(([k]) => k.startsWith(prefix))
+        .map(([key, value]) => [key, structuredClone(value)] as [string, T]),
+  };
+  return {
+    kv,
+    transactionSync: <T>(callback: () => T): T => callback(),
+  } as unknown as Storage;
 }
 
 type Recorded = {
   addComment: { id: string; type: string }[];
   updateContent: { title: string; status?: string }[];
+  uploadAttachment: { id: string; filename: string; data: Uint8Array }[];
 };
 
 // Fake API recording the calls apply/revert make. `contentType` controls what getContentById reports;
 // `status` controls whether the target page reads back as a draft or a published ("current") page.
 function makeApi(contentType: "page" | "blogpost" = "page", status: string = "current") {
-  const calls: Recorded = { addComment: [], updateContent: [] };
+  const calls: Recorded = { addComment: [], updateContent: [], uploadAttachment: [] };
   const api = {
     getContentById: async (id: string) => ({
       id, type: contentType, status, title: "Title", version: { number: 3 },
@@ -45,18 +57,31 @@ function makeApi(contentType: "page" | "blogpost" = "page", status: string = "cu
     restoreContent: async () => {},
     deleteComment: async () => {},
     deleteAttachment: async () => {},
+    uploadAttachment: async (id: string, file: {filename: string; data: Uint8Array}) => {
+      calls.uploadAttachment.push({id, filename: file.filename, data: file.data.slice()});
+      return {id: "attachment-1"};
+    },
   } as unknown as ConfluenceApi;
   return { api, calls };
 }
 
 function storeWith(api: ConfluenceApi) {
-  return new ConfluenceStore(makeKv(), api);
+  return new ConfluenceStore(makeStorage(), api);
 }
 
 function stage(store: ConfluenceStore, action: ConfluenceAction): number {
   const id = store.nextActionId();
   store.putAction({ id, action, state: "pending", submittedAt: id });
   return id;
+}
+
+async function uploadAction(
+  store: ConfluenceStore, data: Uint8Array, contentId = "123",
+): Promise<UploadAttachmentAction> {
+  return {
+    type: "uploadAttachment", contentId, filename: "example.bin",
+    mediaType: "application/octet-stream", file: await store.captureAttachment(data),
+  };
 }
 
 describe("applyStoredAction", () => {
@@ -111,6 +136,99 @@ describe("applyStoredAction", () => {
     await applyStoredAction(store, id);
 
     expect(calls.updateContent[0].status).toBe("current");
+  });
+
+  it("reassembles attachment bytes, uploads once across a retried apply, and releases the file", async () => {
+    const { api, calls } = makeApi();
+    const store = storeWith(api);
+    const data = Uint8Array.from([0, 1, 127, 128, 255]);
+    const action = await uploadAction(store, data);
+    const id = stage(store, action);
+
+    await applyStoredAction(store, id);
+    await applyStoredAction(store, id);
+
+    expect(calls.uploadAttachment).toEqual([{ id: "123", filename: "example.bin", data }]);
+    expect(store.getAction(id)).toMatchObject({ state: "applied", createdAttachmentId: "attachment-1" });
+    await expect(store.readAttachment(action)).rejects.toThrow(/incomplete or corrupted/);
+  });
+
+  it("retains attachment bytes after a retryable upload failure", async () => {
+    const { api } = makeApi();
+    api.uploadAttachment = async () => { throw new Error("temporary failure"); };
+    const store = storeWith(api);
+    const data = Uint8Array.from([1, 2, 3]);
+    const action = await uploadAction(store, data);
+    const id = stage(store, action);
+
+    await expect(applyStoredAction(store, id)).rejects.toThrow("temporary failure");
+
+    expect(store.getAction(id)?.state).toBe("pending");
+    await expect(store.readAttachment(action)).resolves.toEqual(data);
+  });
+
+  it("applies records queued before attachments moved to the chunk store", async () => {
+    const { api, calls } = makeApi();
+    const store = storeWith(api);
+    const data = Uint8Array.from([4, 5, 6]);
+    const id = stage(store, {
+      type: "uploadAttachment", contentId: "123", filename: "legacy.bin",
+      mediaType: "application/octet-stream", data,
+    } as unknown as ConfluenceAction);
+
+    await applyStoredAction(store, id);
+
+    expect(calls.uploadAttachment).toEqual([{ id: "123", filename: "legacy.bin", data }]);
+    expect(store.getAction(id)?.state).toBe("applied");
+  });
+});
+
+describe("attachment files", () => {
+  it("are deleted when approval submission fails", async () => {
+    const { api } = makeApi();
+    const store = storeWith(api);
+    const action = await uploadAction(store, Uint8Array.from([1, 2, 3]));
+    const queue = { submitAction: async () => { throw new Error("submission failed"); } };
+
+    await expect(stageAction(store, queue as never, action)).rejects.toThrow("submission failed");
+
+    expect(store.getAction(1)).toBeUndefined();
+    await expect(store.readAttachment(action)).rejects.toThrow(/incomplete or corrupted/);
+  });
+
+  it("are deleted on direct and cascaded rejection", async () => {
+    const { api } = makeApi();
+    const store = storeWith(api);
+    const direct = await uploadAction(store, Uint8Array.from([1]));
+    rejectStoredAction(store, stage(store, direct));
+
+    const createId = stage(store, {
+      type: "createContent", provisionalId: "~parent", kind: "page",
+      parent: { type: "space", spaceKey: "ENG" }, title: "Parent", status: "current",
+    });
+    const cascaded = await uploadAction(store, Uint8Array.from([2]), "~parent");
+    stage(store, cascaded);
+    expect(rejectStoredAction(store, createId)).toEqual({ restart: true });
+
+    await expect(store.readAttachment(direct)).rejects.toThrow(/incomplete or corrupted/);
+    await expect(store.readAttachment(cascaded)).rejects.toThrow(/incomplete or corrupted/);
+  });
+
+  it("are swept on the next capture once stale and unreferenced by a pending action", async () => {
+    const { api } = makeApi();
+    const storage = makeStorage();
+    const store = new ConfluenceStore(storage, api);
+    const referenced = await uploadAction(store, Uint8Array.from([1]));
+    stage(store, referenced);
+    const orphan = await uploadAction(store, Uint8Array.from([2]));
+    for (const [key, value] of storage.kv.list<{ createdAt: number }>({ prefix: "confluence:actionFileAllocation:" })) {
+      if (typeof value === "object") storage.kv.put(key, { ...value, createdAt: 0 });
+    }
+
+    await store.captureAttachment(Uint8Array.from([3]));
+
+    await expect(store.readAttachment(referenced)).resolves.toEqual(Uint8Array.from([1]));
+    await expect(store.readAttachment(orphan)).rejects.toThrow(/incomplete or corrupted/);
   });
 });
 

--- a/packages/gatekeeper-confluence/package.json
+++ b/packages/gatekeeper-confluence/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@gadgets/configurator-ui": "workspace:*",
+    "@gadgets/gatekeeper-kit": "workspace:*",
     "@gadgets/workshop-shared": "workspace:*",
     "capnweb": "catalog:",
     "capnweb-validate": "catalog:",

--- a/packages/gatekeeper-confluence/src/confluence-actions.ts
+++ b/packages/gatekeeper-confluence/src/confluence-actions.ts
@@ -9,6 +9,7 @@
 // without it.
 
 import type { RpcStub } from "cloudflare:workers";
+import { ActionFileStore, type ActionFileReference } from "@gadgets/gatekeeper-kit/action-files";
 import type { ActionDescription, ApprovalQueue, ObservationDescription } from "@gadgets/workshop-shared/gatekeeper";
 import {
   ConfluenceApi,
@@ -42,16 +43,23 @@ export type ConfluenceAction =
   | { type: "addComment"; contentId: string; text: string }
   | { type: "addLabel"; contentId: string; name: string }
   | { type: "removeLabel"; contentId: string; name: string }
-  | {
-      type: "uploadAttachment";
-      contentId: string;
-      filename: string;
-      mediaType: string;
-      data: Uint8Array;
-      comment?: string;
-    }
+  | UploadAttachmentAction
   | { type: "trash"; contentId: string }
   | { type: "restore"; contentId: string };
+
+/**
+ * The file bytes live in the chunk store until the action is applied or rejected, keeping the
+ * action record itself small. Records queued before that store existed carry them inline as `data`
+ * instead; `ConfluenceStore.readAttachment` still accepts those.
+ */
+export type UploadAttachmentAction = {
+  type: "uploadAttachment";
+  contentId: string;
+  filename: string;
+  mediaType: string;
+  file: ActionFileReference;
+  comment?: string;
+};
 
 export type StoredActionRecord = {
   id: number;
@@ -72,18 +80,30 @@ function actionContentId(action: ConfluenceAction): string | null {
 // ---------------------------------------------------------------------------------------------
 // Store: caching + pending-action storage (backed by the gatekeeper DO's KV storage)
 
-type Kv = DurableObjectStorage["kv"];
+type Storage = Pick<DurableObjectStorage, "kv" | "transactionSync">;
 const CONTENT_TTL_MS = 30_000;
+const MAX_ATTACHMENT_FILE_BYTES = 25 * 1024 * 1024;
+const MAX_ATTACHMENT_TOTAL_BYTES = 50 * 1024 * 1024;
+// How long an attachment file may go unreferenced by a pending action before it is swept: long
+// enough that no staging still in flight could be about to reference it.
+const ATTACHMENT_FILE_GRACE_MS = 60 * 60 * 1000;
 
 type ContentCache = { fetchedAt: number; content: ContentResponse };
 
 export class ConfluenceStore {
-  #kv: Kv;
+  #kv: Storage["kv"];
   #api: ConfluenceApi;
+  #files: ActionFileStore;
 
-  constructor(kv: Kv, api: ConfluenceApi) {
-    this.#kv = kv;
+  constructor(storage: Storage, api: ConfluenceApi) {
+    this.#kv = storage.kv;
     this.#api = api;
+    this.#files = new ActionFileStore(storage, {
+      filePrefix: "confluence:actionFile:",
+      allocationPrefix: "confluence:actionFileAllocation:",
+      maxFileBytes: MAX_ATTACHMENT_FILE_BYTES,
+      maxTotalBytes: MAX_ATTACHMENT_TOTAL_BYTES,
+    });
   }
 
   get api(): ConfluenceApi {
@@ -115,7 +135,9 @@ export class ConfluenceStore {
   }
 
   deleteAction(id: number): void {
+    const action = this.getAction(id)?.action;
     this.#kv.delete(`action:${id}`);
+    if (action?.type === "uploadAttachment") this.releaseAttachment(action);
   }
 
   allActions(): StoredActionRecord[] {
@@ -135,6 +157,32 @@ export class ConfluenceStore {
       const t = actionContentId(r.action);
       return t !== null && this.resolveId(t) === target;
     });
+  }
+
+  // --- attachment files ---
+
+  /**
+   * Retains upload bytes for a pending action. Files no pending action references (a staging that
+   * failed after capture, or an apply cut short before releasing them) are swept first, once old
+   * enough that no in-flight staging could still be about to reference them.
+   */
+  captureAttachment(data: Uint8Array): Promise<ActionFileReference> {
+    const referenced = new Set<string>();
+    for (const { action } of this.pendingActions()) {
+      // Legacy inline records have no `file`; nothing of theirs lives in the chunk store.
+      if (action.type === "uploadAttachment" && action.file) referenced.add(action.file.handle);
+    }
+    this.#files.pruneUnreferenced(referenced, Date.now() - ATTACHMENT_FILE_GRACE_MS);
+    return this.#files.capture(data);
+  }
+
+  readAttachment(action: UploadAttachmentAction): Promise<Uint8Array> {
+    const inline = (action as { data?: unknown }).data;
+    return inline instanceof Uint8Array ? Promise.resolve(inline) : this.#files.read(action.file);
+  }
+
+  releaseAttachment(action: UploadAttachmentAction): void {
+    this.#files.delete(action.file);
   }
 
   // --- provisional ID resolution ---
@@ -389,7 +437,7 @@ function describeAction(action: ConfluenceAction): ActionDescription {
     case "uploadAttachment":
       return {
         title: "Upload attachment to Confluence",
-        description: `Upload **${action.filename}** (${action.mediaType}, ${action.data.byteLength} bytes).`,
+        description: `Upload **${action.filename}** (${action.mediaType}, ${action.file.size} bytes).`,
         implementsRevert: true,
         actionKind: kind("uploadAttachment", "Upload attachment"),
       };
@@ -539,7 +587,9 @@ async function applyAction(store: ConfluenceStore, record: StoredActionRecord): 
       break;
     case "uploadAttachment": {
       const id = requireResolved(store, action.contentId);
-      const created = await api.uploadAttachment(id, action);
+      const created = await api.uploadAttachment(id, {
+        ...action, data: await store.readAttachment(action),
+      });
       record.createdAttachmentId = created.id;
       store.putAction(record);
       break;
@@ -560,11 +610,15 @@ async function applyAction(store: ConfluenceStore, record: StoredActionRecord): 
   // overlaying it on top of the (refetched) real state.
   record.state = "applied";
   store.putAction(record);
+  if (action.type === "uploadAttachment") store.releaseAttachment(action);
 }
 
 export async function applyStoredAction(store: ConfluenceStore, id: number): Promise<void> {
   const record = store.getAction(id);
   if (!record) throw new Error(`Unknown action: ${id}`);
+  // The Workshop marks its side approved only after this RPC returns, so a restart in between
+  // re-applies an action whose work (and attachment file) is already done and gone.
+  if (record.state === "applied") return;
   await applyAction(store, record);
 }
 

--- a/packages/gatekeeper-confluence/src/confluence.ts
+++ b/packages/gatekeeper-confluence/src/confluence.ts
@@ -568,7 +568,7 @@ function makeApi(ctx: { exports: Cloudflare.Env }, props: BaseProps): Confluence
 @validateRpc()
 export class ConfluenceSiteGatekeeperImpl extends DurableObject<Env, SiteGatekeeperProps>
     implements Gatekeeper<ConfluenceSiteSession> {
-  #store() { return new ConfluenceStore(this.ctx.storage.kv, makeApi(this.ctx, this.ctx.props)); }
+  #store() { return new ConfluenceStore(this.ctx.storage, makeApi(this.ctx, this.ctx.props)); }
   #tracker() { return new ConfluenceObserverTracker(this.ctx.storage.kv, this.ctx.props.cloudId); }
 
   async describe(): Promise<ResourceDescription> {
@@ -617,7 +617,7 @@ export class ConfluenceSiteGatekeeperImpl extends DurableObject<Env, SiteGatekee
 @validateRpc()
 export class ConfluenceSpaceGatekeeperImpl extends DurableObject<Env, SpaceGatekeeperProps>
     implements Gatekeeper<ConfluenceSpaceSession> {
-  #store() { return new ConfluenceStore(this.ctx.storage.kv, makeApi(this.ctx, this.ctx.props)); }
+  #store() { return new ConfluenceStore(this.ctx.storage, makeApi(this.ctx, this.ctx.props)); }
   #tracker() { return new ConfluenceObserverTracker(this.ctx.storage.kv, this.ctx.props.cloudId); }
 
   async describe(): Promise<ResourceDescription> {
@@ -663,7 +663,7 @@ export class ConfluenceSpaceGatekeeperImpl extends DurableObject<Env, SpaceGatek
 @validateRpc()
 export class ConfluenceContentGatekeeperImpl extends DurableObject<Env, ContentGatekeeperProps>
     implements Gatekeeper<ConfluenceContentSession> {
-  #store() { return new ConfluenceStore(this.ctx.storage.kv, makeApi(this.ctx, this.ctx.props)); }
+  #store() { return new ConfluenceStore(this.ctx.storage, makeApi(this.ctx, this.ctx.props)); }
   #tracker() { return new ConfluenceObserverTracker(this.ctx.storage.kv, this.ctx.props.cloudId); }
 
   async describe(): Promise<ResourceDescription> {
@@ -1137,14 +1137,16 @@ class ContentSessionImpl extends RpcTarget implements ConfluenceContentSession {
   }
 
   async uploadAttachment(options: UploadAttachmentOptions): Promise<Attachment> {
+    // Staging deletes the action, and its file with it, if approval submission fails.
+    const file = await this.#store.captureAttachment(options.data);
     await this.#stage({
       type: "uploadAttachment", contentId: this.#contentId,
-      filename: options.filename, mediaType: options.mediaType, data: options.data, comment: options.comment,
+      filename: options.filename, mediaType: options.mediaType, file, comment: options.comment,
     });
     // Reflect the pending upload optimistically (it isn't applied until approved). Use a fresh
     // provisional id (like createContent) so concurrent pending uploads don't share one id.
     return { id: this.#store.nextProvisionalId(), title: options.filename, mediaType: options.mediaType,
-      fileSize: options.data.byteLength, version: 1, createdAt: new Date() };
+      fileSize: file.size, version: 1, createdAt: new Date() };
   }
 
   async trash(): Promise<void> {

--- a/packages/gatekeeper-confluence/src/types.d.ts
+++ b/packages/gatekeeper-confluence/src/types.d.ts
@@ -360,7 +360,10 @@ export type UploadAttachmentOptions = {
   filename: string;
   /** MIME type of the file. */
   mediaType: string;
-  /** The raw file bytes. */
+  /**
+   * The raw file bytes. Limited to 25 MiB per attachment, and 50 MiB across all of a connection's
+   * pending (not yet approved) uploads.
+   */
   data: Uint8Array;
   /** Optional comment describing the attachment/upload. */
   comment?: string;

--- a/packages/gatekeeper-google/src/gmail-state.ts
+++ b/packages/gatekeeper-google/src/gmail-state.ts
@@ -1,226 +1,34 @@
 import type {
   GmailAttachmentInfo, GmailCustomLabel, GmailDraftPatch, GmailMutableSystemLabel,
 } from "./types";
+import {
+  ACTION_FILE_CHUNK_BYTES, ActionFileStore, type ActionFileReference,
+} from "@gadgets/gatekeeper-kit/action-files";
 import {emailRecipientToAddress, MAX_GMAIL_FORWARD_SOURCE_BYTES} from "./google-api";
 import type {GmailLabelRaw, GmailNormalizedRecipients, GmailParsedDraft} from "./google-api";
 
 /** Bytes per stored forward-source chunk, leaving ample headroom below the 2 MiB value limit. */
-export const GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES = 1024 * 1024;
+export const GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES = ACTION_FILE_CHUNK_BYTES;
 
 /** Maximum aggregate raw forward-source bytes retained by one Gmail binding. */
 export const MAX_GMAIL_PENDING_FORWARD_SNAPSHOT_BYTES = 50 * 1024 * 1024;
 
 /** Integrity metadata persisted in an action instead of the forward source bytes themselves. */
-export type GmailForwardSnapshotReference = {
-  /** Opaque handle for private Durable Object storage. */
-  handle: string;
-  /** Exact decoded source size. */
-  size: number;
-  /** SHA-256 digest of the decoded source bytes. */
-  digest: string;
-};
-
-type GmailForwardSnapshotManifest = GmailForwardSnapshotReference & {
-  version: 1;
-  chunks: number;
-};
-
-type GmailForwardSnapshotAllocation = {
-  version: 1;
-  size: number;
-  chunks: number;
-  createdAt: number;
-};
+export type GmailForwardSnapshotReference = ActionFileReference;
 
 type GmailSnapshotStorage = Pick<DurableObjectStorage, "kv" | "transactionSync">;
 
 const FORWARD_SNAPSHOT_PREFIX = "gmail:forwardSnapshot:";
 const FORWARD_SNAPSHOT_ALLOCATION_PREFIX = "gmail:forwardSnapshotAllocation:";
-const FORWARD_SNAPSHOT_TOTAL_KEY = `${FORWARD_SNAPSHOT_ALLOCATION_PREFIX}totalBytes`;
-const SNAPSHOT_HANDLE_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-function forwardSnapshotManifestKey(handle: string): string {
-  return `${FORWARD_SNAPSHOT_PREFIX}${handle}:manifest`;
-}
-
-function forwardSnapshotAllocationKey(handle: string): string {
-  return `${FORWARD_SNAPSHOT_ALLOCATION_PREFIX}${handle}`;
-}
-
-function forwardSnapshotChunkPrefix(handle: string): string {
-  return `${FORWARD_SNAPSHOT_PREFIX}${handle}:chunk:`;
-}
-
-function forwardSnapshotChunkKey(handle: string, index: number): string {
-  return `${forwardSnapshotChunkPrefix(handle)}${String(index).padStart(4, "0")}`;
-}
-
-function validSnapshotReference(value: unknown): value is GmailForwardSnapshotReference {
-  if (!value || typeof value !== "object") return false;
-  const snapshot = value as Record<string, unknown>;
-  return typeof snapshot.handle === "string" && SNAPSHOT_HANDLE_PATTERN.test(snapshot.handle) &&
-    Number.isSafeInteger(snapshot.size) && (snapshot.size as number) >= 0 &&
-    (snapshot.size as number) <= MAX_GMAIL_FORWARD_SOURCE_BYTES &&
-    typeof snapshot.digest === "string" && /^[0-9a-f]{64}$/.test(snapshot.digest);
-}
-
-function validSnapshotManifest(value: unknown): value is GmailForwardSnapshotManifest {
-  if (!validSnapshotReference(value)) return false;
-  const manifest = value as GmailForwardSnapshotManifest;
-  return manifest.version === 1 && Number.isSafeInteger(manifest.chunks) && manifest.chunks >= 0 &&
-    manifest.chunks === Math.ceil(manifest.size / GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES);
-}
-
-function validSnapshotAllocation(value: unknown): value is GmailForwardSnapshotAllocation {
-  if (!value || typeof value !== "object") return false;
-  const allocation = value as GmailForwardSnapshotAllocation;
-  return allocation.version === 1 && Number.isSafeInteger(allocation.size) &&
-    allocation.size >= 0 && allocation.size <= MAX_GMAIL_FORWARD_SOURCE_BYTES &&
-    Number.isSafeInteger(allocation.chunks) && allocation.chunks >= 0 &&
-    allocation.chunks === Math.ceil(allocation.size / GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES) &&
-    Number.isSafeInteger(allocation.createdAt) && allocation.createdAt >= 0;
-}
 
 /** Stores and verifies exact forward source bytes in bounded private Durable Object chunks. */
-export class GmailForwardSnapshotStore {
-  #storage: GmailSnapshotStorage;
-
+export class GmailForwardSnapshotStore extends ActionFileStore {
   constructor(storage: GmailSnapshotStorage) {
-    this.#storage = storage;
-  }
-
-  /** Capture exact decoded source bytes and return only bounded integrity metadata. */
-  async capture(bytes: Uint8Array): Promise<GmailForwardSnapshotReference> {
-    if (bytes.byteLength > MAX_GMAIL_FORWARD_SOURCE_BYTES) {
-      throw new Error(
-        `Cannot retain a forward source larger than ${MAX_GMAIL_FORWARD_SOURCE_BYTES} bytes.`);
-    }
-    const snapshot: GmailForwardSnapshotReference = {
-      handle: crypto.randomUUID(),
-      size: bytes.byteLength,
-      digest: await sha256(bytes),
-    };
-    const chunks = Math.ceil(bytes.byteLength / GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES);
-    this.#storage.transactionSync(() => {
-      const storedTotal = this.#storage.kv.get<unknown>(FORWARD_SNAPSHOT_TOTAL_KEY);
-      const total = storedTotal === undefined ? 0 : storedTotal;
-      if (!Number.isSafeInteger(total) || (total as number) < 0 ||
-          (total as number) > MAX_GMAIL_PENDING_FORWARD_SNAPSHOT_BYTES) {
-        throw new Error("Stored Gmail forward snapshot accounting is invalid.");
-      }
-      if ((total as number) + snapshot.size > MAX_GMAIL_PENDING_FORWARD_SNAPSHOT_BYTES) {
-        throw new Error(
-          "Pending Gmail forward snapshots exceed the safe aggregate storage limit. " +
-          "Resolve existing forward actions before adding another.");
-      }
-      this.#storage.kv.put<GmailForwardSnapshotAllocation>(
-        forwardSnapshotAllocationKey(snapshot.handle), {
-          version: 1, size: snapshot.size, chunks, createdAt: Date.now(),
-        });
-      this.#storage.kv.put<GmailForwardSnapshotManifest>(
-        forwardSnapshotManifestKey(snapshot.handle), {...snapshot, version: 1, chunks});
-      for (let index = 0; index < chunks; index++) {
-        const start = index * GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES;
-        this.#storage.kv.put(
-          forwardSnapshotChunkKey(snapshot.handle, index),
-          bytes.slice(start, start + GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES));
-      }
-      this.#storage.kv.put(FORWARD_SNAPSHOT_TOTAL_KEY, (total as number) + snapshot.size);
-    });
-    return snapshot;
-  }
-
-  /** Reassemble a captured source only after checking shape, completeness, size, and digest. */
-  async read(snapshot: GmailForwardSnapshotReference): Promise<Uint8Array> {
-    if (!validSnapshotReference(snapshot)) {
-      throw new Error(
-        "This pending forward uses an obsolete source snapshot. Reject and resubmit it.");
-    }
-    const manifest = this.#storage.kv.get<unknown>(forwardSnapshotManifestKey(snapshot.handle));
-    if (!validSnapshotManifest(manifest) || manifest.size !== snapshot.size ||
-        manifest.digest !== snapshot.digest || manifest.handle !== snapshot.handle) {
-      throw new Error("The stored forward snapshot is incomplete or corrupted.");
-    }
-    const entries = [...this.#storage.kv.list<unknown>({
-      prefix: forwardSnapshotChunkPrefix(snapshot.handle),
-    })].toSorted(([left], [right]) => left.localeCompare(right));
-    if (entries.length !== manifest.chunks) {
-      throw new Error("The stored forward snapshot is incomplete or corrupted.");
-    }
-    const bytes = new Uint8Array(manifest.size);
-    let offset = 0;
-    for (let index = 0; index < entries.length; index++) {
-      const [key, chunk] = entries[index];
-      const expectedKey = forwardSnapshotChunkKey(snapshot.handle, index);
-      const expectedSize = Math.min(
-        GMAIL_FORWARD_SNAPSHOT_CHUNK_BYTES, manifest.size - offset);
-      if (key !== expectedKey || !(chunk instanceof Uint8Array) ||
-          chunk.byteLength !== expectedSize) {
-        throw new Error("The stored forward snapshot is incomplete or corrupted.");
-      }
-      bytes.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    if (offset !== manifest.size || await sha256(bytes) !== manifest.digest) {
-      throw new Error("The stored forward snapshot is incomplete or corrupted.");
-    }
-    return bytes;
-  }
-
-  /** Delete all chunks for a snapshot and release its aggregate storage allocation. */
-  delete(snapshot: GmailForwardSnapshotReference | undefined): void {
-    if (!validSnapshotReference(snapshot)) return;
-    this.#delete(snapshot.handle);
-  }
-
-  /** Delete stale allocations that no pending action references. */
-  pruneUnreferenced(referencedHandles: ReadonlySet<string>, createdBefore: number): void {
-    const orphaned: string[] = [];
-    for (const [key, value] of this.#storage.kv.list<unknown>({
-      prefix: FORWARD_SNAPSHOT_ALLOCATION_PREFIX,
-    })) {
-      if (key === FORWARD_SNAPSHOT_TOTAL_KEY || !validSnapshotAllocation(value) ||
-          value.createdAt > createdBefore) continue;
-      const handle = key.slice(FORWARD_SNAPSHOT_ALLOCATION_PREFIX.length);
-      if (SNAPSHOT_HANDLE_PATTERN.test(handle) && !referencedHandles.has(handle)) orphaned.push(handle);
-    }
-    for (const handle of orphaned) this.#delete(handle);
-  }
-
-  #delete(handle: string): void {
-    this.#storage.transactionSync(() => {
-      const manifest = this.#storage.kv.get<unknown>(forwardSnapshotManifestKey(handle));
-      const allocation = this.#storage.kv.get<unknown>(forwardSnapshotAllocationKey(handle));
-      const chunks = validSnapshotAllocation(allocation)
-        ? allocation.chunks
-        : validSnapshotManifest(manifest)
-          ? manifest.chunks
-          : undefined;
-      if (chunks !== undefined) {
-        for (let index = 0; index < chunks; index++) {
-          this.#storage.kv.delete(forwardSnapshotChunkKey(handle, index));
-        }
-      } else {
-        // Corrupt metadata is exceptional; still make a best effort to remove private bytes.
-        for (const [key] of this.#storage.kv.list({
-          prefix: forwardSnapshotChunkPrefix(handle),
-        })) {
-          this.#storage.kv.delete(key);
-        }
-      }
-      this.#storage.kv.delete(forwardSnapshotManifestKey(handle));
-      this.#storage.kv.delete(forwardSnapshotAllocationKey(handle));
-      const total = this.#storage.kv.get<unknown>(FORWARD_SNAPSHOT_TOTAL_KEY);
-      const allocatedSize = validSnapshotAllocation(allocation)
-        ? allocation.size
-        : validSnapshotManifest(manifest)
-          ? manifest.size
-          : undefined;
-      if (allocatedSize !== undefined && typeof total === "number" &&
-          Number.isSafeInteger(total) && total >= 0) {
-        this.#storage.kv.put(FORWARD_SNAPSHOT_TOTAL_KEY, Math.max(0, total - allocatedSize));
-      }
+    super(storage, {
+      filePrefix: FORWARD_SNAPSHOT_PREFIX,
+      allocationPrefix: FORWARD_SNAPSHOT_ALLOCATION_PREFIX,
+      maxFileBytes: MAX_GMAIL_FORWARD_SOURCE_BYTES,
+      maxTotalBytes: MAX_GMAIL_PENDING_FORWARD_SNAPSHOT_BYTES,
     });
   }
 }

--- a/packages/gatekeeper-kit/__tests__/action-files.test.ts
+++ b/packages/gatekeeper-kit/__tests__/action-files.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTION_FILE_CHUNK_BYTES,
+  ActionFileStore,
+  type ActionFileReference,
+  type ActionFileStoreOptions,
+} from "../src/action-files";
+import { fakeKv, type FakeKv } from "./fake-kv";
+
+// This suite runs in Node, while the package intentionally excludes Node globals from its types.
+const nodeBuffer = (globalThis as typeof globalThis & {
+  Buffer: { from(value: Uint8Array): Uint8Array };
+}).Buffer;
+
+const OPTIONS: ActionFileStoreOptions = {
+  filePrefix: "test:file:",
+  allocationPrefix: "test:allocation:",
+  maxFileBytes: 3 * ACTION_FILE_CHUNK_BYTES,
+  maxTotalBytes: 6 * ACTION_FILE_CHUNK_BYTES,
+};
+
+function actionFiles(overrides: Partial<ActionFileStoreOptions> = {}): {
+  store: ActionFileStore;
+  kv: FakeKv;
+} {
+  const kv = fakeKv();
+  const storage = { kv, transactionSync<T>(callback: () => T): T { return callback(); } };
+  return { store: new ActionFileStore(storage, { ...OPTIONS, ...overrides }), kv };
+}
+
+function chunkKeys(kv: FakeKv, file: ActionFileReference): string[] {
+  return kv.keys().filter(key => key.includes(`${file.handle}:chunk:`));
+}
+
+function bytes(length: number): Uint8Array {
+  return Uint8Array.from({ length }, (_, index) => index % 251);
+}
+
+// `toEqual` walks a typed array element by element, which is too slow for multi-MiB inputs.
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
+}
+
+describe("ActionFileStore", () => {
+  it.each([
+    ["empty", 0],
+    ["one chunk", 17],
+    ["multiple chunks", ACTION_FILE_CHUNK_BYTES + 17],
+  ])("round trips an %s file", async (_name, length) => {
+    const { store } = actionFiles();
+    const input = bytes(length);
+
+    const file = await store.capture(input);
+
+    expect(file.size).toBe(length);
+    expect(file.digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(bytesEqual(await store.read(file), input)).toBe(true);
+  });
+
+  it.each([
+    ["Uint8Array", bytes(32)],
+    ["Buffer", nodeBuffer.from(bytes(32))],
+  ])("snapshots %s chunks before yielding to caller mutation", async (_type, input) => {
+    const { store } = actionFiles();
+    const expected = Uint8Array.from(input);
+
+    const capture = store.capture(input);
+    input.fill(255);
+
+    expect(await store.read(await capture)).toEqual(expected);
+  });
+
+  it.each(["missing", "extra", "truncated", "wrong type", "corrupted"])(
+    "rejects %s chunks before returning bytes",
+    async corruption => {
+      const { store, kv } = actionFiles();
+      const file = await store.capture(bytes(ACTION_FILE_CHUNK_BYTES + 17));
+      const keys = chunkKeys(kv, file);
+
+      if (corruption === "missing") kv.delete(keys[1]);
+      if (corruption === "extra") kv.put(`test:file:${file.handle}:chunk:0002`, new Uint8Array());
+      if (corruption === "truncated") kv.put(keys[0], kv.get<Uint8Array>(keys[0])!.slice(1));
+      if (corruption === "wrong type") kv.put(keys[0], "not bytes");
+      if (corruption === "corrupted") {
+        const chunk = kv.get<Uint8Array>(keys[0])!;
+        chunk[0] ^= 0xff;
+        kv.put(keys[0], chunk);
+      }
+
+      await expect(store.read(file)).rejects.toThrow(/incomplete or corrupted/);
+      store.delete(file);
+      expect(chunkKeys(kv, file)).toEqual([]);
+    },
+  );
+
+  it("rejects a reference that disagrees with its manifest", async () => {
+    const { store } = actionFiles();
+    const file = await store.capture(bytes(3));
+
+    await expect(store.read({ ...file, digest: "0".repeat(64) }))
+      .rejects.toThrow(/incomplete or corrupted/);
+  });
+
+  it("fails obsolete references closed with resubmission guidance", async () => {
+    const { store } = actionFiles();
+
+    await expect(store.read({ size: 1, digest: "0".repeat(64) } as ActionFileReference))
+      .rejects.toThrow(/reject and resubmit/i);
+  });
+
+  it("enforces per-file and aggregate byte limits without partial writes", async () => {
+    const { store, kv } = actionFiles({ maxFileBytes: 4, maxTotalBytes: 5 });
+
+    await expect(store.capture(bytes(5))).rejects.toThrow(/larger than 4 bytes/);
+    expect(kv.keys()).toEqual([]);
+
+    await store.capture(bytes(3));
+    await store.capture(bytes(2));
+    const keysAtLimit = kv.keys();
+    await expect(store.capture(bytes(1))).rejects.toThrow(/aggregate storage limit/);
+    expect(kv.keys()).toEqual(keysAtLimit);
+  });
+
+  it.each(["invalid", -1])("fails closed when aggregate accounting is %j, even after a delete", async total => {
+    const { store, kv } = actionFiles();
+    const file = await store.capture(bytes(1));
+    kv.put("test:allocation:totalBytes", total);
+
+    store.delete(file);
+
+    expect(kv.get("test:allocation:totalBytes")).toBe(total);
+    await expect(store.capture(bytes(1))).rejects.toThrow(/accounting is invalid/);
+    expect(kv.keys()).toEqual(["test:allocation:totalBytes"]);
+  });
+
+  it("deletes every chunk idempotently and releases its allocation", async () => {
+    const { store, kv } = actionFiles();
+    const file = await store.capture(bytes(ACTION_FILE_CHUNK_BYTES + 1));
+
+    store.delete(file);
+    store.delete(file);
+
+    expect(kv.keys().some(key => key.includes(file.handle))).toBe(false);
+    expect(kv.get("test:allocation:totalBytes")).toBe(0);
+    await expect(store.read(file)).rejects.toThrow(/incomplete or corrupted/);
+  });
+
+  it("releases accounting when the manifest is missing", async () => {
+    const { store, kv } = actionFiles();
+    const file = await store.capture(bytes(3));
+    kv.delete(`test:file:${file.handle}:manifest`);
+
+    store.delete(file);
+
+    expect(kv.keys().some(key => key.includes(file.handle))).toBe(false);
+    expect(kv.get("test:allocation:totalBytes")).toBe(0);
+  });
+
+  it("prunes stale unreferenced files while retaining referenced and young files", async () => {
+    const { store, kv } = actionFiles();
+    const retained = await store.capture(bytes(1));
+    const orphaned = await store.capture(bytes(2));
+    const young = await store.capture(bytes(3));
+
+    const youngAllocation = kv.get<{ createdAt: number }>(`test:allocation:${young.handle}`)!;
+    youngAllocation.createdAt = Date.now() + 60_000;
+    kv.put(`test:allocation:${young.handle}`, youngAllocation);
+    store.pruneUnreferenced(new Set([retained.handle]), Date.now() + 1);
+
+    await expect(store.read(retained)).resolves.toEqual(bytes(1));
+    await expect(store.read(young)).resolves.toEqual(bytes(3));
+    expect(kv.keys().some(key => key.includes(orphaned.handle))).toBe(false);
+    expect(kv.get("test:allocation:totalBytes")).toBe(4);
+  });
+
+  it("preserves Gmail's deployed storage key layout", async () => {
+    const { store, kv } = actionFiles({
+      filePrefix: "gmail:forwardSnapshot:",
+      allocationPrefix: "gmail:forwardSnapshotAllocation:",
+    });
+    const file = await store.capture(bytes(ACTION_FILE_CHUNK_BYTES + 1));
+
+    expect(kv.keys()).toEqual([
+      `gmail:forwardSnapshot:${file.handle}:chunk:0000`,
+      `gmail:forwardSnapshot:${file.handle}:chunk:0001`,
+      `gmail:forwardSnapshot:${file.handle}:manifest`,
+      `gmail:forwardSnapshotAllocation:${file.handle}`,
+      "gmail:forwardSnapshotAllocation:totalBytes",
+    ]);
+  });
+
+  it("reads and deletes a seeded Gmail v1 snapshot", async () => {
+    const { store, kv } = actionFiles({
+      filePrefix: "gmail:forwardSnapshot:",
+      allocationPrefix: "gmail:forwardSnapshotAllocation:",
+    });
+    const file = {
+      handle: "00000000-0000-4000-8000-000000000001",
+      size: 3,
+      digest: "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+    };
+    kv.put(`gmail:forwardSnapshot:${file.handle}:manifest`, { ...file, version: 1, chunks: 1 });
+    kv.put(`gmail:forwardSnapshot:${file.handle}:chunk:0000`, Uint8Array.from([1, 2, 3]));
+    kv.put(`gmail:forwardSnapshotAllocation:${file.handle}`, {
+      version: 1, size: 3, chunks: 1, createdAt: 1,
+    });
+    kv.put("gmail:forwardSnapshotAllocation:totalBytes", 3);
+
+    await expect(store.read(file)).resolves.toEqual(Uint8Array.from([1, 2, 3]));
+    store.delete(file);
+    expect(kv.keys()).toEqual(["gmail:forwardSnapshotAllocation:totalBytes"]);
+    expect(kv.get("gmail:forwardSnapshotAllocation:totalBytes")).toBe(0);
+  });
+
+  it.each([
+    [{ maxFileBytes: 0 }, /maxFileBytes must be a positive integer/],
+    [{ maxTotalBytes: 0 }, /maxTotalBytes must be a positive integer/],
+  ] as const)("rejects invalid limits %#", (overrides, error) => {
+    expect(() => actionFiles(overrides)).toThrow(error);
+  });
+});

--- a/packages/gatekeeper-kit/package.json
+++ b/packages/gatekeeper-kit/package.json
@@ -5,6 +5,7 @@
   "description": "Building blocks for gatekeepers: connect-flow, credential, action, observation, and simulation primitives. Not a deployable Worker.",
   "type": "module",
   "exports": {
+    "./action-files": "./src/action-files.ts",
     "./actions": "./src/actions.ts",
     "./auth-retry": "./src/auth-retry.ts",
     "./cache": "./src/cache.ts",

--- a/packages/gatekeeper-kit/src/action-files.ts
+++ b/packages/gatekeeper-kit/src/action-files.ts
@@ -1,0 +1,252 @@
+import type { KvScannable } from "./kv";
+import { requirePositiveInt } from "./positive-int";
+
+/** Bytes per stored action-file chunk, leaving headroom below the 2 MiB KV value limit. */
+export const ACTION_FILE_CHUNK_BYTES = 1024 * 1024;
+
+/** Bounded integrity metadata stored with a queued action instead of its file bytes. */
+export type ActionFileReference = {
+  /** Opaque handle for private Durable Object storage. */
+  readonly handle: string;
+  /** Exact file size in bytes. */
+  readonly size: number;
+  /** SHA-256 digest of the file bytes. */
+  readonly digest: string;
+};
+
+/** Storage keys and byte limits for an action-file store. */
+export type ActionFileStoreOptions = {
+  /** Prefix for manifests and chunks. */
+  readonly filePrefix: string;
+  /** Disjoint prefix for allocation records and aggregate accounting. */
+  readonly allocationPrefix: string;
+  /** Maximum bytes in one file. */
+  readonly maxFileBytes: number;
+  /** Maximum aggregate file bytes retained by this store. */
+  readonly maxTotalBytes: number;
+};
+
+/** Transactional Durable Object storage used by an action-file store. */
+export type ActionFileStorage = {
+  /** Synchronous KV storage for file records. */
+  readonly kv: KvScannable;
+  /** Runs file writes and accounting changes atomically. */
+  transactionSync<T>(callback: () => T): T;
+};
+
+type ActionFileManifest = ActionFileReference & {
+  version: 1;
+  chunks: number;
+};
+
+type ActionFileAllocation = {
+  version: 1;
+  size: number;
+  chunks: number;
+  createdAt: number;
+};
+
+const HANDLE_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CORRUPTED = "The stored queued-action file is incomplete or corrupted.";
+
+/**
+ * Stores queued-action files as bounded, integrity-checked Durable Object KV chunks.
+ *
+ * Each file is a manifest plus 1 MiB chunks under `filePrefix`, and an allocation record under
+ * `allocationPrefix` that feeds the aggregate `totalBytes` counter. A capture writes all of them
+ * in one transaction and a delete removes them in one, so the store's own records are trusted as
+ * consistent; storage that has been edited behind its back is outside its guarantees.
+ */
+export class ActionFileStore {
+  readonly #storage: ActionFileStorage;
+  readonly #filePrefix: string;
+  readonly #allocationPrefix: string;
+  readonly #totalKey: string;
+  readonly #maxFileBytes: number;
+  readonly #maxTotalBytes: number;
+
+  /**
+   * Creates an action-file store.
+   * @param storage Transactional Durable Object storage.
+   * @param options Storage keys and byte limits.
+   */
+  constructor(storage: ActionFileStorage, options: ActionFileStoreOptions) {
+    this.#storage = storage;
+    this.#filePrefix = options.filePrefix;
+    this.#allocationPrefix = options.allocationPrefix;
+    this.#totalKey = `${this.#allocationPrefix}totalBytes`;
+    this.#maxFileBytes = requirePositiveInt("maxFileBytes", options.maxFileBytes);
+    this.#maxTotalBytes = requirePositiveInt("maxTotalBytes", options.maxTotalBytes);
+  }
+
+  /**
+   * Captures exact file bytes and returns bounded integrity metadata.
+   * @param bytes File bytes to retain.
+   * @returns A reference suitable for a queued-action payload.
+   */
+  async capture(bytes: Uint8Array): Promise<ActionFileReference> {
+    const size = bytes.byteLength;
+    if (size > this.#maxFileBytes) {
+      throw new Error(
+        `Cannot retain a queued-action file larger than ${this.#maxFileBytes} bytes.`);
+    }
+
+    // WebCrypto snapshots its input synchronously, and each chunk is copied (`slice()` on a Node
+    // Buffer would alias) before the await, so caller mutation afterwards cannot skew either.
+    const digest = sha256(bytes);
+    const chunks: Uint8Array[] = [];
+    for (let start = 0; start < size; start += ACTION_FILE_CHUNK_BYTES) {
+      chunks.push(Uint8Array.from(bytes.subarray(start, start + ACTION_FILE_CHUNK_BYTES)));
+    }
+    const file: ActionFileReference = { handle: crypto.randomUUID(), size, digest: await digest };
+
+    this.#storage.transactionSync(() => {
+      const total = this.#storage.kv.get<unknown>(this.#totalKey) ?? 0;
+      if (!Number.isSafeInteger(total) || (total as number) < 0) {
+        throw new Error("Stored queued-action file accounting is invalid.");
+      }
+      if ((total as number) + size > this.#maxTotalBytes) {
+        throw new Error(
+          "Queued-action files exceed the safe aggregate storage limit. " +
+          "Resolve existing actions before adding another.");
+      }
+      this.#storage.kv.put<ActionFileAllocation>(this.#allocationKey(file.handle), {
+        version: 1, size, chunks: chunks.length, createdAt: Date.now(),
+      });
+      this.#storage.kv.put<ActionFileManifest>(this.#manifestKey(file.handle), {
+        ...file, version: 1, chunks: chunks.length,
+      });
+      chunks.forEach((chunk, index) => this.#storage.kv.put(this.#chunkKey(file.handle, index), chunk));
+      this.#storage.kv.put(this.#totalKey, (total as number) + size);
+    });
+    return file;
+  }
+
+  /**
+   * Reassembles a captured file after checking its manifest, chunks, size, and digest.
+   * @param file Stored file reference.
+   * @returns The exact captured bytes.
+   */
+  async read(file: ActionFileReference): Promise<Uint8Array> {
+    if (!validReference(file)) {
+      throw new Error(
+        "This queued action uses an obsolete file reference. Reject and resubmit it.");
+    }
+    const manifest = this.#storage.kv.get<unknown>(this.#manifestKey(file.handle));
+    if (!validManifest(manifest) || manifest.handle !== file.handle ||
+        manifest.size !== file.size || manifest.digest !== file.digest) {
+      throw new Error(CORRUPTED);
+    }
+
+    const entries = [...this.#storage.kv.list<unknown>({ prefix: this.#chunkPrefix(file.handle) })]
+      .toSorted(([left], [right]) => left.localeCompare(right));
+    if (entries.length !== manifest.chunks) throw new Error(CORRUPTED);
+
+    const bytes = new Uint8Array(manifest.size);
+    let offset = 0;
+    for (const [index, [key, chunk]] of entries.entries()) {
+      const expectedSize = Math.min(ACTION_FILE_CHUNK_BYTES, manifest.size - offset);
+      if (key !== this.#chunkKey(file.handle, index) || !(chunk instanceof Uint8Array) ||
+          chunk.byteLength !== expectedSize) {
+        throw new Error(CORRUPTED);
+      }
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    if (offset !== manifest.size || await sha256(bytes) !== manifest.digest) {
+      throw new Error(CORRUPTED);
+    }
+    return bytes;
+  }
+
+  /**
+   * Deletes a file's chunks and releases its aggregate allocation. Invalid references are ignored.
+   * @param file File reference to delete, if present.
+   */
+  delete(file: ActionFileReference | undefined): void {
+    if (validReference(file)) this.#delete(file.handle);
+  }
+
+  /**
+   * Deletes old allocations not referenced by a live action or another consumer-owned resource.
+   * @param referencedHandles Handles that remain live.
+   * @param createdBefore Delete unreferenced allocations created at or before this timestamp.
+   */
+  pruneUnreferenced(referencedHandles: ReadonlySet<string>, createdBefore: number): void {
+    const orphaned: string[] = [];
+    for (const [key, value] of this.#storage.kv.list<unknown>({ prefix: this.#allocationPrefix })) {
+      const handle = key.slice(this.#allocationPrefix.length);
+      if (validAllocation(value) && value.createdAt <= createdBefore &&
+          HANDLE_PATTERN.test(handle) && !referencedHandles.has(handle)) {
+        orphaned.push(handle);
+      }
+    }
+    for (const handle of orphaned) this.#delete(handle);
+  }
+
+  #manifestKey(handle: string): string {
+    return `${this.#filePrefix}${handle}:manifest`;
+  }
+
+  #allocationKey(handle: string): string {
+    return `${this.#allocationPrefix}${handle}`;
+  }
+
+  #chunkPrefix(handle: string): string {
+    return `${this.#filePrefix}${handle}:chunk:`;
+  }
+
+  #chunkKey(handle: string, index: number): string {
+    return `${this.#chunkPrefix(handle)}${String(index).padStart(4, "0")}`;
+  }
+
+  #delete(handle: string): void {
+    this.#storage.transactionSync(() => {
+      const allocation = this.#storage.kv.get<unknown>(this.#allocationKey(handle));
+      for (const [key] of this.#storage.kv.list({ prefix: this.#chunkPrefix(handle) })) {
+        this.#storage.kv.delete(key);
+      }
+      this.#storage.kv.delete(this.#manifestKey(handle));
+      this.#storage.kv.delete(this.#allocationKey(handle));
+
+      // The allocation record is the accounting unit: without one, nothing was ever counted. A
+      // counter that is already invalid is left as is, so capture() keeps failing closed on it.
+      const total = this.#storage.kv.get<unknown>(this.#totalKey);
+      if (validAllocation(allocation) && Number.isSafeInteger(total) && (total as number) >= 0) {
+        this.#storage.kv.put(this.#totalKey, Math.max(0, (total as number) - allocation.size));
+      }
+    });
+  }
+}
+
+function validReference(value: unknown): value is ActionFileReference {
+  if (!value || typeof value !== "object") return false;
+  const file = value as Record<string, unknown>;
+  return typeof file.handle === "string" && HANDLE_PATTERN.test(file.handle) &&
+    Number.isSafeInteger(file.size) && (file.size as number) >= 0 &&
+    typeof file.digest === "string" && /^[0-9a-f]{64}$/.test(file.digest);
+}
+
+function validChunkCount(record: { size: number; chunks: unknown }): boolean {
+  return record.chunks === Math.ceil(record.size / ACTION_FILE_CHUNK_BYTES);
+}
+
+function validManifest(value: unknown): value is ActionFileManifest {
+  if (!validReference(value)) return false;
+  const manifest = value as ActionFileManifest;
+  return manifest.version === 1 && validChunkCount(manifest);
+}
+
+function validAllocation(value: unknown): value is ActionFileAllocation {
+  if (!value || typeof value !== "object") return false;
+  const allocation = value as ActionFileAllocation;
+  return allocation.version === 1 &&
+    Number.isSafeInteger(allocation.size) && allocation.size >= 0 && validChunkCount(allocation) &&
+    Number.isSafeInteger(allocation.createdAt) && allocation.createdAt >= 0;
+}
+
+async function sha256(value: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
+  return [...digest].map(byte => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@gadgets/configurator-ui':
         specifier: workspace:*
         version: link:../configurator-ui
+      '@gadgets/gatekeeper-kit':
+        specifier: workspace:*
+        version: link:../gatekeeper-kit
       '@gadgets/workshop-shared':
         specifier: workspace:*
         version: link:../workshop-shared


### PR DESCRIPTION
Pulls the file storage implementation added in #367 out of the Google gatekeeper and into the shared gatekeeper-kit package.

Many gatekeepers support actions that include files, such as sending emails with file attachments or adding files to tickets. These files need to be temporarily stored by the gatekeeper while the action is queued for approval. This PR adds a helper class that handles file chunking and reassembly so multi-MB files can be written to DO storage.