### PR TITLE
Support multi-tab Google Docs

### DIFF
--- a/packages/gatekeeper-google/__tests__/doc-fixture.ts
+++ b/packages/gatekeeper-google/__tests__/doc-fixture.ts
@@ -1,5 +1,5 @@
 import type {
-  GoogleDocsDocument, ParagraphElement, StructuralElement, TextStyle,
+  GoogleDocsTab, ParagraphElement, StructuralElement, TextStyle,
 } from "../src/docs-api";
 
 /** A styled span of text within a paragraph. */
@@ -12,15 +12,15 @@ type ParagraphSpec = {
 };
 
 /**
- * Builds a `GoogleDocsDocument` with the index bookkeeping the real API applies: a section break
- * occupies index 0, and every paragraph's runs are laid out contiguously from index 1.
+ * Builds a normalized `GoogleDocsTab` with the index bookkeeping the real API applies: a section
+ * break occupies index 0, and every paragraph's runs are laid out contiguously from index 1.
  *
  * Every paragraph's last run must end in "\n", as Google's own responses do.
  */
-export function buildDoc(
+export function buildTab(
   paragraphs: ParagraphSpec[],
-  lists: GoogleDocsDocument["lists"] = {},
-): GoogleDocsDocument {
+  lists: GoogleDocsTab["lists"] = {},
+): GoogleDocsTab {
   let index = 1;
   let content: StructuralElement[] = [{ startIndex: 0, endIndex: 1, sectionBreak: {} }];
 
@@ -48,9 +48,10 @@ export function buildDoc(
   }
 
   return {
-    documentId: "doc-1",
+    tabId: "tab-1",
     title: "Fixture",
-    revisionId: "rev-1",
+    index: 0,
+    nestingLevel: 0,
     body: { content },
     lists,
     namedRanges: {},
@@ -58,6 +59,6 @@ export function buildDoc(
 }
 
 /** A single-level bullet list definition, for paragraphs carrying a matching `bullet`. */
-export const BULLET_LIST: GoogleDocsDocument["lists"] = {
+export const BULLET_LIST: GoogleDocsTab["lists"] = {
   L1: { listProperties: { nestingLevels: [{ glyphSymbol: "\u25cf" }] } },
 };

--- a/packages/gatekeeper-google/__tests__/markdown-converter.test.ts
+++ b/packages/gatekeeper-google/__tests__/markdown-converter.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { computeReplaceOperations, docToMarkdown } from "../src/markdown-converter";
+import {
+  computeReplaceOperations, docTabToMarkdown, markdownToDocRequests,
+} from "../src/markdown-converter";
 import type { Segment } from "../src/markdown-converter";
-import { BULLET_LIST, buildDoc } from "./doc-fixture";
+import { BULLET_LIST, buildTab } from "./doc-fixture";
 
 /** A segment with a document counterpart, as opposed to a Markdown-syntax-only one. */
 type ContentSegment = Exclude<Segment, { syntaxOnly: true }>;
 
 const isContent = (seg: Segment): seg is ContentSegment => !("syntaxOnly" in seg);
+
+const TAB_ID = "tab-1";
 
 /**
  * The document text as Google stores it, aligned so that a string index equals a doc index: index
@@ -16,9 +20,23 @@ function docText(runs: string[]): string {
   return "\u0000" + runs.join("");
 }
 
-describe("docToMarkdown", () => {
+/** Every `Location`/`Range` object nested anywhere inside a batchUpdate request. */
+function coordinates(requests: unknown[]): Record<string, unknown>[] {
+  let found: Record<string, unknown>[] = [];
+  let visit = (value: unknown) => {
+    if (!value || typeof value !== "object") return;
+    for (const [key, nested] of Object.entries(value)) {
+      if (key === "location" || key === "range") found.push(nested as Record<string, unknown>);
+      visit(nested);
+    }
+  };
+  visit(requests);
+  return found;
+}
+
+describe("docTabToMarkdown", () => {
   it("renders headings, inline styles, links and bullets", () => {
-    let snapshot = docToMarkdown(buildDoc([
+    let snapshot = docTabToMarkdown(buildTab([
       { runs: ["Title\n"], namedStyleType: "HEADING_1" },
       { runs: ["Sub\n"], namedStyleType: "HEADING_2" },
       { runs: [
@@ -38,10 +56,18 @@ describe("docToMarkdown", () => {
       "# Title\n\n## Sub\n\nHello **bold** and *it* and [link](https://e.com).\n\n- one\n- two\n");
   });
 
-  it("carries the title, revision and body end index through", () => {
-    let snapshot = docToMarkdown(buildDoc([{ runs: ["abc\n"] }]));
-    expect(snapshot.title).toBe("Fixture");
-    expect(snapshot.revisionId).toBe("rev-1");
+  it("carries the tab's identity, position and body end index through", () => {
+    let snapshot = docTabToMarkdown({
+      ...buildTab([{ runs: ["abc\n"] }]),
+      tabId: "metrics",
+      title: "Metrics",
+      parentTabId: "details",
+      index: 1,
+      nestingLevel: 2,
+    });
+    expect(snapshot).toMatchObject({
+      tabId: "metrics", title: "Metrics", parentTabId: "details", index: 1, nestingLevel: 2,
+    });
     // Section break (1) + "abc\n" (4).
     expect(snapshot.bodyEndIndex).toBe(5);
   });
@@ -50,7 +76,7 @@ describe("docToMarkdown", () => {
 // These are what keeps an edit from landing on the wrong characters. A content segment claims a
 // 1:1 mapping between Markdown and document indices, and computeReplaceOperations trusts it.
 describe("source map invariants", () => {
-  let snapshot = docToMarkdown(buildDoc([
+  let snapshot = docTabToMarkdown(buildTab([
     { runs: ["Title\n"], namedStyleType: "HEADING_1" },
     { runs: [
       "Hello ",
@@ -104,8 +130,25 @@ describe("source map invariants", () => {
   });
 });
 
+// Tab bodies have independent index spaces, so a coordinate without the selected tab's ID would
+// land in whichever tab Google picks by default.
+describe("selected-tab write coordinates", () => {
+  it("stamps the tab ID on every inserted location and styled range", () => {
+    let requests = markdownToDocRequests(
+      "# Head\n\n- one\n\n**bold** and [link](https://e.com)\n", 7, "metrics");
+
+    expect(requests.map(request => Object.keys(request)[0])).toEqual([
+      "insertText", "updateParagraphStyle", "createParagraphBullets", "updateTextStyle",
+      "updateTextStyle",
+    ]);
+    let found = coordinates(requests);
+    expect(found).toHaveLength(requests.length);
+    for (const coordinate of found) expect(coordinate.tabId).toBe("metrics");
+  });
+});
+
 describe("computeReplaceOperations", () => {
-  let snapshot = docToMarkdown(buildDoc([
+  let snapshot = docTabToMarkdown(buildTab([
     { runs: ["Title\n"], namedStyleType: "HEADING_1" },
     { runs: ["Hello ", { text: "bold", style: { bold: true } }, " world.\n"] },
   ]));
@@ -114,7 +157,7 @@ describe("computeReplaceOperations", () => {
     let start = md.indexOf(oldText);
     expect(start).toBeGreaterThanOrEqual(0);
     return computeReplaceOperations(
-      snapshot.sourceMap, md, start, start + oldText.length, newText);
+      snapshot.sourceMap, md, start, start + oldText.length, newText, TAB_ID);
   };
 
   it("renders the fixture as expected", () => {
@@ -130,8 +173,8 @@ describe("computeReplaceOperations", () => {
       trimmedOld: "world",
       trimmedNew: "there",
       requests: [
-        { deleteContentRange: { range: { startIndex: 18, endIndex: 23 } } },
-        { insertText: { location: { index: 18 }, text: "there" } },
+        { deleteContentRange: { range: { startIndex: 18, endIndex: 23, tabId: TAB_ID } } },
+        { insertText: { location: { index: 18, tabId: TAB_ID }, text: "there" } },
       ],
     });
   });
@@ -140,7 +183,7 @@ describe("computeReplaceOperations", () => {
     expect(replace("world", "worlds")).toEqual({
       trimmedOld: "",
       trimmedNew: "s",
-      requests: [{ insertText: { location: { index: 23 }, text: "s" } }],
+      requests: [{ insertText: { location: { index: 23, tabId: TAB_ID }, text: "s" } }],
     });
   });
 
@@ -148,7 +191,7 @@ describe("computeReplaceOperations", () => {
     expect(replace("world", "")).toEqual({
       trimmedOld: "world",
       trimmedNew: "",
-      requests: [{ deleteContentRange: { range: { startIndex: 18, endIndex: 23 } } }],
+      requests: [{ deleteContentRange: { range: { startIndex: 18, endIndex: 23, tabId: TAB_ID } } }],
     });
   });
 
@@ -165,7 +208,7 @@ describe("computeReplaceOperations", () => {
     let inserted = result.requests[1].insertText.text;
     // The delete covers "Hello bold world.\n" (doc 7..25), so the insert must restore all of it.
     expect({ deleted, inserted }).toEqual({
-      deleted: { startIndex: 7, endIndex: 25 },
+      deleted: { startIndex: 7, endIndex: 25, tabId: TAB_ID },
       inserted: "Hello plain world.\n",
     });
   });
@@ -173,8 +216,8 @@ describe("computeReplaceOperations", () => {
   it("currently truncates the paragraph in that case", () => {
     let result = replace("**bold**", "plain");
     expect(result.requests).toEqual([
-      { deleteContentRange: { range: { startIndex: 7, endIndex: 25 } } },
-      { insertText: { location: { index: 7 }, text: "plain" } },
+      { deleteContentRange: { range: { startIndex: 7, endIndex: 25, tabId: TAB_ID } } },
+      { insertText: { location: { index: 7, tabId: TAB_ID }, text: "plain" } },
     ]);
   });
 });

--- a/packages/gatekeeper-google/__tests__/native-api.test.ts
+++ b/packages/gatekeeper-google/__tests__/native-api.test.ts
@@ -1,27 +1,41 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { GoogleDocsApi } from "../src/docs-api";
+import { GoogleDocsApi, type GoogleDocsTab } from "../src/docs-api";
 import { GoogleSheetsApi } from "../src/sheets-api";
 import { readGoogleJson } from "../src/google-response";
 
 const token = async () => "access-token";
 
-function docBody() {
+type RawTab = {
+  tabProperties: { tabId: string; title: string };
+  documentTab?: Pick<GoogleDocsTab, "body"> & Partial<Pick<GoogleDocsTab, "lists" | "namedRanges">>;
+  childTabs?: RawTab[];
+};
+
+/** The section break every real document body opens with. */
+const EMPTY_BODY = { content: [{ startIndex: 0, endIndex: 1, sectionBreak: {} }] };
+
+/** One provider tab, with the body and collections a fresh tab really returns. */
+function rawTab(tabId: string, title: string, childTabs?: RawTab[]): RawTab {
   return {
-    documentId: "doc-1",
-    title: "Quarterly plan",
-    revisionId: "revision-1",
-    body: { content: [] },
-    lists: {},
-    namedRanges: {},
+    tabProperties: { tabId, title },
+    documentTab: { body: EMPTY_BODY, lists: {}, namedRanges: {} },
+    ...childTabs ? { childTabs } : {},
   };
 }
 
-function docResponse(tabCount = 1) {
-  const { body, lists, namedRanges, ...document } = docBody();
-  const documentTab = { body, lists, namedRanges };
+function docResponse(tabs: RawTab[] = [rawTab("tab-1", "Main")]) {
+  return { documentId: "doc-1", title: "Quarterly plan", revisionId: "revision-1", tabs };
+}
+
+/** The normalized counterpart of `rawTab`, with ancestry the caller states explicitly. */
+function normalizedTab(
+  tabId: string,
+  title: string,
+  position: Partial<Pick<GoogleDocsTab, "parentTabId" | "index" | "nestingLevel">> = {},
+): GoogleDocsTab {
   return {
-    ...document,
-    tabs: Array.from({ length: tabCount }, () => ({ documentTab, childTabs: [] })),
+    tabId, title, index: 0, nestingLevel: 0, ...position,
+    body: EMPTY_BODY, lists: {}, namedRanges: {},
   };
 }
 
@@ -62,14 +76,19 @@ afterEach(() => {
 });
 
 describe("native Google content API safety", () => {
-  it("requests tabs and normalizes a single-tab document", async () => {
+  it("requests tab content and normalizes a single-tab document", async () => {
     let requestedUrl: string | undefined;
     vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
       requestedUrl = input instanceof Request ? input.url : input.toString();
       return Response.json(docResponse());
     }));
 
-    await expect(new GoogleDocsApi(token).getDocument("doc-1")).resolves.toEqual(docBody());
+    await expect(new GoogleDocsApi(token).getDocument("doc-1")).resolves.toEqual({
+      documentId: "doc-1",
+      title: "Quarterly plan",
+      revisionId: "revision-1",
+      tabs: [normalizedTab("tab-1", "Main")],
+    });
     expect(requestedUrl).toBe(
       "https://docs.googleapis.com/v1/documents/doc-1?includeTabsContent=true",
     );
@@ -112,11 +131,82 @@ describe("native Google content API safety", () => {
       .rejects.toThrow("Google Docs returned a different document");
   });
 
-  it("rejects multi-tab documents instead of silently reading the first tab", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => Response.json(docResponse(2))));
+  it("flattens the tab tree in preorder with derived ancestry", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(docResponse([
+      rawTab("overview", "Overview", [rawTab("details", "Details", [
+        rawTab("metrics", "Metrics"),
+      ])]),
+      rawTab("appendix", "Appendix"),
+    ]))));
 
-    await expect(new GoogleDocsApi(token).getDocument("doc-1"))
-      .rejects.toThrow("Multi-tab Google Docs are not supported");
+    await expect(new GoogleDocsApi(token).getDocument("doc-1")).resolves.toMatchObject({
+      tabs: [
+        normalizedTab("overview", "Overview"),
+        normalizedTab("details", "Details", { parentTabId: "overview", nestingLevel: 1 }),
+        normalizedTab("metrics", "Metrics", { parentTabId: "details", nestingLevel: 2 }),
+        normalizedTab("appendix", "Appendix", { index: 1 }),
+      ],
+    });
+  });
+
+  it("keeps each tab's body, lists and named ranges to itself", async () => {
+    const documentTab = {
+      body: { content: [{ startIndex: 0, endIndex: 1, sectionBreak: {} }] },
+      lists: { L1: { listProperties: { nestingLevels: [{ glyphSymbol: "\u25cf" }] } } },
+      namedRanges: { mark: { namedRanges: [{ namedRangeId: "range-1", name: "mark" }] } },
+    };
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(docResponse([
+      { ...rawTab("overview", "Overview"), documentTab },
+      rawTab("appendix", "Appendix"),
+    ]))));
+
+    const { tabs } = await new GoogleDocsApi(token).getDocument("doc-1");
+
+    expect(tabs[0]).toMatchObject(documentTab);
+    expect(tabs[1]).toMatchObject({ body: EMPTY_BODY, lists: {}, namedRanges: {} });
+  });
+
+  it("defaults absent tab collections to empty", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(docResponse([{
+      tabProperties: { tabId: "solo", title: "Solo" },
+      documentTab: { body: EMPTY_BODY },
+    }]))));
+
+    await expect(new GoogleDocsApi(token).getDocument("doc-1")).resolves.toMatchObject({
+      tabs: [normalizedTab("solo", "Solo")],
+    });
+  });
+
+  it.each([
+    ["no tabs", [], "Google Docs returned no document tab"],
+    ["a duplicate tab ID", [rawTab("dup", "One"), rawTab("dup", "Two")],
+      "Google Docs returned a duplicate tab ID"],
+    ["an empty tab ID", [rawTab("", "Nameless")], "Google Docs returned an invalid tab"],
+    ["a missing title", [{ tabProperties: { tabId: "solo" } }],
+      "Google Docs returned an invalid tab"],
+    ["a tab without content", [{ tabProperties: { tabId: "solo", title: "Solo" } }],
+      "Google Docs returned an invalid tab"],
+    ["a malformed body", [{
+      tabProperties: { tabId: "solo", title: "Solo" },
+      documentTab: { body: { content: "text" } },
+    }], "Google Docs returned an invalid tab"],
+    ["malformed child tabs", [{
+      ...rawTab("solo", "Solo"), childTabs: {},
+    }], "Google Docs returned an invalid tab"],
+    ["an empty body", [{
+      tabProperties: { tabId: "solo", title: "Solo" },
+      documentTab: { body: { content: [] } },
+    }], "Google Docs returned an invalid tab"],
+    ["malformed named ranges", [{
+      tabProperties: { tabId: "solo", title: "Solo" },
+      documentTab: { body: EMPTY_BODY, namedRanges: [] },
+    }], "Google Docs returned an invalid tab"],
+  ] as const)("rejects a response with %s", async (_case, tabs, message) => {
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json(
+      docResponse(tabs as unknown as RawTab[]),
+    )));
+
+    await expect(new GoogleDocsApi(token).getDocument("doc-1")).rejects.toThrow(message);
   });
 
   it("revision-locks marked writes and returns the created range ID", async () => {
@@ -130,10 +220,11 @@ describe("native Google content API safety", () => {
         writeControl: { requiredRevisionId: "revision-2" },
       });
     }));
-    const request = { insertText: { text: "hello", location: { index: 1 } } };
+    const request = { insertText: { text: "hello", location: { index: 1, tabId: "metrics" } } };
 
     const result = await new GoogleDocsApi(token).batchUpdate(
-      "doc-1", [request], "revision-1", { name: "gadgets-write-1", rangeStart: 1 },
+      "doc-1", [request], "revision-1",
+      { name: "gadgets-write-1", rangeStart: 1, tabId: "metrics" },
     );
 
     expect(result).toEqual({ revisionId: "revision-2", writeMarkerId: "range-1" });
@@ -142,7 +233,7 @@ describe("native Google content API safety", () => {
         {
           createNamedRange: {
             name: "gadgets-write-1",
-            range: { startIndex: 1, endIndex: 2 },
+            range: { startIndex: 1, endIndex: 2, tabId: "metrics" },
           },
         },
         request,

--- a/packages/gatekeeper-google/__tests__/types.test.ts
+++ b/packages/gatekeeper-google/__tests__/types.test.ts
@@ -44,34 +44,82 @@ function compileAgentTypes(sourceText: string): string[] {
     ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
 }
 
+/** Guidance the agent must still be reading when it picks a tab to act on. */
+const TAB_GUIDANCE = [
+  "Call `listTabs()` before `getContent()`",
+  "reads exactly one tab and never combines tabs",
+  "pass an ID returned by `listTabs()`",
+  "only when `listTabs()` returns exactly one tab",
+];
+
+/**
+ * Fails to compile unless `GoogleDocTab` has exactly the flattened adjacency-list members.
+ *
+ * Mutual assignability alone misses an added or removed *optional* property, since excess
+ * properties are permitted in both directions, so the key sets are compared as well.
+ */
+const TAB_SHAPE_CHECK = `
+type ExpectedGoogleDocTab = {
+  id: string; title: string; parentTabId?: string; index: number; nestingLevel: number;
+};
+type Mutual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const tabShapeIsExact: Mutual<GoogleDocTab, ExpectedGoogleDocTab> = true;
+const tabKeysAreExact: Mutual<keyof GoogleDocTab, keyof ExpectedGoogleDocTab> = true;
+`;
+
+function docBundle(): string {
+  return [
+    source("docs-read-types.txt"),
+    stripTypeModulePrefix(source("docs-types.txt"), DOCS_TYPES_MODULE_PREFIX),
+  ].join("\n");
+}
+
+function driveBundle(): string {
+  return [
+    source("docs-read-types.txt"),
+    source("sheets-types.txt"),
+    stripTypeModulePrefix(source("drive-types.txt"), DRIVE_TYPES_MODULE_PREFIX),
+  ].join("\n");
+}
+
 describe("embedded agent declarations", () => {
   it("compiles the exact Google Doc agent declaration bundle without module dependencies", () => {
-    const types = [
-      source("docs-read-types.txt"),
-      stripTypeModulePrefix(source("docs-types.txt"), DOCS_TYPES_MODULE_PREFIX),
-    ].join("\n");
-
-    expect(compileAgentTypes(types)).toEqual([]);
+    expect(compileAgentTypes(docBundle())).toEqual([]);
   });
 
   it("compiles the exact Google Drive agent declaration bundle without module dependencies", () => {
-    const types = [
-      source("docs-read-types.txt"),
-      source("sheets-types.txt"),
-      stripTypeModulePrefix(source("drive-types.txt"), DRIVE_TYPES_MODULE_PREFIX),
-    ].join("\n");
-
-    expect(compileAgentTypes(types)).toEqual([]);
+    expect(compileAgentTypes(driveBundle())).toEqual([]);
   });
+
+  it("declares the flattened tab contract on the canonical read session", () => {
+    const readTypes = source("docs-read-types.d.ts");
+    expect(readTypes).toContain("export type GoogleDocTab = {");
+    expect(readTypes).toContain("listTabs(): Promise<GoogleDocTab[]>;");
+    expect(readTypes).toContain("getContent(tabId?: string): Promise<string>;");
+  });
+
+  it.each([["Doc", docBundle], ["Drive", driveBundle]] as const)(
+    "carries the exact tab shape and its selection guidance into the %s bundle",
+    (_name, bundle) => {
+      const types = bundle();
+      for (const phrase of TAB_GUIDANCE) expect(types).toContain(phrase);
+      expect(compileAgentTypes(types + TAB_SHAPE_CHECK)).toEqual([]);
+    },
+  );
 
   it("keeps Drive Docs authority read-only", () => {
     const readTypes = source("docs-read-types.d.ts");
     expect(readTypes).toContain("export interface GoogleDocReadSession");
     expect(readTypes).not.toContain("replaceText");
     expect(readTypes).not.toContain("appendText");
-    expect(source("docs-types.d.ts")).toContain(
+    const writeTypes = source("docs-types.d.ts");
+    expect(writeTypes).toContain(
       "export interface GoogleDocSession extends GoogleDocReadSession",
     );
+    expect(writeTypes).toContain(
+      "replaceText(oldMarkdown: string, newMarkdown: string, tabId?: string): Promise<void>;",
+    );
+    expect(writeTypes).toContain("appendText(markdown: string, tabId?: string): Promise<void>;");
   });
 
   it("hands out only read-only native sessions from Drive", () => {

--- a/packages/gatekeeper-google/__tests__/worker.ts
+++ b/packages/gatekeeper-google/__tests__/worker.ts
@@ -5,7 +5,7 @@ import type {
 } from "@gadgets/workshop-shared/gatekeeper";
 import { TestGitCache } from "./test-git-cache";
 import type { GoogleAccessToken } from "../src/google-api";
-import type { GoogleDocSession } from "../src/docs-types";
+import type { GoogleDocSession, GoogleDocTab } from "../src/docs-types";
 import type { GoogleDocGatekeeperImpl as GoogleDocGatekeeper } from "../src/google";
 
 export { default, GoogleDocGatekeeperImpl } from "../src/google";
@@ -20,15 +20,20 @@ type GatekeeperProps = { userObjectId: string; documentId: string };
 
 class TestApprovalQueue extends RpcTarget implements ApprovalQueue {
   actionId?: number;
+  actionDescription?: string;
+  readonly observations: string[] = [];
 
-  async authorizeObservation(_description: ObservationDescription): Promise<void> {}
+  async authorizeObservation(description: ObservationDescription): Promise<void> {
+    this.observations.push(description.description);
+  }
 
   async getGitCache(): Promise<GitCache> {
     throw new Error("Unexpected git cache access");
   }
 
-  async submitAction(actionId: number, _description: ActionDescription): Promise<void> {
+  async submitAction(actionId: number, description: ActionDescription): Promise<void> {
     this.actionId = actionId;
+    this.actionDescription = description.description;
   }
 
   async bindHook<Hook extends RpcTarget>(
@@ -41,6 +46,19 @@ class TestApprovalQueue extends RpcTarget implements ApprovalQueue {
 }
 
 export class TestHooks extends DurableObject<Env> {
+  #lastActionDescription = "";
+  #lastObservations: string[] = [];
+
+  /** The approval description of the edit most recently submitted through these hooks. */
+  get lastActionDescription(): string {
+    return this.#lastActionDescription;
+  }
+
+  /** Observation descriptions authorized by the most recent session, successful or not. */
+  get lastObservations(): string[] {
+    return this.#lastObservations;
+  }
+
   #gatekeeper(facetName: string) {
     let userObjectId = this.ctx.exports.UserAccount.idFromName("test-user").toString();
     return this.ctx.facets.get<GoogleDocGatekeeper>(facetName, () => ({
@@ -50,37 +68,60 @@ export class TestHooks extends DurableObject<Env> {
     }));
   }
 
-  async submitAppend(facetName: string, markdown: string): Promise<number> {
+  async #withSession<T>(
+    facetName: string,
+    body: (session: GoogleDocSession, queue: TestApprovalQueue) => Promise<T>,
+  ): Promise<T> {
     let queue = new TestApprovalQueue();
-    {
-      using approvalQueue = new RpcStub<ApprovalQueue>(queue);
-      using session = await this.#gatekeeper(facetName).startSession(
-        approvalQueue as unknown as ApprovalQueue,
-      ) as GoogleDocSession & Disposable;
-      await session.appendText(markdown);
+    using approvalQueue = new RpcStub<ApprovalQueue>(queue);
+    using session = await this.#gatekeeper(facetName).startSession(
+      approvalQueue as unknown as ApprovalQueue,
+    ) as GoogleDocSession & Disposable;
+    try {
+      // Awaited inside the scope: `return body(...)` would dispose both stubs mid-call.
+      return await body(session, queue);
+    } finally {
+      this.#lastActionDescription = queue.actionDescription ?? "";
+      this.#lastObservations = queue.observations;
     }
-    if (queue.actionId === undefined) throw new Error("Action was not submitted");
-    return queue.actionId;
+  }
+
+  /** Run one edit and return the action ID it queued. */
+  async #submit(
+    facetName: string,
+    edit: (session: GoogleDocSession) => Promise<void>,
+  ): Promise<number> {
+    return this.#withSession(facetName, async (session, queue) => {
+      await edit(session);
+      if (queue.actionId === undefined) throw new Error("Action was not submitted");
+      return queue.actionId;
+    });
+  }
+
+  async submitAppend(facetName: string, markdown: string, tabId?: string): Promise<number> {
+    return this.#submit(facetName, session => session.appendText(markdown, tabId));
+  }
+
+  async submitReplace(
+    facetName: string, oldMarkdown: string, newMarkdown: string, tabId?: string,
+  ): Promise<number> {
+    return this.#submit(
+      facetName, session => session.replaceText(oldMarkdown, newMarkdown, tabId));
   }
 
   /** The `lastModified` a metadata read reports, as epoch milliseconds. */
   async readMetadata(facetName: string): Promise<number> {
-    using approvalQueue = new RpcStub<ApprovalQueue>(new TestApprovalQueue());
-    using session = await this.#gatekeeper(facetName).startSession(
-      approvalQueue as unknown as ApprovalQueue,
-    ) as GoogleDocSession & Disposable;
-    let metadata = await session.getMetadata();
-    return metadata.lastModified.valueOf();
+    return this.#withSession(
+      facetName, async session => (await session.getMetadata()).lastModified.valueOf());
   }
 
-  /** The simulated document content a read reports. */
-  async readContent(facetName: string): Promise<string> {
-    using approvalQueue = new RpcStub<ApprovalQueue>(new TestApprovalQueue());
-    using session = await this.#gatekeeper(facetName).startSession(
-      approvalQueue as unknown as ApprovalQueue,
-    ) as GoogleDocSession & Disposable;
-    let content = await session.getContent();
-    return content;
+  /** The simulated content of one tab. */
+  async readContent(facetName: string, tabId?: string): Promise<string> {
+    return this.#withSession(facetName, session => session.getContent(tabId));
+  }
+
+  async listTabs(facetName: string): Promise<GoogleDocTab[]> {
+    return this.#withSession(facetName, session => session.listTabs());
   }
 
   async applyAction(facetName: string, actionId: number): Promise<string | null> {

--- a/packages/gatekeeper-google/__tests__/workerd/google-doc-actions.test.ts
+++ b/packages/gatekeeper-google/__tests__/workerd/google-doc-actions.test.ts
@@ -1,23 +1,51 @@
 import { abortAllDurableObjects, env } from "cloudflare:test";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { googleDocActionTab } from "../../src/google";
+
+/** Every write coordinate names the tab it applies to; tab bodies index independently. */
+type DocCoordinate = { tabId?: string };
 
 type BatchRequest = {
-  createNamedRange?: { name: string };
+  createNamedRange?: { name: string; range: DocCoordinate };
   deleteNamedRange?: { namedRangeId: string };
-  insertText?: { location: { index: number }; text: string };
+  insertText?: { location: DocCoordinate & { index: number }; text: string };
+  deleteContentRange?: { range: DocCoordinate & { startIndex: number; endIndex: number } };
+  updateParagraphStyle?: { range: DocCoordinate };
+  createParagraphBullets?: { range: DocCoordinate };
+  updateTextStyle?: { range: DocCoordinate };
 };
+
+/** One tab of the model document: its own text, and its place in the tab tree. */
+type ModelTab = { id: string; title: string; parentId?: string; text: string };
+
+/** The tab a single-tab document has, and the one the tab-agnostic tests exercise. */
+const MAIN_TAB = "tab-1";
 
 /** A batch either carries the edit and its marker, or deletes a marker on its own. */
 type BatchKind = "content" | "cleanup";
 
 class DocsModel {
-  content = "";
   cleanupFailures = 0;
   ambiguousContentResponses = 0;
   contentBatches = 0;
   maxMarkerCount = 0;
+  /** Google withholds `revisionId` from a caller without edit access. */
+  editable = true;
+  /** Full `documents.get` calls, excluding the lightweight revision probe. */
+  documentFetches = 0;
+  revisionProbes = 0;
+  driveFetches = 0;
+  /** Drive's modification time for the document. */
+  driveModifiedTime = "2026-01-02T03:04:05Z";
+  /** What Drive answers with instead of that time, if anything. */
+  driveFailure: { status: number; reason?: string } | "malformed" | null = null;
   readonly deletedMarkerIds: string[] = [];
-  readonly markers = new Map<string, string>();
+  /** Marker ID to its name and owning tab. */
+  readonly markers = new Map<string, { name: string; tabId: string }>();
+  /** Tab each write marker was anchored in, retained after cleanup deletes the marker. */
+  readonly markerTabIds: string[] = [];
+  /** Every tab in preorder; the first is the one a single-tab document has. */
+  readonly tabs: ModelTab[] = [{ id: MAIN_TAB, title: "Main", text: "" }];
   #revision = 1;
   #nextMarkerId = 1;
   readonly #held = new Map<BatchKind, { reach: () => void; released: Promise<void> }>();
@@ -27,9 +55,26 @@ class DocsModel {
       this.fetch(input, init)));
   }
 
-  addMarker(name: string, id: string): void {
-    this.markers.set(id, name);
+  addMarker(name: string, id: string, tabId = MAIN_TAB): void {
+    this.markers.set(id, { name, tabId });
     this.#recordMarkerCount();
+  }
+
+  addTab(id: string, title: string, parentId: string, text = ""): void {
+    this.tabs.push({ id, title, parentId, text });
+  }
+
+  removeTab(id: string): void {
+    this.tabs.splice(this.tabs.findIndex(tab => tab.id === id), 1);
+    this.#revision++;
+  }
+
+  setText(tabId: string, text: string): void {
+    this.#tab(tabId).text = text;
+  }
+
+  text(tabId = MAIN_TAB): string {
+    return this.#tab(tabId).text;
   }
 
   clearMarkers(): void {
@@ -51,17 +96,36 @@ class DocsModel {
   }
 
   /** A collaborator edit: the document changes without this gatekeeper writing to it. */
-  externalEdit(): void {
-    this.content += "collaborator";
+  externalEdit(tabId = MAIN_TAB, text?: string): void {
+    let tab = this.#tab(tabId);
+    tab.text = text ?? tab.text + "collaborator";
     this.#revision++;
   }
 
   async fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
     let url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.hostname === "www.googleapis.com") {
+      this.driveFetches++;
+      if (this.driveFailure === "malformed") {
+        return Response.json({ id: "doc-1", name: "Test document" });
+      }
+      if (this.driveFailure) {
+        let { status, reason } = this.driveFailure;
+        return Response.json(
+          { error: { code: status, errors: reason ? [{ reason }] : [] } }, { status });
+      }
+      return Response.json(
+        { id: "doc-1", name: "Test document", modifiedTime: this.driveModifiedTime });
+    }
     if (url.hostname !== "docs.googleapis.com") {
       throw new Error(`Unexpected provider request: ${url}`);
     }
-    if (!url.pathname.endsWith(":batchUpdate")) return Response.json(this.#document());
+    if (!url.pathname.endsWith(":batchUpdate")) {
+      let fields = url.searchParams.get("fields");
+      if (fields === null) this.documentFetches++;
+      else if (fields === "revisionId") this.revisionProbes++;
+      return Response.json(this.#document());
+    }
 
     let body = JSON.parse(String(init?.body)) as {
       requests: BatchRequest[];
@@ -81,23 +145,40 @@ class DocsModel {
     let replies: unknown[] = [];
     let hasContent = false;
     for (const request of body.requests) {
-      if (request.createNamedRange) {
-        let id = `marker-${this.#nextMarkerId++}`;
-        this.addMarker(request.createNamedRange.name, id);
-        replies.push({ createNamedRange: { namedRangeId: id } });
-      } else if (request.deleteNamedRange) {
+      if (request.deleteNamedRange) {
         this.markers.delete(request.deleteNamedRange.namedRangeId);
         this.deletedMarkerIds.push(request.deleteNamedRange.namedRangeId);
         replies.push({});
-      } else {
-        hasContent = true;
-        if (request.insertText) {
-          let offset = request.insertText.location.index - 1;
-          this.content = this.content.slice(0, offset) + request.insertText.text +
-            this.content.slice(offset);
-        }
-        replies.push({});
+        continue;
       }
+
+      // Google resolves an unqualified coordinate against a default tab, so a request that omits
+      // the ID would edit whichever tab that happens to be.
+      let coordinate = request.createNamedRange?.range ?? request.insertText?.location ??
+        request.deleteContentRange?.range ?? request.updateParagraphStyle?.range ??
+        request.createParagraphBullets?.range ?? request.updateTextStyle?.range;
+      if (!coordinate?.tabId) {
+        throw new Error(`Google Docs request is missing tabId: ${JSON.stringify(request)}`);
+      }
+      let tab = this.#tab(coordinate.tabId);
+
+      if (request.createNamedRange) {
+        let id = `marker-${this.#nextMarkerId++}`;
+        this.addMarker(request.createNamedRange.name, id, tab.id);
+        this.markerTabIds.push(tab.id);
+        replies.push({ createNamedRange: { namedRangeId: id } });
+        continue;
+      }
+
+      hasContent = true;
+      if (request.insertText) {
+        let offset = request.insertText.location.index - 1;
+        tab.text = tab.text.slice(0, offset) + request.insertText.text + tab.text.slice(offset);
+      } else if (request.deleteContentRange) {
+        let { startIndex, endIndex } = request.deleteContentRange.range;
+        tab.text = tab.text.slice(0, startIndex - 1) + tab.text.slice(endIndex - 1);
+      }
+      replies.push({});
     }
     if (hasContent) this.contentBatches++;
     this.#revision++;
@@ -126,36 +207,51 @@ class DocsModel {
     this.maxMarkerCount = Math.max(this.maxMarkerCount, this.markers.size);
   }
 
-  #document() {
-    let text = `${this.content}\n`;
-    let grouped: Record<string, { namedRanges: { namedRangeId: string; name: string }[] }> = {};
-    for (const [namedRangeId, name] of this.markers) {
-      (grouped[name] ??= { namedRanges: [] }).namedRanges.push({ namedRangeId, name });
+  #tab(id: string): ModelTab {
+    let tab = this.tabs.find(candidate => candidate.id === id);
+    if (!tab) throw new Error(`Google Docs has no tab "${id}"`);
+    return tab;
+  }
+
+  #documentTab(tab: ModelTab): unknown {
+    let text = `${tab.text}\n`;
+    let namedRanges: Record<string, { namedRanges: { namedRangeId: string; name: string }[] }> = {};
+    for (const [namedRangeId, marker] of this.markers) {
+      if (marker.tabId !== tab.id) continue;
+      (namedRanges[marker.name] ??= { namedRanges: [] })
+        .namedRanges.push({ namedRangeId, name: marker.name });
     }
+    return {
+      tabProperties: { tabId: tab.id, title: tab.title },
+      documentTab: {
+        body: {
+          content: [{
+            startIndex: 1,
+            endIndex: text.length + 1,
+            paragraph: {
+              elements: [{
+                startIndex: 1, endIndex: text.length + 1,
+                textRun: { content: text, textStyle: {} },
+              }],
+              paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
+            },
+          }],
+        },
+        lists: {},
+        namedRanges,
+      },
+      childTabs: this.tabs.filter(child => child.parentId === tab.id)
+        .map(child => this.#documentTab(child)),
+    };
+  }
+
+  #document() {
     return {
       documentId: "doc-1",
       title: "Test document",
-      revisionId: `revision-${this.#revision}`,
-      tabs: [{
-        documentTab: {
-          body: {
-            content: [{
-              startIndex: 1,
-              endIndex: text.length + 1,
-              paragraph: {
-                elements: [{
-                  startIndex: 1, endIndex: text.length + 1,
-                  textRun: { content: text, textStyle: {} },
-                }],
-                paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
-              },
-            }],
-          },
-          lists: {},
-          namedRanges: grouped,
-        },
-        childTabs: [],
-      }],
+      ...this.editable ? { revisionId: `revision-${this.#revision}` } : {},
+      tabs: this.tabs.filter(tab => tab.parentId === undefined)
+        .map(tab => this.#documentTab(tab)),
     };
   }
 }
@@ -178,7 +274,7 @@ describe("Google Doc write receipts", () => {
 
     await hooks().applyAction("normal", actionId);
 
-    expect(docs.content).toContain("first");
+    expect(docs.text()).toContain("first");
     expect(docs.contentBatches).toBe(1);
     expect(docs.deletedMarkerIds).toEqual(["marker-1"]);
     expect(docs.markers.size).toBe(0);
@@ -214,8 +310,8 @@ describe("Google Doc write receipts", () => {
     let secondId = await hooks().submitAppend("restart", "second");
     await hooks().applyAction("restart", secondId);
 
-    expect(docs.content).toContain("first");
-    expect(docs.content).toContain("second");
+    expect(docs.text()).toContain("first");
+    expect(docs.text()).toContain("second");
     expect(docs.contentBatches).toBe(2);
     expect(docs.maxMarkerCount).toBe(1);
     expect(docs.markers.size).toBe(0);
@@ -285,7 +381,7 @@ describe("Google Doc write receipts", () => {
     expect(await first).toBeNull();
     expect(await second).toMatch(/Unknown pending/);
     expect(docs.contentBatches).toBe(1);
-    expect(docs.content.match(/first/g)).toHaveLength(1);
+    expect(docs.text().match(/first/g)).toHaveLength(1);
     expect(docs.markers.size).toBe(0);
   });
 
@@ -350,5 +446,306 @@ describe("Google Doc metadata", () => {
     await hooks().submitAppend("metadata-pending", "first");
 
     expect(await hooks().readMetadata("metadata-pending")).toBeGreaterThan(baseline);
+  });
+
+  // Without edit access Google reports no revision, so Drive's own timestamp is the only signal
+  // that a collaborator changed anything.
+  it("reports Drive's modification time when there is no revision", async () => {
+    let docs = new DocsModel();
+    docs.editable = false;
+    docs.install();
+
+    let first = await hooks().readMetadata("metadata-read-only");
+    expect(first).toBe(new Date("2026-01-02T03:04:05Z").valueOf());
+
+    await scheduler.wait(2);
+    expect(await hooks().readMetadata("metadata-read-only")).toBe(first);
+
+    docs.driveModifiedTime = "2026-01-02T04:00:00Z";
+    expect(await hooks().readMetadata("metadata-read-only"))
+      .toBe(new Date("2026-01-02T04:00:00Z").valueOf());
+  });
+
+  it("holds the modification time steady when Drive metadata is not granted", async () => {
+    let docs = new DocsModel();
+    docs.editable = false;
+    docs.driveFailure = { status: 403, reason: "insufficientPermissions" };
+    docs.install();
+
+    let first = await hooks().readMetadata("metadata-no-drive");
+    await scheduler.wait(2);
+
+    expect(await hooks().readMetadata("metadata-no-drive")).toBe(first);
+    expect(docs.driveFetches).toBe(2);
+  });
+
+  // Dating the document from a transient failure would report it unchanged for as long as Drive
+  // stayed unhealthy, and the stored observation would outlive the incident.
+  it.each([
+    ["an outage", "metadata-drive-outage", { status: 500 }],
+    ["a quota refusal", "metadata-drive-quota", { status: 403, reason: "userRateLimitExceeded" }],
+    ["a malformed reply", "metadata-drive-malformed", "malformed"],
+  ] as const)("fails a metadata read rather than dating a document from %s", async (
+    _case, facetName, failure,
+  ) => {
+    let docs = new DocsModel();
+    docs.editable = false;
+    docs.driveFailure = failure;
+    docs.install();
+
+    await expect(Promise.resolve(hooks().readMetadata(facetName))).rejects.toThrow();
+
+    docs.driveFailure = null;
+    expect(await hooks().readMetadata(facetName))
+      .toBe(new Date("2026-01-02T03:04:05Z").valueOf());
+  });
+});
+
+// Google withholds revisionId from a caller without edit access, which is the ordinary case for
+// a Doc shared read-only.
+describe("Google Doc with no revision ID", () => {
+  it("reuses its snapshot inside the TTL and refetches once expired", async () => {
+    let docs = new DocsModel();
+    docs.editable = false;
+    docs.install();
+
+    await hooks().readContent("no-revision");
+    await hooks().readContent("no-revision");
+    expect(docs.documentFetches).toBe(1);
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + 60_000);
+    docs.externalEdit(MAIN_TAB, "collaborator edit");
+
+    expect(await hooks().readContent("no-revision")).toContain("collaborator edit");
+    expect(docs.documentFetches).toBe(2);
+    // Nothing to compare, so the probe is not worth a request.
+    expect(docs.revisionProbes).toBe(0);
+  });
+});
+
+/** A nested document whose three tabs all hold the same text, so an edit cannot be mistaken. */
+function nestedDocs(): DocsModel {
+  let docs = new DocsModel();
+  docs.setText(MAIN_TAB, "shared");
+  docs.addTab("details", "Details", MAIN_TAB, "shared");
+  docs.addTab("metrics", "Metrics", "details", "shared");
+  docs.install();
+  return docs;
+}
+
+describe("Google Doc tab isolation", () => {
+  it("lists the tab tree and appends only to the tab it names", async () => {
+    let docs = nestedDocs();
+
+    expect(await hooks().listTabs("tabs-append")).toEqual([
+      { id: MAIN_TAB, title: "Main", index: 0, nestingLevel: 0 },
+      { id: "details", title: "Details", parentTabId: MAIN_TAB, index: 0, nestingLevel: 1 },
+      { id: "metrics", title: "Metrics", parentTabId: "details", index: 0, nestingLevel: 2 },
+    ]);
+
+    let actionId = await hooks().submitAppend("tabs-append", "added", "metrics");
+    expect(await hooks().readContent("tabs-append", "metrics")).toContain("added");
+    expect(await hooks().readContent("tabs-append", MAIN_TAB)).not.toContain("added");
+
+    expect(await hooks().applyAction("tabs-append", actionId)).toBeNull();
+
+    // The marker must be anchored in the tab that was edited: a marker left in another tab is
+    // invisible to the retry lookup, which would re-apply the write after a lost response.
+    expect(docs.markerTabIds).toEqual(["metrics"]);
+    expect(docs.text("metrics")).toContain("added");
+    expect(docs.text(MAIN_TAB)).toBe("shared");
+    expect(docs.text("details")).toBe("shared");
+  });
+
+  it("replaces identical text in the selected tab only", async () => {
+    let docs = nestedDocs();
+    let actionId = await hooks().submitReplace("tabs-replace", "shared", "changed", "metrics");
+
+    expect(await hooks().applyAction("tabs-replace", actionId)).toBeNull();
+
+    expect(docs.markerTabIds).toEqual(["metrics"]);
+    expect(docs.text("metrics")).toBe("changed");
+    expect(docs.text(MAIN_TAB)).toBe("shared");
+    expect(docs.text("details")).toBe("shared");
+  });
+
+  it("submits nothing for an omitted or unknown tab", async () => {
+    let docs = nestedDocs();
+
+    await expect(Promise.resolve(hooks().submitAppend("tabs-selector", "added")))
+      .rejects.toThrow(/tabId is required for documents with multiple tabs/);
+    await expect(Promise.resolve(
+      hooks().submitReplace("tabs-selector", "shared", "changed", "ghost"),
+    )).rejects.toThrow(/no tab with ID "ghost"/);
+
+    expect(docs.contentBatches).toBe(0);
+    expect(docs.text("metrics")).toBe("shared");
+  });
+
+  // A failed edit still tells the caller whether a tab, or the text in it, exists. Leaving the
+  // write paths ungated would let a caller ask through appendText what getContent refuses.
+  const GENERIC_READ = "Read the content of one tab of the document.";
+
+  it.each([
+    ["an omitted tab", () => hooks().submitAppend("tabs-write-oracle", "added"),
+      /tabId is required for documents with multiple tabs/],
+    ["an unknown tab", () => hooks().submitAppend("tabs-write-oracle", "added", "ghost"),
+      /no tab with ID "ghost"/],
+    ["unmatched text",
+      () => hooks().submitReplace("tabs-write-oracle", "absent", "changed", "metrics"),
+      /was not found in the current simulated tab/],
+  ] as const)("authorizes a generic observation when an edit fails on %s", async (
+    _case, submit, message,
+  ) => {
+    let docs = nestedDocs();
+
+    await expect(Promise.resolve(submit())).rejects.toThrow(message);
+
+    expect(await hooks().lastObservations).toEqual([GENERIC_READ]);
+    expect(docs.contentBatches).toBe(0);
+  });
+
+  it("is not suppressed by a same-named write marker in another tab", async () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("fixed-write-id");
+    let docs = nestedDocs();
+    docs.addMarker("gadgets-write-fixed-write-id", "other-1", MAIN_TAB);
+
+    let actionId = await hooks().submitAppend("tabs-foreign-marker", "added", "metrics");
+    expect(await hooks().applyAction("tabs-foreign-marker", actionId)).toBeNull();
+
+    expect(docs.contentBatches).toBe(1);
+    expect(docs.text("metrics")).toContain("added");
+    expect(docs.text(MAIN_TAB)).toBe("shared");
+  });
+
+  it("refuses an edit whose tab is deleted before approval", async () => {
+    let docs = nestedDocs();
+    let actionId = await hooks().submitAppend("tabs-deleted", "added", "metrics");
+
+    docs.removeTab("metrics");
+    expect(await hooks().applyAction("tabs-deleted", actionId)).toBe(
+      'appendText: no tab with ID "metrics" exists in this document. ' +
+      "Call listTabs() to refresh the tab list.");
+
+    // Approving it again must not report success for a write that never happened, and must not
+    // decay into "unknown action" either — rejecting is the way out.
+    let repeated = "Pending Google Doc edit could not be applied: " +
+      'appendText: no tab with ID "metrics" exists in this document. ' +
+      "Call listTabs() to refresh the tab list.";
+    expect(await hooks().applyAction("tabs-deleted", actionId)).toBe(repeated);
+    expect(await hooks().applyAction("tabs-deleted", actionId)).toBe(repeated);
+
+    expect(docs.contentBatches).toBe(0);
+    expect(docs.text(MAIN_TAB)).toBe("shared");
+    expect(docs.text("details")).toBe("shared");
+  });
+
+  // Actions are approved in one global order, but each replays against only its own tab, so
+  // neither edit may shift or shadow the other.
+  it("replays edits queued on different tabs independently", async () => {
+    let docs = nestedDocs();
+    let metricsId = await hooks().submitAppend("tabs-interleaved", "alpha", "metrics");
+    let mainId = await hooks().submitAppend("tabs-interleaved", "beta", MAIN_TAB);
+
+    let metricsPreview = await hooks().readContent("tabs-interleaved", "metrics");
+    let mainPreview = await hooks().readContent("tabs-interleaved", MAIN_TAB);
+    expect(metricsPreview).toContain("alpha");
+    expect(metricsPreview).not.toContain("beta");
+    expect(mainPreview).toContain("beta");
+    expect(mainPreview).not.toContain("alpha");
+
+    expect(await hooks().applyAction("tabs-interleaved", metricsId)).toBeNull();
+    expect(await hooks().applyAction("tabs-interleaved", mainId)).toBeNull();
+
+    expect(docs.text("metrics")).toBe("shared\nalpha");
+    expect(docs.text(MAIN_TAB)).toBe("shared\nbeta");
+    expect(docs.text("details")).toBe("shared");
+  });
+
+  it("invalidates only the edit whose own tab moved", async () => {
+    let docs = nestedDocs();
+    await hooks().submitReplace("tabs-invalidate", "shared", "changed", "metrics");
+    let mainId = await hooks().submitAppend("tabs-invalidate", "beta", MAIN_TAB);
+
+    // A collaborator rewrites Metrics, so the replace no longer matches. The append targets a
+    // different tab whose text never moved, so it must survive and stop waiting behind it.
+    docs.externalEdit("metrics", "rewritten");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + 60_000);
+
+    let metricsPreview = await hooks().readContent("tabs-invalidate", "metrics");
+    expect(metricsPreview).not.toContain("changed");
+    expect(metricsPreview).not.toContain("beta");
+    expect(await hooks().readContent("tabs-invalidate", MAIN_TAB)).toContain("beta");
+
+    expect(await hooks().applyAction("tabs-invalidate", mainId)).toBeNull();
+
+    expect(docs.text(MAIN_TAB)).toBe("shared\nbeta");
+    expect(docs.text("metrics")).toBe("rewritten");
+  });
+
+  // Titles are user-authored, need not be unique and may be empty, so the approval a user
+  // consents to has to carry the ID the write actually targets.
+  it("names the target tab by ID when two tabs share a title", async () => {
+    let docs = new DocsModel();
+    docs.setText(MAIN_TAB, "shared");
+    docs.addTab("notes-a", "Notes", MAIN_TAB, "shared");
+    docs.addTab("notes-b", "Notes", MAIN_TAB, "shared");
+    docs.install();
+
+    await hooks().submitAppend("tabs-duplicate-title", "added", "notes-b");
+
+    expect(await hooks().lastActionDescription).toContain('tab "Notes" (notes-b)');
+  });
+});
+
+// A stored edit with no tab predates tab support. No current write path produces one, so this is
+// the only place the migration refusal can be reached.
+describe("Google Doc edits stored before tab support", () => {
+  function tabSnapshot(tabId: string, title: string) {
+    return {
+      tabId, title, index: 0, nestingLevel: 0,
+      markdown: "shared\n", sourceMap: { blocks: [] }, bodyEndIndex: 8,
+      committedWriteIds: [],
+    };
+  }
+
+  const snapshot = {
+    title: "Test document",
+    revisionId: "revision-1",
+    tabs: [tabSnapshot(MAIN_TAB, "Main")],
+    fetchedAt: 0,
+  };
+
+  const storedAppend = {
+    type: "appendText" as const,
+    documentId: "doc-1",
+    submittedAt: 0,
+    baseRevisionId: "revision-1",
+    markdown: "added",
+  };
+
+  // The old code refused to read a multi-tab document, so a stored record was approved against
+  // the one tab such a document had.
+  it("retargets a record naming no tab when the document still has exactly one", () => {
+    expect(googleDocActionTab(snapshot, storedAppend).tabId).toBe(MAIN_TAB);
+  });
+
+  it("refuses a record naming no tab once the document has gained tabs", () => {
+    let grown = { ...snapshot, tabs: [...snapshot.tabs, tabSnapshot("second", "Second")] };
+    expect(() => googleDocActionTab(grown, storedAppend)).toThrow(
+      "Pending Google Doc edit predates tab support and the document has gained tabs since, " +
+      "so the tab it was approved against is unknown. Reject it and retry on a selected tab.");
+  });
+
+  it("refuses a vanished tab rather than retargeting to the first", () => {
+    expect(() => googleDocActionTab(snapshot, { ...storedAppend, tabId: "ghost" })).toThrow(
+      'appendText: no tab with ID "ghost" exists in this document. ' +
+      "Call listTabs() to refresh the tab list.");
+  });
+
+  it("resolves a record that names a live tab", () => {
+    expect(googleDocActionTab(snapshot, { ...storedAppend, tabId: MAIN_TAB }).title).toBe("Main");
   });
 });

--- a/packages/gatekeeper-google/__tests__/workerd/native-sessions.test.ts
+++ b/packages/gatekeeper-google/__tests__/workerd/native-sessions.test.ts
@@ -12,6 +12,10 @@ import { GoogleSheetsApi } from "../../src/sheets-api";
 const DOC_MIME = "application/vnd.google-apps.document";
 const SHEET_MIME = "application/vnd.google-apps.spreadsheet";
 let providerUrls: string[];
+/** The document the provider currently serves; a test may replace it mid-session. */
+let providerTabs: unknown[];
+/** Absent for a document the caller cannot edit, as Google returns it. */
+let providerRevision: string | undefined;
 
 async function getAccessToken(): Promise<string> {
   return "access-token";
@@ -49,8 +53,50 @@ function providerFile(id: string, mimeType: string) {
   };
 }
 
-function installProvider() {
+/** One provider tab: the section break every body opens with, then an optional paragraph. */
+function docTab(tabId: string, title: string, text: string, childTabs: unknown[] = []) {
+  const paragraph = `${text}\n`;
+  return {
+    tabProperties: { tabId, title },
+    documentTab: {
+      body: {
+        content: [
+          { startIndex: 0, endIndex: 1, sectionBreak: {} },
+          ...text ? [{
+            startIndex: 1,
+            endIndex: paragraph.length + 1,
+            paragraph: {
+              elements: [{
+                startIndex: 1,
+                endIndex: paragraph.length + 1,
+                textRun: { content: paragraph, textStyle: {} },
+              }],
+              paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
+            },
+          }] : [],
+        ],
+      },
+      lists: {},
+      namedRanges: {},
+    },
+    childTabs,
+  };
+}
+
+/** Two roots, a child and a grandchild — the shape `listTabs()` must flatten in preorder. */
+const NESTED_TABS = [
+  docTab("overview", "Overview", "Overview body", [
+    docTab("details", "Details", "Details body", [
+      docTab("metrics", "Metrics", "Metrics body"),
+    ]),
+  ]),
+  docTab("appendix", "Appendix", "Appendix body"),
+];
+
+function installProvider(tabs: unknown[] = [docTab("solo", "Solo", "")]) {
   const urls: string[] = [];
+  providerTabs = tabs;
+  providerRevision = "revision-1";
   vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
     const url = new URL(input instanceof Request ? input.url : input.toString());
     urls.push(url.toString());
@@ -66,16 +112,21 @@ function installProvider() {
       return Response.json({
         documentId: "doc-1",
         title: "Quarterly plan",
-        revisionId: "revision-1",
-        tabs: [{
-          documentTab: { body: { content: [] }, lists: {}, namedRanges: {} },
-          childTabs: [],
-        }],
+        ...providerRevision === undefined ? {} : { revisionId: providerRevision },
+        tabs: providerTabs,
       });
     }
     throw new Error(`Unexpected provider request: ${url.origin}${url.pathname}`);
   }));
   return urls;
+}
+
+/** Full `documents.get` calls, excluding the lightweight revision check. */
+function docFetches(): number {
+  return providerUrls.filter(url => {
+    const { hostname, searchParams } = new URL(url);
+    return hostname === "docs.googleapis.com" && !searchParams.has("fields");
+  }).length;
 }
 
 function newSession() {
@@ -98,7 +149,10 @@ function newSession() {
 beforeEach(() => {
   providerUrls = installProvider();
 });
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe("Drive nested native sessions", () => {
   it("pipelines a Doc call before resolving its disposable child stub", async () => {
@@ -148,5 +202,136 @@ describe("Drive nested native sessions", () => {
 
     expect(await cursor.next()).toEqual([expect.objectContaining({ id: "doc-1" })]);
     expect(queue.observations.at(-1)?.title).toBe("Read Google Drive metadata");
+  });
+});
+
+describe("Drive Doc tab selection", () => {
+  beforeEach(() => {
+    providerUrls = installProvider(NESTED_TABS);
+  });
+
+  it("flattens the tab tree in preorder with derived ancestry", async () => {
+    using session = newSession().session;
+    using doc = await session.openGoogleDoc("doc-1");
+
+    expect(await doc.listTabs()).toEqual([
+      { id: "overview", title: "Overview", index: 0, nestingLevel: 0 },
+      { id: "details", title: "Details", parentTabId: "overview", index: 0, nestingLevel: 1 },
+      { id: "metrics", title: "Metrics", parentTabId: "details", index: 0, nestingLevel: 2 },
+      { id: "appendix", title: "Appendix", index: 1, nestingLevel: 0 },
+    ]);
+  });
+
+  it("reads only the selected tab and fetches the document once", async () => {
+    const { queue, session } = newSession();
+    using owned = session;
+    using doc = await owned.openGoogleDoc("doc-1");
+
+    await doc.listTabs();
+    expect(await doc.getContent("metrics")).toBe("Metrics body\n");
+    expect(await doc.getContent("appendix")).toBe("Appendix body\n");
+
+    expect(docFetches()).toBe(1);
+    expect(queue.observations.map(({ title }) => title)).toEqual([
+      "Open Google Doc from Google Drive", "List Google Doc tabs",
+      "Read Google Doc content", "Read Google Doc content",
+    ]);
+    expect(queue.observations.at(-1)?.description).toContain('tab "Appendix" (appendix)');
+  });
+
+  // Reads issued without awaiting the first must share one provider revision, or they can
+  // observe different documents and the later response can be the older one.
+  it("fetches the document once for concurrent reads", async () => {
+    using session = newSession().session;
+    using doc = await session.openGoogleDoc("doc-1");
+
+    const [tabs, content] = await Promise.all([doc.listTabs(), doc.getContent("metrics")]);
+
+    expect(tabs).toHaveLength(4);
+    expect(content).toBe("Metrics body\n");
+    expect(docFetches()).toBe(1);
+  });
+
+  // The session is a long-lived stub, so pinning it to the revision of its first read would hide
+  // every later collaborator edit -- and the selector error tells the caller to call listTabs(),
+  // which could not refresh anything.
+  it("sees a collaborator's new tab once the snapshot expires", async () => {
+    using session = newSession().session;
+    using doc = await session.openGoogleDoc("doc-1");
+    expect(await doc.listTabs()).toHaveLength(4);
+
+    providerTabs = [...NESTED_TABS, docTab("addendum", "Addendum", "Addendum body")];
+    providerRevision = "revision-2";
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + 60_000);
+
+    expect(await doc.listTabs()).toHaveLength(5);
+    expect(await doc.getContent("addendum")).toBe("Addendum body\n");
+    expect(docFetches()).toBe(2);
+  });
+
+  it("reuses the expired snapshot when the revision is unchanged", async () => {
+    using session = newSession().session;
+    using doc = await session.openGoogleDoc("doc-1");
+    await doc.listTabs();
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + 60_000);
+
+    expect(await doc.getContent("metrics")).toBe("Metrics body\n");
+    expect(docFetches()).toBe(1);
+    expect(providerUrls.some(url => new URL(url).searchParams.get("fields") === "revisionId"))
+      .toBe(true);
+  });
+
+  // Google omits revisionId unless the caller can edit, which is the normal case for a Doc
+  // opened read-only through Drive. Two absent revisions must not compare as unchanged.
+  it("refetches a document that has no revision ID", async () => {
+    providerRevision = undefined;
+    using session = newSession().session;
+    using doc = await session.openGoogleDoc("doc-1");
+    expect(await doc.listTabs()).toHaveLength(4);
+
+    providerTabs = [...NESTED_TABS, docTab("addendum", "Addendum", "Addendum body")];
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + 60_000);
+
+    expect(await doc.listTabs()).toHaveLength(5);
+    expect(docFetches()).toBe(2);
+    // Nothing to compare, so the revision probe is not worth a request.
+    expect(providerUrls.some(url => new URL(url).searchParams.get("fields") === "revisionId"))
+      .toBe(false);
+  });
+
+  it("pipelines a tab read before its session stub resolves", async () => {
+    using session = newSession().session;
+
+    const docPromise = session.openGoogleDoc("doc-1");
+    const contentPromise = docPromise.getContent("details");
+    using doc = await docPromise;
+
+    expect(await contentPromise).toBe("Details body\n");
+    doc[Symbol.dispose]();
+    await expect(Promise.resolve(doc.listTabs())).rejects.toThrow();
+  });
+
+  it.each([
+    [undefined, "getContent: tabId is required for documents with multiple tabs. " +
+      "Call listTabs() to choose a tab."],
+    ["ghost", 'getContent: no tab with ID "ghost" exists in this document. ' +
+      "Call listTabs() to refresh the tab list."],
+  ] as const)("fails closed on selector %s", async (tabId, message) => {
+    const { queue, session } = newSession();
+    using owned = session;
+    using doc = await owned.openGoogleDoc("doc-1");
+
+    await expect(Promise.resolve(doc.getContent(tabId))).rejects.toThrow(message);
+
+    // The selector error says whether a tab exists, so the attempt is itself an observation --
+    // recorded, but naming no tab, since none was disclosed.
+    expect(queue.observations.at(-1)).toMatchObject({
+      title: "Read Google Doc content",
+      description: "Read the content of one tab of the document.",
+    });
   });
 });

--- a/packages/gatekeeper-google/src/docs-api.ts
+++ b/packages/gatekeeper-google/src/docs-api.ts
@@ -12,17 +12,43 @@ import { readGoogleJson } from "./google-response";
 // use are included.
 // ---------------------------------------------------------------------------
 
-/** Top-level document response from `documents.get`. */
+/**
+ * A document from `documents.get`, with Google's recursive tab tree flattened in preorder.
+ *
+ * Content lives on the tabs: a document itself has none, and every tab body has its own index
+ * space, so nothing outside one tab may be read or written with that tab's indices.
+ */
 export type GoogleDocsDocument = {
   documentId: string;
   title: string;
-  revisionId: string;
-  body: { content: StructuralElement[] };
-  lists: Record<string, DocList>;
-  namedRanges: Record<string, {
-    namedRanges: { namedRangeId: string; name?: string }[];
-  }>;
+  /** Google populates this only for callers with edit access, so a reader sees no revision. */
+  revisionId?: string;
+  /** Every tab, depth-first, parents before children. Never empty. */
+  tabs: GoogleDocsTab[];
 }
+
+/** One tab's content and its place in the document's tab tree. */
+export type GoogleDocsTab = {
+  /** Google's immutable tab ID, which every write coordinate into this tab must carry. */
+  tabId: string;
+  title: string;
+  /** The containing tab, absent for a top-level tab. */
+  parentTabId?: string;
+  /** Position among the tabs sharing this parent. */
+  index: number;
+  /** Depth in the tab tree; 0 for a top-level tab. */
+  nestingLevel: number;
+  body: { content: StructuralElement[] };
+  /** List definitions this tab's paragraphs reference. */
+  lists: Record<string, DocList>;
+  /** Named ranges anchored in this tab. */
+  namedRanges: NamedRanges;
+}
+
+/** Named ranges grouped by name, as `documents.get` returns them. */
+export type NamedRanges = Record<string, {
+  namedRanges: { namedRangeId: string; name?: string }[];
+}>
 
 /** A list definition, referenced by paragraphs that are list items. */
 export type DocList = {
@@ -86,45 +112,79 @@ export type TextStyle = {
   link?: { url: string };
 }
 
-type GoogleDocsTabContent = Pick<GoogleDocsDocument, "body"> & {
-  lists?: GoogleDocsDocument["lists"];
-  namedRanges?: GoogleDocsDocument["namedRanges"];
-};
-
-type GoogleDocsTab = {
-  documentTab?: GoogleDocsTabContent;
-  childTabs?: GoogleDocsTab[];
-};
-
 type GoogleDocsResponse = Pick<
   GoogleDocsDocument, "documentId" | "title" | "revisionId"
-> & { tabs?: GoogleDocsTab[] };
+> & { tabs?: unknown };
 
-type GoogleDocsWriteMarker = { name: string; rangeStart: number };
+/** Where one write's marker range goes: one character at `rangeStart` inside tab `tabId`. */
+type GoogleDocsWriteMarker = { name: string; rangeStart: number; tabId: string };
 
-function singleTabDocument(document: GoogleDocsResponse): GoogleDocsDocument {
-  let tabs = document.tabs;
-  if (!tabs || tabs.length === 0) {
+const INVALID_TAB = "Google Docs returned an invalid tab";
+
+/** An optional provider collection, which must be a plain object when present. */
+function tabCollection<T>(value: unknown): T {
+  if (value === undefined) return {} as T;
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(INVALID_TAB);
+  return value as T;
+}
+
+/**
+ * Flatten Google's recursive `tabs`/`childTabs` tree into a preorder list.
+ *
+ * Ancestry, sibling order and depth are derived from the tree actually returned rather than read
+ * from `tabProperties`, and tab IDs must be unique document-wide, because everything downstream
+ * addresses a tab by ID alone.
+ */
+function normalizeDocumentTabs(tabs: unknown): GoogleDocsTab[] {
+  if (!Array.isArray(tabs) || tabs.length === 0) {
     throw new Error("Google Docs returned no document tab");
   }
 
-  let [tab] = tabs;
-  if (tabs.length !== 1 || tab.childTabs?.length) {
-    throw new Error("Multi-tab Google Docs are not supported");
-  }
-  let tabContent = tab.documentTab;
-  if (!tabContent) {
-    throw new Error("Google Docs returned a tab without document content");
-  }
+  let normalized: GoogleDocsTab[] = [];
+  let seen = new Set<string>();
 
-  return {
-    documentId: document.documentId,
-    title: document.title,
-    revisionId: document.revisionId,
-    body: tabContent.body,
-    lists: tabContent.lists ?? {},
-    namedRanges: tabContent.namedRanges ?? {},
+  let visit = (siblings: unknown[], parentTabId: string | undefined, nestingLevel: number) => {
+    for (let [index, raw] of siblings.entries()) {
+      if (!raw || typeof raw !== "object") throw new Error(INVALID_TAB);
+      let { tabProperties, documentTab, childTabs } = raw as Record<string, unknown>;
+      if (!tabProperties || typeof tabProperties !== "object") throw new Error(INVALID_TAB);
+      let { tabId, title } = tabProperties as Record<string, unknown>;
+      if (typeof tabId !== "string" || tabId.length === 0 || typeof title !== "string") {
+        throw new Error(INVALID_TAB);
+      }
+      if (seen.has(tabId)) throw new Error("Google Docs returned a duplicate tab ID");
+      seen.add(tabId);
+
+      if (!documentTab || typeof documentTab !== "object") throw new Error(INVALID_TAB);
+      let { body, lists, namedRanges } = documentTab as Record<string, unknown>;
+      // A real body always holds at least a section break, and `bodyEndIndex` arithmetic assumes
+      // it: an empty one would place an append at index -1.
+      if (!body || typeof body !== "object" || !("content" in body) ||
+          !Array.isArray(body.content) || body.content.length === 0) {
+        throw new Error(INVALID_TAB);
+      }
+      // Structural elements stay unvalidated here; the converter reads them defensively.
+      let content = body.content as StructuralElement[];
+
+      normalized.push({
+        tabId,
+        title,
+        ...parentTabId === undefined ? {} : { parentTabId },
+        index,
+        nestingLevel,
+        body: { content },
+        lists: tabCollection<GoogleDocsTab["lists"]>(lists),
+        namedRanges: tabCollection<NamedRanges>(namedRanges),
+      });
+
+      if (childTabs === undefined) continue;
+      if (!Array.isArray(childTabs)) throw new Error(INVALID_TAB);
+      visit(childTabs, tabId, nestingLevel + 1);
+    }
   };
+
+  visit(tabs, undefined, 0);
+  return normalized;
 }
 
 // ---------------------------------------------------------------------------
@@ -152,17 +212,17 @@ export class GoogleDocsApi {
     });
   }
 
-  /** Fetch and normalize a single-tab document. */
+  /** Fetch a document and flatten its tab tree. */
   async getDocument(documentId: string): Promise<GoogleDocsDocument> {
-    let document = await this.#request<GoogleDocsResponse>(
+    let { documentId: id, title, revisionId, tabs } = await this.#request<GoogleDocsResponse>(
       `${DOCS_API_BASE}/${encodeURIComponent(documentId)}?includeTabsContent=true`,
       {},
       "get document",
     );
-    if (document.documentId !== documentId) {
+    if (id !== documentId) {
       throw new Error("Google Docs returned a different document");
     }
-    return singleTabDocument(document);
+    return { documentId: id, title, revisionId, tabs: normalizeDocumentTabs(tabs) };
   }
 
   /**
@@ -188,14 +248,13 @@ export class GoogleDocsApi {
   }
 
   /**
-   * Lightweight revision check. Uses the `fields` query parameter to request
-   * only the revisionId, avoiding downloading the full document body.
+   * Lightweight revision check, requesting only the revisionId rather than the whole body.
    *
-   * If the API doesn't support field filtering (returns the full doc anyway),
-   * that's fine — we just parse revisionId from whatever comes back.
+   * Absent when the caller cannot edit the document, in which case there is no change token and
+   * a reader has to refetch to see whether anything moved.
    */
-  async getRevisionId(documentId: string): Promise<string> {
-    let data = await this.#request<{ revisionId: string }>(
+  async getRevisionId(documentId: string): Promise<string | undefined> {
+    let data = await this.#request<{ revisionId?: string }>(
       `${DOCS_API_BASE}/${encodeURIComponent(documentId)}?fields=revisionId`,
       {},
       "get revision ID",
@@ -217,6 +276,7 @@ export class GoogleDocsApi {
             range: {
               startIndex: writeMarker.rangeStart,
               endIndex: writeMarker.rangeStart + 1,
+              tabId: writeMarker.tabId,
             },
           },
         }, ...requests]

--- a/packages/gatekeeper-google/src/docs-read-types.d.ts
+++ b/packages/gatekeeper-google/src/docs-read-types.d.ts
@@ -7,11 +7,47 @@ export type DocMetadata = {
   lastModified: Date;
 }
 
-/** Read-only access to one native Google Doc. */
+/**
+ * One tab of a native Google Doc.
+ *
+ * A document is a tree of tabs; `listTabs()` returns that tree flattened depth-first, parents
+ * before children, so `parentTabId` reconstructs the hierarchy without nested objects.
+ */
+export type GoogleDocTab = {
+  /** Immutable tab ID. Pass it to `getContent()` and to edits to target this tab. */
+  id: string;
+
+  /** Tab name, as shown in the document's tab list. */
+  title: string;
+
+  /** The tab that contains this one, absent for a top-level tab. */
+  parentTabId?: string;
+
+  /** Position among the tabs sharing this parent, counting from 0. */
+  index: number;
+
+  /** Depth in the tab tree: 0 for a top-level tab, 1 for its child, and so on. */
+  nestingLevel: number;
+}
+
+/**
+ * Read-only access to one native Google Doc.
+ *
+ * Each tab holds its own content. Call `listTabs()` before `getContent()` to see which tabs
+ * exist, then read one of them.
+ */
 export interface GoogleDocReadSession {
   /** Return current document metadata. Works with any number of tabs. */
   getMetadata(): Promise<DocMetadata>;
 
-  /** Return the document body as Markdown. Requires exactly one tab. */
-  getContent(): Promise<string>;
+  /** Return every tab in the document, flattened depth-first with parents before children. */
+  listTabs(): Promise<GoogleDocTab[]>;
+
+  /**
+   * Return one tab's content as Markdown.
+   *
+   * This reads exactly one tab and never combines tabs, so pass an ID returned by `listTabs()`.
+   * Omitting `tabId` is valid only when `listTabs()` returns exactly one tab.
+   */
+  getContent(tabId?: string): Promise<string>;
 }

--- a/packages/gatekeeper-google/src/docs-types.d.ts
+++ b/packages/gatekeeper-google/src/docs-types.d.ts
@@ -1,25 +1,30 @@
 import type { GoogleDocReadSession } from "./docs-read-types";
-export type { DocMetadata, GoogleDocReadSession } from "./docs-read-types";
+export type { DocMetadata, GoogleDocReadSession, GoogleDocTab } from "./docs-read-types";
 
 /**
  * Read/write access to one directly bound native Google Doc.
- * Metadata works with any number of tabs; content conversion and edits require exactly one tab.
+ *
+ * Metadata covers the whole document; reads and edits each target exactly one tab, so call
+ * `listTabs()` first and pass the ID of the tab to act on.
  */
 export interface GoogleDocSession extends GoogleDocReadSession {
 
   /**
-   * Find `oldMarkdown` in the current document content and replace it with `newMarkdown`.
+   * Find `oldMarkdown` in tab `tabId` and replace it with `newMarkdown`.
    * Both parameters are Markdown text.
    *
+   * Matching and editing are local to that one tab: pass an ID returned by `listTabs()`, and omit
+   * `tabId` only when `listTabs()` returns exactly one tab.
+   *
    * The match must be unique -- if `oldMarkdown` appears zero times or more than once in the
-   * document, an error is thrown. If the match is ambiguous, include more surrounding context
+   * selected tab, an error is thrown. If the match is ambiguous, include more surrounding context
    * in `oldMarkdown` to disambiguate.
    *
    * The gatekeeper automatically trims unchanged leading and trailing text before sending the
    * edit to Google Docs, so it's fine (and encouraged) to include extra context in `oldMarkdown`
    * and `newMarkdown` for matching purposes.
    *
-   * The Markdown is mapped back to Google Docs operations using the document's source map. The
+   * The Markdown is mapped back to Google Docs operations using the tab's source map. The
    * following Markdown features are supported in `newMarkdown`:
    * - Headings (`# ` through `###### `)
    * - Bold (`**text**`)
@@ -33,13 +38,13 @@ export interface GoogleDocSession extends GoogleDocReadSession {
    *
    * Unsupported Markdown features (tables, images, code blocks, etc.) are inserted as plain text.
    *
-   * A subsequent `getContent()` call reflects this replacement.
+   * A subsequent `getContent(tabId)` call reflects this replacement.
    */
-  replaceText(oldMarkdown: string, newMarkdown: string): Promise<void>;
+  replaceText(oldMarkdown: string, newMarkdown: string, tabId?: string): Promise<void>;
 
   /**
-   * Append Markdown content to the end of the document. The same Markdown features as
-   * `replaceText()` are supported.
+   * Append Markdown content to the end of tab `tabId`. The same Markdown features and tab
+   * selection rules as `replaceText()` apply.
    */
-  appendText(markdown: string): Promise<void>;
+  appendText(markdown: string, tabId?: string): Promise<void>;
 }

--- a/packages/gatekeeper-google/src/drive-session.ts
+++ b/packages/gatekeeper-google/src/drive-session.ts
@@ -46,13 +46,21 @@ function requiredString(value: string | undefined, field: string): string {
   return value;
 }
 
+/** Drive's `modifiedTime`, validated. */
+export function driveModifiedTime(file: DriveFile): Date {
+  let modifiedTime = new Date(requiredString(file.modifiedTime, "modifiedTime"));
+  if (Number.isNaN(modifiedTime.valueOf())) {
+    throw new Error("Google Drive returned an invalid modifiedTime");
+  }
+  return modifiedTime;
+}
+
 /** Maps one validated provider file to the permanent agent-facing declaration. */
 export function driveFileToEntry(file: DriveFile): DriveEntry {
   let mimeType = requiredString(file.mimeType, "mimeType");
   let isFolder = mimeType === FOLDER_MIME_TYPE;
   let isShortcut = mimeType === SHORTCUT_MIME_TYPE;
-  let modifiedTime = new Date(requiredString(file.modifiedTime, "modifiedTime"));
-  if (Number.isNaN(modifiedTime.valueOf())) throw new Error("Google Drive returned an invalid modifiedTime");
+  let modifiedTime = driveModifiedTime(file);
 
   let size: number | undefined;
   if (file.size !== undefined && !isFolder && !isShortcut) {

--- a/packages/gatekeeper-google/src/google.ts
+++ b/packages/gatekeeper-google/src/google.ts
@@ -7,18 +7,21 @@ import {
   type PreviewOAuthState,
 } from "@gadgets/gatekeeper-kit/preview-oauth";
 import { exchangeAuthCode, getAccessToken, getGoogleAccountDescription, getGoogleVerifiedEmail, GoogleAccessToken, revokeGoogleToken } from "./google-api";
-import { GoogleDocSession, DocMetadata, type GoogleDocReadSession } from "./docs-types";
-import { GoogleDocsApi, type GoogleDocsDocument } from "./docs-api";
+import { GoogleDocSession, DocMetadata, type GoogleDocReadSession, type GoogleDocTab } from "./docs-types";
+import { GoogleDocsApi, type GoogleDocsDocument, type GoogleDocsTab } from "./docs-api";
 import { GoogleSheetsApi } from "./sheets-api";
 import type {
   GoogleSpreadsheetReadSession, GoogleSpreadsheetSession, SpreadsheetInfo, SpreadsheetRange,
   SpreadsheetValueMode,
 } from "./sheets-types";
-import { docToMarkdown, markdownToDocRequests, computeReplaceOperations, DocSnapshot } from "./markdown-converter";
-import { DriveApi } from "./drive-api";
+import {
+  computeReplaceOperations, docTabToMarkdown, markdownToDocRequests, type DocTabSnapshot,
+} from "./markdown-converter";
+import { DriveApi, DriveApiRequestError } from "./drive-api";
 import { driveObserverTracker } from "./drive-observers";
 import {
-  DriveSessionCore, GOOGLE_DOC_MIME_TYPE, GOOGLE_SHEET_MIME_TYPE, type DriveBindingScope,
+  DriveSessionCore, driveModifiedTime, GOOGLE_DOC_MIME_TYPE, GOOGLE_SHEET_MIME_TYPE,
+  type DriveBindingScope,
   type DriveSessionCoreOptions,
 } from "./drive-session";
 import type { DriveEntry, DriveListOptions, DriveSearchQuery, GoogleDriveSession } from "./drive-types";
@@ -1063,8 +1066,13 @@ class RpcCursor<Entry> extends RpcTarget implements Cursor<Entry> {
 
 type GoogleDocActionBase = {
   documentId: string;
+  /**
+   * The tab this edit targets. Absent only on records stored before tab support, which are
+   * invalidated rather than retargeted: the first tab is not necessarily the one they meant.
+   */
+  tabId?: string;
   submittedAt: number;
-  baseRevisionId: string;
+  baseRevisionId?: string;
   writeId?: string;
   invalidatedReason?: string;
 }
@@ -1084,7 +1092,9 @@ type GoogleDocAction = GoogleDocReplaceAction | GoogleDocAppendAction;
 
 const DOC_WRITE_RECEIPT_KEY = "docWriteReceipt";
 const DOC_METADATA_REVISION_KEY = "docMetadataRevision";
-/** The last document read, replayed for 10s. Pending actions overlay it, so it outlives none. */
+/** The last document read, replayed for this long before its revision is rechecked. */
+const DOC_SNAPSHOT_TTL_MS = 10_000;
+/** The last document read. Pending actions overlay it, so it outlives none. */
 const DOC_SNAPSHOT_KEY = "docSnapshot";
 /** Name prefix of the named range that marks one Gadgets write. Permanent: retries match on it. */
 const WRITE_MARKER_PREFIX = "gadgets-write-";
@@ -1092,14 +1102,12 @@ const WRITE_MARKER_PREFIX = "gadgets-write-";
 type GoogleDocWriteReceipt = { actionId: number; markerId: string };
 
 /** The document revision this binding has already reported, and when it first saw it. */
-type GoogleDocMetadataRevision = { revisionId: string; observedAt: number };
+type GoogleDocMetadataRevision = { revisionId?: string; observedAt: number };
 type GoogleDocNamedRange = { id: string; name: string };
 
-function googleDocNamedRanges(document: GoogleDocsDocument): GoogleDocNamedRange[] {
+function googleDocNamedRanges(tab: GoogleDocsTab): GoogleDocNamedRange[] {
   let result: GoogleDocNamedRange[] = [];
-  for (const [fallbackName, collection] of Object.entries(
-    document.namedRanges as Record<string, unknown>,
-  )) {
+  for (const [fallbackName, collection] of Object.entries<unknown>(tab.namedRanges)) {
     if (!collection || typeof collection !== "object") {
       throw new Error("Google Docs returned invalid named ranges");
     }
@@ -1122,9 +1130,9 @@ function googleDocNamedRanges(document: GoogleDocsDocument): GoogleDocNamedRange
   return result;
 }
 
-function googleDocNamedRangeIds(document: GoogleDocsDocument, name: string): string[] {
+function googleDocNamedRangeIds(tab: GoogleDocsTab, name: string): string[] {
   let ids = new Set<string>();
-  for (let range of googleDocNamedRanges(document)) {
+  for (let range of googleDocNamedRanges(tab)) {
     if (range.name === name) ids.add(range.id);
   }
   return [...ids];
@@ -1136,15 +1144,15 @@ function googleDocWriteMarkerName(writeId: string): string {
 }
 
 /**
- * The write IDs whose content `document` already contains.
+ * The write IDs whose content `tab` already contains.
  *
  * A marker and its content go up in one atomic batch, so a marker naming a write ID proves that
  * write committed — including the case where its response was lost and its action is still
- * pending. Simulating such an action over this document would show its content twice.
+ * pending. Simulating such an action over this tab would show its content twice.
  */
-function googleDocCommittedWriteIds(document: GoogleDocsDocument): string[] {
+function googleDocCommittedWriteIds(tab: GoogleDocsTab): string[] {
   let writeIds = new Set<string>();
-  for (let range of googleDocNamedRanges(document)) {
+  for (let range of googleDocNamedRanges(tab)) {
     if (range.name.startsWith(WRITE_MARKER_PREFIX)) {
       writeIds.add(range.name.slice(WRITE_MARKER_PREFIX.length));
     }
@@ -1152,12 +1160,102 @@ function googleDocCommittedWriteIds(document: GoogleDocsDocument): string[] {
   return [...writeIds];
 }
 
-/** Markdown snapshot of `document`, tagged with the writes it already contains. */
-function googleDocSnapshot(document: GoogleDocsDocument): DocSnapshot {
+/** One tab's Markdown rendering, tagged with the writes that tab already contains. */
+type GoogleDocTabSnapshot = DocTabSnapshot & { committedWriteIds: string[] };
+
+/** A whole document as this gatekeeper caches it: one independent rendering per tab. */
+type GoogleDocSnapshot = {
+  title: string;
+  /** Absent unless the caller can edit the document; see `GoogleDocsDocument.revisionId`. */
+  revisionId?: string;
+  tabs: GoogleDocTabSnapshot[];
+  /** `Date.now()` at the time of fetch, used for TTL checks. */
+  fetchedAt: number;
+}
+
+function googleDocSnapshot(document: GoogleDocsDocument): GoogleDocSnapshot {
   return {
-    ...docToMarkdown(document),
-    committedWriteIds: googleDocCommittedWriteIds(document),
+    title: document.title,
+    revisionId: document.revisionId,
+    tabs: document.tabs.map(tab => ({
+      ...docTabToMarkdown(tab),
+      committedWriteIds: googleDocCommittedWriteIds(tab),
+    })),
+    fetchedAt: Date.now(),
   };
+}
+
+/** Accept a cached snapshot only if it predates nothing this code depends on. */
+function isGoogleDocSnapshot(value: unknown): value is GoogleDocSnapshot {
+  if (!value || typeof value !== "object") return false;
+  let { tabs, revisionId, fetchedAt } = value as Partial<GoogleDocSnapshot>;
+  return Array.isArray(tabs) && (revisionId === undefined || typeof revisionId === "string") &&
+      typeof fetchedAt === "number" && Number.isFinite(fetchedAt);
+}
+
+/**
+ * Whether an expired snapshot still describes the current document.
+ *
+ * Google withholds `revisionId` from a caller without edit access, leaving no change token, so
+ * such a document is refetched rather than spending a request on an answer that could never
+ * confirm the cache.
+ */
+async function googleDocRevisionUnchanged(
+  docsApi: GoogleDocsApi,
+  documentId: string,
+  cached: GoogleDocSnapshot,
+): Promise<boolean> {
+  return cached.revisionId !== undefined &&
+      await docsApi.getRevisionId(documentId) === cached.revisionId;
+}
+
+/**
+ * The tab an operation names, or a failure telling the agent how to name one.
+ *
+ * Omission is resolved from the flattened tab list, so a single root with any child counts as
+ * multi-tab. An unknown ID never falls back to the first tab: the caller meant a specific one.
+ */
+function resolveGoogleDocTab(
+  snapshot: GoogleDocSnapshot,
+  tabId: string | undefined,
+  operation: "getContent" | "replaceText" | "appendText",
+): GoogleDocTabSnapshot {
+  if (tabId === undefined) {
+    if (snapshot.tabs.length !== 1) {
+      throw new Error(
+        `${operation}: tabId is required for documents with multiple tabs. ` +
+        `Call listTabs() to choose a tab.`);
+    }
+    return snapshot.tabs[0];
+  }
+  let tab = snapshot.tabs.find(candidate => candidate.tabId === tabId);
+  if (!tab) {
+    throw new Error(
+      `${operation}: no tab with ID "${tabId}" exists in this document. ` +
+      `Call listTabs() to refresh the tab list.`);
+  }
+  return tab;
+}
+
+/** The agent-facing view of one tab: identity and position, never content. */
+function googleDocTabMetadata(tab: DocTabSnapshot): GoogleDocTab {
+  return {
+    id: tab.tabId,
+    title: tab.title,
+    ...tab.parentTabId === undefined ? {} : { parentTabId: tab.parentTabId },
+    index: tab.index,
+    nestingLevel: tab.nestingLevel,
+  };
+}
+
+/**
+ * How a tab is named in approval and observation text.
+ *
+ * The ID is included because it is what the write actually targets: titles are user-authored,
+ * are not required to be unique, and may be empty.
+ */
+function googleDocTabLabel(tab: DocTabSnapshot): string {
+  return `"${tab.title}" (${tab.tabId})`;
 }
 
 function parseGoogleDocWriteReceipt(value: unknown): GoogleDocWriteReceipt | undefined {
@@ -1175,12 +1273,12 @@ function parseGoogleDocWriteReceipt(value: unknown): GoogleDocWriteReceipt | und
 
 type GoogleDocPendingAction = { id: number; action: GoogleDocAction };
 
+/** One replay of the pending queue, keyed by the state it was computed from. */
 type GoogleDocSimulatedContentCache = {
-  baseRevisionId: string;
+  baseRevisionId?: string;
   pendingFingerprint: string;
-  markdown: string;
-  pendingActions: GoogleDocAction[];
-  computedAt: number;
+  /** The simulated Markdown of every tab, since one replay covers them all. */
+  markdownByTabId: Map<string, string>;
 }
 
 type GoogleDocSimulationCacheHolder = {
@@ -1195,7 +1293,12 @@ function previewMarkdown(markdown: string, maxLength: number): string {
   return markdown.length > maxLength ? markdown.slice(0, maxLength) + "..." : markdown;
 }
 
-function findUniqueMarkdown(markdown: string, oldMarkdown: string, operation: string): number {
+function findUniqueMarkdown(
+  markdown: string,
+  oldMarkdown: string,
+  operation: string,
+  tabId: string,
+): number {
   if (oldMarkdown.length === 0) {
     throw new Error(`${operation}: oldMarkdown must not be empty.`);
   }
@@ -1203,15 +1306,15 @@ function findUniqueMarkdown(markdown: string, oldMarkdown: string, operation: st
   let index = markdown.indexOf(oldMarkdown);
   if (index === -1) {
     throw new Error(
-      `${operation}: oldMarkdown was not found in the current simulated document. ` +
-      `Make sure the text exactly matches content returned by getContent().`);
+      `${operation}: oldMarkdown was not found in the current simulated tab "${tabId}". ` +
+      `Make sure the text exactly matches content returned by getContent("${tabId}").`);
   }
 
   let secondIndex = markdown.indexOf(oldMarkdown, index + 1);
   if (secondIndex !== -1) {
     throw new Error(
-      `${operation}: oldMarkdown matches multiple locations in the current simulated document. ` +
-      `Include more surrounding context to make the match unique.`);
+      `${operation}: oldMarkdown matches multiple locations in the current simulated tab ` +
+      `"${tabId}". Include more surrounding context to make the match unique.`);
   }
 
   return index;
@@ -1219,15 +1322,15 @@ function findUniqueMarkdown(markdown: string, oldMarkdown: string, operation: st
 
 function applyMarkdownReplacement(
   markdown: string,
-  oldMarkdown: string,
-  newMarkdown: string,
-  operation: string,
+  action: GoogleDocReplaceAction,
+  tabId: string,
 ): string {
+  let { oldMarkdown, newMarkdown } = action;
   if (oldMarkdown === newMarkdown) {
     return markdown;
   }
 
-  let index = findUniqueMarkdown(markdown, oldMarkdown, operation);
+  let index = findUniqueMarkdown(markdown, oldMarkdown, "replaceText", tabId);
   return markdown.slice(0, index) + newMarkdown + markdown.slice(index + oldMarkdown.length);
 }
 
@@ -1249,15 +1352,18 @@ function appendMarkdownForSimulation(markdown: string, appendedMarkdown: string)
   return markdown + "\n\n" + normalizedAppend;
 }
 
-function applyGoogleDocActionToMarkdown(markdown: string, action: GoogleDocAction): string {
+function applyGoogleDocActionToMarkdown(
+  markdown: string,
+  action: GoogleDocAction,
+  tabId: string,
+): string {
   if (action.invalidatedReason) {
     throw new Error(action.invalidatedReason);
   }
 
   switch (action.type) {
     case "replaceText":
-      return applyMarkdownReplacement(
-          markdown, action.oldMarkdown, action.newMarkdown, "replaceText");
+      return applyMarkdownReplacement(markdown, action, tabId);
     case "appendText":
       return appendMarkdownForSimulation(markdown, action.markdown);
     default:
@@ -1281,58 +1387,107 @@ function invalidateGoogleDocAction(
   }
 }
 
+/**
+ * The tabs that could hold the write marker of an edit targeting `tabId`.
+ *
+ * A marker lives in the tab its write landed in, so one elsewhere belongs to a different write.
+ * A pre-tab-support edit names no tab, so its marker — and therefore the proof that its write
+ * already committed — could be in any of them.
+ */
+function googleDocActionTabs<T extends { tabId: string }>(
+  tabs: T[],
+  tabId: string | undefined,
+): T[] {
+  return tabId === undefined ? tabs : tabs.filter(tab => tab.tabId === tabId);
+}
+
+/**
+ * The tab an edit targets.
+ *
+ * A record stored before tabs were addressable names none, but the old code refused to read a
+ * document with more than one tab, so such a record was approved against a document that had
+ * exactly one. A document still holding one tab therefore resolves unambiguously; tabs added
+ * since leave the approved target unknowable.
+ *
+ * Exported for coverage: no current write path can produce such a record.
+ */
+export function googleDocActionTab(
+  snapshot: GoogleDocSnapshot,
+  action: GoogleDocAction,
+): GoogleDocTabSnapshot {
+  if (action.tabId === undefined && snapshot.tabs.length !== 1) {
+    throw new Error(
+      "Pending Google Doc edit predates tab support and the document has gained tabs since, " +
+      "so the tab it was approved against is unknown. Reject it and retry on a selected tab.");
+  }
+  return resolveGoogleDocTab(snapshot, action.tabId, action.type);
+}
+
+/**
+ * Replay the pending queue over `snapshot`, invalidating any edit that no longer applies.
+ *
+ * Actions are replayed in global approval order, but each one only touches its own tab, so an
+ * edit to one tab can neither shift nor be shifted by an edit to another.
+ */
 function invalidateUnreplayableGoogleDocActions(
   pendingActions: PendingActionStore<GoogleDocAction>,
-  baseMarkdown: string,
+  snapshot: GoogleDocSnapshot,
   pending: GoogleDocPendingAction[],
   context: string,
-): {markdown: string, pendingActions: GoogleDocAction[]} {
-  let markdown = baseMarkdown;
-  let replayedActions: GoogleDocAction[] = [];
-  for (let i = 0; i < pending.length; i++) {
-    let action = pending[i].action;
-    if (action.invalidatedReason) {
+): Map<string, string> {
+  let markdownByTabId = new Map(snapshot.tabs.map(tab => [tab.tabId, tab.markdown]));
+  for (let record of pending) {
+    if (record.action.invalidatedReason) {
       continue;
     }
 
     try {
-      markdown = applyGoogleDocActionToMarkdown(markdown, action);
+      let { tabId } = googleDocActionTab(snapshot, record.action);
+      markdownByTabId.set(
+          tabId,
+          applyGoogleDocActionToMarkdown(markdownByTabId.get(tabId)!, record.action, tabId));
     } catch (error) {
       invalidateGoogleDocAction(
           pendingActions,
-          pending[i],
+          record,
           `${context}: ${errorMessage(error)} This edit was dropped from the document. ` +
           `Reject it and retry if it is still needed.`);
-      continue;
     }
-    replayedActions.push(action);
   }
 
-  return {markdown, pendingActions: replayedActions};
+  return markdownByTabId;
 }
 
-function materializeGoogleDocAction(snapshot: DocSnapshot, action: GoogleDocAction): any[] {
+/** The batch requests for one edit, together with the tab they are addressed to. */
+function materializeGoogleDocAction(
+  snapshot: GoogleDocSnapshot,
+  action: GoogleDocAction,
+): { tab: GoogleDocTabSnapshot; requests: any[] } {
   if (action.invalidatedReason) {
     throw new Error(action.invalidatedReason);
   }
+  let tab = googleDocActionTab(snapshot, action);
 
   switch (action.type) {
     case "replaceText": {
       let matchStart = findUniqueMarkdown(
-          snapshot.markdown, action.oldMarkdown, "applyAction(replaceText)");
-      let result = computeReplaceOperations(
-          snapshot.sourceMap,
-          snapshot.markdown,
+          tab.markdown, action.oldMarkdown, "applyAction(replaceText)", tab.tabId);
+      let { requests } = computeReplaceOperations(
+          tab.sourceMap,
+          tab.markdown,
           matchStart,
           matchStart + action.oldMarkdown.length,
-          action.newMarkdown);
-      return result.requests;
+          action.newMarkdown,
+          tab.tabId);
+      return { tab, requests };
     }
 
-    case "appendText": {
-      let insertAt = snapshot.bodyEndIndex - 1;
-      return markdownToDocRequests("\n" + action.markdown, insertAt);
-    }
+    case "appendText":
+      return {
+        tab,
+        requests: markdownToDocRequests(
+            "\n" + action.markdown, tab.bodyEndIndex - 1, tab.tabId),
+      };
 
     default:
       action satisfies never;
@@ -1390,8 +1545,9 @@ export class GoogleDocGatekeeperImpl
     let receipt = this.#readDocWriteReceipt();
     if (!receipt) return document;
 
-    let markerExists = googleDocNamedRanges(document).some(
-      ({ id }) => id === receipt.markerId,
+    // The marker ID is exact, but its tab is not recorded, so every tab is searched for it.
+    let markerExists = document.tabs.some(
+      tab => googleDocNamedRanges(tab).some(({ id }) => id === receipt.markerId),
     );
     if (!markerExists) {
       this.#clearDocWriteReceipt(receipt.markerId);
@@ -1452,6 +1608,7 @@ export class GoogleDocGatekeeperImpl
     let pendingActions = new PendingActionStore<GoogleDocAction>(this.ctx.storage.kv);
     return new GoogleDocSessionImpl(
         api,
+        new DriveApi(opts => this.#getAccessToken(opts)),
         this.ctx.props.documentId,
         approvalQueue.dup(),
         pendingActions,
@@ -1475,10 +1632,11 @@ export class GoogleDocGatekeeperImpl
       throw new Error(`Unknown pending Google Doc action: ${actionId}`);
     }
     let action = pending[pendingIndex].action;
+    // Left pending, not removed: the overseer keeps its own record when this throws, so removing
+    // ours would answer the next retry with "unknown action" instead of the reason. Rejecting
+    // clears both.
     if (action.invalidatedReason) {
-      pendingActions.remove(actionId);
-      this.#simulationCache.current = undefined;
-      return;
+      throw new Error(action.invalidatedReason);
     }
 
     let firstPending = pending.find(record => !record.action.invalidatedReason);
@@ -1497,34 +1655,37 @@ export class GoogleDocGatekeeperImpl
     let doc = await api.getDocument(action.documentId);
     doc = await this.#reconcileDocWriteReceipt(api, doc);
     let snapshot = googleDocSnapshot(doc);
-    let markerIds = googleDocNamedRangeIds(doc, writeMarkerName);
+    let markerIds = [...new Set(googleDocActionTabs(doc.tabs, action.tabId)
+        .flatMap(tab => googleDocNamedRangeIds(tab, writeMarkerName)))];
     if (markerIds.length > 1) {
       throw new Error(`Google Docs returned multiple write markers for action ${actionId}`);
     }
     let [writeMarkerId] = markerIds;
     if (!writeMarkerId) {
-      let requests: any[];
+      let materialized: { tab: GoogleDocTabSnapshot; requests: any[] };
       try {
-        requests = materializeGoogleDocAction(snapshot, action);
+        materialized = materializeGoogleDocAction(snapshot, action);
       } catch (error) {
-        logger.error("dropping stale Google Doc action during apply", {
-          event: "google.doc.action.apply.stale.dropped",
+        // Invalidated, not removed: later edits stop waiting behind it, and approving it again
+        // repeats the reason rather than reporting success for a write that never happened.
+        logger.error("Google Doc action cannot be applied", {
+          event: "google.doc.action.apply.unapplyable",
           actionId, error,
         });
-        pendingActions.remove(actionId);
+        invalidateGoogleDocAction(
+            pendingActions,
+            pending[pendingIndex],
+            `Pending Google Doc edit could not be applied: ${errorMessage(error)}`);
         this.#simulationCache.current = undefined;
         await this.ctx.storage.put(DOC_SNAPSHOT_KEY, snapshot);
-        invalidateUnreplayableGoogleDocActions(
-            pendingActions,
-            snapshot.markdown,
-            pending.slice(pendingIndex + 1),
-            `Pending Google Doc edits could not be replayed after edit ${actionId} was dropped`);
-        return;
+        throw error;
       }
+      let { tab, requests } = materialized;
       if (requests.length > 0) {
         let result = await api.batchUpdate(action.documentId, requests, snapshot.revisionId, {
           name: writeMarkerName,
-          rangeStart: snapshot.bodyEndIndex - 1,
+          rangeStart: tab.bodyEndIndex - 1,
+          tabId: tab.tabId,
         });
         if (!result.writeMarkerId) {
           throw new Error(`Google Docs did not return a write marker for action ${actionId}`);
@@ -1555,7 +1716,7 @@ export class GoogleDocGatekeeperImpl
       await this.ctx.storage.put(DOC_SNAPSHOT_KEY, refreshedSnapshot);
       invalidateUnreplayableGoogleDocActions(
           pendingActions,
-          refreshedSnapshot.markdown,
+          refreshedSnapshot,
           pending.slice(pendingIndex + 1),
           `Pending Google Doc edits could not be replayed after edit ${actionId} was applied`);
     } catch (error) {
@@ -1612,6 +1773,7 @@ export class GoogleDocGatekeeperImpl
 @validateRpc()
 class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
   #docsApi: GoogleDocsApi;
+  #driveApi: DriveApi;
   #documentId: string;
   #approvalQueue: RpcStub<ApprovalQueue>;
   #pendingActions: PendingActionStore<GoogleDocAction>;
@@ -1620,6 +1782,7 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
 
   constructor(
     docsApi: GoogleDocsApi,
+    driveApi: DriveApi,
     documentId: string,
     approvalQueue: RpcStub<ApprovalQueue>,
     pendingActions: PendingActionStore<GoogleDocAction>,
@@ -1628,6 +1791,7 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
   ) {
     super();
     this.#docsApi = docsApi;
+    this.#driveApi = driveApi;
     this.#documentId = documentId;
     this.#approvalQueue = approvalQueue;
     this.#pendingActions = pendingActions;
@@ -1635,21 +1799,17 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
     this.#simulationCache = simulationCache;
   }
 
-  async #getSnapshot(forceRefresh?: boolean): Promise<DocSnapshot> {
-    if (!forceRefresh) {
-      let cached = await this.#storage.get<DocSnapshot>(DOC_SNAPSHOT_KEY);
-      if (cached) {
-        let age = Date.now() - cached.fetchedAt;
-        if (age < 10_000) {
-          return cached;
-        }
-        // TTL expired — check if document has changed.
-        let currentRevisionId = await this.#docsApi.getRevisionId(this.#documentId);
-        if (currentRevisionId === cached.revisionId) {
-          cached.fetchedAt = Date.now();
-          await this.#storage.put(DOC_SNAPSHOT_KEY, cached);
-          return cached;
-        }
+  async #getSnapshot(): Promise<GoogleDocSnapshot> {
+    // A snapshot written before tabs existed has no tab list and is simply replaced.
+    let cached = await this.#storage.get<unknown>(DOC_SNAPSHOT_KEY);
+    if (isGoogleDocSnapshot(cached)) {
+      if (Date.now() - cached.fetchedAt < DOC_SNAPSHOT_TTL_MS) {
+        return cached;
+      }
+      if (await googleDocRevisionUnchanged(this.#docsApi, this.#documentId, cached)) {
+        cached.fetchedAt = Date.now();
+        await this.#storage.put(DOC_SNAPSHOT_KEY, cached);
+        return cached;
       }
     }
 
@@ -1660,44 +1820,52 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
     return snapshot;
   }
 
-  async #getSimulatedContent(): Promise<{
-    snapshot: DocSnapshot,
+  /**
+   * The selected tab's content with every pending edit replayed over it.
+   *
+   * The selector is resolved before anything is replayed or cached, so naming a tab that does not
+   * exist cannot disturb the pending queue.
+   */
+  async #getSimulatedContent(
+    tabId: string | undefined,
+    operation: "getContent" | "replaceText" | "appendText",
+  ): Promise<{
+    snapshot: GoogleDocSnapshot,
+    tab: GoogleDocTabSnapshot,
     markdown: string,
-    pendingActions: GoogleDocAction[],
   }> {
     let snapshot = await this.#getSnapshot();
+    let tab = resolveGoogleDocTab(snapshot, tabId, operation);
     let pending = this.#pendingActions.list();
     let pendingFingerprint = googleDocPendingFingerprint(pending);
     let cached = this.#simulationCache.current;
-    if (cached && cached.baseRevisionId === snapshot.revisionId &&
+    // An unknown revision cannot be shown to match, so the replay is recomputed.
+    if (cached && cached.baseRevisionId !== undefined &&
+        cached.baseRevisionId === snapshot.revisionId &&
         cached.pendingFingerprint === pendingFingerprint) {
-      return {
-        snapshot,
-        markdown: cached.markdown,
-        pendingActions: cached.pendingActions,
-      };
+      return {snapshot, tab, markdown: cached.markdownByTabId.get(tab.tabId) ?? tab.markdown};
     }
 
-    // An edit whose marker is already in the document committed even though its response never
+    // An edit whose marker is already in its tab committed even though its response never
     // arrived, so this snapshot contains it. Replaying it would show that content twice; the
     // action stays pending, and applyAction() settles it from the same marker.
-    let committed = new Set(snapshot.committedWriteIds);
-    let replayable = pending.filter(
-        ({action}) => action.writeId === undefined || !committed.has(action.writeId));
+    let replayable = pending.filter(({action}) => {
+      let {writeId} = action;
+      return writeId === undefined || !googleDocActionTabs(snapshot.tabs, action.tabId)
+          .some(tab => tab.committedWriteIds.includes(writeId));
+    });
 
-    let {markdown, pendingActions} = invalidateUnreplayableGoogleDocActions(
+    let markdownByTabId = invalidateUnreplayableGoogleDocActions(
         this.#pendingActions,
-        snapshot.markdown,
+        snapshot,
         replayable,
         "Pending Google Doc edit could not be replayed against the current document");
     this.#simulationCache.current = {
       baseRevisionId: snapshot.revisionId,
       pendingFingerprint: googleDocPendingFingerprint(this.#pendingActions.list()),
-      markdown,
-      pendingActions,
-      computedAt: Date.now(),
+      markdownByTabId,
     };
-    return {snapshot, markdown, pendingActions};
+    return {snapshot, tab, markdown: markdownByTabId.get(tab.tabId) ?? tab.markdown};
   }
 
   /**
@@ -1705,12 +1873,15 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
    *
    * Google Docs exposes no modification time, so the moment this binding first saw the current
    * revision stands in for it and is reused for as long as that revision holds — reading a
-   * document must not make it look freshly edited. Pending edits still move it forward, since
+   * document must not make it look freshly edited. Without edit access there is no revision to
+   * date, and Drive's own timestamp is used instead. Pending edits still move it forward, since
    * `getContent()` already shows them.
    */
   async getMetadata(): Promise<DocMetadata> {
     let metadata = await this.#docsApi.getDocumentMetadata(this.#documentId);
-    let revisedAt = this.#observeDocRevision(metadata.revisionId);
+    let revisedAt = metadata.revisionId === undefined
+        ? await this.#modifiedWithoutRevision()
+        : this.#observeDocRevision(metadata.revisionId);
     let pendingActions = this.#pendingActions.list()
         .map(({action}) => action)
         .filter(action => !action.invalidatedReason);
@@ -1729,16 +1900,43 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
   }
 
   /**
+   * The modification time of a document Google reports no revision for.
+   *
+   * Without edit access there is no revision to date, so Drive is asked instead. An account
+   * connected before per-resource grants may not hold the picker's metadata scope, leaving no
+   * signal at all; the first observation then stands rather than every read looking like an edit.
+   */
+  async #modifiedWithoutRevision(): Promise<number> {
+    try {
+      return driveModifiedTime(await this.#driveApi.getFile(this.#documentId)).valueOf();
+    } catch (error) {
+      // Only a refused grant means no signal will ever arrive. A quota 403 (also 403), an outage
+      // or a malformed body are transient or fixable, and dating the document from one would
+      // report a changed document as unchanged for as long as Drive stays unhealthy.
+      let refusedGrant = error instanceof DriveApiRequestError && error.status === 403 &&
+          !error.isQuotaExceeded;
+      if (!refusedGrant) throw error;
+      logger.warn("no Drive grant to date a Google Doc that has no revision", {
+        event: "google.doc.metadata.drive.ungranted", error,
+      });
+      return this.#observeDocRevision(undefined);
+    }
+  }
+
+  /**
    * When this binding first saw `revisionId`, recording it if the revision is new.
    *
    * An unreadable record is re-observed rather than rejected: it only dates a revision, so the
-   * worst a lost record costs is one timestamp that moves when the document did not.
+   * worst a lost record costs is one timestamp that moves when the document did not. Two absent
+   * revisions count as the same: a document that offers no change token must not look edited by
+   * every read, which is the opposite of what a cache needs from the same comparison.
    */
-  #observeDocRevision(revisionId: string): number {
+  #observeDocRevision(revisionId?: string): number {
     let stored = this.#storage.kv.get<unknown>(DOC_METADATA_REVISION_KEY);
     if (stored && typeof stored === "object") {
       let { revisionId: seen, observedAt } = stored as Partial<GoogleDocMetadataRevision>;
-      if (seen === revisionId && typeof observedAt === "number" && Number.isFinite(observedAt)) {
+      if (seen === revisionId &&
+          typeof observedAt === "number" && Number.isFinite(observedAt)) {
         return observedAt;
       }
     }
@@ -1748,28 +1946,61 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
     return observedAt;
   }
 
-  async getContent(): Promise<string> {
-    let {markdown} = await this.#getSimulatedContent();
+  async listTabs(): Promise<GoogleDocTab[]> {
+    let snapshot = await this.#getSnapshot();
+
+    await this.#approvalQueue.authorizeObservation({
+      title: "List Google Doc tabs",
+      description: "Read the document's tab names and hierarchy.",
+    });
+
+    return snapshot.tabs.map(googleDocTabMetadata);
+  }
+
+  async getContent(tabId?: string): Promise<string> {
+    let selected;
+    try {
+      selected = await this.#getSimulatedContent(tabId, "getContent");
+    } catch (error) {
+      // The error says whether that tab exists, so the attempt discloses something too.
+      await this.#approvalQueue.authorizeObservation({
+        title: "Read Google Doc content",
+        description: "Read the content of one tab of the document.",
+      });
+      throw error;
+    }
 
     await this.#approvalQueue.authorizeObservation({
       title: "Read Google Doc content",
-      description: "Read the full simulated content of the document as Markdown.",
+      description:
+        `Read the full simulated content of tab ${googleDocTabLabel(selected.tab)} as Markdown.`,
     });
-
-    return markdown;
+    return selected.markdown;
   }
 
-  async replaceText(oldMarkdown: string, newMarkdown: string): Promise<void> {
+  async replaceText(oldMarkdown: string, newMarkdown: string, tabId?: string): Promise<void> {
     if (oldMarkdown === newMarkdown) {
       return;
     }
 
-    let {snapshot, markdown} = await this.#getSimulatedContent();
-    findUniqueMarkdown(markdown, oldMarkdown, "replaceText");
+    let selected;
+    try {
+      selected = await this.#getSimulatedContent(tabId, "replaceText");
+      findUniqueMarkdown(selected.markdown, oldMarkdown, "replaceText", selected.tab.tabId);
+    } catch (error) {
+      // The error says whether that tab, or that text, exists.
+      await this.#approvalQueue.authorizeObservation({
+        title: "Read Google Doc content",
+        description: "Read the content of one tab of the document.",
+      });
+      throw error;
+    }
+    let {snapshot, tab} = selected;
 
     let action: GoogleDocAction = {
       type: "replaceText",
       documentId: this.#documentId,
+      tabId: tab.tabId,
       submittedAt: Date.now(),
       baseRevisionId: snapshot.revisionId,
       writeId: crypto.randomUUID(),
@@ -1786,7 +2017,7 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
       await this.#approvalQueue.submitAction(actionId, {
         title: "Edit Google Doc",
         description:
-          `Replace text in the document.\n\n` +
+          `Replace text in tab ${googleDocTabLabel(tab)}.\n\n` +
           `**Old:** ${oldPreview}\n\n` +
           `**New:** ${newPreview}`,
         implementsRevert: false,
@@ -1801,12 +2032,24 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
     }
   }
 
-  async appendText(markdown: string): Promise<void> {
-    let {snapshot} = await this.#getSimulatedContent();
+  async appendText(markdown: string, tabId?: string): Promise<void> {
+    let selected;
+    try {
+      selected = await this.#getSimulatedContent(tabId, "appendText");
+    } catch (error) {
+      // The error says whether that tab exists, so the attempt discloses something too.
+      await this.#approvalQueue.authorizeObservation({
+        title: "Read Google Doc content",
+        description: "Read the content of one tab of the document.",
+      });
+      throw error;
+    }
+    let {snapshot, tab} = selected;
 
     let action: GoogleDocAction = {
       type: "appendText",
       documentId: this.#documentId,
+      tabId: tab.tabId,
       submittedAt: Date.now(),
       baseRevisionId: snapshot.revisionId,
       writeId: crypto.randomUUID(),
@@ -1820,7 +2063,7 @@ class GoogleDocSessionImpl extends RpcTarget implements GoogleDocSession {
     try {
       await this.#approvalQueue.submitAction(actionId, {
         title: "Append to Google Doc",
-        description: `Append content to the end of the document:\n\n${preview}`,
+        description: `Append content to the end of tab ${googleDocTabLabel(tab)}:\n\n${preview}`,
         implementsRevert: false,
         // Same "editDocument" tag as replaceText
         actionKind: EDIT_DOCUMENT_ACTION,
@@ -2606,6 +2849,8 @@ class GoogleDocReadSessionImpl extends RpcTarget implements GoogleDocReadSession
   #driveApi: DriveApi;
   #documentId: string;
   #approvalQueue: RpcStub<ApprovalQueue>;
+  /** The most recent snapshot request. Chaining onto it serializes concurrent reads. */
+  #snapshot?: Promise<GoogleDocSnapshot>;
 
   constructor(
     docsApi: GoogleDocsApi,
@@ -2626,10 +2871,7 @@ class GoogleDocReadSessionImpl extends RpcTarget implements GoogleDocReadSession
 
   async getMetadata(): Promise<DocMetadata> {
     let file = await this.#driveApi.getFile(this.#documentId);
-    let lastModified = new Date(file.modifiedTime ?? "");
-    if (Number.isNaN(lastModified.valueOf())) {
-      throw new Error("Google Drive returned an invalid modifiedTime");
-    }
+    let lastModified = driveModifiedTime(file);
     await this.#approvalQueue.authorizeObservation({
       title: "Read Google Doc metadata",
       description: "Read the current title and modification time of the Drive document.",
@@ -2637,13 +2879,53 @@ class GoogleDocReadSessionImpl extends RpcTarget implements GoogleDocReadSession
     return { title: file.name, lastModified };
   }
 
-  async getContent(): Promise<string> {
-    let snapshot = docToMarkdown(await this.#docsApi.getDocument(this.#documentId));
+  // Each call chains onto the previous request, so concurrent reads share one fetch instead of
+  // racing to overwrite each other with whichever response lands last.
+  #getSnapshot(): Promise<GoogleDocSnapshot> {
+    return this.#snapshot = this.#nextSnapshot(this.#snapshot);
+  }
+
+  /** Reuse one revision for the TTL, then confirm it is still current before reusing it again. */
+  async #nextSnapshot(pending?: Promise<GoogleDocSnapshot>): Promise<GoogleDocSnapshot> {
+    let cached = await pending?.catch(() => undefined);
+    if (cached) {
+      if (Date.now() - cached.fetchedAt < DOC_SNAPSHOT_TTL_MS) return cached;
+      if (await googleDocRevisionUnchanged(this.#docsApi, this.#documentId, cached)) {
+        cached.fetchedAt = Date.now();
+        return cached;
+      }
+    }
+    return googleDocSnapshot(await this.#docsApi.getDocument(this.#documentId));
+  }
+
+  async listTabs(): Promise<GoogleDocTab[]> {
+    let snapshot = await this.#getSnapshot();
+    await this.#approvalQueue.authorizeObservation({
+      title: "List Google Doc tabs",
+      description: "Read the document's tab names and hierarchy.",
+    });
+    return snapshot.tabs.map(googleDocTabMetadata);
+  }
+
+  async getContent(tabId?: string): Promise<string> {
+    let snapshot = await this.#getSnapshot();
+    let tab: GoogleDocTabSnapshot;
+    try {
+      tab = resolveGoogleDocTab(snapshot, tabId, "getContent");
+    } catch (error) {
+      // The selector error says whether a tab exists, so the attempt discloses something too.
+      await this.#approvalQueue.authorizeObservation({
+        title: "Read Google Doc content",
+        description: "Read the content of one tab of the document.",
+      });
+      throw error;
+    }
+
     await this.#approvalQueue.authorizeObservation({
       title: "Read Google Doc content",
-      description: "Read the current document body as Markdown.",
+      description: `Read the current content of tab ${googleDocTabLabel(tab)} as Markdown.`,
     });
-    return snapshot.markdown;
+    return tab.markdown;
   }
 }
 

--- a/packages/gatekeeper-google/src/markdown-converter.ts
+++ b/packages/gatekeeper-google/src/markdown-converter.ts
@@ -2,32 +2,34 @@
 // with source mapping to allow Markdown-level edits to be translated back
 // to Google Docs batchUpdate operations.
 
-import type { GoogleDocsDocument, Paragraph } from "./docs-api";
+import type { GoogleDocsTab, Paragraph } from "./docs-api";
 
 // ---------------------------------------------------------------------------
 // Source map types
 // ---------------------------------------------------------------------------
 
-/** A complete snapshot of a document, cached in the gatekeeper's DO storage. */
-export type DocSnapshot = {
-  /** Document title. */
+/**
+ * The Markdown rendering of one document tab, with the map back to that tab's indices.
+ *
+ * Every tab body has its own index space, so a snapshot is only ever valid for the tab it was
+ * built from — Markdown, source map and end index all restart per tab.
+ */
+export type DocTabSnapshot = {
+  /** The tab this rendering came from; every write derived from it must carry this ID. */
+  tabId: string;
+  /** Tab name, as shown in the Docs tab list. */
   title: string;
-  /** The revisionId at the time the document was fetched. */
-  revisionId: string;
-  /** The Markdown rendering of the document content. */
+  /** The containing tab, absent for a top-level tab. */
+  parentTabId?: string;
+  /** Position among the tabs sharing this parent. */
+  index: number;
+  /** Depth in the tab tree; 0 for a top-level tab. */
+  nestingLevel: number;
+  /** The Markdown rendering of this tab's content. */
   markdown: string;
-  /** Maps Markdown positions back to Google Docs character indices. */
+  /** Maps Markdown positions back to this tab's Google Docs character indices. */
   sourceMap: SourceMap;
-  /** `Date.now()` at the time of fetch, used for TTL checks. */
-  fetchedAt: number;
-  /**
-   * Write IDs whose marked batch is already present in this snapshot's document.
-   *
-   * Filled in by the gatekeeper, which owns the write-marker convention; absent on snapshots
-   * persisted before it existed, which self-correct on the next fetch.
-   */
-  committedWriteIds?: string[];
-  /** The endIndex of the last structural element in the document body. */
+  /** The endIndex of the last structural element in this tab's body. */
   bodyEndIndex: number;
 }
 
@@ -61,13 +63,13 @@ export type Segment =
 // Google Docs → Markdown
 // ---------------------------------------------------------------------------
 
-/** Convert a Google Docs document to Markdown with source map. */
-export function docToMarkdown(document: GoogleDocsDocument): DocSnapshot {
+/** Convert one document tab to Markdown with a source map into that tab's index space. */
+export function docTabToMarkdown(tab: GoogleDocsTab): DocTabSnapshot {
   let md = "";
   let blocks: BlockMapping[] = [];
   let lastWasListItem = false;
 
-  let elements = document.body.content;
+  let elements = tab.body.content;
   let bodyEndIndex = elements.length > 0 ? elements[elements.length - 1].endIndex : 0;
 
   for (let elem of elements) {
@@ -89,7 +91,7 @@ export function docToMarkdown(document: GoogleDocsDocument): DocSnapshot {
 
     if (para.bullet) {
       nestingLevel = para.bullet.nestingLevel;
-      let list = document.lists[para.bullet.listId];
+      let list = tab.lists[para.bullet.listId];
       if (list) {
         let level = list.listProperties.nestingLevels[nestingLevel];
         if (level) {
@@ -137,11 +139,13 @@ export function docToMarkdown(document: GoogleDocsDocument): DocSnapshot {
   }
 
   return {
-    title: document.title,
-    revisionId: document.revisionId,
+    tabId: tab.tabId,
+    title: tab.title,
+    ...tab.parentTabId === undefined ? {} : { parentTabId: tab.parentTabId },
+    index: tab.index,
+    nestingLevel: tab.nestingLevel,
     markdown: md,
     sourceMap: { blocks },
-    fetchedAt: Date.now(),
     bodyEndIndex,
   };
 }
@@ -562,12 +566,19 @@ function parseInlineFormatting(text: string): { plainText: string; spans: Format
 }
 
 /**
- * Convert a Markdown string into Google Docs batchUpdate request objects
- * that insert the content at the given document index.
+ * Convert a Markdown string into Google Docs batchUpdate request objects that insert the content
+ * at the given index inside tab `tabId`.
+ *
+ * Every emitted coordinate names that tab: tab bodies have independent index spaces, so an
+ * unqualified index lands in whichever tab Google picks.
  *
  * Returns requests in the order they should appear in the batchUpdate array.
  */
-export function markdownToDocRequests(markdown: string, insertAt: number): any[] {
+export function markdownToDocRequests(
+  markdown: string,
+  insertAt: number,
+  tabId: string,
+): any[] {
   let blocks = parseMarkdown(markdown);
   if (blocks.length === 0) return [];
 
@@ -580,14 +591,14 @@ export function markdownToDocRequests(markdown: string, insertAt: number): any[]
   if (fullText.length === 0) {
     // `parseMarkdown()` treats whitespace-only input as blank Markdown blocks, but replacements
     // can legitimately insert whitespace inside existing text, e.g. splitting a word in two.
-    return [{ insertText: { location: { index: insertAt }, text: markdown } }];
+    return [{ insertText: { location: { index: insertAt, tabId }, text: markdown } }];
   }
 
   // Insert the full text in one go. This is more efficient and avoids
   // index-shifting complexity from multiple insertions.
   requests.push({
     insertText: {
-      location: { index: insertAt },
+      location: { index: insertAt, tabId },
       text: fullText,
     },
   });
@@ -603,7 +614,7 @@ export function markdownToDocRequests(markdown: string, insertAt: number): any[]
       let styleType = `HEADING_${block.headingLevel}`;
       requests.push({
         updateParagraphStyle: {
-          range: { startIndex: blockStart, endIndex: blockEnd + 1 },
+          range: { startIndex: blockStart, endIndex: blockEnd + 1, tabId },
           paragraphStyle: { namedStyleType: styleType },
           fields: "namedStyleType",
         },
@@ -617,7 +628,7 @@ export function markdownToDocRequests(markdown: string, insertAt: number): any[]
         : "BULLET_DISC_CIRCLE_SQUARE";
       requests.push({
         createParagraphBullets: {
-          range: { startIndex: blockStart, endIndex: blockEnd + 1 },
+          range: { startIndex: blockStart, endIndex: blockEnd + 1, tabId },
           bulletPreset: preset,
         },
       });
@@ -637,7 +648,7 @@ export function markdownToDocRequests(markdown: string, insertAt: number): any[]
         if (span.strikethrough) { textStyle.strikethrough = true; fields.push("strikethrough"); }
         requests.push({
           updateTextStyle: {
-            range: { startIndex: spanStart, endIndex: spanEnd },
+            range: { startIndex: spanStart, endIndex: spanEnd, tabId },
             textStyle,
             fields: fields.join(","),
           },
@@ -647,7 +658,7 @@ export function markdownToDocRequests(markdown: string, insertAt: number): any[]
       if (span.link) {
         requests.push({
           updateTextStyle: {
-            range: { startIndex: spanStart, endIndex: spanEnd },
+            range: { startIndex: spanStart, endIndex: spanEnd, tabId },
             textStyle: { link: { url: span.link } },
             fields: "link",
           },
@@ -667,8 +678,8 @@ export function markdownToDocRequests(markdown: string, insertAt: number): any[]
 // ---------------------------------------------------------------------------
 
 /**
- * Given a match range in the Markdown snapshot, compute the batchUpdate
- * operations to replace that range with new Markdown content.
+ * Given a match range in one tab's Markdown snapshot, compute the batchUpdate operations to
+ * replace that range with new Markdown content inside tab `tabId`.
  *
  * Automatically trims unchanged leading/trailing text to minimize the edit.
  */
@@ -678,6 +689,7 @@ export function computeReplaceOperations(
   matchStart: number,
   matchEnd: number,
   newMarkdown: string,
+  tabId: string,
 ): { requests: any[]; trimmedOld: string; trimmedNew: string } {
   let oldText = markdown.slice(matchStart, matchEnd);
 
@@ -721,14 +733,14 @@ export function computeReplaceOperations(
   if (docRange.start < docRange.end) {
     requests.push({
       deleteContentRange: {
-        range: { startIndex: docRange.start, endIndex: docRange.end },
+        range: { startIndex: docRange.start, endIndex: docRange.end, tabId },
       },
     });
   }
 
   // Insert the new content (if any).
   if (trimmedNew.length > 0) {
-    let insertRequests = markdownToDocRequests(trimmedNew, docRange.start);
+    let insertRequests = markdownToDocRequests(trimmedNew, docRange.start, tabId);
     requests.push(...insertRequests);
   }
 

--- a/packages/gatekeeper-google/src/type-bundle.ts
+++ b/packages/gatekeeper-google/src/type-bundle.ts
@@ -1,7 +1,7 @@
 /** Module-only prefix of the Google Docs declaration. */
 export const DOCS_TYPES_MODULE_PREFIX =
   'import type { GoogleDocReadSession } from "./docs-read-types";\n' +
-  'export type { DocMetadata, GoogleDocReadSession } from "./docs-read-types";\n\n';
+  'export type { DocMetadata, GoogleDocReadSession, GoogleDocTab } from "./docs-read-types";\n\n';
 
 /** Module-only prefix of the Google Drive declaration. */
 export const DRIVE_TYPES_MODULE_PREFIX =


### PR DESCRIPTION
Updates the Docs session to support tabbed Docs. What's a tab in a doc, you ask? 

<img width="895" height="503" alt="image" src="https://github.com/user-attachments/assets/f0b02d10-d033-4140-bd43-bad8de950a62" />
These things

One document can hold a tree of tabs, each with its own body and its own character indices. We were asking Google for all of it and then erroring out if there was more than one tab, which blocked the whole document, including read-only Docs opened through Drive.

Now `listTabs()` returns that tree flattened depth-first, and `getContent()`, `replaceText()` and `appendText()` each take an optional `tabId`. Every operation reads or edits exactly one tab; we never merge them. You can leave `tabId` off only when the doc has exactly one tab, and an ID we don't recognize errors instead of quietly falling back to the first tab. Since each tab has its own index space, every write coordinate we send now carries the tab ID.

This avoids being a breaking api change while also not introducing weird markers in the markdown.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->