### PR TITLE
fix: preserve custom resource URL schemes

### DIFF
--- a/packages/workshop-frontend/src/resourceMatching.test.ts
+++ b/packages/workshop-frontend/src/resourceMatching.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeResourceUrl } from './resourceMatching'
+
+describe('resource URL normalization', () => {
+  it('preserves custom schemes while supplying HTTPS for bare hosts', () => {
+    expect(normalizeResourceUrl('gitlab://inspekter-estate/*')).toBe('gitlab://inspekter-estate')
+    expect(normalizeResourceUrl('inspekter-estate/*')).toBe('https://inspekter-estate')
+  })
+})

--- a/packages/workshop-frontend/src/resourceMatching.ts
+++ b/packages/workshop-frontend/src/resourceMatching.ts
@@ -208,13 +208,13 @@ export function matchesResource(search: string, resource: SupportedResource): bo
 }
 
 /**
- * Normalize a resource URL for sending to the backend. Prepends https:// if no protocol
+ * Normalize a resource URL for sending to the backend. Prepends https:// if no scheme
  * is present, and strips a trailing /* wildcard (which is just "everything under here").
  */
 export function normalizeResourceUrl(url: string): string {
   let normalized = url.trim()
-  // Default to https:// if no protocol specified.
-  if (normalized && !/^https?:\/\//i.test(normalized)) {
+  // Default to https:// if no scheme specified.
+  if (normalized && !/^[a-z][a-z0-9+.-]*:\/\//i.test(normalized)) {
     normalized = 'https://' + normalized
   }
   // Strip trailing /* wildcard — it's not meaningful for the backend.


### PR DESCRIPTION
## What does this change?

`normalizeResourceUrl()` now preserves resource URLs with a custom `scheme://` prefix instead of prepending `https://`. Bare resource hosts still receive the existing HTTPS default, and trailing `/*` is still removed.

Fixes #390

## Why is this obviously correct and trivially verifiable?

The one shared normalizer now recognizes the URL scheme form already used by custom resource patterns. Its existing default only applies when that prefix is absent. The focused test covers both the reported `gitlab://` path and the bare-host default.

## Checklist

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->