### PR TITLE
Fix Cloudflare OAuth token handling

### DIFF
--- a/packages/gatekeeper-cloudflare/README.md
+++ b/packages/gatekeeper-cloudflare/README.md
@@ -113,7 +113,10 @@ a visible truncation for an invisible one.
 You need a Cloudflare dashboard OAuth client (client id + secret). The dashboard OAuth endpoints and
 scopes are hardcoded in `src/oauth.ts`, so you only configure the client id/secret and register the
 redirect URI. Ensure the client's scope allowlist includes `workers-observability.read` when this
-deployment offers Workers Observability resources.
+deployment offers Workers Observability resources. Enable both the `authorization_code` and
+`refresh_token` grant types, and allow `offline_access`; persistent billing and observability
+connections fail closed if Cloudflare does not issue a refresh token. Select `client_secret_basic`
+as the token endpoint authentication method, matching the gatekeeper's token requests.
 
 ### Step 1: Register the redirect URI
 
@@ -186,3 +189,10 @@ trailing slash, `http` not `https` for localhost.
 
 `CLIENT_ID` / `CLIENT_SECRET` are missing. Ensure they're set (per-package `.env` or seeded from the
 root `.dev.vars`), then restart the dev server.
+
+### "no refresh token for a persistent connection"
+
+The OAuth client does not allow refresh tokens. Enable the `refresh_token` grant type and
+`offline_access` scope in the Cloudflare OAuth client configuration. Auth-only flows intentionally
+use only their short-lived access token, but billing and observability connections must remain
+refreshable.

--- a/packages/gatekeeper-cloudflare/__tests__/oauth.test.ts
+++ b/packages/gatekeeper-cloudflare/__tests__/oauth.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  AUTH_SCOPES,
+  BILLING_SCOPES,
   buildAuthorizeUrl,
   exchangeCode,
   generatePkce,
+  refreshTokenForConnection,
   refreshTokens,
   type CloudflareOAuthConfig,
 } from "../src/oauth";
@@ -28,6 +31,30 @@ function captureRedeem(payload: Record<string, unknown>) {
 }
 
 describe("Cloudflare OAuth", () => {
+  it("requests offline access only for persistent connections", () => {
+    expect(AUTH_SCOPES).toEqual(["user-details.read"]);
+    expect(BILLING_SCOPES).toContain("offline_access");
+  });
+
+  it("allows a transient sign-in grant to omit a refresh token", () => {
+    const tokens = { accessToken: "access", expiresIn: 3600 };
+
+    expect(refreshTokenForConnection(tokens, true)).toBeUndefined();
+  });
+
+  it("requires a refresh token for persistent connections", () => {
+    const tokens = { accessToken: "access", expiresIn: 3600 };
+
+    expect(() => refreshTokenForConnection(tokens, false))
+      .toThrow(/OAuth client allows the refresh_token grant and offline_access scope/);
+  });
+
+  it("returns a refresh token when the provider supplies one", () => {
+    const tokens = { accessToken: "access", refreshToken: "refresh", expiresIn: 3600 };
+
+    expect(refreshTokenForConnection(tokens, false)).toBe("refresh");
+  });
+
   it("returns the scopes granted by the token endpoint", async () => {
     captureRedeem({
       access_token: "access",
@@ -43,7 +70,7 @@ describe("Cloudflare OAuth", () => {
 
   it("reports no granted scopes when the provider omits them", async () => {
     // The caller must be able to tell "granted nothing extra" from "granted everything": this is what
-    // `handleOAuthCallback` keys its fail-closed scope record on.
+    // `acceptAuthCode` keys its fail-closed scope record on.
     captureRedeem({ access_token: "access", expires_in: 3600 });
 
     const tokens = await exchangeCode(config, "code", "verifier");

--- a/packages/gatekeeper-cloudflare/src/cloudflare.ts
+++ b/packages/gatekeeper-cloudflare/src/cloudflare.ts
@@ -9,7 +9,7 @@ import {
 import { CloudflareGatekeeperUser } from "@gadgets/workshop-shared/cloudflare-gatekeeper";
 import {
   getOAuthConfig, buildAuthorizeUrl, generatePkce, exchangeCode, refreshTokens,
-  AUTH_SCOPES, BILLING_SCOPES, persistentScopesForResources,
+  AUTH_SCOPES, BILLING_SCOPES, persistentScopesForResources, refreshTokenForConnection,
 } from "./oauth";
 import { fetchIdentity } from "./cloudflare-api";
 import {
@@ -233,6 +233,7 @@ export class UserAccount extends DurableObject<Env> {
 
   async prepareReconnect(initiationNonce: string, scopes: string[]) {
     this.ctx.storage.kv.put<boolean>("reconnecting", true);
+    this.ctx.storage.kv.put<boolean>("ephemeral", false);
     this.ctx.storage.kv.put<string[]>("scopes", scopes);
     this.ctx.storage.kv.put<StoredNonce>("nonce", {
       value: initiationNonce,
@@ -284,11 +285,11 @@ export class UserAccount extends DurableObject<Env> {
     }
 
     const tokens = await exchangeCode(this.#config(), code, stored.verifier);
-    if (!tokens || !tokens.refreshToken) {
-      throw new Error("Cloudflare OAuth exchange failed or returned no refresh token.");
-    }
+    if (!tokens) throw new Error("Cloudflare OAuth token exchange failed.");
 
-    this.ctx.storage.kv.put<string>("refreshToken", tokens.refreshToken);
+    const ephemeral = this.ctx.storage.kv.get<boolean>("ephemeral") ?? false;
+    const refreshToken = refreshTokenForConnection(tokens, ephemeral);
+    if (refreshToken) this.ctx.storage.kv.put<string>("refreshToken", refreshToken);
     this.ctx.storage.kv.put<StoredAccessToken>("accessToken", {
       token: tokens.accessToken,
       expires: Date.now() + tokens.expiresIn * 1000,
@@ -315,7 +316,7 @@ export class UserAccount extends DurableObject<Env> {
       // Auth-only sign-in grants are transient: the caller read the email via complete(), so
       // schedule a prompt self-destruct. We do NOT call a provider revoke endpoint; we just drop
       // our local copy.
-      if (this.ctx.storage.kv.get<boolean>("ephemeral")) {
+      if (ephemeral) {
         this.ctx.storage.setAlarm(Date.now() + 2 * 60 * 1000);
       }
     }
@@ -331,13 +332,13 @@ export class UserAccount extends DurableObject<Env> {
    * can no longer be refreshed (in which case the workshop is notified via credentialsExpired()).
    */
   async getAccessToken(): Promise<string | null> {
-    const refreshToken = this.ctx.storage.kv.get<string>("refreshToken");
-    if (!refreshToken) return null;
-
     const cached = this.ctx.storage.kv.get<StoredAccessToken>("accessToken");
     if (cached && cached.expires > Date.now() + ACCESS_TOKEN_EXPIRY_SAFETY_MS) {
       return cached.token;
     }
+
+    const refreshToken = this.ctx.storage.kv.get<string>("refreshToken");
+    if (!refreshToken) return null;
 
     const refreshed = await refreshTokens(this.#config(), refreshToken);
     if (!refreshed) {

--- a/packages/gatekeeper-cloudflare/src/oauth.ts
+++ b/packages/gatekeeper-cloudflare/src/oauth.ts
@@ -29,11 +29,10 @@ export function persistentScopesForResources(resourceUrlPatterns?: string[]): st
 }
 
 /**
- * Minimal scopes for sign-in only: a refresh token + the /user identity read. Used in "auth" mode
- * (the resulting grant is transient).
+ * Minimal scopes for sign-in only. The resulting grant is transient, so it deliberately does not
+ * request offline access or require a refresh token.
  */
 export const AUTH_SCOPES = [
-  "offline_access",
   "user-details.read",
 ];
 
@@ -94,6 +93,20 @@ export interface TokenResponse {
   expiresIn: number;
   tokenType?: string;
   scopes?: string[];
+}
+
+/**
+ * Select the refresh token for a completed connection. Transient authentication only needs its
+ * short-lived access token; every persistent connection must remain refreshable.
+ */
+export function refreshTokenForConnection(
+  tokens: TokenResponse, ephemeral: boolean,
+): string | undefined {
+  if (tokens.refreshToken || ephemeral) return tokens.refreshToken;
+  throw new Error(
+    "Cloudflare OAuth returned no refresh token for a persistent connection. " +
+    "Ensure the OAuth client allows the refresh_token grant and offline_access scope.",
+  );
 }
 
 interface RawTokenResponse {


### PR DESCRIPTION
> [!IMPORTANT]
> We are not generally accepting outside contributions. We may accept a small
> change only when, in the maintainers' assessment, it is obviously correct and
> trivially verifiable by reading the patch.
>
> If you found a bug, please [file an issue](https://github.com/cloudflare/cloudflare-os/issues/new)
> first. For feature requests and other proposals, please
> [open a discussion](https://github.com/cloudflare/cloudflare-os/discussions).

## What does this change?

Cloudflare OAuth can return a valid access token without a refresh token when the client has not enabled the optional `refresh_token` grant. The callback previously collapsed that configuration problem into a generic exchange failure and also rejected access-token-only responses for transient authentication flows that do not need refresh credentials.

This patch separates the two policies: transient auth-only flows request only `user-details.read` and may use their short-lived access token, while persistent billing and observability connections continue to require a refresh token and fail with actionable `refresh_token`/`offline_access` configuration guidance. It also checks a valid cached access token before requiring refresh credentials, resets reconnects to persistent mode, adds regression tests, and documents the required OAuth client settings.

## Why is this obviously correct and trivially verifiable?

The decision is centralized in a small pure helper with exhaustive tests for transient, persistent, and refresh-token-present cases. The Durable Object stores no absent credential, persistent flows still throw before completing, and only an unexpired cached access token can bypass refresh. The package's 115 tests, build/type-check, targeted lint, and Wrangler dry-run pass.

## Checklist

Checking every item does not guarantee acceptance. Maintainers determine whether
a pull request meets the contribution policy.

- [x] <!-- contribution-policy:concrete-change --> This is a small, concrete change; it is not a feature, refactor, or low-value cleanup.
- [x] <!-- contribution-policy:maintainer-assessment --> I understand that maintainers decide whether the change is obviously correct and trivially verifiable.
- [x] <!-- contribution-policy:guidelines --> I have read and followed the contribution guidelines.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->