### PR TITLE
Fix Outputs sidebar not stretching to full height

### DIFF
--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -1921,7 +1921,7 @@ export default function GadgetEditor() {
         </div>
 
         {showOutputRail && (
-          <div className="max-md:hidden">
+          <div className="flex flex-shrink-0 max-md:hidden">
             <WorkpiecePicker
               gadgets={allGadgets}
               selectedId={null}


### PR DESCRIPTION
Fixes small bug where outputs sidebar wouldn't take up full height
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->