### PR TITLE
Keep the scheduler hook session alive until its disposers run

### DIFF
--- a/packages/gatekeeper-scheduler/__tests__/schedule-driver.test.ts
+++ b/packages/gatekeeper-scheduler/__tests__/schedule-driver.test.ts
@@ -30,6 +30,10 @@ type TestHooks = HookInitiator<ScheduleHookTarget> & {
   }>;
   release(): Promise<void>;
   reset(): Promise<void>;
+  waitForDisposals(
+    target: { approvalQueues: number; callbacks: number },
+    budgetMs: number,
+  ): Promise<void>;
   waitUntilBlocked(): Promise<void>;
 };
 
@@ -318,12 +322,7 @@ describe("ScheduleDriver", () => {
     expect(
       (await testEnv.TEST_HOOKS.read()).events.filter((event) => event.startsWith("callback:")),
     ).toHaveLength(2);
-    await vi.waitFor(async () => {
-      expect(await testEnv.TEST_HOOKS.read()).toMatchObject({
-        disposedApprovalQueues: 2,
-        disposedCallbacks: 2,
-      });
-    }, { timeout: 5_000 });
+    await testEnv.TEST_HOOKS.waitForDisposals({ approvalQueues: 2, callbacks: 2 }, 2_000);
 
     await driver.disable("workspace-a", "schedule-a");
     const keys = await runInDurableObject(driver, (_instance, state) =>
@@ -540,12 +539,7 @@ describe("ScheduleDriver", () => {
       "authorize",
       `callback:${runId}`,
     ]);
-    await vi.waitFor(async () => {
-      expect(await testEnv.TEST_HOOKS.read()).toMatchObject({
-        disposedApprovalQueues: 2,
-        disposedCallbacks: 2,
-      });
-    }, { timeout: 5_000 });
+    await testEnv.TEST_HOOKS.waitForDisposals({ approvalQueues: 2, callbacks: 2 }, 2_000);
     expect(reportIssue).not.toHaveBeenCalled();
   });
 

--- a/packages/gatekeeper-scheduler/__tests__/worker.ts
+++ b/packages/gatekeeper-scheduler/__tests__/worker.ts
@@ -24,7 +24,10 @@ let disposedApprovalQueues = 0;
 let disposedCallbacks = 0;
 let blockPoint: BlockPoint | null = null;
 let blockedPoint: BlockPoint | null = null;
-// Relative-ms timeline of hook lifecycle events, reported when a disposal wait times out.
+// Bumped by reset(). A capability minted under an earlier generation belongs to a previous test, so
+// its disposer, which runs asynchronously and may land after the reset, is not counted.
+let generation = 0;
+// Relative-ms timeline of hook lifecycle events, reported when a disposal wait fails.
 let timelineStart = Date.now();
 let timeline: string[] = [];
 function mark(label: string): void {
@@ -35,6 +38,17 @@ type DisposalCounts = { approvalQueues: number; callbacks: number };
 
 function disposalsReached(target: DisposalCounts): boolean {
   return disposedApprovalQueues >= target.approvalQueues && disposedCallbacks >= target.callbacks;
+}
+
+function disposalsExact(target: DisposalCounts): boolean {
+  return disposedApprovalQueues === target.approvalQueues && disposedCallbacks === target.callbacks;
+}
+
+function describeDisposals(target: DisposalCounts): string {
+  return (
+    `approvalQueues=${disposedApprovalQueues}/${target.approvalQueues} ` +
+    `callbacks=${disposedCallbacks}/${target.callbacks}; timeline: ${timeline.join(" ")}`
+  );
 }
 
 /** Longest a hook session is held open waiting for the driver to release its capabilities. */
@@ -68,6 +82,7 @@ async function pauseIfBlocked(point: BlockPoint): Promise<void> {
 }
 
 class TestApprovalQueue extends RpcTarget {
+  readonly #generation = generation;
   #markDisposed!: () => void;
   readonly disposed = new Promise<void>((resolve) => {
     this.#markDisposed = resolve;
@@ -80,13 +95,16 @@ class TestApprovalQueue extends RpcTarget {
   }
 
   [Symbol.dispose](): void {
-    disposedApprovalQueues++;
-    mark("dispose-aq");
+    if (this.#generation === generation) {
+      disposedApprovalQueues++;
+      mark("dispose-aq");
+    }
     this.#markDisposed();
   }
 }
 
 class TestCallback extends RpcTarget {
+  readonly #generation = generation;
   #markDisposed!: () => void;
   readonly disposed = new Promise<void>((resolve) => {
     this.#markDisposed = resolve;
@@ -108,8 +126,10 @@ class TestCallback extends RpcTarget {
   }
 
   [Symbol.dispose](): void {
-    disposedCallbacks++;
-    mark("dispose-cb");
+    if (this.#generation === generation) {
+      disposedCallbacks++;
+      mark("dispose-cb");
+    }
     this.#markDisposed();
   }
 }
@@ -146,21 +166,23 @@ export class TestHooks extends WorkerEntrypoint {
   }
 
   /**
-   * Resolves once at least `target` hook capabilities have run their server-side disposers, or
-   * rejects after `budgetMs` naming the counts reached and the hook timeline. Polled in-Worker
-   * like `waitUntilBlocked`, so the test awaits one RPC instead of racing a 50ms `vi.waitFor`.
+   * Resolves once exactly `target` hook capabilities from this generation have run their
+   * server-side disposers; rejects after `budgetMs` without them, or as soon as the counts overshoot,
+   * naming the counts reached and the hook timeline either way. Polled in-Worker like
+   * `waitUntilBlocked`, so the test awaits one RPC instead of racing a 50ms `vi.waitFor`.
    */
   async waitForDisposals(target: DisposalCounts, budgetMs: number): Promise<void> {
     const deadline = Date.now() + budgetMs;
     while (!disposalsReached(target)) {
       if (Date.now() >= deadline) {
         throw new Error(
-          `hook capabilities not disposed within ${budgetMs}ms: ` +
-            `approvalQueues=${disposedApprovalQueues}/${target.approvalQueues} ` +
-            `callbacks=${disposedCallbacks}/${target.callbacks}; timeline: ${timeline.join(" ")}`,
+          `hook capabilities not disposed within ${budgetMs}ms: ${describeDisposals(target)}`,
         );
       }
       await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    if (!disposalsExact(target)) {
+      throw new Error(`hook capabilities disposed more than once: ${describeDisposals(target)}`);
     }
   }
 
@@ -176,6 +198,7 @@ export class TestHooks extends WorkerEntrypoint {
 
   reset(): void {
     this.release();
+    generation++;
     timelineStart = Date.now();
     timeline = [];
     mode = "success";

--- a/packages/gatekeeper-scheduler/__tests__/worker.ts
+++ b/packages/gatekeeper-scheduler/__tests__/worker.ts
@@ -24,6 +24,40 @@ let disposedApprovalQueues = 0;
 let disposedCallbacks = 0;
 let blockPoint: BlockPoint | null = null;
 let blockedPoint: BlockPoint | null = null;
+// Relative-ms timeline of hook lifecycle events, reported when a disposal wait times out.
+let timelineStart = Date.now();
+let timeline: string[] = [];
+function mark(label: string): void {
+  timeline.push(`${label}@${Date.now() - timelineStart}`);
+}
+
+type DisposalCounts = { approvalQueues: number; callbacks: number };
+
+function disposalsReached(target: DisposalCounts): boolean {
+  return disposedApprovalQueues >= target.approvalQueues && disposedCallbacks >= target.callbacks;
+}
+
+/** Longest a hook session is held open waiting for the driver to release its capabilities. */
+const HOOK_SESSION_HOLD_MS = 5_000;
+
+// workerd runs an RpcTarget's disposer as a task of the execution context that created it (the
+// `startHook` RPC session here) and aborts a non-actor context as "hung" as soon as its last pending
+// I/O event is gone and the thread goes idle (IoContext::PendingEvent in io-context.c++). The
+// capabilities returned from `startHook` are that session's only pending events, so the moment the
+// driver releases them the abort is armed and races the disposer task, which still has to take the
+// isolate lock; when the abort wins the disposer never runs. A pending timer is a pending event, so
+// holding one until both disposers have run keeps the session alive exactly long enough for them.
+async function holdSessionUntilDisposed(disposals: Promise<void>[]): Promise<void> {
+  let hold: ReturnType<typeof setTimeout> | undefined;
+  const capped = new Promise<void>((resolve) => {
+    hold = setTimeout(resolve, HOOK_SESSION_HOLD_MS);
+  });
+  try {
+    await Promise.race([Promise.all(disposals), capped]);
+  } finally {
+    clearTimeout(hold);
+  }
+}
 
 async function pauseIfBlocked(point: BlockPoint): Promise<void> {
   if (blockPoint !== point) return;
@@ -34,6 +68,11 @@ async function pauseIfBlocked(point: BlockPoint): Promise<void> {
 }
 
 class TestApprovalQueue extends RpcTarget {
+  #markDisposed!: () => void;
+  readonly disposed = new Promise<void>((resolve) => {
+    this.#markDisposed = resolve;
+  });
+
   async authorizeObservation(): Promise<void> {
     events.push("authorize");
     await pauseIfBlocked("authorization");
@@ -42,10 +81,17 @@ class TestApprovalQueue extends RpcTarget {
 
   [Symbol.dispose](): void {
     disposedApprovalQueues++;
+    mark("dispose-aq");
+    this.#markDisposed();
   }
 }
 
 class TestCallback extends RpcTarget {
+  #markDisposed!: () => void;
+  readonly disposed = new Promise<void>((resolve) => {
+    this.#markDisposed = resolve;
+  });
+
   async onSchedule(firing: { runId: string; scheduleId: string }): Promise<void> {
     events.push(`callback:${firing.runId}`);
     callbackScheduleIds.push(firing.scheduleId);
@@ -57,11 +103,14 @@ class TestCallback extends RpcTarget {
       await new Promise((resolve) => setTimeout(resolve, 10));
     } finally {
       activeCallbacks--;
+      mark("callback-done");
     }
   }
 
   [Symbol.dispose](): void {
     disposedCallbacks++;
+    mark("dispose-cb");
+    this.#markDisposed();
   }
 }
 
@@ -69,9 +118,13 @@ class TestCallback extends RpcTarget {
 export class TestHooks extends WorkerEntrypoint {
   async startHook(): Promise<{ callback: TestCallback; approvalQueue: TestApprovalQueue }> {
     events.push("start");
+    mark("start");
     await pauseIfBlocked("start");
     if (mode === "start-reject") throw new Error("opaque admission rejection");
-    return { callback: new TestCallback(), approvalQueue: new TestApprovalQueue() };
+    const callback = new TestCallback();
+    const approvalQueue = new TestApprovalQueue();
+    this.ctx.waitUntil(holdSessionUntilDisposed([callback.disposed, approvalQueue.disposed]));
+    return { callback, approvalQueue };
   }
 
   configure(nextMode: TestMode): void {
@@ -92,6 +145,25 @@ export class TestHooks extends WorkerEntrypoint {
     blockPoint = null;
   }
 
+  /**
+   * Resolves once at least `target` hook capabilities have run their server-side disposers, or
+   * rejects after `budgetMs` naming the counts reached and the hook timeline. Polled in-Worker
+   * like `waitUntilBlocked`, so the test awaits one RPC instead of racing a 50ms `vi.waitFor`.
+   */
+  async waitForDisposals(target: DisposalCounts, budgetMs: number): Promise<void> {
+    const deadline = Date.now() + budgetMs;
+    while (!disposalsReached(target)) {
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `hook capabilities not disposed within ${budgetMs}ms: ` +
+            `approvalQueues=${disposedApprovalQueues}/${target.approvalQueues} ` +
+            `callbacks=${disposedCallbacks}/${target.callbacks}; timeline: ${timeline.join(" ")}`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+  }
+
   read() {
     return {
       events: [...events],
@@ -104,6 +176,8 @@ export class TestHooks extends WorkerEntrypoint {
 
   reset(): void {
     this.release();
+    timelineStart = Date.now();
+    timeline = [];
     mode = "success";
     events = [];
     callbackScheduleIds = [];


### PR DESCRIPTION
Fixes the `schedule-driver.test.ts` disposal-count flake (e.g. https://github.com/cloudflare/cloudflare-os/actions/runs/33825527399/job/100877250818).

workerd aborts the `startHook` RPC session as "hung" the moment the driver releases the returned capabilities, racing the task that runs their `Symbol.dispose`, when the abort wins, the disposer never runs. The test initiator now holds the session open until both disposers have run, and the tests await one in-Worker `waitForDisposals` that reports the counts reached on failure. Test fixture only.

Reproduced 1 in 60 runs under CPU load before; 0 in 100 after.