### PR TITLE
Fix eval config startup

### DIFF
--- a/packages/workshop-evals/src/budgets.ts
+++ b/packages/workshop-evals/src/budgets.ts
@@ -1,0 +1,3 @@
+export const EVAL_AGENT_BUDGET_MS = 28 * 60_000;
+export const EVAL_VERIFICATION_BUDGET_MS = 2 * 60_000;
+export const EVAL_TEST_TIMEOUT_MS = 40 * 60_000;

--- a/packages/workshop-evals/src/config.test.ts
+++ b/packages/workshop-evals/src/config.test.ts
@@ -1,8 +1,8 @@
 import { expect, it } from "vitest";
 import {
-  EVAL_AGENT_BUDGET_MS, EVAL_TEST_TIMEOUT_MS, EVAL_VERIFICATION_BUDGET_MS, evalMatrix,
-  resolveEvalCommit, resolveEvalModel,
-} from "./config.js";
+  EVAL_AGENT_BUDGET_MS, EVAL_TEST_TIMEOUT_MS, EVAL_VERIFICATION_BUDGET_MS,
+} from "./budgets.js";
+import { evalMatrix, resolveEvalCommit, resolveEvalModel } from "./config.js";
 import { taskVersion, type EvalTask } from "./task.js";
 
 it("leaves an outer margin for setup and cleanup", () => {

--- a/packages/workshop-evals/src/config.ts
+++ b/packages/workshop-evals/src/config.ts
@@ -23,9 +23,6 @@ const DEFAULT_MODELS: readonly SuggestedModelId<"cloudflare">[] =
   ["@cf/deepseek-ai/deepseek-v4-pro-0813"];
 const GIT_SHA_PATTERN = /^[a-f0-9]{40}$/;
 
-export const EVAL_AGENT_BUDGET_MS = 28 * 60_000;
-export const EVAL_VERIFICATION_BUDGET_MS = 2 * 60_000;
-export const EVAL_TEST_TIMEOUT_MS = 40 * 60_000;
 export type EvalIdentity = { gitCommit: string; taskVersion: string };
 export type EvalMatrix = { models: EvalModelId[]; trials: number };
 

--- a/packages/workshop-evals/src/harness.test.ts
+++ b/packages/workshop-evals/src/harness.test.ts
@@ -3,7 +3,7 @@ import type {
   AgentTurnOutcome, AgentTurnResult, WorkshopAgentSession,
 } from "@gadgets/integration-tests/agent-session";
 import type { AiChatMessage, WorkpieceSummary } from "@gadgets/workshop-shared/api";
-import { EVAL_VERIFICATION_BUDGET_MS } from "./config.js";
+import { EVAL_VERIFICATION_BUDGET_MS } from "./budgets.js";
 import { createWorkshopHarness } from "./harness.js";
 import type { LocalEvalTarget, LocalModelAccess } from "./target.js";
 import type { EvalTask } from "./task.js";

--- a/packages/workshop-evals/src/harness.ts
+++ b/packages/workshop-evals/src/harness.ts
@@ -4,9 +4,8 @@ import {
   attachHarnessRunToError, createHarness, normalizeHarnessRun, type JsonValue,
   type TranscriptEvent,
 } from "vitest-evals";
-import {
-  EVAL_AGENT_BUDGET_MS, EVAL_VERIFICATION_BUDGET_MS, resolveEvalModel, type EvalIdentity,
-} from "./config.js";
+import { EVAL_AGENT_BUDGET_MS, EVAL_VERIFICATION_BUDGET_MS } from "./budgets.js";
+import { resolveEvalModel, type EvalIdentity } from "./config.js";
 import type { EvalCheck, EvalRunInput, EvalRunOutput, EvalTask, EvalTurnResult } from "./task.js";
 import { measureHistory, toTranscriptEvents } from "./transcript.js";
 import {

--- a/packages/workshop-evals/vitest.eval.config.ts
+++ b/packages/workshop-evals/vitest.eval.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vitest/config";
-import { EVAL_TEST_TIMEOUT_MS } from "./src/config.js";
+import { EVAL_TEST_TIMEOUT_MS } from "./src/budgets.js";
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
`pnpm evals` fails while loading `vitest.eval.config.ts`. Commit `b288c0e` made `config.ts` load the runtime model catalog, so importing timeout constants from it enters the source-only shared API before Vite can resolve its `.js` specifiers.

Move the three eval budget constants into a dependency-free module and import them directly where needed. The values and runtime behavior do not change.

Verification:
- `pnpm --filter @gadgets/workshop-evals build`
- `pnpm --filter @gadgets/workshop-evals test:run` (51 tests)
- `vitest list --config vitest.eval.config.ts` (all three eval files collected)
- `pnpm lint:check`
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->