### PR TITLE
upstream enhancements to the sheets blueprint

### DIFF
--- a/packages/workshop-backend/__tests__/workspace-sheets-xlsx.test.ts
+++ b/packages/workshop-backend/__tests__/workspace-sheets-xlsx.test.ts
@@ -581,14 +581,282 @@ describe("Workspace Sheets XLSX", () => {
     })).toThrow("XLSX fill count exceeds Excel's limit of 256");
   });
 
-  it("ignores v5-only metadata while exporting ordinary and materialized pivot cells", async () => {
+  it("converts the grid's single-quoted and backslash-escaped string literals to Excel's form", async () => {
+    const cells = {
+      A1: cell("=COUNTIF(A2:A20,'Complete')"),
+      A2: cell("='It''s'&'say \"hi\"'&\"a\\\"b\"&\"c\"\"d\""),
+      A3: cell("='It''s'!A1&'x'"),
+      A4: cell("='Jan':'It''s'!A1"),
+      A5: cell("=Table1[[A'[B]]&'q'"),
+      A6: cell("='unterminated"),
+      A7: cell("='esc\\'"),
+      A8: cell("=\"tail\\\""),
+    };
+    const {entries} = await readZip(workbookToXlsx({
+      sheetOrder: ["sheet", "its"],
+      sheets: {sheet: sheet("Sheet"), its: sheet("It's")},
+      cells: {sheet: cells, its: {}},
+    }));
+    const worksheet = text(entries, "xl/worksheets/sheet1.xml");
+
+    expect(cellXml(worksheet, "A1")).toContain('<f>COUNTIF(A2:A20,"Complete")</f>');
+    expect(cellXml(worksheet, "A2")).toContain('<f>"It\'s"&amp;"say ""hi"""&amp;"a""b"&amp;"c""d"</f>');
+    expect(cellXml(worksheet, "A3")).toContain("<f>'It''s'!A1&amp;\"x\"</f>");
+    expect(cellXml(worksheet, "A4")).toContain("<f>'Jan':'It''s'!A1</f>");
+    expect(cellXml(worksheet, "A5")).toContain("<f>Table1[[A'[B]]&amp;\"q\"</f>");
+    for (const reference of ["A6", "A7", "A8"]) expect(cellXml(worksheet, reference)).toContain('t="inlineStr"');
+  });
+
+  it("exports a filter row as an autofilter with criteria, hidden buttons, sort state and hidden rows", async () => {
+    const document = {
+      sheetOrder: ["data"],
+      sheets: {
+        data: sheet("Data & Co", {
+          rows: 8,
+          cols: 5,
+          filter: {
+            row: 1, endRow: 6, columns: [1, 3, 4], rowOrder: [2, 3, 4, 5, 6],
+            criteria: {1: ["s:East", "z:", "x:__none__"], 3: ["b:1", "n:1234.5", "e:#DIV/0!"], 4: [], 2: ["s:ignored"], 9: ["s:out"]},
+            sort: {column: 3, direction: "desc"},
+          },
+        }),
+      },
+      cells: {
+        data: {
+          B2: cell("Zone"), D2: cell("Flag"), E2: cell("None"),
+          B3: cell("East"), D3: cell(" true "),
+          B4: cell("West"), D4: cell("TRUE"),
+          B5: cell(""), D5: cell("=D4"),
+          B6: cell("East"), D6: cell("$1,234.50"),
+          B7: cell("East"), D7: cell("FALSE"),
+          B8: cell("outside"), D8: cell("outside"),
+        },
+      },
+    };
+    const {entries} = await readZip(workbookToXlsx(document));
+    const worksheet = text(entries, "xl/worksheets/sheet1.xml");
+
+    expect(worksheet).toContain(
+      '<autoFilter ref="B2:E7">' +
+      '<filterColumn colId="0"><filters blank="1"><filter val="East"/></filters></filterColumn>' +
+      '<filterColumn colId="1" hiddenButton="1"/>' +
+      '<filterColumn colId="2"><filters><filter val="TRUE"/><filter val="1234.5"/><filter val="#DIV/0!"/></filters></filterColumn>' +
+      '<sortState ref="B3:E7"><sortCondition ref="D3:D7" descending="1"/></sortState></autoFilter>');
+    // Row 3 passes; row 4 fails on West; row 5 has a formula in D and a blank in B, so it stays
+    // visible; row 6 passes; row 7 fails on FALSE.
+    expect([...worksheet.matchAll(/<row r="(\d+)"[^>]*hidden="1"/g)].map(match => match[1])).toEqual(["4", "7"]);
+    expect(worksheet).not.toContain('<row r="8" hidden');
+    expect(text(entries, "xl/workbook.xml")).toContain(
+      '<definedNames><definedName name="_xlnm._FilterDatabase" localSheetId="0" hidden="1">\'Data &amp; Co\'!$B$2:$E$7</definedName></definedNames>');
+  });
+
+  it("hides rows failing a filter even when they hold no cells, and every row when nothing is selected", async () => {
+    const {entries} = await readZip(workbookToXlsx({
+      sheetOrder: ["data", "none"],
+      sheets: {
+        data: sheet("Data", {rows: 5, cols: 1, rowHeights: {2: 40}, filter: {row: 0, endRow: 4, columns: [0], criteria: {0: ["s:keep"]}}}),
+        none: sheet("None", {rows: 3, cols: 2, filter: {row: 0, endRow: 2, columns: [0, 1], criteria: {1: ["x:__none__"]}}}),
+      },
+      cells: {data: {A1: cell("Header"), A2: cell("keep"), A4: cell("drop")}, none: {A2: cell("x"), B3: cell("=A2")}},
+    }));
+    const worksheet = text(entries, "xl/worksheets/sheet1.xml");
+
+    expect(worksheet).toContain('<row r="3" ht="30" customHeight="1" hidden="1"></row>');
+    expect(worksheet).toContain('<row r="4" hidden="1"><c r="A4"');
+    expect(worksheet).toContain('<row r="5" hidden="1"></row>');
+    expect(worksheet).toContain('<autoFilter ref="A1:A5"><filterColumn colId="0"><filters><filter val="keep"/></filters></filterColumn></autoFilter>');
+    // A blank literal is a value that was not selected; the formula row cannot be judged.
+    const none = text(entries, "xl/worksheets/sheet2.xml");
+    expect(none).toContain('<row r="2" hidden="1">');
+    expect(none).toContain('<row r="3"><c r="B3">');
+    expect(none).toContain('<autoFilter ref="A1:B3"></autoFilter>');
+  });
+
+  it("exports open comments as legacy notes with VML shapes and skips resolved ones", async () => {
+    const {entries} = await readZip(workbookToXlsx({
+      sheetOrder: ["plain", "notes"],
+      sheets: {
+        plain: sheet("Plain"),
+        notes: sheet("Notes", {comments: [
+          {id: "a", ref: "B3", text: "first <note>", createdAt: 1, resolved: false},
+          {id: "b", ref: "B3", text: "second", createdAt: 2},
+          {id: "c", ref: "C1", text: "resolved", resolved: true},
+          {id: "d", ref: "A1", text: "   "},
+          {id: "e", ref: "bad", text: "unplaced"},
+          {id: "f", ref: "XFD1048576", text: "last cell"},
+        ]}),
+      },
+      cells: {plain: {}, notes: {}},
+    }));
+
+    expect([...entries.keys()].filter(name => /comments|vml/.test(name))).toEqual([
+      "xl/comments1.xml",
+      "xl/drawings/vmlDrawing1.vml",
+    ]);
+    const comments = text(entries, "xl/comments1.xml");
+    expect(comments).toContain('<comment ref="B3" authorId="0"><text><t xml:space="preserve">first &lt;note&gt;\n\nsecond</t></text></comment>');
+    expect(comments).toContain('<comment ref="XFD1048576"');
+    expect(comments).not.toContain("resolved");
+    expect(comments).not.toContain("unplaced");
+    const vml = text(entries, "xl/drawings/vmlDrawing1.vml");
+    expect(vml).toContain('<o:idmap v:ext="edit" data="1"/>');
+    expect(vml).toContain('<v:shape id="_x0000_s1025"');
+    expect(vml).toContain("<x:Anchor>2, 15, 1, 10, 4, 15, 5, 4</x:Anchor><x:AutoFill>False</x:AutoFill><x:Row>2</x:Row><x:Column>1</x:Column>");
+    expect(vml).toContain("<x:Anchor>16383, 15, 1048574, 10, 16383, 15, 1048575, 4</x:Anchor>");
+    const worksheet = text(entries, "xl/worksheets/sheet2.xml");
+    expect(worksheet).toContain('<legacyDrawing r:id="rId1"/>');
+    const relationships = text(entries, "xl/worksheets/_rels/sheet2.xml.rels");
+    expect(relationships).toContain('Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing" Target="../drawings/vmlDrawing1.vml"');
+    expect(relationships).toContain('Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments1.xml"');
+    const contentTypes = text(entries, "[Content_Types].xml");
+    expect(contentTypes).toContain('<Default Extension="vml" ContentType="application/vnd.openxmlformats-officedocument.vmlDrawing"/>');
+    expect(contentTypes).toContain('<Override PartName="/xl/comments1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml"/>');
+    expect(text(entries, "xl/worksheets/sheet1.xml")).not.toContain("legacyDrawing");
+  });
+
+  it("exports charts as DrawingML anchored at the cell under their grid position", async () => {
+    const {entries} = await readZip(workbookToXlsx({
+      sheetOrder: ["data"],
+      sheets: {data: sheet("Q&A", {
+        colWidths: {0: 150},
+        rowHeights: {1: 40},
+        charts: [
+          {id: "bar", type: "stackedBar", range: "A2:C6", title: "Sales & Co", xAxisTitle: "Amount", yAxisTitle: "Region", legend: true, x: 400, y: 100, width: 520, height: 320},
+          {id: "pie", type: "pie", range: "A2:B6", title: "", legend: false, x: 48, y: 28},
+          {id: "line", type: "line", range: "B2:C6", firstColLabels: false, firstRowHeaders: false},
+          {id: "area", type: "area", range: "B4", firstRowHeaders: true, firstColLabels: true},
+          {id: "unknown", type: "scatter", range: "A2:C6"},
+          {id: "none", type: "line", range: ""},
+          {id: "single", type: "line", range: "A1:A2"},
+        ],
+      })},
+      cells: {data: {}},
+    }));
+
+    expect(entries.has("xl/worksheets/_rels/sheet1.xml.rels")).toBe(true);
+    expect([...entries.keys()].filter(name => /drawing|chart/.test(name))).toEqual([
+      "xl/drawings/drawing1.xml",
+      "xl/drawings/_rels/drawing1.xml.rels",
+      "xl/charts/chart1.xml",
+      "xl/charts/chart2.xml",
+      "xl/charts/chart3.xml",
+      "xl/charts/chart4.xml",
+      "xl/charts/chart5.xml",
+      "xl/charts/chart6.xml",
+    ]);
+    expect(text(entries, "xl/worksheets/sheet1.xml")).toContain('<drawing r:id="rId1"/>');
+    const drawing = text(entries, "xl/drawings/drawing1.xml");
+    // 400px - 44px header = 356px: past a 150px column and two 92px ones, 22px into column D;
+    // 100px - 22px header = 78px: past a 24px row and the 40px one, 14px into row 3.
+    expect(drawing).toContain('<xdr:from><xdr:col>3</xdr:col><xdr:colOff>209550</xdr:colOff><xdr:row>2</xdr:row><xdr:rowOff>133350</xdr:rowOff></xdr:from><xdr:ext cx="4953000" cy="3048000"/>');
+    expect(drawing).toContain('<xdr:from><xdr:col>0</xdr:col><xdr:colOff>38100</xdr:colOff><xdr:row>0</xdr:row><xdr:rowOff>57150</xdr:rowOff></xdr:from>');
+    expect(drawing).toContain('r:id="rId6"');
+    expect(text(entries, "xl/drawings/_rels/drawing1.xml.rels")).toContain('Id="rId6" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart6.xml"');
+
+    const bar = text(entries, "xl/charts/chart1.xml");
+    expect(bar).toContain('<c:barChart><c:barDir val="bar"/><c:grouping val="stacked"/>');
+    expect(bar).toContain("<a:t>Sales &amp; Co</a:t>");
+    expect(bar).toContain("<c:tx><c:strRef><c:f>'Q&amp;A'!$B$2</c:f></c:strRef></c:tx>");
+    expect(bar).toContain("<c:cat><c:strRef><c:f>'Q&amp;A'!$A$3:$A$6</c:f></c:strRef></c:cat><c:val><c:numRef><c:f>'Q&amp;A'!$B$3:$B$6</c:f></c:numRef></c:val>");
+    expect(bar).toContain("<c:f>'Q&amp;A'!$C$3:$C$6</c:f>");
+    expect(bar).toContain('<c:orientation val="maxMin"/>');
+    expect(bar).toContain('<c:axPos val="l"/><c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Region</a:t>');
+    expect(bar).toContain('<c:axPos val="b"/><c:majorGridlines/><c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Amount</a:t>');
+    expect(bar).toContain('<c:legend><c:legendPos val="r"/>');
+
+    const pie = text(entries, "xl/charts/chart2.xml");
+    expect(pie).toContain('<c:autoTitleDeleted val="1"/>');
+    expect(pie.match(/<c:ser>/g)).toHaveLength(1);
+    expect(pie).toContain('<c:dPt><c:idx val="3"/><c:bubble3D val="0"/><c:spPr><a:solidFill><a:srgbClr val="8B5FBF"/></a:solidFill>');
+    expect(pie).not.toContain("<c:legend>");
+
+    const line = text(entries, "xl/charts/chart3.xml");
+    expect(line).toContain("<c:tx><c:v>B</c:v></c:tx>");
+    expect(line).toContain("<c:f>'Q&amp;A'!$B$2:$B$6</c:f>");
+    expect(line).not.toContain("<c:cat>");
+    expect(line).toContain('<c:smooth val="0"/>');
+
+    const area = text(entries, "xl/charts/chart4.xml");
+    expect(area).toContain("<c:areaChart>");
+    expect(area).toContain('<a:srgbClr val="E1632E"><a:alpha val="18000"/></a:srgbClr>');
+    expect(area).toContain("<c:f>'Q&amp;A'!$B$4</c:f>");
+    // An unknown type falls back to a line chart; a single column keeps its header and has no labels.
+    expect(text(entries, "xl/charts/chart5.xml")).toContain("<c:lineChart>");
+    const single = text(entries, "xl/charts/chart6.xml");
+    expect(single).toContain("<c:tx><c:strRef><c:f>'Q&amp;A'!$A$1</c:f></c:strRef></c:tx>");
+    expect(single).toContain("<c:val><c:numRef><c:f>'Q&amp;A'!$A$2</c:f></c:numRef></c:val>");
+    expect(single).not.toContain("<c:cat>");
+    const contentTypes = text(entries, "[Content_Types].xml");
+    expect(contentTypes).toContain('<Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>');
+    expect(contentTypes).toContain('<Override PartName="/xl/charts/chart5.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>');
+    expect(contentTypes).not.toContain('Extension="vml"');
+  });
+
+  it("numbers drawing, chart and comment parts across sheets and orders sheet relationships", async () => {
+    const chart = {id: "c", type: "line", range: "A1:B3"};
+    const comment = {id: "k", ref: "A1", text: "note"};
+    const {entries} = await readZip(workbookToXlsx({
+      sheetOrder: ["first", "second"],
+      sheets: {
+        first: sheet("First", {charts: [chart], comments: [comment]}),
+        second: sheet("Second", {charts: [chart, chart], comments: Array.from({length: 1500}, () => comment)}),
+      },
+      cells: {first: {B1: cell("https://example.com/")}, second: {}},
+    }));
+
+    expect(text(entries, "xl/worksheets/sheet1.xml")).toContain('<hyperlinks><hyperlink ref="B1" r:id="rId1"/></hyperlinks><drawing r:id="rId2"/><legacyDrawing r:id="rId3"/>');
+    expect(text(entries, "xl/worksheets/_rels/sheet1.xml.rels")).toContain('Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments1.xml"');
+    expect(text(entries, "xl/worksheets/sheet2.xml")).toContain('<drawing r:id="rId1"/><legacyDrawing r:id="rId2"/>');
+    expect(text(entries, "xl/worksheets/_rels/sheet2.xml.rels")).toContain('Target="../drawings/drawing2.xml"');
+    expect(text(entries, "xl/drawings/_rels/drawing2.xml.rels")).toContain('Target="../charts/chart3.xml"');
+    expect(entries.has("xl/charts/chart3.xml")).toBe(true);
+    expect(entries.has("xl/charts/chart4.xml")).toBe(false);
+    // 1500 comments joined into one note still reserve two 1024-id VML blocks after sheet 1's one.
+    expect(text(entries, "xl/drawings/vmlDrawing2.vml")).toContain('<o:idmap v:ext="edit" data="2"/>');
+    expect(text(entries, "xl/drawings/vmlDrawing2.vml")).toContain('<v:shape id="_x0000_s2049"');
+    expect(text(entries, "xl/comments2.xml")).toContain("note\n\nnote");
+  });
+
+  it("links literal URL cells with the grid's link styling and leaves other cells alone", async () => {
+    const {entries} = await readZip(workbookToXlsx({
+      sheetOrder: ["data"],
+      sheets: {data: sheet("Data")},
+      cells: {data: {
+        A1: cell("https://example.com/a b?x=1#frag", {b: true, c: "#ff0000"}),
+        A2: cell("'HTTP://Example.com"),
+        A3: cell("https://nolink.example", {nf: "text"}),
+        A4: cell("ftp://example.com"),
+        A5: cell("https://"),
+        A6: cell('=HYPERLINK("https://example.com","x")'),
+        A7: cell(" https://leading.example "),
+        A8: cell("see https://example.com"),
+        A9: cell("https://example.com/" + "x".repeat(2100)),
+      }},
+    }));
+    const worksheet = text(entries, "xl/worksheets/sheet1.xml");
+    const styles = text(entries, "xl/styles.xml");
+
+    expect(worksheet).toContain('<hyperlinks><hyperlink ref="A1" r:id="rId1"/><hyperlink ref="A2" r:id="rId2"/><hyperlink ref="A7" r:id="rId3"/></hyperlinks>');
+    const relationships = text(entries, "xl/worksheets/_rels/sheet1.xml.rels");
+    expect(relationships).toContain('Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/a%20b?x=1#frag" TargetMode="External"');
+    expect(relationships).toContain('Target="http://example.com/"');
+    expect(relationships).toContain('Target="https://leading.example/"');
+    expect(cellXml(worksheet, "A1")).toContain(">https://example.com/a b?x=1#frag</t>");
+    expect(styleId(worksheet, "A1")).toBeDefined();
+    expect(styleId(worksheet, "A2")).toBeDefined();
+    expect(styles).toContain('<font><b/><u/><sz val="11"/><color rgb="FF1967D2"/>');
+    expect(styleId(worksheet, "A4")).toBeUndefined();
+    expect(styleId(worksheet, "A9")).toBeUndefined();
+  });
+
+  it("ignores malformed feature metadata while exporting ordinary and materialized pivot cells", async () => {
     const document = {
       sheetOrder: ["v5"],
       sheets: {
         v5: {
           ...sheet("V5"),
-          filter: {range: "A1:B4"},
-          charts: [{type: "bar"}],
+          filter: {range: "A1:B4", criteria: "x", columns: "all"},
+          charts: [{type: "bar"}, null, {range: "A1:B2:C3"}, {range: 42}],
           comments: {A1: "note"},
           pivot: {source: "A1:B4", destination: "D1"},
         },
@@ -611,7 +879,8 @@ describe("Workspace Sheets XLSX", () => {
     expect(cellXml(worksheet, "D1")).toContain("Pivot total");
     expect(cellXml(worksheet, "D2")).toContain("<v>125</v>");
     expect(worksheet).not.toContain("autoFilter");
-    expect([...entries.keys()].some(name => /chart|comment|pivot/i.test(name))).toBe(false);
+    expect(worksheet).not.toContain("<drawing");
+    expect([...entries.keys()].some(name => /chart|comment|pivot|rels\/sheet/i.test(name))).toBe(false);
   });
 });
 

--- a/packages/workshop-backend/__tests__/workspace-sheets-xlsx.test.ts
+++ b/packages/workshop-backend/__tests__/workspace-sheets-xlsx.test.ts
@@ -597,6 +597,7 @@ describe("Workspace Sheets XLSX", () => {
       A6: cell("='unterminated"),
       A7: cell("='esc\\'"),
       A8: cell("=\"tail\\\""),
+      A9: cell("='don\\'!t'"),
     };
     const {entries} = await readZip(workbookToXlsx({
       sheetOrder: ["sheet", "its"],
@@ -611,6 +612,8 @@ describe("Workspace Sheets XLSX", () => {
     expect(cellXml(worksheet, "A4")).toContain("<f>'Jan':'It''s'!A1</f>");
     expect(cellXml(worksheet, "A5")).toContain("<f>Table1[[A'[B]]&amp;\"q\"</f>");
     for (const reference of ["A6", "A7", "A8"]) expect(cellXml(worksheet, reference)).toContain('t="inlineStr"');
+    // An escaped quote followed by `!` is still inside the string, not a sheet name's closing quote.
+    expect(cellXml(worksheet, "A9")).toContain("<f>\"don'!t\"</f>");
   });
 
   it("exports a filter row as an autofilter with criteria, hidden buttons, sort state and hidden rows", async () => {
@@ -814,12 +817,21 @@ describe("Workspace Sheets XLSX", () => {
       cells[`${columnName(column)}2`] = cell(column === 3 + 255 ? "=A2" : String(column));
     }
     const {entries} = await readZip(workbookToXlsx({
-      sheetOrder: ["data", "empty"],
+      sheetOrder: ["data", "empty", "filtered"],
       sheets: {
         data: sheet("Data", {cols: 260, charts: [{id: "wide", type: "line", range: "A1:IZ3"}, {id: "pie", type: "pie", range: "A1:IZ3"}]}),
         empty: sheet("Empty", {charts: [{id: "text", type: "line", range: "A1:B3"}]}),
+        // B is numeric only in a row the filter hides, so the visible pie uses C, as the grid does.
+        filtered: sheet("Filtered", {
+          filter: {row: 0, endRow: 3, columns: [0, 1, 2], criteria: {0: ["s:keep"]}},
+          charts: [{id: "pie", type: "pie", range: "A1:C4"}],
+        }),
       },
-      cells: {data: cells, empty: {A1: cell("Name"), B1: cell("Note"), A2: cell("x"), B2: cell("words")}},
+      cells: {
+        data: cells,
+        empty: {A1: cell("Name"), B1: cell("Note"), A2: cell("x"), B2: cell("words")},
+        filtered: {A1: cell("k"), B1: cell("b"), C1: cell("c"), A2: cell("drop"), B2: cell("5"), A3: cell("keep"), C3: cell("7"), A4: cell("keep"), C4: cell("8")},
+      },
     }));
 
     const wide = text(entries, "xl/charts/chart1.xml");
@@ -833,8 +845,11 @@ describe("Workspace Sheets XLSX", () => {
     expect(pie.match(/<c:ser>/g)).toHaveLength(1);
     expect(pie).toContain("<c:f>'Data'!$D$2:$D$3</c:f>");
     // A chart over text only draws a placeholder in the grid and is not exported.
-    expect(entries.has("xl/charts/chart3.xml")).toBe(false);
+    expect([...entries.keys()].filter(name => name.startsWith("xl/charts/"))).toHaveLength(3);
     expect(text(entries, "xl/worksheets/sheet2.xml")).not.toContain("<drawing");
+    const filteredPie = text(entries, "xl/charts/chart3.xml");
+    expect(filteredPie.match(/<c:ser>/g)).toHaveLength(1);
+    expect(filteredPie).toContain("<c:f>'Filtered'!$C$2:$C$4</c:f>");
   });
 
   it("numbers drawing, chart and comment parts across sheets and orders sheet relationships", async () => {

--- a/packages/workshop-backend/__tests__/workspace-sheets-xlsx.test.ts
+++ b/packages/workshop-backend/__tests__/workspace-sheets-xlsx.test.ts
@@ -124,6 +124,12 @@ function styleId(xml: string, reference: string): string | undefined {
   return / s="(\d+)"/.exec(cellXml(xml, reference))?.[1];
 }
 
+function columnName(index: number): string {
+  let name = "";
+  for (let value = index + 1; value > 0; value = Math.floor((value - 1) / 26)) name = String.fromCharCode(65 + (value - 1) % 26) + name;
+  return name;
+}
+
 function handler(): ExportHandler {
   return Object.create(ExportHandler.prototype) as ExportHandler;
 }
@@ -665,10 +671,10 @@ describe("Workspace Sheets XLSX", () => {
     expect(worksheet).toContain('<row r="4" hidden="1"><c r="A4"');
     expect(worksheet).toContain('<row r="5" hidden="1"></row>');
     expect(worksheet).toContain('<autoFilter ref="A1:A5"><filterColumn colId="0"><filters><filter val="keep"/></filters></filterColumn></autoFilter>');
-    // A blank literal is a value that was not selected; the formula row cannot be judged.
+    // Nothing selected hides every row, including the formula row that cannot be judged.
     const none = text(entries, "xl/worksheets/sheet2.xml");
     expect(none).toContain('<row r="2" hidden="1">');
-    expect(none).toContain('<row r="3"><c r="B3">');
+    expect(none).toContain('<row r="3" hidden="1"><c r="B3">');
     expect(none).toContain('<autoFilter ref="A1:B3"></autoFilter>');
   });
 
@@ -730,7 +736,14 @@ describe("Workspace Sheets XLSX", () => {
           {id: "single", type: "line", range: "A1:A2"},
         ],
       })},
-      cells: {data: {}},
+      cells: {data: {
+        A1: cell("Total"), A2: cell("5"),
+        B2: cell("Q1"), C2: cell("Q2"),
+        A3: cell("East"), B3: cell("1"), C3: cell("2"),
+        A4: cell("West"), B4: cell("3"), C4: cell("4"),
+        A5: cell("North"), B5: cell("5"), C5: cell("=B5*2"),
+        A6: cell("South"), B6: cell("7"), C6: cell("8"),
+      }},
     }));
 
     expect(entries.has("xl/worksheets/_rels/sheet1.xml.rels")).toBe(true);
@@ -792,6 +805,38 @@ describe("Workspace Sheets XLSX", () => {
     expect(contentTypes).not.toContain('Extension="vml"');
   });
 
+  it("selects series the way the grid does, then applies Excel's series limit", async () => {
+    const cells: Record<string, {value: unknown; fmt: Record<string, unknown> | null; version: number}> = {A1: cell("Label"), A2: cell("x"), A3: cell("y")};
+    // B and C hold no numbers; D..IY (256 columns) do, the last of them as a formula.
+    cells.B2 = cell("text");
+    cells.C1 = cell("header only");
+    for (let column = 3; column < 3 + 256; ++column) {
+      cells[`${columnName(column)}2`] = cell(column === 3 + 255 ? "=A2" : String(column));
+    }
+    const {entries} = await readZip(workbookToXlsx({
+      sheetOrder: ["data", "empty"],
+      sheets: {
+        data: sheet("Data", {cols: 260, charts: [{id: "wide", type: "line", range: "A1:IZ3"}, {id: "pie", type: "pie", range: "A1:IZ3"}]}),
+        empty: sheet("Empty", {charts: [{id: "text", type: "line", range: "A1:B3"}]}),
+      },
+      cells: {data: cells, empty: {A1: cell("Name"), B1: cell("Note"), A2: cell("x"), B2: cell("words")}},
+    }));
+
+    const wide = text(entries, "xl/charts/chart1.xml");
+    expect(wide.match(/<c:ser>/g)).toHaveLength(255);
+    expect(wide).not.toContain("<c:f>'Data'!$B$");
+    expect(wide).not.toContain("<c:f>'Data'!$C$");
+    expect(wide).toContain("<c:f>'Data'!$D$2:$D$3</c:f>");
+    expect(wide).toContain("<c:f>'Data'!$IX$2:$IX$3</c:f>");
+    expect(wide).not.toContain("<c:f>'Data'!$IY$");
+    const pie = text(entries, "xl/charts/chart2.xml");
+    expect(pie.match(/<c:ser>/g)).toHaveLength(1);
+    expect(pie).toContain("<c:f>'Data'!$D$2:$D$3</c:f>");
+    // A chart over text only draws a placeholder in the grid and is not exported.
+    expect(entries.has("xl/charts/chart3.xml")).toBe(false);
+    expect(text(entries, "xl/worksheets/sheet2.xml")).not.toContain("<drawing");
+  });
+
   it("numbers drawing, chart and comment parts across sheets and orders sheet relationships", async () => {
     const chart = {id: "c", type: "line", range: "A1:B3"};
     const comment = {id: "k", ref: "A1", text: "note"};
@@ -801,7 +846,7 @@ describe("Workspace Sheets XLSX", () => {
         first: sheet("First", {charts: [chart], comments: [comment]}),
         second: sheet("Second", {charts: [chart, chart], comments: Array.from({length: 1500}, () => comment)}),
       },
-      cells: {first: {B1: cell("https://example.com/")}, second: {}},
+      cells: {first: {B1: cell("https://example.com/"), B2: cell("1")}, second: {B2: cell("1")}},
     }));
 
     expect(text(entries, "xl/worksheets/sheet1.xml")).toContain('<hyperlinks><hyperlink ref="B1" r:id="rId1"/></hyperlinks><drawing r:id="rId2"/><legacyDrawing r:id="rId3"/>');
@@ -1006,6 +1051,34 @@ describe("Workspace Sheets document snapshots", () => {
     expect(callback.dup).not.toHaveBeenCalled();
     expect(fixture.subscribers.size).toBe(0);
     await expect(fixture.applyOperation(setCell("A1", "still works"))).resolves.toMatchObject({status: "applied"});
+  });
+
+  it("clamps chart and pivot ranges to their sheet and rejects ones clients could not walk", async () => {
+    const fixture = inMemoryGadget();
+    const pivot = {sourceSheetId: "sheet", rowField: "a", columnField: "", valueField: "b", aggregate: "sum"};
+    await fixture.applyOperation({senderId: "test", structure: {
+      sheetOrder: ["pivot", "sheet", "orphan", "big"],
+      sheets: {
+        sheet: {...sheet("Sheet", {rows: 50, cols: 4}), charts: [
+          {id: "beyond", type: "line", range: "A1:XFD1048576"},
+          {id: "single", type: "line", range: "b2"},
+          {id: "outside", type: "line", range: "E60:F70"},
+        ]},
+        pivot: {...sheet("Pivot"), pivot: {...pivot, sourceRange: "A1:ZZ50000"}},
+        orphan: {...sheet("Orphan"), pivot: {...pivot, sourceSheetId: "missing", sourceRange: "A1:B2"}},
+        // Within the sheet, but 35 million cells: every client would hang walking it.
+        big: {...sheet("Big", {rows: 50000, cols: 702}), charts: [
+          {id: "huge", type: "line", range: "A1:ZZ50000"},
+          {id: "large", type: "line", range: "A1:D50000"},
+        ], pivot: {...pivot, sourceSheetId: "big", sourceRange: "A1:E50000"}},
+      },
+    }});
+    const document = await fixture.getDocument();
+    expect(document.sheets.sheet.charts.map((chart: {range: string}) => chart.range)).toEqual(["A1:D50", "B2", ""]);
+    expect(document.sheets.big.charts.map((chart: {range: string}) => chart.range)).toEqual(["", "A1:D50000"]);
+    expect(document.sheets.big.pivot.sourceRange).toBe("");
+    expect(document.sheets.pivot.pivot.sourceRange).toBe("A1:D50");
+    expect(document.sheets.orphan.pivot.sourceRange).toBe("");
   });
 });
 

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/README.md
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/README.md
@@ -6,29 +6,42 @@ A lightweight, persistent spreadsheet Gadget with a familiar grid interface, for
 
 - Editable spreadsheet title and multiple sheet tabs
 - Add, rename, duplicate, and delete sheets
-- Cell and range selection with keyboard navigation
-- Formula bar and A1-style references
+- Cell and range selection with keyboard navigation, plus an Excel-style drag-to-fill handle
+- Formula bar, A1-style references, searchable function picker, inline autocomplete, live syntax guidance, actionable validation errors, and draggable formula-range handles
 - Cross-sheet references such as `Sheet2!A1` and `'Sales Data'!B4`
+- Clickable HTTP/HTTPS cell links and `HYPERLINK(url, label)` formulas with open/copy actions
 - 100+ spreadsheet functions across math, statistics, logic, text, lookup, date/time, and information categories
 - Number, currency, percent, scientific, date, and time formatting
-- Bold, italic, underline, strikethrough, text color, fill color, alignment, and wrapping
+- Bold, italic, underline, strikethrough, text color, fill color, alignment, wrapping, and text overflow into adjacent empty cells
 - Row and column insertion, deletion, and resizing
 - Range sorting, AutoSum, copy/paste via TSV, and local undo/redo for cell edits
+- Persistent filter rows with per-column, multi-value dropdown filters and reversible sorting
+- Line, pie, area, and stacked bar charts created from selected ranges, with an adjustable right-side settings panel, drag positioning, and rich SVG copy
+- Persistent cell comments with in-cell markers, hover previews, a consolidated sidebar, and resolve/delete actions
+- Distinctly styled pivot tables generated from selected ranges with row, column, value, aggregation, row/column total, and multi-value filter settings
 - Automatic persistent saving with optimistic per-cell conflict detection
 - Real-time operation and presence synchronization in the server architecture
-- Excel workbook and per-sheet CSV export
+- Excel workbook export (cells, layout, filters, charts, comments and links) and per-sheet CSV export
 
 ## Using the spreadsheet
 
-- Click a cell to select it.
-- Double-click a cell, press **F2**, or begin typing to edit it.
+- Click a cell to select it. Click a row or column header to select the whole row or column; Shift-click another header to extend a contiguous selection. Cmd-click on macOS or Ctrl-click on Windows/Linux to add non-adjacent cells, rows, or columns. Choosing a row or column header drops any individual-cell ranges while retaining other whole-row or whole-column selections.
+- Double-click a cell, press **F2**, or begin typing to edit it. Drag the small handle at the selection’s bottom-right to fill neighboring rows or columns; copied formulas adjust relative references while `$A$1`, `$A1`, and `A$1` preserve their absolute column and/or row components.
+- HTTP/HTTPS values are displayed as links. Cmd/Ctrl-click a link to open it, or right-click for **Open link** and **Copy link**. Use `=HYPERLINK("https://example.com","Example")` for custom link text.
+- While building a formula, click or drag cells to insert a live cell/range reference without leaving the editor. All currently referenced cells are highlighted; clicking an already-selected individual reference toggles it out of aggregate functions such as SUM and AVERAGE, preventing duplicate point selections. Clicking within the formula bar immediately synchronizes its caret and selection with the in-cell editor. Clicking an existing highlighted reference activates that whole reference for resizing; a normal click elsewhere replaces the active reference. Only typing a comma or using Cmd-click on macOS / Ctrl-click on Windows/Linux adds another reference such as `C3, C5`; Shift extends the current range. Click row or column headers for full-row/full-column ranges, or use Arrow keys and Shift+Arrow to select and extend references. Place the caret within a specific range endpoint and use the toolbar **$** control or Ctrl/Cmd+Shift+L to cycle only that reference through `A1`, `$A$1`, `A$1`, and `$A1`. Function parentheses are inserted as a pair, missing closing parentheses are completed on submission, and unmatched or missing required parentheses keep the editor open.
+- Formula error cells provide hover diagnostics with a likely cause and highlight the suspicious formula segment when it can be identified.
 - Start formulas with `=`, for example:
   - `=SUM(A1:A10)`
   - `=IF(B2>100,"High","Low")`
-  - `=VLOOKUP(E2,A2:C20,3,FALSE)`
+  - `=VLOOKUP(E2,A2:C20,3,FALSE)` (`TRUE` and `FALSE` are accepted as logical values without parentheses)
+  - `=COUNTIF(A2:A20,'Complete')` (single-quoted text is accepted in addition to double quotes)
   - `=Sheet2!A1*2`
 - Use the name box to jump to a cell or range such as `D12` or `A1:C8`.
-- Right-click the grid for cut/copy/paste and row or column actions.
+- Use the filter toolbar button to detect the current data table automatically. The app identifies the likely header row (including tables below a title row) and adds dropdowns only to columns containing data. Selecting a range first explicitly sets the filter range and its top row as the header.
+- Highlight a data range and use the chart toolbar button to create a line, pie, area, or stacked bar chart. The right-side settings panel controls chart type, range, titles, headers, labels, and legend; it can be collapsed at any time. Drag a chart by its header to reposition it. **Copy SVG** uses a rich clipboard format that may not be accepted by every destination.
+- Select a cell and use the comment toolbar button or right-click → **Comment** to add a comment in place. Comment markers reveal text on hover. The layered right sidebar shows top-level **Charts**, **Pivot tables**, and **Comments** destinations when available, with back navigation into their lists and details.
+- Select a table including its header row and use the pivot toolbar button or right-click → **Create pivot table**. The result is generated on a new sheet with distinct pivot styling and automatically sized columns; configure row, column, value, aggregation, and optional multi-value filters from the Pivot tables section of the sidebar.
+- Right-click the grid for cut/copy/paste, **Paste without formatting**, and row or column actions. Menu paste works for cells copied or cut inside the spreadsheet; browser security requires Ctrl/Cmd+V for content copied from another application. Pasted blocks expand from the active cell, repeat across compatible selected ranges, preserve internal formatting when requested, adjust copied relative formulas, and move cells only after an internal cut is pasted.
 - Double-click a sheet tab to rename it; right-click it to duplicate or delete it.
 
 ## Keyboard shortcuts
@@ -41,6 +54,8 @@ A lightweight, persistent spreadsheet Gadget with a familiar grid interface, for
 | Tab / Shift + Tab | Move right / left |
 | Delete / Backspace | Clear selected cells |
 | Ctrl/Cmd + C, X, V | Copy, cut, paste |
+| Ctrl/Cmd + Shift + V | Paste without source formatting |
+| Ctrl/Cmd + Shift + L | Cycle the formula reference under the caret through relative/absolute forms |
 | Ctrl/Cmd + Z | Undo |
 | Ctrl/Cmd + Y or Ctrl/Cmd + Shift + Z | Redo |
 | Ctrl/Cmd + B | Bold |
@@ -184,14 +199,15 @@ Exports the Durable Object class `Gadget`, which is the authoritative persistenc
 ### `xlsx.js` and `zip.js`
 
 `xlsx.js` converts a complete document snapshot into a streaming XLSX workbook: sparse worksheet XML
-with inline strings, deduplicated styles, and frozen panes. `zip.js` is a dependency-free streaming
-ZIP writer (raw DEFLATE via `CompressionStream`, incremental CRC32, data descriptors).
+with inline strings, deduplicated styles, frozen panes, autofilters, hyperlinks, legacy-note
+comments (with their VML shapes) and DrawingML charts. `zip.js` is a dependency-free streaming ZIP
+writer (raw DEFLATE via `CompressionStream`, incremental CRC32, data descriptors).
 
 ## Storage model
 
 The server stores:
 
-- `meta`: revision, title, sheet order, sheet metadata, and modification time
+- `meta`: revision, title, sheet order, sheet metadata (including filter-row criteria), and modification time
 - `cells:<sheetId>`: a map of A1 references to `{ value, fmt, version }`
 
 Default sheets have 100 rows and 26 columns. Server validation permits up to 50,000 rows and 702 columns per sheet. Cell values are limited to 8,192 characters, and titles are limited to 200 characters.
@@ -228,18 +244,39 @@ commas, a leading `$` or a trailing `%`. Everything else is text; date-looking t
 
 Formulas are written without cached results and the workbook requests a full recalculation on open,
 so Excel evaluates them itself. To keep them valid there, the exporter rewrites cross-sheet
-references to the exported worksheet names, prefixes OOXML "future functions" (`IFS`, `CONCAT`, ...)
-with `_xlfn.`, renames `ERRORTYPE()` to `ERROR.TYPE()`, and drops whitespace between a function
-name and its `(`. A formula that is empty, structurally unbalanced (unterminated string or quoted
-name, mismatched parentheses or brackets — the grid's parser tolerates these) or that would exceed
-Excel's 8,192-character limit after rewriting is exported as text, since one such formula makes
-Excel report the whole workbook as damaged. Formula semantics are otherwise not translated (for
-example `^` associativity differs, and a reference outside the grid such as `XFE1` is empty here
-but `#NAME?` in Excel), and compatibility with Excel is not claimed beyond this.
+references to the exported worksheet names, converts single-quoted and backslash-escaped string
+literals (`'Complete'`, `"say \"hi\""`) to Excel's double-quote form, prefixes OOXML "future
+functions" (`IFS`, `CONCAT`, ...) with `_xlfn.`, renames `ERRORTYPE()` to `ERROR.TYPE()`, and drops
+whitespace between a function name and its `(`. A formula that is empty, structurally unbalanced
+(unterminated string or quoted name, mismatched parentheses or brackets — the grid's parser tolerates
+these) or that would exceed Excel's 8,192-character limit after rewriting is exported as text, since
+one such formula makes Excel report the whole workbook as damaged. Formula semantics are otherwise
+not translated (for example `^` associativity differs, and a reference outside the grid such as
+`XFE1` is empty here but `#NAME?` in Excel), and compatibility with Excel is not claimed beyond this.
 
 Worksheet names are made Excel-safe: invalid characters become `_`, blank names become `Sheet`,
 names are cut to 31 characters, and case-insensitive collisions get ` (2)`, ` (3)`, ... suffixes.
 References resolve to the first worksheet with a matching source name, as in the grid.
 
-Filters, charts, comments and pivot tables are not exported; cells already materialized from them
-export as ordinary values.
+Cells whose literal text is an `http(s)` URL (unless formatted as text) become Excel hyperlinks with
+the grid's link styling; `HYPERLINK()` formulas need no translation.
+
+A filter row exports as an Excel autofilter over the same range, with dropdown buttons only on the
+grid's filter columns, the sort indicator, and each column's selected values as filter criteria.
+Sorting reorders the stored cells in the grid, so no reordering is needed here. Rows are hidden by
+comparing the literal values in the criteria columns; a row whose criteria cell holds a formula stays
+visible, since formulas are not evaluated here, and Excel's **Reapply** refilters it. Criteria are
+written as the grid's raw values, so a formatted number (`$1,234.00`) may not match Excel's displayed
+text until reapplied. A column with nothing selected hides every row but carries no criteria.
+
+Open comments export as Excel notes; resolved comments are hidden in the grid and omitted. Several
+comments on one cell are joined into one note.
+
+Charts export as native Excel charts of the same type (line, area, pie, stacked bar) over the same
+range, reading headers and labels the way the grid does, with the grid's palette, titles, axis titles
+and legend setting. Series reference the worksheet directly, so Excel computes them on open. A chart
+is positioned at the cell under its grid coordinates, at the same pixel size. Charts without a usable
+data range are skipped.
+
+Pivot tables export as their materialized output cells (with their formatting), not as Excel pivot
+tables: the pivot's source definition is dropped and the values no longer refresh.

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/README.md
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/README.md
@@ -267,16 +267,19 @@ Sorting reorders the stored cells in the grid, so no reordering is needed here. 
 comparing the literal values in the criteria columns; a row whose criteria cell holds a formula stays
 visible, since formulas are not evaluated here, and Excel's **Reapply** refilters it. Criteria are
 written as the grid's raw values, so a formatted number (`$1,234.00`) may not match Excel's displayed
-text until reapplied. A column with nothing selected hides every row but carries no criteria.
+text until reapplied. A column with nothing selected hides every row, formulas included, but carries
+no criteria.
 
 Open comments export as Excel notes; resolved comments are hidden in the grid and omitted. Several
 comments on one cell are joined into one note.
 
 Charts export as native Excel charts of the same type (line, area, pie, stacked bar) over the same
 range, reading headers and labels the way the grid does, with the grid's palette, titles, axis titles
-and legend setting. Series reference the worksheet directly, so Excel computes them on open. A chart
+and legend setting. As in the grid, a column with no numeric value is not a series - a column holding
+formulas is kept, since they are not evaluated here - and Excel's limit of 255 series applies to the
+columns that remain. Series reference the worksheet directly, so Excel computes them on open. A chart
 is positioned at the cell under its grid coordinates, at the same pixel size. Charts without a usable
-data range are skipped.
+data range or series are skipped.
 
 Pivot tables export as their materialized output cells (with their formatting), not as Excel pivot
 tables: the pivot's source definition is dropped and the values no longer refresh.

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/README.md
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/README.md
@@ -219,8 +219,11 @@ The server and client synchronization code support multiple connected clients an
 ## Current limitations
 
 - There is no file import workflow; clipboard operations use tab-separated text.
-- Structural edits and sorting clear local undo/redo history.
-- Formula reference adjustment during row/column changes is limited to references on the current sheet.
+- Structural edits and sorting clear local undo/redo history. Both save the sheet's cells as a
+  whole-sheet replacement without a base revision, so a cell edited by another client in the
+  short window before that save flushes is overwritten without a conflict.
+- Sorting moves formulas with their rows and shifts their relative references, as Excel does.
+- Formula reference adjustment during row/column changes is limited to references on the current sheet; chart ranges and pivot sources on the edited sheet move with it.
 - Formula support is broad but is not intended to be fully compatible with Excel or Google Sheets.
 - Frozen row/column metadata exists in the model, but the current UI does not expose controls for it.
 

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
@@ -1615,12 +1615,14 @@ function queueCellOp(sheetId, ref, value, fmt, baseVersion) {
   pendingCellOps.set(sheetId + "!" + ref, { sheetId, ref, value, fmt, baseVersion });
   scheduleSave();
 }
+// Structure is saved as a whole-workbook snapshot, so `ackedStructure` (what the server last held)
+// lets a remote update be merged with the local changes still pending.
+let ackedStructure = null;
+function structureSnapshot() {
+  return { title: model.title, sheetOrder: model.sheetOrder.slice(), sheets: JSON.parse(JSON.stringify(model.sheets)) };
+}
 function queueStructure() {
-  pendingStructure = {
-    title: model.title,
-    sheetOrder: model.sheetOrder.slice(),
-    sheets: JSON.parse(JSON.stringify(model.sheets)),
-  };
+  pendingStructure = structureSnapshot();
   scheduleSave();
 }
 function queueReplacement(sheetId) {
@@ -1655,6 +1657,7 @@ async function doSave() {
   try {
     const result = await gadget.applyOperation({ senderId: clientId, structure, cellOps, sheetReplacements });
     model.revision = Math.max(model.revision, result.revision || 0);
+    if (structure) ackedStructure = structure;
     // Adopt acknowledged versions without overwriting a newer local edit that
     // was queued while this save was in flight.
     for (const up of result.upserts || []) {
@@ -1904,24 +1907,40 @@ function rewriteAllFormulas(rowAt, rowDelta, colAt, colDelta) {
   }
 }
 
-function rebuildSheetCells(mapFn) {
-  // mapFn(r,c) -> {r,c}|null ; moves cells to new positions.
+// Moves every cell and range-bearing piece of metadata through the row and column maps
+// (`index -> index | null` for deleted). Chart ranges and pivot sources that reference this sheet
+// shrink around deleted lines and grow around inserted ones.
+function rebuildSheetCells(mapRow, mapCol) {
   const old = curCells();
   const next = {};
   for (const [ref, cell] of Object.entries(old)) {
     const rc = parseRef(ref); if (!rc) continue;
-    const nn = mapFn(rc.r, rc.c);
-    if (!nn) continue;
-    next[rcToRef(nn.r, nn.c)] = { ...cell, version: cell.version };
+    const r = mapRow(rc.r), c = mapCol(rc.c);
+    if (r == null || c == null) continue;
+    next[rcToRef(r, c)] = { ...cell, version: cell.version };
   }
   model.cells[activeSheetId] = next;
   if (Array.isArray(curSheet().comments)) {
     curSheet().comments = curSheet().comments.flatMap((comment) => {
       const position = parseRef(comment.ref); if (!position) return [];
-      const moved = mapFn(position.r, position.c); if (!moved) return [];
-      return [{ ...comment, ref: rcToRef(moved.r, moved.c) }];
+      const r = mapRow(position.r), c = mapCol(position.c); if (r == null || c == null) return [];
+      return [{ ...comment, ref: rcToRef(r, c) }];
     });
   }
+  for (const chart of curSheet().charts || []) chart.range = remapRange(chart.range, mapRow, mapCol);
+  for (const id of pivotSheets()) {
+    const pivot = model.sheets[id].pivot;
+    if (pivot.sourceSheetId === activeSheetId) pivot.sourceRange = remapRange(pivot.sourceRange, mapRow, mapCol);
+  }
+}
+function remapRange(text, mapRow, mapCol) {
+  const range = parseChartRange(text); if (!range) return text;
+  const first = (from, to, map) => { for (let i = from; i <= to; i++) { const m = map(i); if (m != null) return m; } return null; };
+  const last = (from, to, map) => { for (let i = to; i >= from; i--) { const m = map(i); if (m != null) return m; } return null; };
+  const r1 = first(range.r1, range.r2, mapRow), r2 = last(range.r1, range.r2, mapRow);
+  const c1 = first(range.c1, range.c2, mapCol), c2 = last(range.c1, range.c2, mapCol);
+  if (r1 == null || c1 == null) return "";
+  return text.includes(":") || r1 !== r2 || c1 !== c2 ? `${rcToRef(r1, c1)}:${rcToRef(r2, c2)}` : rcToRef(r1, c1);
 }
 
 function insertRows(at, count) {
@@ -1931,7 +1950,7 @@ function insertRows(at, count) {
     else if (at <= (sh.filter.endRow ?? sh.rows - 1)) sh.filter.endRow = (sh.filter.endRow ?? sh.rows - 1) + count;
   }
   rewriteAllFormulas(at, count, 0, 0);
-  rebuildSheetCells((r, c) => ({ r: r >= at ? r + count : r, c }));
+  rebuildSheetCells((r) => r >= at ? r + count : r, (c) => c);
   sh.rows += count;
   shiftDims(sh.rowHeights, at, count);
   commitStructuralChange();
@@ -1946,7 +1965,7 @@ function insertCols(at, count) {
     sh.filter.columns = filterColumns(sh.filter).map((column) => column >= at ? column + count : column);
   }
   rewriteAllFormulas(0, 0, at, count);
-  rebuildSheetCells((r, c) => ({ r, c: c >= at ? c + count : c }));
+  rebuildSheetCells((r) => r, (c) => c >= at ? c + count : c);
   sh.cols += count;
   shiftDims(sh.colWidths, at, count);
   commitStructuralChange();
@@ -1967,7 +1986,7 @@ function deleteRows() {
     }
   }
   rewriteAllFormulas(at + count, -count, 0, 0);
-  rebuildSheetCells((row, c) => (row >= at && row < at + count) ? null : ({ r: row > at ? row - count : row, c }));
+  rebuildSheetCells((row) => (row >= at && row < at + count) ? null : (row > at ? row - count : row), (c) => c);
   sh.rows -= count;
   removeDims(sh.rowHeights, at, count);
   commitStructuralChange();
@@ -1992,7 +2011,7 @@ function deleteCols() {
     if (!sh.filter.columns.length) sh.filter = null;
   }
   rewriteAllFormulas(0, 0, at + count, -count);
-  rebuildSheetCells((row, c) => (c >= at && c < at + count) ? null : ({ r: row, c: c > at ? c - count : c }));
+  rebuildSheetCells((row) => row, (c) => (c >= at && c < at + count) ? null : (c > at ? c - count : c));
   sh.cols -= count;
   removeDims(sh.colWidths, at, count);
   commitStructuralChange();
@@ -2032,7 +2051,7 @@ function sortSelection(asc) {
     for (let col = r.c1; col <= r.c2; col++) { const c = cells[rcToRef(row, col)]; if (c) rowCells[col] = { ...c }; }
     const keyVal = engine.computeRef(activeSheetId, rcToRef(row, r.c1));
     const rowComments = sheetComments().filter((comment) => { const position = parseRef(comment.ref); return position?.r === row && position.c >= r.c1 && position.c <= r.c2; });
-    rows.push({ rowCells, keyVal, rowComments });
+    rows.push({ rowCells, keyVal, rowComments, sourceRow: row });
   }
   rows.sort((x, y) => {
     let a = x.keyVal, b = y.keyVal;
@@ -2049,7 +2068,7 @@ function sortSelection(asc) {
     for (let col = r.c1; col <= r.c2; col++) {
       const src = rows[i].rowCells[col];
       const ref = rcToRef(row, col);
-      if (src) cells[ref] = { value: src.value, fmt: src.fmt, version: (cells[ref]?.version || 0) };
+      if (src) cells[ref] = { value: shiftedCopyFormula(src.value, rcToRef(rows[i].sourceRow, col), ref, false), fmt: src.fmt, version: (cells[ref]?.version || 0) };
       else delete cells[ref];
     }
     for (const comment of rows[i].rowComments) {
@@ -2103,7 +2122,7 @@ function aggregateState() { return { sum: 0, count: 0, numericCount: 0, min: Inf
 function addAggregate(state, value) {
   if (value != null && value !== "" && !isErr(value)) state.count++;
   const number = typeof value === "number" ? value : Number(value);
-  if (Number.isFinite(number) && value !== "") { state.sum += number; state.numericCount++; state.min = Math.min(state.min, number); state.max = Math.max(state.max, number); }
+  if (value != null && value !== "" && Number.isFinite(number)) { state.sum += number; state.numericCount++; state.min = Math.min(state.min, number); state.max = Math.max(state.max, number); }
 }
 function finishAggregate(state, kind) {
   if (kind === "count") return state.count;
@@ -2174,11 +2193,15 @@ function refreshPivot(sheetId, save = true) {
   rebuildEngine();
   if (activeSheetId === sheetId) renderGrid();
 }
+// Edits to several source sheets inside the debounce window refresh every one of their pivots.
+const pendingPivotSources = new Set();
 function schedulePivotRefreshes(sourceSheetId) {
+  pendingPivotSources.add(sourceSheetId);
   clearTimeout(pivotRefreshTimer);
   pivotRefreshTimer = setTimeout(() => {
+    const sources = new Set(pendingPivotSources); pendingPivotSources.clear();
     rebuildEngine();
-    for (const id of pivotSheets()) if (model.sheets[id].pivot.sourceSheetId === sourceSheetId) refreshPivot(id);
+    for (const id of pivotSheets()) if (sources.has(model.sheets[id].pivot.sourceSheetId)) refreshPivot(id);
   }, 320);
 }
 function createPivotTable() {
@@ -2797,12 +2820,12 @@ function filterTokenLabel(token) {
 function filterColumns(filter) {
   return filter?.columns?.length ? filter.columns : Array.from({ length: curSheet().cols }, (_, column) => column);
 }
-function rowPassesFilter(row) {
-  const filter = curSheet()?.filter;
-  if (!filter || row <= filter.row || row > (filter.endRow ?? curSheet().rows - 1)) return true;
+function rowPassesFilter(row, sheetId = activeSheetId) {
+  const sheet = model.sheets[sheetId], filter = sheet?.filter;
+  if (!filter || row <= filter.row || row > (filter.endRow ?? sheet.rows - 1)) return true;
   for (const [column, selected] of Object.entries(filter.criteria || {})) {
     if (!selected?.length) continue;
-    const token = filterToken(engine.computeRef(activeSheetId, rcToRef(row, Number(column))));
+    const token = filterToken(engine.computeRef(sheetId, rcToRef(row, Number(column))));
     if (!selected.includes(token)) return false;
   }
   return true;
@@ -2816,15 +2839,10 @@ function detectFilterRange() {
   const selection = selRange();
   const explicit = selection.r2 > selection.r1;
   if (explicit) {
-    const columns = [];
-    for (let column = selection.c1; column <= selection.c2; column++) {
-      let populated = false;
-      for (let row = selection.r1; row <= selection.r2; row++) if (hasCellData(row, column)) { populated = true; break; }
-      if (populated) columns.push(column);
-    }
-    return columns.length && selection.r2 > selection.r1
-      ? { row: selection.r1, endRow: selection.r2, columns, criteria: {}, rowOrder: Array.from({ length: selection.r2 - selection.r1 }, (_, index) => selection.r1 + 1 + index), sort: null }
-      : null;
+    // Every selected column belongs to the record, even one still blank, so a later sort moves
+    // whole rows.
+    const columns = Array.from({ length: selection.c2 - selection.c1 + 1 }, (_, index) => selection.c1 + index);
+    return { row: selection.r1, endRow: selection.r2, columns, criteria: {}, rowOrder: Array.from({ length: selection.r2 - selection.r1 }, (_, index) => selection.r1 + 1 + index), sort: null };
   }
 
   let minRow = sheet.rows, maxRow = -1, minColumn = sheet.cols, maxColumn = -1;
@@ -2924,7 +2942,8 @@ function reorderFilteredRows(compare, nextSort) {
     const row = filter.row + 1 + index;
     for (const col of columns) {
       const ref = rcToRef(row, col), source = rows[index].rowCells[col];
-      if (source) curCells()[ref] = { value: source.value, fmt: source.fmt, version: getCell(ref)?.version || 0 };
+      // Rows move as in Excel's sort: relative references travel with the formula.
+      if (source) curCells()[ref] = { value: shiftedCopyFormula(source.value, rcToRef(rows[index].currentRow, col), ref, false), fmt: source.fmt, version: getCell(ref)?.version || 0 };
       else delete curCells()[ref];
     }
     for (const comment of rows[index].rowComments) {
@@ -2974,7 +2993,7 @@ function openFilterMenu(column, trigger) {
   clearSort.disabled = !filter.sort;
   sortUp.addEventListener("click", () => { closeCtx(); sortFilteredRange(column, true); });
   sortDown.addEventListener("click", () => { closeCtx(); sortFilteredRange(column, false); });
-  clearSort.addEventListener("click", () => { if (filter.sort) { closeCtx(); clearFilteredSort(); } });
+  clearSort.addEventListener("click", () => { if (curSheet()?.filter?.sort) { closeCtx(); clearFilteredSort(); } });
   menu.appendChild(el("div", { class: "filter-sort" }, [sortUp, sortDown, clearSort]));
   const list = el("div", { class: "filter-options" });
   const checks = [];
@@ -3000,15 +3019,22 @@ function openFilterMenu(column, trigger) {
   menu.appendChild(list);
   const clear = el("button", {}, "Clear filter");
   const apply = el("button", { class: "primary" }, "Apply");
+  // Remote structure updates replace the sheet's metadata object, so the filter is resolved when
+  // the button is clicked rather than when the menu opened.
+  const liveFilter = () => curSheet()?.filter;
   clear.addEventListener("click", () => {
-    delete filter.criteria[column];
-    closeCtx(); queueStructure(); renderGrid(); refreshToolbarState();
+    const current = liveFilter(); closeCtx();
+    if (!current) return;
+    delete current.criteria[column];
+    queueStructure(); renderGrid(); refreshToolbarState();
   });
   apply.addEventListener("click", () => {
+    const current = liveFilter(); closeCtx();
+    if (!current) return;
     const selected = checks.filter((entry) => entry.checkbox.checked).map((entry) => entry.token);
-    if (selected.length === checks.length) delete filter.criteria[column];
-    else filter.criteria[column] = selected.length ? selected : ["x:__none__"];
-    closeCtx(); queueStructure(); renderGrid(); refreshToolbarState();
+    if (selected.length === checks.length) delete current.criteria[column];
+    else current.criteria[column] = selected.length ? selected : ["x:__none__"];
+    queueStructure(); renderGrid(); refreshToolbarState();
   });
   menu.appendChild(el("div", { class: "filter-actions" }, [clear, apply]));
   const rect = trigger.getBoundingClientRect();
@@ -3311,6 +3337,7 @@ function renderPrintSheet(sheetId) {
 
   const tbody = el("tbody");
   for (let r = 0; r < bounds.rows; r++) {
+    if (!rowPassesFilter(r, sheetId)) continue; // rows the filter hides in the grid stay hidden in print
     const height = Math.max(20, Math.min(120, sheet.rowHeights[r] || DEFAULT_ROW_H));
     const row = el("tr", { style: `height:${height}px` });
     row.appendChild(el("th", { class: "rowhead" }, String(r + 1)));
@@ -3964,7 +3991,7 @@ function startEdit(ref, replace = false, seed = null, fromCapture = false, keepI
   const rc = parseRef(ref);
   const td = cellEl(rc.r, rc.c);
   if (!td) return;
-  editing = { ref, r: rc.r, c: rc.c };
+  editing = { ref, r: rc.r, c: rc.c, sheetId: activeSheetId };
   fillHandle.style.display = "none";
   const cell = getCell(ref);
   let text = seed != null ? seed : (replace ? "" : (cell ? cell.value : ""));
@@ -4071,14 +4098,17 @@ function showFormulaError(message) {
   formulaAssistItems = []; formulaAssist.style.display = "block"; requestAnimationFrame(positionFormulaAssist);
   setStatus("bad", "Fix formula error");
 }
+// Returns false when the value was rejected and the editor stays open, so callers that would
+// navigate away (sheet switches) can stop.
 function commitEdit(advance = "down") {
-  if (!editing) return;
+  if (!editing) return true;
+  if (editing.sheetId !== activeSheetId) { cancelEdit(); return true; }
   const { ref, r, c } = editing;
   let value = completeFormulaParentheses(cellEditor.value);
-  if (value == null) { showFormulaError("Formula quotes and parentheses must be balanced."); cellEditor.focus(); return; }
+  if (value == null) { showFormulaError("Formula quotes and parentheses must be balanced."); cellEditor.focus(); return false; }
   cellEditor.value = value;
   const formulaError = validateFormula(value);
-  if (formulaError) { showFormulaError(formulaError); cellEditor.focus(); return; }
+  if (formulaError) { showFormulaError(formulaError); cellEditor.focus(); return false; }
   imeComposing = false;
   editing = null; absoluteRefBtn.disabled = true;
   closeFormulaAssist(); clearFormulaPick();
@@ -4094,6 +4124,7 @@ function commitEdit(advance = "down") {
   else if (advance === "left") moveActive(r, c - 1);
   else moveActive(r, c);
   gridScroll.focus();
+  return true;
 }
 function cancelEdit() {
   if (!editing) return;
@@ -4393,11 +4424,16 @@ function deleteSelectionContents() {
 // ===========================================================================
 let copyRange = null;
 let copyFallback = null;
+// Whole-row and whole-column selections are trimmed to the populated extent; `trimmed` records
+// which axis, so a paste does not mistake the trimmed block for a repeatable pattern.
 function clipboardReferenceMatrix() {
   const ranges = selectionRanges();
   const sheet = curSheet();
   const allRows = ranges.every((range) => range.c1 === 0 && range.c2 === sheet.cols - 1);
   const allColumns = ranges.every((range) => range.r1 === 0 && range.r2 === sheet.rows - 1);
+  return { refs: clipboardReferences(ranges, sheet, allRows, allColumns), trimmed: allRows ? "rows" : allColumns ? "columns" : null };
+}
+function clipboardReferences(ranges, sheet, allRows, allColumns) {
   if (allRows) {
     const rows = [...new Set(ranges.flatMap((range) => Array.from({ length: range.r2 - range.r1 + 1 }, (_, index) => range.r1 + index)))].sort((a, b) => a - b);
     let lastColumn = 0;
@@ -4427,14 +4463,14 @@ function clipboardCellText(ref) {
   return cell.value?.startsWith("=") ? (isErr(value) ? value.value : (value == null ? "" : String(value))) : (cell.value || "");
 }
 function prepareClipboard(cut = false) {
-  const refs = clipboardReferenceMatrix();
+  const { refs, trimmed } = clipboardReferenceMatrix();
   const cells = refs.map((row) => row.map((ref) => {
     const cell = ref ? getCell(ref) : null;
     return cell ? { value: cell.value, fmt: cell.fmt, sourceRef: ref } : (ref ? { value: null, fmt: null, sourceRef: ref } : null);
   }));
   const tsv = refs.map((row) => row.map(clipboardCellText).join("\t")).join("\n");
   copyRange = { ...selRange() };
-  copyFallback = { tsv, cells, refs, sheetId: activeSheetId, cut };
+  copyFallback = { tsv, cells, refs, trimmed, sheetId: activeSheetId, cut };
   return tsv;
 }
 function requestGridClipboard(cut = false) {
@@ -4491,7 +4527,8 @@ function shiftedCopyFormula(value, sourceRef, targetRef, isCut) {
   const source = parseRef(sourceRef), target = parseRef(targetRef);
   if (!source || !target) return value;
   const rowDelta = target.r - source.r, colDelta = target.c - source.c;
-  return rewriteFormulaOutsideQuotes(value, (segment) => segment.replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,2})(\$?)([1-9]\d*)(?![A-Z0-9_])/gi, (match, fixedColumn, letters, fixedRow, rowText) => {
+  // `(?!!)` leaves an unquoted sheet name such as `Q1!` alone.
+  return rewriteFormulaOutsideQuotes(value, (segment) => segment.replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,2})(\$?)([1-9]\d*)(?![A-Z0-9_!])/gi, (match, fixedColumn, letters, fixedRow, rowText) => {
     let row = Number(rowText) - 1, column = letterToCol(letters);
     if (!fixedRow) row += rowDelta;
     if (!fixedColumn) column += colDelta;
@@ -4523,9 +4560,14 @@ function pasteText(text, { keepFormatting = true } = {}) {
   beginBatch();
   for (const target of targetRanges) {
     const targetHeight = target.r2 - target.r1 + 1, targetWidth = target.c2 - target.c1 + 1;
-    const repeat = (sourceHeight === 1 && sourceWidth === 1) || (targetHeight >= sourceHeight && targetWidth >= sourceWidth && targetHeight % sourceHeight === 0 && targetWidth % sourceWidth === 0);
-    const pasteHeight = repeat ? targetHeight : sourceHeight;
-    const pasteWidth = repeat ? targetWidth : sourceWidth;
+    // A trimmed whole-row copy keeps its own width (and a whole-column copy its height): the trim
+    // is not a pattern to tile across the destination.
+    const trimmedRows = useSnapshot && copyFallback.trimmed === "rows", trimmedColumns = useSnapshot && copyFallback.trimmed === "columns";
+    const widthFits = trimmedRows || (targetWidth >= sourceWidth && targetWidth % sourceWidth === 0);
+    const heightFits = trimmedColumns || (targetHeight >= sourceHeight && targetHeight % sourceHeight === 0);
+    const repeat = (sourceHeight === 1 && sourceWidth === 1 && !trimmedRows && !trimmedColumns) || (widthFits && heightFits);
+    const pasteHeight = repeat && !trimmedColumns ? targetHeight : sourceHeight;
+    const pasteWidth = repeat && !trimmedRows ? targetWidth : sourceWidth;
     for (let i = 0; i < pasteHeight; i++) for (let j = 0; j < pasteWidth; j++) {
       const row = target.r1 + i, column = target.c1 + j;
       if (row > target.r2 && targetRanges.length > 1 || column > target.c2 && targetRanges.length > 1) continue;
@@ -4787,7 +4829,7 @@ function renderTabs() {
   tabbar.appendChild(add);
 }
 function switchSheet(id) {
-  if (editing) commitEdit("none");
+  if (editing && !commitEdit("none")) return;
   activeSheetId = id;
   if (model.sheets[id]?.pivot) refreshPivot(id);
   anchor = { r: 0, c: 0 }; focus = { r: 0, c: 0 }; extraRanges = [];
@@ -4796,6 +4838,7 @@ function switchSheet(id) {
   sendPresence();
 }
 function addSheet() {
+  if (editing && !commitEdit("none")) return;
   const id = "s_" + Math.random().toString(36).slice(2, 8);
   let n = model.sheetOrder.length + 1;
   while (model.sheetOrder.some((sid) => model.sheets[sid].name === "Sheet" + n)) n++;
@@ -4821,6 +4864,7 @@ function sheetTabMenu(id, e) {
   showCtx(menu, e.clientX, e.clientY);
 }
 function duplicateSheet(id) {
+  if (editing && !commitEdit("none")) return;
   const src = model.sheets[id];
   const nid = "s_" + Math.random().toString(36).slice(2, 8);
   model.sheets[nid] = { ...JSON.parse(JSON.stringify(src)), id: nid, name: src.name + " copy" };
@@ -4831,7 +4875,7 @@ function duplicateSheet(id) {
   switchSheet(nid);
 }
 function deleteSheet(id) {
-  if (model.sheetOrder.length <= 1) return;
+  if (model.sheetOrder.length <= 1 || (editing && !commitEdit("none"))) return;
   const idx = model.sheetOrder.indexOf(id);
   model.sheetOrder.splice(idx, 1);
   delete model.sheets[id]; delete model.cells[id];
@@ -4928,18 +4972,59 @@ function applyRemoteOperation(event) {
   if (event.replacedCells) for (const [sid, cells] of Object.entries(event.replacedCells)) model.cells[sid] = cells;
   applyingRemote = false;
   rebuildEngine();
-  if (!model.sheets[activeSheetId]) activeSheetId = model.sheetOrder[0];
+  if (!model.sheets[activeSheetId]) { if (editing) cancelEdit(); activeSheetId = model.sheetOrder[0]; }
   if (selectedChartId && !(curSheet().charts || []).some((chart) => chart.id === selectedChartId)) selectedChartId = null;
   renderTabs(); renderGrid(); renderChartPanel();
   setStatus("synced", "Live update");
   setTimeout(() => { if (!saveInFlight && !pendingCellOps.size) setStatus("saved", "Saved"); }, 900);
 }
+// Remote structure replaces the model wholesale (last writer wins on the server). Local changes
+// that are still pending are diffed against `ackedStructure` and replayed on top, per sheet field,
+// so a remote chart and a local comment on the same sheet both survive.
 function applyStructure(s) {
+  const local = pendingStructure ? localStructureChanges() : null;
   if (s.title != null && document.activeElement !== titleInput) { model.title = s.title; titleInput.value = s.title; }
   else if (s.title != null) model.title = s.title;
   model.sheetOrder = s.sheetOrder.slice();
   for (const id of model.sheetOrder) model.sheets[id] = { ...model.sheets[id], ...s.sheets[id] };
-  for (const id of Object.keys(model.sheets)) if (!model.sheetOrder.includes(id)) { delete model.sheets[id]; delete model.cells[id]; }
+  const added = new Set(local?.added);
+  for (const id of Object.keys(model.sheets)) if (!model.sheetOrder.includes(id) && !added.has(id)) { delete model.sheets[id]; delete model.cells[id]; }
+  ackedStructure = { title: model.title, sheetOrder: model.sheetOrder.slice(), sheets: JSON.parse(JSON.stringify(Object.fromEntries(model.sheetOrder.map((id) => [id, model.sheets[id]])))) };
+  if (!local) return;
+  if (local.title != null) { model.title = local.title; if (document.activeElement !== titleInput) titleInput.value = local.title; }
+  for (const id of local.removed) {
+    const index = model.sheetOrder.indexOf(id);
+    if (index >= 0) { model.sheetOrder.splice(index, 1); delete model.sheets[id]; delete model.cells[id]; }
+  }
+  for (const [id, fields] of Object.entries(local.sheets)) {
+    if (added.has(id)) { model.sheets[id] = { ...model.sheets[id], ...fields }; model.sheetOrder.push(id); }
+    else if (model.sheetOrder.includes(id)) Object.assign(model.sheets[id], fields);
+    // A sheet deleted remotely while edited here stays deleted.
+  }
+  if (local.sheetOrder) {
+    const order = local.sheetOrder.filter((id) => model.sheetOrder.includes(id));
+    model.sheetOrder = [...order, ...model.sheetOrder.filter((id) => !order.includes(id))];
+  }
+  pendingStructure = structureSnapshot();
+}
+function localStructureChanges() {
+  const base = ackedStructure || { title: pendingStructure.title, sheetOrder: [], sheets: {} };
+  const same = (a, b) => JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+  const changes = {
+    title: pendingStructure.title !== base.title ? pendingStructure.title : null,
+    sheetOrder: same(pendingStructure.sheetOrder, base.sheetOrder) ? null : pendingStructure.sheetOrder,
+    added: Object.keys(pendingStructure.sheets).filter((id) => !base.sheets[id]),
+    removed: base.sheetOrder.filter((id) => !pendingStructure.sheets[id]),
+    sheets: {},
+  };
+  for (const [id, sheet] of Object.entries(pendingStructure.sheets)) {
+    const baseSheet = base.sheets[id];
+    if (!baseSheet) { changes.sheets[id] = sheet; continue; }
+    const fields = {};
+    for (const key of new Set([...Object.keys(sheet), ...Object.keys(baseSheet)])) if (!same(sheet[key], baseSheet[key])) fields[key] = sheet[key];
+    if (Object.keys(fields).length) changes.sheets[id] = fields;
+  }
+  return changes;
 }
 
 function applySnapshot(doc) {
@@ -4950,6 +5035,7 @@ function applySnapshot(doc) {
   model.sheets = doc.sheets || {};
   model.cells = doc.cells || {};
   for (const id of model.sheetOrder) if (!model.cells[id]) model.cells[id] = {};
+  ackedStructure = structureSnapshot();
   titleInput.value = model.title;
   if (!activeSheetId || !model.sheets[activeSheetId]) activeSheetId = model.sheetOrder[0];
   applyingRemote = false;

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
@@ -141,7 +141,75 @@ html, body {
 .finput:focus { background: #fffdfa; }
 
 /* --- Grid ----------------------------------------------------------------*/
-.grid-scroll { flex: 1 1 auto; overflow: auto; position: relative; background: var(--surface); outline: none; }
+.workarea { flex: 1 1 auto; min-height: 0; display: flex; position: relative; }
+.grid-scroll { flex: 1 1 auto; min-width: 0; overflow: auto; position: relative; background: var(--surface); outline: none; }
+.chart-layer { position: absolute; left: 0; top: 0; width: 100%; min-height: 100%; pointer-events: none; z-index: 7; }
+.chart-card { position: absolute; background: var(--surface); border: 1px solid var(--line-strong); border-radius: 9px;
+  box-shadow: 0 8px 24px rgba(0,0,0,.14); pointer-events: auto; overflow: hidden; }
+.chart-card.selected { box-shadow: 0 0 0 2px var(--accent), 0 8px 24px rgba(0,0,0,.16); }
+.chart-card-head { height: 32px; display: flex; align-items: center; gap: 8px; padding: 0 7px 0 10px; border-bottom: 1px solid var(--line); cursor: move; user-select: none; touch-action: none; }
+.chart-card-head strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12.5px; }
+.chart-card-range { color: var(--faint); font-size: 11px; margin-left: auto; }
+.chart-card-copy { flex: 0 0 auto; border: 0; border-radius: 5px; background: transparent; color: var(--muted); padding: 4px 6px; cursor: pointer; font-size: 11px; }
+.chart-card-copy:hover { background: var(--surface-2); color: var(--text); }
+.chart-card-body { height: calc(100% - 32px); padding: 8px; }
+.chart-card svg { width: 100%; height: 100%; display: block; }
+.chart-empty { height: 100%; display: flex; align-items: center; justify-content: center; color: var(--faint); text-align: center; padding: 24px; }
+.chart-panel { width: 330px; flex: 0 0 330px; border-left: 1px solid var(--line); background: var(--surface); overflow-y: auto;
+  transition: width .18s var(--ease-out), flex-basis .18s var(--ease-out); }
+.chart-panel.collapsed { width: 38px; flex-basis: 38px; overflow: hidden; }
+.chart-panel-head { height: 42px; display: flex; align-items: center; gap: 8px; padding: 0 10px; border-bottom: 1px solid var(--line); position: sticky; top: 0; background: var(--surface); z-index: 2; }
+.chart-panel-head strong { white-space: nowrap; }
+.chart-panel-toggle, .chart-panel-back { width: 26px; height: 26px; flex: 0 0 auto; border: 0; border-radius: 5px; background: transparent; cursor: pointer; color: var(--muted); font-size: 17px; }
+.chart-panel-toggle { margin-left: auto; }
+.chart-panel-toggle:hover, .chart-panel-back:hover { background: var(--surface-2); }
+.chart-panel.collapsed .chart-panel-head strong, .chart-panel.collapsed .chart-panel-content, .chart-panel.collapsed .chart-panel-back { display: none; }
+.chart-panel-content { padding: 14px; display: flex; flex-direction: column; gap: 13px; }
+.chart-field { display: flex; flex-direction: column; gap: 5px; }
+.chart-field > span { color: var(--muted); font-size: 11.5px; font-weight: 600; }
+.chart-field input[type=text], .chart-field select { width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; padding: 7px 8px; outline: none; color: var(--text); background: var(--surface); }
+.chart-field input[type=text]:focus, .chart-field select:focus { border-color: var(--accent); }
+.chart-check { display: flex; align-items: center; gap: 8px; color: var(--text); }
+.chart-check input { accent-color: var(--accent); }
+.chart-panel-actions { display: flex; justify-content: space-between; gap: 8px; border-top: 1px solid var(--line); padding-top: 12px; }
+.chart-copy { border: 1px solid var(--line-strong); background: var(--surface); color: var(--text); border-radius: 6px; padding: 6px 10px; cursor: pointer; }
+.chart-copy:hover { background: var(--surface-2); }
+.chart-delete { border: 1px solid rgba(196,86,106,.35); background: rgba(196,86,106,.08); color: var(--bad); border-radius: 6px; padding: 6px 10px; cursor: pointer; }
+.chart-copy-note { margin: -5px 1px 0; color: var(--faint); font-size: 10.5px; line-height: 1.4; }
+.sidebar-menu { display: flex; flex-direction: column; gap: 8px; }
+.sidebar-menu-item { width: 100%; display: flex; align-items: center; gap: 10px; padding: 12px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: var(--text); cursor: pointer; text-align: left; }
+.sidebar-menu-item:hover { background: var(--surface-2); border-color: var(--line-strong); }
+.sidebar-menu-icon { width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; border-radius: 7px; background: var(--accent-soft); color: var(--accent); }
+.sidebar-menu-icon svg { width: 15px; height: 15px; }
+.sidebar-menu-label { font-weight: 650; }
+.sidebar-menu-count { margin-left: auto; color: var(--faint); }
+.sidebar-menu-arrow { color: var(--faint); font-size: 17px; }
+.chart-list { display: flex; flex-direction: column; gap: 8px; }
+.chart-list-item { width: 100%; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); padding: 10px; cursor: pointer; text-align: left; color: var(--text); }
+.chart-list-item:hover { background: var(--surface-2); border-color: var(--line-strong); }
+.chart-list-item strong { display: block; margin-bottom: 3px; }
+.chart-list-item span { color: var(--faint); font-size: 11px; }
+.pivot-note { color: var(--faint); font-size: 11px; line-height: 1.4; }
+.pivot-filter-values { border: 1px solid var(--line); border-radius: 7px; max-height: 180px; overflow: auto; padding: 5px; }
+.pivot-filter-option { display: flex; align-items: center; gap: 7px; padding: 5px; border-radius: 5px; cursor: pointer; }
+.pivot-filter-option:hover { background: var(--surface-2); }
+.pivot-filter-option input { accent-color: var(--accent); }
+.pivot-actions { display: flex; gap: 8px; padding-top: 4px; }
+.pivot-actions button { border: 1px solid var(--line-strong); border-radius: 6px; padding: 6px 10px; background: var(--surface); color: var(--text); cursor: pointer; }
+.pivot-actions button:hover { background: var(--surface-2); }
+.pivot-actions button.danger { margin-left: auto; color: var(--bad); border-color: rgba(196,86,106,.35); background: rgba(196,86,106,.08); }
+.comments-section { display: flex; flex-direction: column; gap: 8px; }
+.comments-section:first-child { border-top: 0; padding-top: 0; }
+.comments-heading { display: flex; align-items: center; justify-content: space-between; color: var(--muted); font-size: 11.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .045em; }
+.comment-card { border: 1px solid var(--line); border-radius: 7px; padding: 8px; cursor: pointer; background: var(--surface); }
+.comment-card:hover { border-color: var(--line-strong); background: #fffdfa; }
+.comment-card-ref { color: var(--accent); font-weight: 700; font-size: 11px; margin-bottom: 4px; }
+.comment-card-text { white-space: pre-wrap; overflow-wrap: anywhere; line-height: 1.4; }
+.comment-card-actions { display: flex; gap: 6px; margin-top: 8px; }
+.comment-card-actions button { border: 1px solid var(--line); border-radius: 5px; padding: 4px 7px; background: var(--surface); color: var(--muted); cursor: pointer; font-size: 11px; }
+.comment-card-actions button:hover { background: var(--surface-2); color: var(--text); }
+.comment-card-actions button.danger:hover { color: var(--bad); background: rgba(196,86,106,.08); }
+@media (max-width: 760px) { .chart-panel { position: absolute; right: 0; top: 0; bottom: 0; z-index: 30; box-shadow: -8px 0 24px rgba(0,0,0,.12); } }
 table.grid { border-collapse: separate; border-spacing: 0; table-layout: fixed; width: max-content; }
 table.grid th, table.grid td { padding: 0; margin: 0; }
 .grid th.colhead, .grid th.rowhead, .grid th.corner {
@@ -159,13 +227,71 @@ table.grid th, table.grid td { padding: 0; margin: 0; }
   font-size: 13px; line-height: 24px; padding: 0 4px; vertical-align: middle; cursor: cell;
   color: var(--text); }
 .grid td.cell .cv { display: block; overflow: hidden; text-overflow: clip; white-space: nowrap; }
+.grid td.cell a.cell-link { color: #1967d2; text-decoration: underline; cursor: pointer; }
+.grid td.cell a.cell-link:hover { color: #174ea6; }
 .grid td.cell.num .cv { text-align: right; }
 .grid td.cell.err { color: var(--bad); }
 .grid td.cell.err .cv { text-align: center; }
+.grid td.cell.has-error-detail { overflow: visible; z-index: 6; }
+.formula-error-tooltip { display: none; position: absolute; left: calc(100% + 4px); top: -5px; z-index: 40; width: 300px; padding: 9px 10px; border: 1px solid rgba(196,86,106,.35); border-radius: 7px; background: #fff8f9; color: var(--text); box-shadow: 0 9px 24px rgba(0,0,0,.17); white-space: normal; line-height: 1.4; text-align: left; font-weight: 400; }
+.grid td.cell.has-error-detail:hover > .formula-error-tooltip { display: block; }
+.formula-error-tooltip strong { display: block; color: var(--bad); margin-bottom: 4px; }
+.formula-error-preview { margin-top: 7px; padding: 6px 7px; border-radius: 5px; background: #fff; color: var(--muted); font-family: ui-monospace, "SF Mono", Menlo, monospace; overflow-wrap: anywhere; }
+.formula-error-preview mark { background: rgba(196,86,106,.22); color: #9d3048; border-radius: 3px; padding: 1px 2px; }
 .grid td.cell.sel { background: var(--accent-soft); }
 .grid td.cell.active { box-shadow: inset 0 0 0 2px var(--accent); z-index: 2; }
-.grid td.cell.wrap { white-space: normal; line-height: 1.35; }
-.grid td.cell.wrap .cv { white-space: normal; }
+.grid td.cell.wrap { white-space: normal; line-height: 1.35; height: auto; padding-top: 3px; padding-bottom: 3px; }
+.grid td.cell.wrap .cv {
+  white-space: normal;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.35;
+}
+.grid td.cell.text-overflow { overflow: visible; z-index: 1; }
+.grid td.cell.text-overflow .cv { position: absolute; left: 4px; top: 0; overflow: hidden; white-space: nowrap; z-index: 2; pointer-events: none; }
+.grid td.cell.text-overflow a.cell-link { pointer-events: auto; }
+.grid td.cell.has-comment { overflow: visible; z-index: 4; }
+.comment-marker { position: absolute; right: 0; top: 0; width: 0; height: 0; border-top: 9px solid var(--accent); border-left: 9px solid transparent; z-index: 5; cursor: pointer; }
+.filter-cell .comment-marker { right: auto; left: 0; border-left: 0; border-right: 9px solid transparent; }
+.cell-comment-tooltip { display: none; position: absolute; z-index: 30; left: 100%; top: -4px; width: 230px; max-height: 150px; overflow: auto; white-space: normal; line-height: 1.4; padding: 9px 10px; border: 1px solid var(--line-strong); border-radius: 7px; background: var(--surface); color: var(--text); box-shadow: 0 8px 22px rgba(0,0,0,.17); font-weight: 400; }
+.grid td.cell:hover > .cell-comment-tooltip { display: block; }
+.comment-popover { position: fixed; z-index: 1500; width: min(320px, calc(100vw - 20px)); padding: 10px; border: 1px solid var(--line-strong); border-radius: 9px; background: var(--surface); box-shadow: 0 12px 32px rgba(0,0,0,.2); }
+.comment-popover textarea { width: 100%; min-height: 84px; resize: vertical; border: 1px solid var(--line-strong); border-radius: 6px; padding: 8px; outline: none; color: var(--text); font: inherit; }
+.comment-popover textarea:focus { border-color: var(--accent); }
+.comment-popover-actions { display: flex; justify-content: flex-end; gap: 7px; margin-top: 8px; }
+.comment-popover button { border: 1px solid var(--line); border-radius: 6px; background: var(--surface); color: var(--text); padding: 5px 9px; cursor: pointer; }
+.comment-popover button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.grid tr.filter-row td.cell.filter-cell { background: #fff8f3; font-weight: 600; padding-right: 27px; }
+.grid tr.filter-row th.rowhead:not(.hl):not(.full) { background: #edf3ef; color: #52715f; box-shadow: inset 3px 0 #7ba889; }
+.filter-trigger { position: absolute; right: 3px; top: 3px; width: 18px; height: 18px; border: 1px solid var(--line);
+  border-radius: 4px; background: var(--surface); color: var(--muted); display: inline-flex; align-items: center;
+  justify-content: center; cursor: pointer; padding: 0; z-index: 3; }
+.filter-trigger:hover, .filter-trigger.active { color: var(--accent); border-color: rgba(225,99,46,.5); background: var(--accent-soft); }
+.filter-trigger svg { width: 11px; height: 11px; }
+.filter-menu { min-width: 230px; max-width: min(320px, 90vw); }
+.filter-menu-title { padding: 7px 9px 5px; font-size: 11px; font-weight: 700; color: var(--faint); text-transform: uppercase; letter-spacing: .05em; }
+.filter-sort { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 5px; padding: 2px 5px 7px; border-bottom: 1px solid var(--line); }
+.filter-sort button, .filter-links button { border: 0; background: transparent; color: var(--text); padding: 6px; border-radius: 5px; cursor: pointer; text-align: left; }
+.filter-sort button:hover, .filter-links button:hover { background: var(--surface-2); }
+.filter-sort button[disabled] { color: var(--faint); cursor: default; background: transparent; }
+.filter-links { display: flex; align-items: center; justify-content: space-between; padding: 5px; }
+.filter-links button { color: var(--accent); padding: 4px; }
+.filter-search { margin: 0 5px 5px; width: calc(100% - 10px); border: 1px solid var(--line-strong); border-radius: 6px; padding: 7px 9px; outline: none; }
+.filter-search:focus { border-color: var(--accent); }
+.filter-options { max-height: 240px; overflow: auto; padding: 2px 4px; }
+.filter-option { display: flex; align-items: center; gap: 8px; padding: 6px; border-radius: 5px; cursor: pointer; }
+.filter-option:hover { background: var(--surface-2); }
+.filter-option input { accent-color: var(--accent); }
+.filter-option span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.filter-actions { display: flex; justify-content: space-between; gap: 8px; padding: 7px 5px 3px; border-top: 1px solid var(--line); }
+.filter-actions button { border: 1px solid var(--line); border-radius: 5px; background: var(--surface); color: var(--text); padding: 5px 9px; cursor: pointer; }
+.filter-actions button.primary { background: var(--accent); color: white; border-color: var(--accent); }
+.filter-empty { padding: 10px; color: var(--faint); }
+
+/* Fill handle + resize handles */
+.fill-handle { position: absolute; z-index: 22; width: 8px; height: 8px; border: 1px solid #fff; border-radius: 2px; background: var(--accent); cursor: crosshair; display: none; }
+.grid td.cell.fill-preview { background: rgba(52,120,199,.10); box-shadow: inset 0 0 0 1px #3478c7; }
 
 /* Column resize handle */
 .col-resize { position: absolute; top: 0; right: -3px; width: 7px; height: 100%; cursor: col-resize; z-index: 5; }
@@ -177,6 +303,27 @@ table.grid th, table.grid td { padding: 0; margin: 0; }
   outline: none; resize: none; overflow: hidden; box-shadow: 0 2px 12px rgba(0,0,0,0.18);
   font-family: ui-sans-serif, system-ui, sans-serif; color: var(--text); border-radius: 0;
   min-width: 60px; white-space: pre; }
+.cell-editor.capture { display: block; opacity: 0; width: 1px !important; min-width: 1px; height: 1px !important;
+  min-height: 1px; padding: 0; border: 0; box-shadow: none; pointer-events: none; overflow: hidden; }
+.formula-assist { position: fixed; z-index: 1400; width: min(360px, calc(100vw - 20px)); max-height: 250px; overflow: auto; border: 1px solid var(--line-strong); border-radius: 8px; background: var(--surface); box-shadow: 0 10px 28px rgba(0,0,0,.18); display: none; }
+.formula-suggestion { padding: 7px 10px; cursor: pointer; border-bottom: 1px solid var(--line); }
+.formula-suggestion:last-child { border-bottom: 0; }
+.formula-suggestion.active, .formula-suggestion:hover { background: var(--accent-soft); }
+.formula-suggestion strong { display: block; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; }
+.formula-suggestion span { display: block; color: var(--muted); font-size: 11px; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.formula-syntax { padding: 9px 11px; }
+.formula-syntax-code { font-family: ui-monospace, "SF Mono", Menlo, monospace; color: #24733f; font-weight: 650; line-height: 1.5; }
+.formula-syntax-code .current { color: #fff; background: #2b8a4b; border-radius: 4px; padding: 1px 3px; }
+.formula-syntax-desc { color: var(--muted); font-size: 11px; margin-top: 4px; }
+.formula-error { padding: 9px 11px; color: var(--bad); background: rgba(196,86,106,.08); font-size: 12px; line-height: 1.4; }
+.grid td.cell.formula-ref { background: rgba(52,120,199,.12); z-index: 5; }
+.grid td.cell.formula-ref-top { border-top: 2px solid #3478c7; }
+.grid td.cell.formula-ref-bottom { border-bottom: 2px solid #3478c7; }
+.grid td.cell.formula-ref-left { border-left: 2px solid #3478c7; }
+.grid td.cell.formula-ref-right { border-right: 2px solid #3478c7; }
+.grid td.cell.formula-ref:not(.formula-ref-right) { border-right-color: transparent; }
+.grid td.cell.formula-ref:not(.formula-ref-bottom) { border-bottom-color: transparent; }
+.formula-range-handle { position: absolute; z-index: 24; width: 9px; height: 9px; border: 1px solid #fff; border-radius: 50%; background: #3478c7; cursor: nwse-resize; display: none; touch-action: none; }
 
 /* Remote presence selection boxes */
 .remote-layer { position: absolute; inset: 0; pointer-events: none; z-index: 8; }
@@ -212,6 +359,21 @@ table.grid th, table.grid td { padding: 0; margin: 0; }
 .ctx-item.danger:hover { background: rgba(196,86,106,0.12); color: var(--bad); }
 .ctx-item .k { color: var(--faint); font-size: 11px; }
 .ctx-sep { height: 1px; background: var(--line); margin: 4px 6px; }
+.fn-menu { width: 286px; max-height: min(540px, 78vh); overflow-y: auto; padding: 6px; }
+.fn-search-wrap { position: sticky; top: -6px; z-index: 3; background: var(--surface); padding: 5px 3px 8px; }
+.fn-search { width: 100%; border: 1px solid var(--line-strong); border-radius: 7px; padding: 8px 10px; outline: none; color: var(--text); background: var(--surface); }
+.fn-search:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.fn-group { border-top: 1px solid var(--line); }
+.fn-group:first-of-type { border-top: 0; }
+.fn-head { width: 100%; min-height: 34px; border: 0; background: transparent; color: var(--muted); padding: 7px 8px; display: flex; align-items: center; justify-content: space-between; cursor: pointer; text-align: left; }
+.fn-head:hover { background: var(--surface-2); border-radius: 6px; color: var(--text); }
+.fn-head-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .055em; }
+.fn-head-count { margin-left: auto; margin-right: 8px; color: var(--faint); font-size: 10.5px; }
+.fn-chev { transition: transform .14s var(--ease-out); }
+.fn-group.open .fn-chev { transform: rotate(90deg); }
+.fn-items { display: none; padding-bottom: 4px; }
+.fn-group.open .fn-items { display: block; }
+.fn-no-results { padding: 18px 10px; text-align: center; color: var(--faint); }
 
 /* Inline dialog (alert/prompt blocked in sandbox) */
 .overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
@@ -311,6 +473,10 @@ const ICONS = {
   trash: '<path d="M4 7h16"/><path d="M9 7V5h6v2"/><path d="M6 7l1 13h10l1-13"/>',
   plus: '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>',
   clear: '<path d="M4 7V5h12v2"/><path d="M9 5l-2 14"/><line x1="14" y1="13" x2="20" y2="19"/><line x1="20" y1="13" x2="14" y2="19"/>',
+  filter: '<path d="M4 5h16l-6.5 7.5V19l-3 1v-7.5z"/>',
+  chart: '<path d="M4 19V5"/><path d="M4 19h16"/><polyline points="6 15 10 10 14 13 20 6"/>',
+  comment: '<path d="M5 5h14v11H9l-4 4z"/><line x1="8" y1="9" x2="16" y2="9"/><line x1="8" y1="12" x2="14" y2="12"/>',
+  pivot: '<rect x="3" y="4" width="18" height="16" rx="1"/><path d="M3 9h18M9 4v16"/><path d="M13 13h5M15.5 10.5V16"/>',
 };
 
 // A1 <-> (row, col) — both zero-based internally.
@@ -339,6 +505,16 @@ class CellError {
   constructor(v) { this.value = v; }
   toString() { return this.value; }
 }
+class HyperlinkValue {
+  constructor(url, label) { this.url = url; this.label = label || url; }
+  toString() { return this.label; }
+}
+function safeHyperlinkUrl(value) {
+  try {
+    const url = new URL(String(value));
+    return url.protocol === "http:" || url.protocol === "https:" ? url.href : null;
+  } catch (error) { return null; }
+}
 const ERR = {
   DIV0: () => new CellError("#DIV/0!"),
   VALUE: () => new CellError("#VALUE!"),
@@ -358,10 +534,20 @@ function tokenize(src) {
   while (i < n) {
     const ch = src[i];
     if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") { i++; continue; }
-    if (ch === '"') {
+    const singleQuotedSheet = ch === "'" && (() => {
+      let j = i + 1;
+      while (j < n) {
+        if (src[j] === "'") { if (src[j + 1] === "'") { j += 2; continue; } return src[j + 1] === "!"; }
+        j++;
+      }
+      return false;
+    })();
+    if (ch === '"' || (ch === "'" && !singleQuotedSheet)) {
+      const quote = ch;
       let j = i + 1, str = "";
       while (j < n) {
-        if (src[j] === '"') { if (src[j + 1] === '"') { str += '"'; j += 2; continue; } j++; break; }
+        if (src[j] === quote) { if (src[j + 1] === quote) { str += quote; j += 2; continue; } j++; break; }
+        if (src[j] === "\\" && src[j + 1] === quote) { str += quote; j += 2; continue; }
         str += src[j++];
       }
       tokens.push({ t: "str", v: str }); i = j; continue;
@@ -384,7 +570,10 @@ function tokenize(src) {
       let j = i, word = "";
       if (ch === "'") { // 'Sheet Name'!Ref
         j++;
-        while (j < n && src[j] !== "'") word += src[j++];
+        while (j < n) {
+          if (src[j] === "'") { if (src[j + 1] === "'") { word += "'"; j += 2; continue; } break; }
+          word += src[j++];
+        }
         j++; word = "'" + word + "'";
       } else {
         while (j < n && /[A-Za-z0-9_$.]/.test(src[j])) word += src[j++];
@@ -453,6 +642,7 @@ function parseFormula(src) {
     throw ERR.VALUE();
   }
   const ast = parseExpr(0);
+  if (pos !== tokens.length) throw ERR.VALUE();
   return ast;
 }
 const BP = {
@@ -499,6 +689,7 @@ function toNum(v) {
 }
 function toStr(v) {
   if (isErr(v)) throw v;
+  if (v instanceof HyperlinkValue) return v.label;
   if (v == null) return "";
   if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
   return String(v);
@@ -542,6 +733,7 @@ function fmtTime(serial) {
 // Returns { text, numeric, err } for a computed value + format.
 function displayValue(computed, fmt) {
   if (isErr(computed)) return { text: computed.value, err: true };
+  if (computed instanceof HyperlinkValue) return { text: computed.label, link: computed.url };
   if (computed == null || computed === "") return { text: "" };
   const nf = fmt?.nf;
   const d = fmt?.d;
@@ -565,7 +757,9 @@ function displayValue(computed, fmt) {
   }
   // string
   if (nf === "text") return { text: String(computed) };
-  return { text: String(computed) };
+  const text = String(computed);
+  const link = safeHyperlinkUrl(text);
+  return link ? { text, link } : { text };
 }
 
 // ===========================================================================
@@ -942,6 +1136,12 @@ const FUNCTIONS = (() => {
   F.T = (a, c, H) => { const v = H.scalar(a[0], c); return typeof v === "string" ? v : ""; };
   F.VALUE = (a, c, H) => H.toNum(H.scalar(a[0], c));
   F.TEXT = (a, c, H) => { const v = H.toNum(H.scalar(a[0], c)); const f = H.toStr(H.scalar(a[1], c)); return applyTextFormat(v, f); };
+  F.HYPERLINK = (a, c, H) => {
+    const rawUrl = H.toStr(H.scalar(a[0], c));
+    const url = safeHyperlinkUrl(rawUrl); if (!url) return ERR.VALUE();
+    const label = a.length > 1 ? H.toStr(H.scalar(a[1], c)) : rawUrl;
+    return new HyperlinkValue(url, label);
+  };
 
   function applyTextFormat(v, f) {
     if (/%/.test(f)) { const dec = (f.split(".")[1] || "").length; return (v * 100).toFixed(dec) + "%"; }
@@ -1080,6 +1280,68 @@ const FUNCTIONS = (() => {
 
 // Full list of function names for the insert-function menu / documentation.
 const FUNCTION_NAMES = Object.keys(FUNCTIONS).sort();
+const FUNCTION_HELP = {
+  SUM: ["SUM(value1, [value2, …])", "Adds numbers or ranges."],
+  AVERAGE: ["AVERAGE(value1, [value2, …])", "Returns the arithmetic mean."],
+  COUNT: ["COUNT(value1, [value2, …])", "Counts numeric values."],
+  COUNTA: ["COUNTA(value1, [value2, …])", "Counts non-empty values."],
+  COUNTIF: ["COUNTIF(range, criterion)", "Counts cells matching a condition."],
+  COUNTIFS: ["COUNTIFS(range1, criterion1, …)", "Counts rows matching multiple conditions."],
+  SUMIF: ["SUMIF(range, criterion, [sum_range])", "Sums values matching a condition."],
+  SUMIFS: ["SUMIFS(sum_range, range1, criterion1, …)", "Sums values matching multiple conditions."],
+  AVERAGEIF: ["AVERAGEIF(range, criterion, [average_range])", "Averages values matching a condition."],
+  MIN: ["MIN(value1, [value2, …])", "Returns the smallest number."],
+  MAX: ["MAX(value1, [value2, …])", "Returns the largest number."],
+  MEDIAN: ["MEDIAN(value1, [value2, …])", "Returns the median value."],
+  ROUND: ["ROUND(value, places)", "Rounds a number to a specified precision."],
+  ROUNDUP: ["ROUNDUP(value, places)", "Rounds a number away from zero."],
+  ROUNDDOWN: ["ROUNDDOWN(value, places)", "Rounds a number toward zero."],
+  IF: ["IF(condition, value_if_true, [value_if_false])", "Returns values based on a condition."],
+  IFS: ["IFS(condition1, value1, [condition2, value2, …])", "Tests multiple conditions in order."],
+  IFERROR: ["IFERROR(value, fallback)", "Returns a fallback when a value is an error."],
+  IFNA: ["IFNA(value, fallback)", "Returns a fallback for #N/A."],
+  AND: ["AND(condition1, [condition2, …])", "Returns TRUE when every condition is true."],
+  OR: ["OR(condition1, [condition2, …])", "Returns TRUE when any condition is true."],
+  NOT: ["NOT(condition)", "Reverses a logical value."],
+  CONCAT: ["CONCAT(value1, [value2, …])", "Joins text values."],
+  TEXTJOIN: ["TEXTJOIN(delimiter, ignore_empty, text1, …)", "Joins text with a delimiter."],
+  LEFT: ["LEFT(text, [characters])", "Returns characters from the beginning of text."],
+  RIGHT: ["RIGHT(text, [characters])", "Returns characters from the end of text."],
+  MID: ["MID(text, start, length)", "Returns characters from the middle of text."],
+  LEN: ["LEN(text)", "Returns the number of characters."],
+  TEXT: ["TEXT(value, format)", "Formats a number as text."],
+  HYPERLINK: ["HYPERLINK(url, [link_label])", "Creates a clickable HTTP or HTTPS link."],
+  VLOOKUP: ["VLOOKUP(search_key, range, column, [approximate])", "Looks down the first column of a range."],
+  HLOOKUP: ["HLOOKUP(search_key, range, row, [approximate])", "Looks across the first row of a range."],
+  INDEX: ["INDEX(reference, row, [column])", "Returns a value at a row and column."],
+  MATCH: ["MATCH(search_key, range, [search_type])", "Returns the position of a matching value."],
+  LOOKUP: ["LOOKUP(search_key, search_range, [result_range])", "Finds a value in a sorted range."],
+  TODAY: ["TODAY()", "Returns the current date."],
+  NOW: ["NOW()", "Returns the current date and time."],
+  DATE: ["DATE(year, month, day)", "Builds a date from year, month, and day."],
+  YEAR: ["YEAR(date)", "Returns the year of a date."],
+  MONTH: ["MONTH(date)", "Returns the month of a date."],
+  DAY: ["DAY(date)", "Returns the day of the month."],
+  PRODUCT: ["PRODUCT(value1, [value2, …])", "Multiplies numbers or ranges."],
+  ABS: ["ABS(value)", "Returns the absolute value."],
+  SQRT: ["SQRT(value)", "Returns the positive square root."],
+  MOD: ["MOD(dividend, divisor)", "Returns the remainder after division."],
+  POWER: ["POWER(base, exponent)", "Raises a number to a power."],
+  STDEV: ["STDEV(value1, [value2, …])", "Estimates sample standard deviation."],
+  VAR: ["VAR(value1, [value2, …])", "Estimates sample variance."],
+  RANK: ["RANK(value, range, [ascending])", "Returns a value’s rank in a range."],
+  LARGE: ["LARGE(range, rank)", "Returns the nth largest value."],
+  SWITCH: ["SWITCH(expression, case1, value1, [default])", "Matches an expression to cases."],
+  UPPER: ["UPPER(text)", "Converts text to uppercase."],
+  LOWER: ["LOWER(text)", "Converts text to lowercase."],
+  TRIM: ["TRIM(text)", "Removes repeated and surrounding spaces."],
+  SUBSTITUTE: ["SUBSTITUTE(text, old_text, new_text, [instance])", "Replaces matching text."],
+  CHOOSE: ["CHOOSE(index, choice1, [choice2, …])", "Returns a choice by numeric index."],
+  WEEKDAY: ["WEEKDAY(date, [type])", "Returns the weekday number."],
+  EDATE: ["EDATE(start_date, months)", "Moves a date by a number of months."],
+  DATEDIF: ["DATEDIF(start_date, end_date, unit)", "Returns the difference between two dates."],
+};
+function functionHelp(name) { return FUNCTION_HELP[name] || [`${name}(value, …)`, "Spreadsheet function."]; }
 
 // ===========================================================================
 // Client model + collaboration state
@@ -1093,7 +1355,7 @@ const model = {
   revision: 0,
   title: "Untitled spreadsheet",
   sheetOrder: [],
-  sheets: {},           // id -> { id, name, rows, cols, colWidths, rowHeights, frozenRows, frozenCols }
+  sheets: {},           // id -> { id, name, rows, cols, colWidths, rowHeights, frozenRows, frozenCols, filter, charts, comments }
   cells: {},            // id -> { REF -> { value, fmt, version } }
 };
 let activeSheetId = null;
@@ -1102,8 +1364,25 @@ function rebuildEngine() { engine = makeEngine(model); }
 
 // Selection: anchor + focus (row/col). The visible rectangle is selRange().
 let anchor = { r: 0, c: 0 };
+let extraRanges = [];
 function selRange() {
   return { r1: Math.min(anchor.r, focus.r), c1: Math.min(anchor.c, focus.c), r2: Math.max(anchor.r, focus.r), c2: Math.max(anchor.c, focus.c) };
+}
+function selectionRanges() { return [...extraRanges, selRange()]; }
+function addCurrentRangeToSelection() {
+  const range = selRange();
+  if (!extraRanges.some((item) => item.r1 === range.r1 && item.c1 === range.c1 && item.r2 === range.r2 && item.c2 === range.c2)) extraRanges.push(range);
+}
+function cellInSelection(row, column) {
+  return selectionRanges().some((range) => row >= range.r1 && row <= range.r2 && column >= range.c1 && column <= range.c2);
+}
+function isWholeHeaderRange(range, sheet = curSheet()) {
+  return (range.r1 === 0 && range.r2 === sheet.rows - 1) || (range.c1 === 0 && range.c2 === sheet.cols - 1);
+}
+function prepareHeaderSelection(additive) {
+  if (!additive) { extraRanges = []; return; }
+  const retained = selectionRanges().filter((range) => isWholeHeaderRange(range));
+  extraRanges = retained.filter((range, index) => retained.findIndex((item) => item.r1 === range.r1 && item.c1 === range.c1 && item.r2 === range.r2 && item.c2 === range.c2) === index);
 }
 let focus = { r: 0, c: 0 };
 
@@ -1212,6 +1491,8 @@ const undoBtn = iconBtn("undo", "Undo (Ctrl+Z)", () => undo());
 const redoBtn = iconBtn("redo", "Redo (Ctrl+Y)", () => redo());
 const sumBtn = iconBtn("sigma", "Sum (auto)", () => autoSum());
 const fxBtn = iconBtn(null, "Insert function", (e) => openFunctionMenu(e), "ƒx");
+const absoluteRefBtn = iconBtn(null, "Cycle absolute reference (Ctrl/Cmd+Shift+L)", () => cycleAbsoluteReference(), "$");
+absoluteRefBtn.disabled = true;
 
 const currencyBtn = iconBtn("currency", "Format as currency", () => setFmtOnSelection((f) => { f.nf = "currency"; }));
 const percentBtn = iconBtn("percent", "Format as percent", () => setFmtOnSelection((f) => { f.nf = "percent"; }));
@@ -1255,10 +1536,14 @@ const delRowBtn = iconBtn("trash", "Delete row(s)", () => deleteRows());
 const sortAscBtn = iconBtn("sortAsc", "Sort range A→Z", () => sortSelection(true));
 const sortDescBtn = iconBtn("sortDesc", "Sort range Z→A", () => sortSelection(false));
 const clearBtn = iconBtn("clear", "Clear formatting", () => clearFormatting());
+const filterBtn = iconBtn("filter", "Detect and filter the current data table", () => toggleFilterRow());
+const chartBtn = iconBtn("chart", "Create a chart from the selected data", (event) => openCreateChartMenu(event));
+const commentBtn = iconBtn("comment", "Add a comment to the active cell", () => openCommentEditor(rcToRef(focus.r, focus.c)));
+const pivotBtn = iconBtn("pivot", "Create a pivot table from the selected data", () => createPivotTable());
 
 const toolbar = el("div", { class: "toolbar" }, [
   group(null, [undoBtn, redoBtn], true),
-  group(null, [sumBtn, fxBtn]),
+  group(null, [sumBtn, fxBtn, absoluteRefBtn]),
   group("p2", [fmtSel.el]),
   group("p2", [currencyBtn, percentBtn, decDecBtn, incDecBtn]),
   group(null, [boldBtn, italicBtn, underlineBtn, strikeBtn]),
@@ -1266,6 +1551,7 @@ const toolbar = el("div", { class: "toolbar" }, [
   group("p1", [alignSegment, wrapBtn]),
   group("p2", [insRowBtn, insColBtn, delRowBtn]),
   group("p3", [sortAscBtn, sortDescBtn]),
+  group(null, [filterBtn, chartBtn, pivotBtn, commentBtn]),
   group("p3", [clearBtn]),
 ]);
 
@@ -1279,16 +1565,32 @@ const fbar = el("div", { class: "fbar" }, [
 // --- Grid container ---
 const gridTable = el("table", { class: "grid" });
 const remoteLayer = el("div", { class: "remote-layer" });
+const chartLayer = el("div", { class: "chart-layer" });
+const fillHandle = el("div", { class: "fill-handle", title: "Drag to fill" });
+const formulaRangeHandle = el("div", { class: "formula-range-handle", title: "Drag to resize formula range" });
 const cellEditor = el("textarea", { class: "cell-editor", spellcheck: "false", wrap: "off" });
-const gridScroll = el("div", { class: "grid-scroll", tabindex: "0" }, [gridTable, remoteLayer, cellEditor]);
+const gridScroll = el("div", { class: "grid-scroll", tabindex: "0" }, [gridTable, remoteLayer, chartLayer, fillHandle, formulaRangeHandle, cellEditor]);
+
+const chartPanelBack = el("button", { class: "chart-panel-back", title: "Back", "aria-label": "Back" }, "‹");
+const chartPanelTitle = el("strong", {}, "Details");
+const chartPanelToggle = el("button", { class: "chart-panel-toggle", title: "Expand sidebar", "aria-label": "Expand sidebar" }, "‹");
+const chartPanelContent = el("div", { class: "chart-panel-content" });
+const chartPanel = el("aside", { class: "chart-panel collapsed" }, [
+  el("div", { class: "chart-panel-head" }, [chartPanelBack, chartPanelTitle, chartPanelToggle]), chartPanelContent,
+]);
+chartPanelBack.addEventListener("click", navigateSidebarBack);
+chartPanelToggle.addEventListener("click", () => setChartPanelCollapsed(!chartPanel.classList.contains("collapsed")));
+const workarea = el("div", { class: "workarea" }, [gridScroll, chartPanel]);
 
 // --- Tab bar ---
 const tabbar = el("div", { class: "tabbar" });
 
-const app = el("div", { class: "app" }, [topbar, toolbar, fbar, gridScroll, tabbar]);
+const app = el("div", { class: "app" }, [topbar, toolbar, fbar, workarea, tabbar]);
 const printWorkbook = el("div", { id: "printWorkbook", "data-print-root": "workbook" });
+const formulaAssist = el("div", { class: "formula-assist", role: "listbox", "aria-label": "Formula suggestions" });
 document.body.appendChild(app);
 document.body.appendChild(printWorkbook);
+document.body.appendChild(formulaAssist);
 
 // ===========================================================================
 // Save / operations queue (mirrors Docs optimistic model)
@@ -1309,8 +1611,8 @@ let pendingCellOps = new Map(); // "sheetId!REF" -> { sheetId, ref, value, fmt }
 let pendingStructure = null;    // latest structure snapshot to send
 let pendingReplacements = new Map(); // sheetId -> cells (full)
 
-function queueCellOp(sheetId, ref, value, fmt) {
-  pendingCellOps.set(sheetId + "!" + ref, { sheetId, ref, value, fmt });
+function queueCellOp(sheetId, ref, value, fmt, baseVersion) {
+  pendingCellOps.set(sheetId + "!" + ref, { sheetId, ref, value, fmt, baseVersion });
   scheduleSave();
 }
 function queueStructure() {
@@ -1341,7 +1643,7 @@ async function doSave() {
   const cellOps = [];
   for (const op of pendingCellOps.values()) {
     const cur = (model.cells[op.sheetId] || {})[op.ref];
-    cellOps.push({ sheetId: op.sheetId, ref: op.ref, value: op.value, fmt: op.fmt, baseVersion: op.baseVersion || (cur ? cur.version : 0) });
+    cellOps.push({ sheetId: op.sheetId, ref: op.ref, value: op.value, fmt: op.fmt, baseVersion: op.baseVersion ?? (cur ? cur.version : 0) });
   }
   const structure = pendingStructure;
   const sheetReplacements = Array.from(pendingReplacements.entries()).map(([sheetId, cells]) => ({ sheetId, cells }));
@@ -1353,17 +1655,39 @@ async function doSave() {
   try {
     const result = await gadget.applyOperation({ senderId: clientId, structure, cellOps, sheetReplacements });
     model.revision = Math.max(model.revision, result.revision || 0);
-    // Adopt acknowledged versions.
+    // Adopt acknowledged versions without overwriting a newer local edit that
+    // was queued while this save was in flight.
     for (const up of result.upserts || []) {
       const cells = model.cells[up.sheetId] || (model.cells[up.sheetId] = {});
-      cells[up.ref] = { ...up.cell };
+      const key = up.sheetId + "!" + up.ref;
+      const newer = pendingCellOps.get(key);
+      if (!newer) cells[up.ref] = { ...up.cell };
+      else {
+        newer.baseVersion = up.cell.version;
+        if (newer.value == null && newer.fmt == null) delete cells[up.ref];
+        else cells[up.ref] = { value: newer.value ?? "", fmt: newer.fmt ?? null, version: up.cell.version };
+      }
     }
-    for (const del of result.deletes || []) { const cells = model.cells[del.sheetId]; if (cells) delete cells[del.ref]; }
+    for (const del of result.deletes || []) {
+      const cells = model.cells[del.sheetId];
+      const key = del.sheetId + "!" + del.ref;
+      const newer = pendingCellOps.get(key);
+      if (!newer) { if (cells) delete cells[del.ref]; }
+      else {
+        newer.baseVersion = 0;
+        if (cells && !(newer.value == null && newer.fmt == null)) cells[del.ref] = { value: newer.value ?? "", fmt: newer.fmt ?? null, version: 0 };
+      }
+    }
     if (result.status === "conflict" && result.conflicts) {
-      // Rebase: adopt server versions, then re-queue our local intents.
+      // Rebase each rejected local intent onto the latest server version.
+      const intents = new Map(cellOps.map((op) => [op.sheetId + "!" + op.ref, op]));
       for (const cf of result.conflicts) {
         const cells = model.cells[cf.sheetId] || (model.cells[cf.sheetId] = {});
-        cells[cf.ref] = { ...cf.cell };
+        const intent = intents.get(cf.sheetId + "!" + cf.ref);
+        if (!intent) { cells[cf.ref] = { ...cf.cell }; continue; }
+        if (intent.value == null && intent.fmt == null) delete cells[cf.ref];
+        else cells[cf.ref] = { value: intent.value ?? "", fmt: intent.fmt ?? null, version: cf.cell?.version || 0 };
+        pendingCellOps.set(cf.sheetId + "!" + cf.ref, { ...intent, baseVersion: cf.cell?.version || 0 });
       }
       setStatus("synced", "Resolving edit…");
       scheduleSave(40);
@@ -1435,12 +1759,13 @@ function setCellValue(ref, value, { batch = true } = {}) {
   const cells = curCells();
   const cur = cells[ref];
   if ((value == null || value === "") && (!cur || !cur.fmt)) {
-    if (cur) { delete cells[ref]; queueCellOp(sheetId, ref, null, null); }
+    if (cur) { const baseVersion = cur.version || 0; delete cells[ref]; queueCellOp(sheetId, ref, null, null, baseVersion); schedulePivotRefreshes(sheetId); }
     return;
   }
   const fmt = cur ? cur.fmt : null;
   cells[ref] = { value: value == null ? "" : String(value), fmt: fmt || null, version: cur ? cur.version : 0 };
   queueCellOp(sheetId, ref, cells[ref].value, cells[ref].fmt);
+  schedulePivotRefreshes(sheetId);
 }
 function setCellFmt(ref, mutator) {
   const sheetId = activeSheetId;
@@ -1451,7 +1776,7 @@ function setCellFmt(ref, mutator) {
   mutator(fmt);
   const clean = Object.keys(fmt).length ? fmt : null;
   const value = cur ? cur.value : "";
-  if ((value == null || value === "") && !clean) { if (cur) { delete cells[ref]; queueCellOp(sheetId, ref, null, null); } return; }
+  if ((value == null || value === "") && !clean) { if (cur) { const baseVersion = cur.version || 0; delete cells[ref]; queueCellOp(sheetId, ref, null, null, baseVersion); } return; }
   cells[ref] = { value: value || "", fmt: clean, version: cur ? cur.version : 0 };
   queueCellOp(sheetId, ref, cells[ref].value, clean);
 }
@@ -1460,16 +1785,17 @@ function setCellFmt(ref, mutator) {
 // Formatting actions over the selection
 // ===========================================================================
 function forEachSelected(fn) {
-  const r = selRange();
+  const seen = new Set();
   beginBatch();
-  for (let row = r.r1; row <= r.r2; row++) for (let col = r.c1; col <= r.c2; col++) fn(rcToRef(row, col), row, col);
+  for (const range of selectionRanges()) for (let row = range.r1; row <= range.r2; row++) for (let col = range.c1; col <= range.c2; col++) {
+    const ref = rcToRef(row, col); if (!seen.has(ref)) { seen.add(ref); fn(ref, row, col); }
+  }
   commitBatch();
   rebuildEngine();
   renderGrid();
 }
 function selectionFmtAllHave(key) {
-  const r = selRange();
-  for (let row = r.r1; row <= r.r2; row++) for (let col = r.c1; col <= r.c2; col++) {
+  for (const range of selectionRanges()) for (let row = range.r1; row <= range.r2; row++) for (let col = range.c1; col <= range.c2; col++) {
     const c = getCell(rcToRef(row, col));
     if (!c || !c.fmt || !c.fmt[key]) return false;
   }
@@ -1584,10 +1910,21 @@ function rebuildSheetCells(mapFn) {
     next[rcToRef(nn.r, nn.c)] = { ...cell, version: cell.version };
   }
   model.cells[activeSheetId] = next;
+  if (Array.isArray(curSheet().comments)) {
+    curSheet().comments = curSheet().comments.flatMap((comment) => {
+      const position = parseRef(comment.ref); if (!position) return [];
+      const moved = mapFn(position.r, position.c); if (!moved) return [];
+      return [{ ...comment, ref: rcToRef(moved.r, moved.c) }];
+    });
+  }
 }
 
 function insertRows(at, count) {
   const sh = curSheet();
+  if (sh.filter) {
+    if (at <= sh.filter.row) { sh.filter.row += count; sh.filter.endRow = (sh.filter.endRow ?? sh.rows - 1) + count; }
+    else if (at <= (sh.filter.endRow ?? sh.rows - 1)) sh.filter.endRow = (sh.filter.endRow ?? sh.rows - 1) + count;
+  }
   rewriteAllFormulas(at, count, 0, 0);
   rebuildSheetCells((r, c) => ({ r: r >= at ? r + count : r, c }));
   sh.rows += count;
@@ -1597,6 +1934,12 @@ function insertRows(at, count) {
 }
 function insertCols(at, count) {
   const sh = curSheet();
+  if (sh.filter) {
+    const next = {};
+    for (const [column, values] of Object.entries(sh.filter.criteria || {})) next[Number(column) >= at ? Number(column) + count : Number(column)] = values;
+    sh.filter.criteria = next;
+    sh.filter.columns = filterColumns(sh.filter).map((column) => column >= at ? column + count : column);
+  }
   rewriteAllFormulas(0, 0, at, count);
   rebuildSheetCells((r, c) => ({ r, c: c >= at ? c + count : c }));
   sh.cols += count;
@@ -1609,6 +1952,15 @@ function deleteRows() {
   const at = r.r1, count = r.r2 - r.r1 + 1;
   const sh = curSheet();
   if (sh.rows - count < 1) return;
+  if (sh.filter) {
+    const deletionEnd = at + count - 1;
+    if (sh.filter.row >= at && sh.filter.row <= deletionEnd) sh.filter = null;
+    else {
+      if (deletionEnd < sh.filter.row) sh.filter.row -= count;
+      const endRow = sh.filter.endRow ?? sh.rows - 1;
+      if (at <= endRow) sh.filter.endRow = endRow - Math.min(count, endRow - at + 1);
+    }
+  }
   rewriteAllFormulas(at + count, -count, 0, 0);
   rebuildSheetCells((row, c) => (row >= at && row < at + count) ? null : ({ r: row > at ? row - count : row, c }));
   sh.rows -= count;
@@ -1621,6 +1973,19 @@ function deleteCols() {
   const at = r.c1, count = r.c2 - r.c1 + 1;
   const sh = curSheet();
   if (sh.cols - count < 1) return;
+  if (sh.filter) {
+    const next = {};
+    for (const [column, values] of Object.entries(sh.filter.criteria || {})) {
+      const col = Number(column);
+      if (col >= at && col < at + count) continue;
+      next[col >= at + count ? col - count : col] = values;
+    }
+    sh.filter.criteria = next;
+    sh.filter.columns = filterColumns(sh.filter)
+      .filter((column) => column < at || column >= at + count)
+      .map((column) => column >= at + count ? column - count : column);
+    if (!sh.filter.columns.length) sh.filter = null;
+  }
   rewriteAllFormulas(0, 0, at + count, -count);
   rebuildSheetCells((row, c) => (c >= at && c < at + count) ? null : ({ r: row, c: c > at ? c - count : c }));
   sh.cols -= count;
@@ -1639,12 +2004,14 @@ function removeDims(dims, at, count) {
   for (const [k, v] of entries) { if (k >= at && k < at + count) continue; dims[k > at ? k - count : k] = v; }
 }
 function commitStructuralChange() {
-  // Structural row/col changes move many cells: resend whole sheet + structure.
+  // Structural row/col changes establish a new natural row order.
+  resetFilterSortBaseline();
   queueStructure();
   queueReplacement(activeSheetId);
   rebuildEngine();
   renderGrid();
   undoStack.length = 0; redoStack.length = 0; updateUndoButtons(); // structural ops aren't locally undoable
+  schedulePivotRefreshes(activeSheetId);
 }
 
 // ===========================================================================
@@ -1659,7 +2026,8 @@ function sortSelection(asc) {
     const rowCells = {};
     for (let col = r.c1; col <= r.c2; col++) { const c = cells[rcToRef(row, col)]; if (c) rowCells[col] = { ...c }; }
     const keyVal = engine.computeRef(activeSheetId, rcToRef(row, r.c1));
-    rows.push({ rowCells, keyVal });
+    const rowComments = sheetComments().filter((comment) => { const position = parseRef(comment.ref); return position?.r === row && position.c >= r.c1 && position.c <= r.c2; });
+    rows.push({ rowCells, keyVal, rowComments });
   }
   rows.sort((x, y) => {
     let a = x.keyVal, b = y.keyVal;
@@ -1669,7 +2037,8 @@ function sortSelection(asc) {
     else cmp = String(a).toLowerCase() < String(b).toLowerCase() ? -1 : String(a).toLowerCase() > String(b).toLowerCase() ? 1 : 0;
     return asc ? cmp : -cmp;
   });
-  // Write back.
+  // Write back, keeping comments attached to the cells that moved.
+  curSheet().comments = sheetComments().filter((comment) => { const position = parseRef(comment.ref); return !position || position.r < r.r1 || position.r > r.r2 || position.c < r.c1 || position.c > r.c2; });
   for (let i = 0; i < rows.length; i++) {
     const row = r.r1 + i;
     for (let col = r.c1; col <= r.c2; col++) {
@@ -1678,11 +2047,965 @@ function sortSelection(asc) {
       if (src) cells[ref] = { value: src.value, fmt: src.fmt, version: (cells[ref]?.version || 0) };
       else delete cells[ref];
     }
+    for (const comment of rows[i].rowComments) {
+      const position = parseRef(comment.ref); if (position) curSheet().comments.push({ ...comment, ref: rcToRef(row, position.c) });
+    }
   }
+  resetFilterSortBaseline();
+  queueStructure();
   queueReplacement(activeSheetId);
   rebuildEngine();
   renderGrid();
   undoStack.length = 0; redoStack.length = 0; updateUndoButtons();
+  schedulePivotRefreshes(activeSheetId);
+}
+
+// ===========================================================================
+// Pivot tables
+// ===========================================================================
+let pivotRefreshTimer = null;
+function pivotSheets() { return model.sheetOrder.filter((id) => model.sheets[id]?.pivot); }
+function pivotCellValue(sheetId, row, column) { return engine.computeRef(sheetId, rcToRef(row, column)); }
+function pivotDisplay(value) { return value == null || value === "" ? "(Blank)" : (isErr(value) ? value.value : String(value)); }
+function pivotSourceRange() {
+  let range = selRange();
+  if (range.r1 === range.r2 && range.c1 === range.c2) {
+    const detected = detectFilterRange();
+    if (detected) range = { r1: detected.row, c1: Math.min(...detected.columns), r2: detected.endRow, c2: Math.max(...detected.columns) };
+  }
+  let r1 = Infinity, c1 = Infinity, r2 = -1, c2 = -1;
+  for (const [ref, cell] of Object.entries(curCells())) {
+    if (cell.value == null || cell.value === "") continue;
+    const position = parseRef(ref); if (!position) continue;
+    if (position.r >= range.r1 && position.r <= range.r2 && position.c >= range.c1 && position.c <= range.c2) {
+      r1 = Math.min(r1, position.r); c1 = Math.min(c1, position.c); r2 = Math.max(r2, position.r); c2 = Math.max(c2, position.c);
+    }
+  }
+  return r2 > r1 && c2 >= c1 ? `${rcToRef(r1, c1)}:${rcToRef(r2, c2)}` : "";
+}
+function pivotFields(pivot) {
+  const range = parseChartRange(pivot.sourceRange); if (!range || !model.sheets[pivot.sourceSheetId]) return [];
+  const fields = [], used = new Map();
+  for (let column = range.c1; column <= range.c2; column++) {
+    let name = pivotDisplay(pivotCellValue(pivot.sourceSheetId, range.r1, column));
+    if (name === "(Blank)") name = `Column ${colToLetter(column)}`;
+    const count = (used.get(name) || 0) + 1; used.set(name, count);
+    fields.push({ name: count > 1 ? `${name} (${count})` : name, column });
+  }
+  return fields;
+}
+function aggregateState() { return { sum: 0, count: 0, numericCount: 0, min: Infinity, max: -Infinity }; }
+function addAggregate(state, value) {
+  if (value != null && value !== "" && !isErr(value)) state.count++;
+  const number = typeof value === "number" ? value : Number(value);
+  if (Number.isFinite(number) && value !== "") { state.sum += number; state.numericCount++; state.min = Math.min(state.min, number); state.max = Math.max(state.max, number); }
+}
+function finishAggregate(state, kind) {
+  if (kind === "count") return state.count;
+  if (!state.numericCount) return 0;
+  if (kind === "average") return state.sum / state.numericCount;
+  if (kind === "min") return state.min;
+  if (kind === "max") return state.max;
+  return state.sum;
+}
+function buildPivotOutput(pivot) {
+  const range = parseChartRange(pivot.sourceRange), fields = pivotFields(pivot);
+  if (!range || !fields.length) return { cells: {}, rows: 20, cols: 8 };
+  const byName = new Map(fields.map((field) => [field.name, field.column]));
+  const rowColumn = byName.get(pivot.rowField), columnColumn = byName.get(pivot.columnField), valueColumn = byName.get(pivot.valueField);
+  const records = [];
+  for (let row = range.r1 + 1; row <= range.r2; row++) {
+    if (pivot.filterField) {
+      const filterColumn = byName.get(pivot.filterField);
+      const selectedValues = pivot.filterValues || (pivot.filterValue ? [pivot.filterValue] : []);
+      if (filterColumn != null && selectedValues.length && !selectedValues.includes(pivotDisplay(pivotCellValue(pivot.sourceSheetId, row, filterColumn)))) continue;
+    }
+    records.push({
+      row: rowColumn == null ? "Values" : pivotDisplay(pivotCellValue(pivot.sourceSheetId, row, rowColumn)),
+      column: columnColumn == null ? (pivot.valueField || "Value") : pivotDisplay(pivotCellValue(pivot.sourceSheetId, row, columnColumn)),
+      value: valueColumn == null ? 1 : pivotCellValue(pivot.sourceSheetId, row, valueColumn),
+    });
+  }
+  const rowKeys = [...new Set(records.map((record) => record.row))].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const columnKeys = [...new Set(records.map((record) => record.column))].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const states = new Map(), rowTotals = new Map(), columnTotals = new Map(), grandTotal = aggregateState();
+  const stateFor = (map, key) => { if (!map.has(key)) map.set(key, aggregateState()); return map.get(key); };
+  for (const record of records) {
+    addAggregate(stateFor(states, record.row + "\u0000" + record.column), record.value);
+    addAggregate(stateFor(rowTotals, record.row), record.value); addAggregate(stateFor(columnTotals, record.column), record.value); addAggregate(grandTotal, record.value);
+  }
+  const cells = {}, put = (row, column, value, fmt = null) => { cells[rcToRef(row, column)] = { value: String(value ?? ""), fmt, version: 1 }; };
+  const headerFmt = { b: true, bg: "#e1632e", c: "#ffffff" };
+  const rowHeaderFmt = { b: true, bg: "#fff7f2", c: "#3f332e" };
+  const totalFmt = { b: true, bg: "#fde9dc", c: "#3f332e" };
+  put(0, 0, pivot.rowField || "Rows", headerFmt);
+  columnKeys.forEach((key, index) => put(0, index + 1, key, headerFmt));
+  if (pivot.showRowTotals !== false) put(0, columnKeys.length + 1, "Grand Total", totalFmt);
+  rowKeys.forEach((rowKey, rowIndex) => {
+    put(rowIndex + 1, 0, rowKey, rowHeaderFmt);
+    columnKeys.forEach((columnKey, columnIndex) => put(rowIndex + 1, columnIndex + 1, finishAggregate(states.get(rowKey + "\u0000" + columnKey) || aggregateState(), pivot.aggregate), pivot.aggregate === "average" ? { nf: "number", d: 2 } : null));
+    if (pivot.showRowTotals !== false) put(rowIndex + 1, columnKeys.length + 1, finishAggregate(rowTotals.get(rowKey) || aggregateState(), pivot.aggregate), totalFmt);
+  });
+  if (pivot.showColumnTotals !== false) {
+    const totalRow = rowKeys.length + 1; put(totalRow, 0, "Grand Total", totalFmt);
+    columnKeys.forEach((key, index) => put(totalRow, index + 1, finishAggregate(columnTotals.get(key) || aggregateState(), pivot.aggregate), totalFmt));
+    if (pivot.showRowTotals !== false) put(totalRow, columnKeys.length + 1, finishAggregate(grandTotal, pivot.aggregate), totalFmt);
+  }
+  return { cells, rows: Math.max(20, rowKeys.length + 4), cols: Math.max(8, columnKeys.length + 3) };
+}
+function refreshPivot(sheetId, save = true) {
+  const sheet = model.sheets[sheetId]; if (!sheet?.pivot) return;
+  const output = buildPivotOutput(sheet.pivot);
+  model.cells[sheetId] = output.cells; sheet.rows = Math.max(sheet.rows, output.rows); sheet.cols = Math.max(sheet.cols, output.cols);
+  const widths = {};
+  for (const [ref, cell] of Object.entries(output.cells)) {
+    const position = parseRef(ref); if (!position) continue;
+    const minimum = position.c === 0 ? 150 : 110;
+    widths[position.c] = Math.max(widths[position.c] || minimum, Math.min(320, String(cell.value || "").length * 8 + 30));
+  }
+  sheet.colWidths = { ...sheet.colWidths, ...widths };
+  sheet.rowHeights = { ...sheet.rowHeights, 0: 30 };
+  if (save) { queueStructure(); queueReplacement(sheetId); }
+  rebuildEngine();
+  if (activeSheetId === sheetId) renderGrid();
+}
+function schedulePivotRefreshes(sourceSheetId) {
+  clearTimeout(pivotRefreshTimer);
+  pivotRefreshTimer = setTimeout(() => {
+    rebuildEngine();
+    for (const id of pivotSheets()) if (model.sheets[id].pivot.sourceSheetId === sourceSheetId) refreshPivot(id);
+  }, 320);
+}
+function createPivotTable() {
+  const sourceSheetId = activeSheetId, sourceRange = pivotSourceRange();
+  if (!sourceRange) { setStatus("bad", "Select data with a header row"); return; }
+  const id = "s_" + Math.random().toString(36).slice(2, 8);
+  let number = 1; while (model.sheetOrder.some((sheetId) => model.sheets[sheetId].name === `Pivot table ${number}`)) number++;
+  const pivot = { sourceSheetId, sourceRange, rowField: "", columnField: "", valueField: "", aggregate: "sum", showRowTotals: true, showColumnTotals: true, filterField: "", filterValues: [] };
+  const fields = pivotFields(pivot); pivot.rowField = fields[0]?.name || "";
+  pivot.valueField = fields.find((field) => {
+    const range = parseChartRange(sourceRange); if (!range) return false;
+    for (let row = range.r1 + 1; row <= range.r2; row++) if (typeof pivotCellValue(sourceSheetId, row, field.column) === "number") return true;
+    return false;
+  })?.name || fields[1]?.name || fields[0]?.name || "";
+  model.sheets[id] = { id, name: `Pivot table ${number}`, rows: 100, cols: 26, colWidths: {}, rowHeights: {}, frozenRows: 0, frozenCols: 0, filter: null, charts: [], comments: [], pivot };
+  model.cells[id] = {}; model.sheetOrder.push(id); refreshPivot(id, false);
+  queueStructure(); queueReplacement(id); switchSheet(id); selectedPivotSheetId = id; sidebarView = "pivot"; setChartPanelCollapsed(false); renderChartPanel();
+}
+function pivotSelectField(label, value, options, onChange, allowNone = true) {
+  const select = el("select");
+  if (allowNone) select.appendChild(el("option", { value: "" }, "None"));
+  for (const optionValue of options) { const option = el("option", { value: optionValue }, optionValue); if (optionValue === value) option.selected = true; select.appendChild(option); }
+  select.addEventListener("change", () => onChange(select.value));
+  return el("label", { class: "chart-field" }, [el("span", {}, label), select]);
+}
+function updatePivot(sheetId, key, value) {
+  const pivot = model.sheets[sheetId]?.pivot; if (!pivot) return;
+  pivot[key] = value; if (key === "filterField") pivot.filterValues = [];
+  if (key === "sourceRange") {
+    const fields = pivotFields(pivot).map((field) => field.name);
+    if (!fields.includes(pivot.rowField)) pivot.rowField = fields[0] || "";
+    if (!fields.includes(pivot.valueField)) pivot.valueField = fields[1] || fields[0] || "";
+    if (!fields.includes(pivot.columnField)) pivot.columnField = "";
+    if (!fields.includes(pivot.filterField)) { pivot.filterField = ""; pivot.filterValues = []; }
+  }
+  refreshPivot(sheetId); renderChartPanel();
+}
+function pivotFilterValues(pivot) {
+  if (!pivot.filterField) return [];
+  const range = parseChartRange(pivot.sourceRange), field = pivotFields(pivot).find((item) => item.name === pivot.filterField);
+  if (!range || !field) return [];
+  const values = []; for (let row = range.r1 + 1; row <= range.r2; row++) values.push(pivotDisplay(pivotCellValue(pivot.sourceSheetId, row, field.column)));
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+}
+function pivotFilterMultiSelect(sheetId, pivot) {
+  const options = pivotFilterValues(pivot), selected = pivot.filterValues || (pivot.filterValue ? [pivot.filterValue] : []);
+  const allSelected = !selected.length, wrap = el("div", { class: "chart-field" });
+  wrap.appendChild(el("span", {}, "Filter values"));
+  const list = el("div", { class: "pivot-filter-values" }), checks = [];
+  for (const value of options) {
+    const input = el("input", { type: "checkbox" }); input.checked = allSelected || selected.includes(value);
+    const option = el("label", { class: "pivot-filter-option" }, [input, el("span", {}, value)]);
+    checks.push({ value, input }); list.appendChild(option);
+  }
+  const apply = () => {
+    const values = checks.filter((item) => item.input.checked).map((item) => item.value);
+    pivot.filterValues = values.length === options.length ? [] : (values.length ? values : ["__PIVOT_NONE__"]);
+    refreshPivot(sheetId);
+  };
+  checks.forEach((item) => item.input.addEventListener("change", apply));
+  if (!options.length) list.appendChild(el("div", { class: "pivot-note" }, "No values available"));
+  wrap.appendChild(list); return wrap;
+}
+
+// ===========================================================================
+// Cell comments
+// ===========================================================================
+let commentPopover = null;
+function sheetComments() { return curSheet().comments || (curSheet().comments = []); }
+function activeComments() { return sheetComments().filter((comment) => !comment.resolved); }
+function commentsForRef(ref) { return activeComments().filter((comment) => comment.ref === ref); }
+function closeCommentEditor() { if (commentPopover) { commentPopover.remove(); commentPopover = null; } }
+document.addEventListener("mousedown", (event) => { if (commentPopover && !commentPopover.contains(event.target)) closeCommentEditor(); });
+function openCommentEditor(ref) {
+  closeCommentEditor();
+  const cell = gridTable.querySelector(`td.cell[data-ref="${ref}"]`);
+  if (!cell) return;
+  const textarea = el("textarea", { placeholder: `Comment on ${ref}`, "aria-label": `Comment on ${ref}` });
+  const cancel = el("button", {}, "Cancel");
+  const save = el("button", { class: "primary" }, "Comment");
+  const popover = el("div", { class: "comment-popover" }, [textarea, el("div", { class: "comment-popover-actions" }, [cancel, save])]);
+  document.body.appendChild(popover); commentPopover = popover;
+  const rect = cell.getBoundingClientRect();
+  const width = popover.offsetWidth, height = popover.offsetHeight;
+  popover.style.left = Math.max(10, Math.min(window.innerWidth - width - 10, rect.right + 6)) + "px";
+  popover.style.top = Math.max(10, Math.min(window.innerHeight - height - 10, rect.top)) + "px";
+  const done = () => {
+    const text = textarea.value.trim();
+    if (!text) return;
+    sheetComments().push({ id: "comment_" + Math.random().toString(36).slice(2, 10), ref, text, createdAt: Date.now(), resolved: false });
+    closeCommentEditor(); sidebarView = "comments"; queueStructure(); renderGrid(); renderChartPanel(); setChartPanelCollapsed(false); refreshToolbarState();
+  };
+  cancel.addEventListener("click", closeCommentEditor); save.addEventListener("click", done);
+  textarea.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") { event.preventDefault(); closeCommentEditor(); }
+    else if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) { event.preventDefault(); done(); }
+  });
+  requestAnimationFrame(() => textarea.focus());
+}
+function resolveComment(id) {
+  const comment = sheetComments().find((item) => item.id === id); if (!comment) return;
+  comment.resolved = true; if (!activeComments().length) sidebarView = "home"; queueStructure(); renderGrid(); renderChartPanel(); refreshToolbarState();
+}
+function deleteComment(id) {
+  curSheet().comments = sheetComments().filter((item) => item.id !== id);
+  if (!activeComments().length) sidebarView = "home";
+  queueStructure(); renderGrid(); renderChartPanel(); refreshToolbarState();
+}
+function renderCommentsSection() {
+  const comments = activeComments();
+  if (!comments.length) return null;
+  const section = el("section", { class: "comments-section" });
+  for (const comment of comments.sort((a, b) => b.createdAt - a.createdAt)) {
+    const card = el("article", { class: "comment-card" }, [
+      el("div", { class: "comment-card-ref" }, comment.ref),
+      el("div", { class: "comment-card-text" }, comment.text),
+    ]);
+    card.addEventListener("click", () => { const position = parseRef(comment.ref); if (position) moveActive(position.r, position.c); });
+    const resolve = el("button", {}, "Resolve");
+    const remove = el("button", { class: "danger" }, "Delete");
+    resolve.addEventListener("click", (event) => { event.stopPropagation(); resolveComment(comment.id); });
+    remove.addEventListener("click", (event) => { event.stopPropagation(); deleteComment(comment.id); });
+    card.appendChild(el("div", { class: "comment-card-actions" }, [resolve, remove]));
+    section.appendChild(card);
+  }
+  return section;
+}
+
+// ===========================================================================
+// Charts
+// ===========================================================================
+let selectedChartId = null;
+let selectedPivotSheetId = null;
+let sidebarView = "home"; // home | charts | chart | pivots | pivot | comments
+const CHART_COLORS = ["#e1632e", "#3478c7", "#1f9d77", "#8b5fbf", "#c49324", "#c4566a"];
+function sheetCharts() { return curSheet().charts || (curSheet().charts = []); }
+function selectedChart() { return sheetCharts().find((chart) => chart.id === selectedChartId) || null; }
+function parseChartRange(value) {
+  const match = /^([A-Z]+[1-9]\d*)(?::([A-Z]+[1-9]\d*))?$/.exec(String(value || "").trim().toUpperCase());
+  if (!match) return null;
+  const a = parseRef(match[1]), b = parseRef(match[2] || match[1]);
+  if (!a || !b) return null;
+  return { r1: Math.min(a.r, b.r), c1: Math.min(a.c, b.c), r2: Math.max(a.r, b.r), c2: Math.max(a.c, b.c) };
+}
+function rangeHasData(range) {
+  for (let row = range.r1; row <= range.r2; row++) for (let column = range.c1; column <= range.c2; column++) {
+    if (hasCellData(row, column)) return true;
+  }
+  return false;
+}
+function defaultChartRange() {
+  const range = selRange();
+  return rangeHasData(range) ? rcToRef(range.r1, range.c1) + (range.r1 === range.r2 && range.c1 === range.c2 ? "" : ":" + rcToRef(range.r2, range.c2)) : "";
+}
+function inferChartLayout(rangeText) {
+  const range = parseChartRange(rangeText);
+  if (!range) return { firstRowHeaders: true, firstColLabels: true };
+  let firstRowHeaders = false, firstColLabels = false;
+  if (range.r2 > range.r1) {
+    for (let column = range.c1; column <= range.c2; column++) {
+      const value = engine.computeRef(activeSheetId, rcToRef(range.r1, column));
+      if (typeof value === "string" && value !== "") { firstRowHeaders = true; break; }
+    }
+  }
+  if (range.c2 > range.c1) {
+    let textCount = 0, populated = 0;
+    for (let row = range.r1 + (firstRowHeaders ? 1 : 0); row <= range.r2; row++) {
+      const value = engine.computeRef(activeSheetId, rcToRef(row, range.c1));
+      if (value != null && value !== "") { populated++; if (typeof value === "string") textCount++; }
+    }
+    firstColLabels = populated > 0 && textCount >= Math.ceil(populated / 2);
+  }
+  return { firstRowHeaders, firstColLabels };
+}
+const CHART_TYPES = [
+  { value: "line", label: "Line chart" },
+  { value: "pie", label: "Pie chart" },
+  { value: "area", label: "Area chart" },
+  { value: "stackedBar", label: "Stacked bar chart" },
+];
+function chartTypeLabel(type) { return CHART_TYPES.find((item) => item.value === type)?.label || "Chart"; }
+function openCreateChartMenu(event) {
+  const menu = el("div", { class: "ctx" });
+  for (const type of CHART_TYPES) {
+    const item = el("div", { class: "ctx-item" }, [el("span", {}, type.label)]);
+    item.addEventListener("click", () => { closeCtx(); createChart(type.value); });
+    menu.appendChild(item);
+  }
+  const rect = chartBtn.getBoundingClientRect();
+  showCtx(menu, rect.left, rect.bottom + 4);
+}
+function createChart(type = "line") {
+  const range = defaultChartRange();
+  const inferred = inferChartLayout(range);
+  const chart = {
+    id: "chart_" + Math.random().toString(36).slice(2, 9), type, range,
+    title: chartTypeLabel(type), xAxisTitle: "", yAxisTitle: "", legend: true,
+    firstRowHeaders: inferred.firstRowHeaders, firstColLabels: inferred.firstColLabels,
+    x: Math.max(60, gridScroll.scrollLeft + 80), y: Math.max(32, gridScroll.scrollTop + 40), width: 520, height: 320,
+  };
+  sheetCharts().push(chart);
+  selectedChartId = chart.id; sidebarView = "chart";
+  queueStructure(); renderCharts(); renderChartPanel(); setChartPanelCollapsed(false);
+}
+function setChartPanelCollapsed(collapsed) {
+  chartPanel.classList.toggle("collapsed", collapsed);
+  chartPanelToggle.textContent = collapsed ? "‹" : "×";
+  chartPanelToggle.title = collapsed ? "Expand sidebar" : "Close sidebar";
+  chartPanelToggle.setAttribute("aria-label", chartPanelToggle.title);
+}
+function updateSelectedChart(key, value) {
+  const chart = selectedChart(); if (!chart) return;
+  chart[key] = value; queueStructure(); renderCharts();
+}
+function chartTextField(label, key, chart, placeholder = "") {
+  const input = el("input", { type: "text", value: chart[key] || "", placeholder });
+  input.addEventListener("input", () => updateSelectedChart(key, key === "range" ? input.value.toUpperCase() : input.value));
+  return el("label", { class: "chart-field" }, [el("span", {}, label), input]);
+}
+function chartTypeField(chart) {
+  const select = el("select", { "aria-label": "Chart type" });
+  for (const type of CHART_TYPES) {
+    const option = el("option", { value: type.value }, type.label);
+    if (type.value === chart.type) option.selected = true;
+    select.appendChild(option);
+  }
+  select.addEventListener("change", () => { updateSelectedChart("type", select.value); renderChartPanel(); });
+  return el("label", { class: "chart-field" }, [el("span", {}, "Chart type"), select]);
+}
+function chartCheckbox(label, key, chart) {
+  const input = el("input", { type: "checkbox" }); input.checked = chart[key] !== false;
+  input.addEventListener("change", () => updateSelectedChart(key, input.checked));
+  return el("label", { class: "chart-check" }, [input, el("span", {}, label)]);
+}
+function navigateSidebarBack() {
+  if (sidebarView === "chart") { sidebarView = sheetCharts().length ? "charts" : "home"; selectedChartId = null; renderCharts(); }
+  else if (sidebarView === "pivot") { sidebarView = pivotSheets().length ? "pivots" : "home"; selectedPivotSheetId = null; }
+  else sidebarView = "home";
+  renderChartPanel();
+}
+function sidebarMenuItem(label, count, iconName, onClick) {
+  const button = el("button", { class: "sidebar-menu-item" }, [
+    el("span", { class: "sidebar-menu-icon", html: icon(ICONS[iconName]) }),
+    el("span", { class: "sidebar-menu-label" }, label),
+    el("span", { class: "sidebar-menu-count" }, String(count)),
+    el("span", { class: "sidebar-menu-arrow" }, "›"),
+  ]);
+  button.addEventListener("click", onClick); return button;
+}
+function renderSidebarHome() {
+  const menu = el("div", { class: "sidebar-menu" });
+  const charts = sheetCharts(), comments = activeComments();
+  if (charts.length) menu.appendChild(sidebarMenuItem("Charts", charts.length, "chart", () => { sidebarView = "charts"; renderChartPanel(); }));
+  const pivots = pivotSheets();
+  if (pivots.length) menu.appendChild(sidebarMenuItem("Pivot tables", pivots.length, "pivot", () => { sidebarView = "pivots"; renderChartPanel(); }));
+  if (comments.length) menu.appendChild(sidebarMenuItem("Comments", comments.length, "comment", () => { sidebarView = "comments"; renderChartPanel(); }));
+  return menu;
+}
+function renderChartList() {
+  const list = el("div", { class: "chart-list" });
+  for (const chart of sheetCharts()) {
+    const item = el("button", { class: "chart-list-item" }, [el("strong", {}, chart.title || chartTypeLabel(chart.type)), el("span", {}, `${chartTypeLabel(chart.type)} · ${chart.range || "No data range"}`)]);
+    item.addEventListener("click", () => { selectedChartId = chart.id; sidebarView = "chart"; renderCharts(); renderChartPanel(); });
+    list.appendChild(item);
+  }
+  return list;
+}
+function renderPivotList() {
+  const list = el("div", { class: "chart-list" });
+  for (const sheetId of pivotSheets()) {
+    const sheet = model.sheets[sheetId], source = model.sheets[sheet.pivot.sourceSheetId];
+    const item = el("button", { class: "chart-list-item" }, [el("strong", {}, sheet.name), el("span", {}, `${source?.name || "Missing source"}!${sheet.pivot.sourceRange || "No range"}`)]);
+    item.addEventListener("click", () => { switchSheet(sheetId); selectedPivotSheetId = sheetId; sidebarView = "pivot"; setChartPanelCollapsed(false); renderChartPanel(); });
+    list.appendChild(item);
+  }
+  return list;
+}
+function renderPivotDetails(sheetId) {
+  const sheet = model.sheets[sheetId], pivot = sheet?.pivot; if (!pivot) return null;
+  const fields = pivotFields(pivot).map((field) => field.name);
+  const content = el("div"); content.style.display = "contents";
+  content.appendChild(el("div", { class: "pivot-note" }, `Source sheet: ${model.sheets[pivot.sourceSheetId]?.name || "Missing sheet"}`));
+  const rangeInput = el("input", { type: "text", value: pivot.sourceRange, placeholder: "A1:D100" });
+  rangeInput.addEventListener("change", () => updatePivot(sheetId, "sourceRange", rangeInput.value.toUpperCase()));
+  content.appendChild(el("label", { class: "chart-field" }, [el("span", {}, "Source range"), rangeInput]));
+  content.appendChild(pivotSelectField("Rows", pivot.rowField, fields, (value) => updatePivot(sheetId, "rowField", value)));
+  content.appendChild(pivotSelectField("Columns", pivot.columnField, fields.filter((field) => field !== pivot.rowField), (value) => updatePivot(sheetId, "columnField", value)));
+  content.appendChild(pivotSelectField("Values", pivot.valueField, fields, (value) => updatePivot(sheetId, "valueField", value), false));
+  content.appendChild(pivotSelectField("Summarize by", pivot.aggregate, ["sum", "count", "average", "min", "max"], (value) => updatePivot(sheetId, "aggregate", value), false));
+  for (const [label, key] of [["Show row totals", "showRowTotals"], ["Show column totals", "showColumnTotals"]]) {
+    const input = el("input", { type: "checkbox" }); input.checked = pivot[key] !== false;
+    input.addEventListener("change", () => updatePivot(sheetId, key, input.checked));
+    content.appendChild(el("label", { class: "chart-check" }, [input, el("span", {}, label)]));
+  }
+  content.appendChild(pivotSelectField("Filter field", pivot.filterField, fields, (value) => updatePivot(sheetId, "filterField", value)));
+  if (pivot.filterField) content.appendChild(pivotFilterMultiSelect(sheetId, pivot));
+  content.appendChild(el("div", { class: "pivot-note" }, "Pivot output is generated on this sheet and refreshes when source cells change. Manual edits to the output may be replaced."));
+  const refresh = el("button", {}, "Refresh"); refresh.addEventListener("click", () => refreshPivot(sheetId));
+  const remove = el("button", { class: "danger" }, "Delete pivot");
+  remove.addEventListener("click", () => { selectedPivotSheetId = null; sidebarView = "home"; deleteSheet(sheetId); renderChartPanel(); });
+  content.appendChild(el("div", { class: "pivot-actions" }, [refresh, remove]));
+  return content;
+}
+function renderChartPanel() {
+  chartPanelContent.replaceChildren();
+  chartPanelBack.style.display = sidebarView === "home" ? "none" : "";
+  if (sidebarView === "home") {
+    chartPanelTitle.textContent = "Details";
+    const home = renderSidebarHome(); chartPanelContent.appendChild(home);
+    if (!home.children.length) setChartPanelCollapsed(true);
+    return;
+  }
+  if (sidebarView === "comments") {
+    chartPanelTitle.textContent = `Comments (${activeComments().length})`;
+    const comments = renderCommentsSection();
+    if (comments) chartPanelContent.appendChild(comments); else { sidebarView = "home"; renderChartPanel(); }
+    return;
+  }
+  if (sidebarView === "charts") {
+    chartPanelTitle.textContent = "Charts";
+    if (sheetCharts().length) chartPanelContent.appendChild(renderChartList()); else { sidebarView = "home"; renderChartPanel(); }
+    return;
+  }
+  if (sidebarView === "pivots") {
+    chartPanelTitle.textContent = "Pivot tables";
+    if (pivotSheets().length) chartPanelContent.appendChild(renderPivotList()); else { sidebarView = "home"; renderChartPanel(); }
+    return;
+  }
+  if (sidebarView === "pivot") {
+    const details = renderPivotDetails(selectedPivotSheetId);
+    if (details) { chartPanelTitle.textContent = model.sheets[selectedPivotSheetId].name; chartPanelContent.appendChild(details); }
+    else { sidebarView = "home"; renderChartPanel(); }
+    return;
+  }
+  const chart = selectedChart();
+  if (!chart) { sidebarView = "home"; renderChartPanel(); return; }
+  chartPanelTitle.textContent = chartTypeLabel(chart.type);
+  chartPanelContent.append(
+    chartTypeField(chart),
+    chartTextField("Data range", "range", chart, "A1:C10"),
+    chartTextField("Chart title", "title", chart)
+  );
+  if (chart.type !== "pie") chartPanelContent.append(
+    chartTextField("Horizontal axis title", "xAxisTitle", chart),
+    chartTextField("Vertical axis title", "yAxisTitle", chart)
+  );
+  chartPanelContent.append(
+    chartCheckbox("Use first row as headers", "firstRowHeaders", chart),
+    chartCheckbox("Use first column as labels", "firstColLabels", chart),
+    chartCheckbox("Show legend", "legend", chart)
+  );
+  const copy = el("button", { class: "chart-copy", title: "Rich SVG copy; use PNG export for Google Slides" }, "Copy SVG");
+  copy.addEventListener("click", () => copyChartImage(chart));
+  const remove = el("button", { class: "chart-delete" }, "Delete chart");
+  remove.addEventListener("click", () => {
+    curSheet().charts = sheetCharts().filter((item) => item.id !== chart.id);
+    selectedChartId = null; sidebarView = sheetCharts().length ? "charts" : "home"; queueStructure(); renderCharts(); renderChartPanel();
+  });
+  chartPanelContent.appendChild(el("div", { class: "chart-panel-actions" }, [copy, remove]));
+  chartPanelContent.appendChild(el("p", { class: "chart-copy-note" }, "SVG can’t currently be pasted into a Gadget workspace or Google Slides due to security restrictions."));
+}
+function chartCellLabel(row, column) {
+  const cell = getCell(rcToRef(row, column));
+  if (!cell) return "";
+  return displayValue(engine.computeRef(activeSheetId, rcToRef(row, column)), cell.fmt).text;
+}
+function chartData(chart) {
+  const range = parseChartRange(chart.range);
+  if (!range || !rangeHasData(range)) return null;
+  const dataRow = range.r1 + (chart.firstRowHeaders && range.r2 > range.r1 ? 1 : 0);
+  let seriesColumn = range.c1 + (chart.firstColLabels && range.c2 > range.c1 ? 1 : 0);
+  if (seriesColumn > range.c2 || dataRow > range.r2) return null;
+  const labels = [];
+  for (let row = dataRow; row <= range.r2; row++) labels.push(chart.firstColLabels ? chartCellLabel(row, range.c1) : String(row - dataRow + 1));
+  const series = [];
+  for (let column = seriesColumn; column <= range.c2; column++) {
+    const values = [];
+    for (let row = dataRow; row <= range.r2; row++) {
+      const value = engine.computeRef(activeSheetId, rcToRef(row, column));
+      values.push(typeof value === "number" && Number.isFinite(value) ? value : null);
+    }
+    if (values.some((value) => value != null)) series.push({
+      name: chart.firstRowHeaders ? (chartCellLabel(range.r1, column) || colToLetter(column)) : colToLetter(column), values,
+    });
+  }
+  return series.length ? { labels, series } : null;
+}
+function svgNode(tag, attrs = {}, text = null) {
+  const node = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, String(value));
+  if (text != null) node.textContent = text;
+  return node;
+}
+function renderLineChartSvg(chart, data) {
+  const svg = svgNode("svg", { viewBox: "0 0 520 270", role: "img", "aria-label": chart.title || "Line chart" });
+  const left = 54, top = 18, right = chart.legend ? 118 : 24, bottom = 48;
+  const width = 520 - left - right, height = 270 - top - bottom;
+  const all = data.series.flatMap((series) => series.values.filter((value) => value != null));
+  let min = Math.min(...all), max = Math.max(...all);
+  if (chart.type === "area") { min = Math.min(0, min); max = Math.max(0, max); }
+  if (min === max) { min -= Math.abs(min || 1) * .5; max += Math.abs(max || 1) * .5; }
+  const y = (value) => top + height - (value - min) / (max - min) * height;
+  const x = (index) => left + (data.labels.length <= 1 ? width / 2 : index / (data.labels.length - 1) * width);
+  for (let tick = 0; tick <= 4; tick++) {
+    const yy = top + height * tick / 4;
+    svg.appendChild(svgNode("line", { x1: left, y1: yy, x2: left + width, y2: yy, stroke: "#e4e4e1", "stroke-width": 1 }));
+    const value = max - (max - min) * tick / 4;
+    svg.appendChild(svgNode("text", { x: left - 7, y: yy + 4, "text-anchor": "end", fill: "#77777f", "font-size": 10 }, fmtGeneral(value)));
+  }
+  svg.appendChild(svgNode("line", { x1: left, y1: top, x2: left, y2: top + height, stroke: "#9a9aa2" }));
+  svg.appendChild(svgNode("line", { x1: left, y1: top + height, x2: left + width, y2: top + height, stroke: "#9a9aa2" }));
+  const labelStep = Math.max(1, Math.ceil(data.labels.length / 7));
+  data.labels.forEach((label, index) => { if (index % labelStep === 0 || index === data.labels.length - 1) svg.appendChild(svgNode("text", { x: x(index), y: top + height + 17, "text-anchor": "middle", fill: "#77777f", "font-size": 10 }, String(label).slice(0, 16))); });
+  data.series.forEach((series, seriesIndex) => {
+    const color = CHART_COLORS[seriesIndex % CHART_COLORS.length];
+    const segments = []; let segment = [];
+    series.values.forEach((value, index) => {
+      if (value == null) { if (segment.length) segments.push(segment); segment = []; }
+      else segment.push({ index, value });
+    });
+    if (segment.length) segments.push(segment);
+    const path = segments.map((points) => points.map((point, index) => (index ? "L " : "M ") + x(point.index).toFixed(2) + " " + y(point.value).toFixed(2)).join(" ")).join(" ");
+    if (chart.type === "area") {
+      const baseline = y(Math.max(min, Math.min(max, 0)));
+      for (const points of segments) {
+        const areaPath = `M ${x(points[0].index)} ${baseline} ` + points.map((point) => `L ${x(point.index)} ${y(point.value)}`).join(" ") + ` L ${x(points[points.length - 1].index)} ${baseline} Z`;
+        svg.appendChild(svgNode("path", { d: areaPath, fill: color, opacity: .18 }));
+      }
+    }
+    svg.appendChild(svgNode("path", { d: path, fill: "none", stroke: color, "stroke-width": 2.2, "stroke-linecap": "round", "stroke-linejoin": "round" }));
+    series.values.forEach((value, index) => { if (value != null) svg.appendChild(svgNode("circle", { cx: x(index), cy: y(value), r: 2.5, fill: color })); });
+    if (chart.legend) {
+      const legendY = top + 10 + seriesIndex * 19;
+      svg.appendChild(svgNode("line", { x1: left + width + 15, y1: legendY, x2: left + width + 31, y2: legendY, stroke: color, "stroke-width": 3 }));
+      svg.appendChild(svgNode("text", { x: left + width + 37, y: legendY + 4, fill: "#55555d", "font-size": 10 }, series.name.slice(0, 15)));
+    }
+  });
+  if (chart.xAxisTitle) svg.appendChild(svgNode("text", { x: left + width / 2, y: 266, "text-anchor": "middle", fill: "#55555d", "font-size": 11 }, chart.xAxisTitle));
+  if (chart.yAxisTitle) { const title = svgNode("text", { x: 12, y: top + height / 2, "text-anchor": "middle", fill: "#55555d", "font-size": 11, transform: `rotate(-90 12 ${top + height / 2})` }, chart.yAxisTitle); svg.appendChild(title); }
+  return svg;
+}
+function renderPieChartSvg(chart, data) {
+  const svg = svgNode("svg", { viewBox: "0 0 520 270", role: "img", "aria-label": chart.title || "Pie chart" });
+  const series = data.series[0];
+  const slices = series.values.map((value, index) => ({ value: value != null && value > 0 ? value : 0, label: data.labels[index] || String(index + 1) })).filter((slice) => slice.value > 0);
+  const total = slices.reduce((sum, slice) => sum + slice.value, 0);
+  if (!total) return svg;
+  const cx = chart.legend ? 175 : 260, cy = 135, radius = 100;
+  let angle = -Math.PI / 2;
+  slices.forEach((slice, index) => {
+    const next = angle + slice.value / total * Math.PI * 2;
+    const color = CHART_COLORS[index % CHART_COLORS.length];
+    if (slices.length === 1) svg.appendChild(svgNode("circle", { cx, cy, r: radius, fill: color }));
+    else {
+      const x1 = cx + Math.cos(angle) * radius, y1 = cy + Math.sin(angle) * radius;
+      const x2 = cx + Math.cos(next) * radius, y2 = cy + Math.sin(next) * radius;
+      const large = next - angle > Math.PI ? 1 : 0;
+      svg.appendChild(svgNode("path", { d: `M ${cx} ${cy} L ${x1} ${y1} A ${radius} ${radius} 0 ${large} 1 ${x2} ${y2} Z`, fill: color, stroke: "#fff", "stroke-width": 2 }));
+    }
+    if (chart.legend) {
+      const ly = 35 + index * 22;
+      svg.appendChild(svgNode("rect", { x: 310, y: ly - 9, width: 12, height: 12, rx: 2, fill: color }));
+      svg.appendChild(svgNode("text", { x: 329, y: ly + 1, fill: "#55555d", "font-size": 11 }, `${slice.label}`.slice(0, 18)));
+      svg.appendChild(svgNode("text", { x: 493, y: ly + 1, "text-anchor": "end", fill: "#77777f", "font-size": 10 }, `${Math.round(slice.value / total * 100)}%`));
+    }
+    angle = next;
+  });
+  return svg;
+}
+function renderStackedBarChartSvg(chart, data) {
+  const svg = svgNode("svg", { viewBox: "0 0 520 270", role: "img", "aria-label": chart.title || "Stacked bar chart" });
+  const left = 78, top = 18, right = chart.legend ? 112 : 24, bottom = 42;
+  const width = 520 - left - right, height = 270 - top - bottom;
+  const totals = data.labels.map((_, index) => data.series.reduce((sum, series) => sum + Math.max(0, series.values[index] || 0), 0));
+  const max = Math.max(...totals, 1);
+  const rowHeight = height / Math.max(1, data.labels.length);
+  for (let tick = 0; tick <= 4; tick++) {
+    const xx = left + width * tick / 4;
+    svg.appendChild(svgNode("line", { x1: xx, y1: top, x2: xx, y2: top + height, stroke: "#e4e4e1" }));
+    svg.appendChild(svgNode("text", { x: xx, y: top + height + 15, "text-anchor": "middle", fill: "#77777f", "font-size": 10 }, fmtGeneral(max * tick / 4)));
+  }
+  data.labels.forEach((label, row) => {
+    const barY = top + row * rowHeight + rowHeight * .18, barHeight = Math.max(3, rowHeight * .64);
+    svg.appendChild(svgNode("text", { x: left - 7, y: barY + barHeight / 2 + 4, "text-anchor": "end", fill: "#66666e", "font-size": 10 }, String(label).slice(0, 12)));
+    let offset = 0;
+    data.series.forEach((series, index) => {
+      const value = Math.max(0, series.values[row] || 0), barWidth = value / max * width;
+      svg.appendChild(svgNode("rect", { x: left + offset, y: barY, width: barWidth, height: barHeight, fill: CHART_COLORS[index % CHART_COLORS.length] }));
+      offset += barWidth;
+    });
+  });
+  if (chart.legend) data.series.forEach((series, index) => {
+    const ly = top + 10 + index * 19, color = CHART_COLORS[index % CHART_COLORS.length];
+    svg.appendChild(svgNode("rect", { x: left + width + 15, y: ly - 8, width: 12, height: 12, rx: 2, fill: color }));
+    svg.appendChild(svgNode("text", { x: left + width + 33, y: ly + 2, fill: "#55555d", "font-size": 10 }, series.name.slice(0, 14)));
+  });
+  if (chart.xAxisTitle) svg.appendChild(svgNode("text", { x: left + width / 2, y: 268, "text-anchor": "middle", fill: "#55555d", "font-size": 11 }, chart.xAxisTitle));
+  if (chart.yAxisTitle) svg.appendChild(svgNode("text", { x: 12, y: top + height / 2, "text-anchor": "middle", fill: "#55555d", "font-size": 11, transform: `rotate(-90 12 ${top + height / 2})` }, chart.yAxisTitle));
+  return svg;
+}
+function renderChartSvg(chart, data) {
+  if (chart.type === "pie") return renderPieChartSvg(chart, data);
+  if (chart.type === "stackedBar") return renderStackedBarChartSvg(chart, data);
+  return renderLineChartSvg(chart, data);
+}
+function selectChart(chart, card = null) {
+  selectedChartId = chart.id; sidebarView = "chart";
+  chartLayer.querySelectorAll(".chart-card.selected").forEach((element) => element.classList.remove("selected"));
+  if (card) card.classList.add("selected");
+  setChartPanelCollapsed(false); renderChartPanel();
+}
+function startChartDrag(chart, card, event) {
+  if (event.button !== 0 || event.target.closest("button")) return;
+  event.preventDefault(); event.stopPropagation();
+  selectChart(chart, card);
+  const startClientX = event.clientX, startClientY = event.clientY;
+  const startX = chart.x ?? 96, startY = chart.y ?? 44;
+  let nextX = startX, nextY = startY;
+  const move = (moveEvent) => {
+    nextX = Math.max(0, Math.round(startX + moveEvent.clientX - startClientX));
+    nextY = Math.max(0, Math.round(startY + moveEvent.clientY - startClientY));
+    card.style.left = nextX + "px"; card.style.top = nextY + "px";
+  };
+  const up = () => {
+    window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", up); window.removeEventListener("pointercancel", up);
+    if (nextX !== startX || nextY !== startY) { chart.x = nextX; chart.y = nextY; queueStructure(); renderCharts(); }
+  };
+  window.addEventListener("pointermove", move); window.addEventListener("pointerup", up); window.addEventListener("pointercancel", up);
+}
+function chartClipboardSvg(chart) {
+  const data = chartData(chart);
+  if (!data) return null;
+  const output = svgNode("svg", { xmlns: "http://www.w3.org/2000/svg", width: 560, height: 330, viewBox: "0 0 560 330" });
+  output.appendChild(svgNode("rect", { x: 0, y: 0, width: 560, height: 330, fill: "#ffffff" }));
+  output.appendChild(svgNode("text", { x: 20, y: 28, fill: "#1d1d20", "font-size": 18, "font-weight": 650, "font-family": "Arial, sans-serif" }, chart.title || "Line chart"));
+  const group = svgNode("g", { transform: "translate(20 45)", "font-family": "Arial, sans-serif" });
+  const graph = renderChartSvg(chart, data);
+  for (const child of [...graph.childNodes]) group.appendChild(child.cloneNode(true));
+  output.appendChild(group);
+  return output;
+}
+function copyChartSvgSelection(svgMarkup) {
+  // The iframe's Permissions Policy blocks the asynchronous Clipboard API.
+  // A selected rich-HTML image can still use the browser's synchronous copy
+  // command and paste into Slides, PowerPoint, Keynote, and similar tools.
+  const host = el("div", { contenteditable: "true", "aria-hidden": "true" });
+  host.style.cssText = "position:fixed;left:-10000px;top:0;width:560px;height:330px;overflow:hidden;background:white";
+  const image = el("img", {
+    src: "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svgMarkup),
+    width: "560", height: "330", alt: "Chart",
+  });
+  host.appendChild(image);
+  document.body.appendChild(host);
+  host.focus({ preventScroll: true });
+  const selection = window.getSelection();
+  if (!selection) { host.remove(); return false; }
+  const saved = selection.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
+  const range = document.createRange(); range.selectNode(image);
+  selection.removeAllRanges(); selection.addRange(range);
+  let copied = false;
+  try { copied = document.execCommand("copy"); }
+  catch (error) { console.error("Chart rich-copy failed:", error?.name || "Error", error?.message || String(error)); }
+  selection.removeAllRanges(); if (saved) selection.addRange(saved);
+  host.remove(); armEditorCapture(true);
+  return copied;
+}
+function copyChartImage(chart) {
+  const svg = chartClipboardSvg(chart);
+  if (!svg) { setStatus("bad", "Chart has no data"); return; }
+  const markup = new XMLSerializer().serializeToString(svg);
+  if (copyChartSvgSelection(markup)) setStatus("saved", "Chart SVG copied");
+  else setStatus("bad", "Browser blocked chart copy");
+}
+function renderCharts() {
+  if (!curSheet()) return;
+  chartLayer.replaceChildren();
+  let maxX = gridScroll.clientWidth, maxY = gridScroll.clientHeight;
+  for (const chart of sheetCharts()) {
+    const card = el("div", { class: "chart-card" + (chart.id === selectedChartId ? " selected" : ""), "data-chart-id": chart.id });
+    card.style.cssText += `left:${chart.x ?? 96}px;top:${chart.y ?? 44}px;width:${chart.width ?? 520}px;height:${chart.height ?? 320}px`;
+    const copyButton = el("button", { class: "chart-card-copy", title: "Copy rich SVG; use PNG export for Google Slides", "aria-label": "Copy chart as SVG" }, "Copy SVG");
+    copyButton.addEventListener("pointerdown", (event) => event.stopPropagation());
+    copyButton.addEventListener("click", (event) => { event.stopPropagation(); selectChart(chart, card); copyChartImage(chart); });
+    const head = el("div", { class: "chart-card-head", title: "Drag to move chart" }, [
+      el("strong", {}, chart.title || "Line chart"), el("span", { class: "chart-card-range" }, chart.range || "No data range"), copyButton,
+    ]);
+    head.addEventListener("pointerdown", (event) => startChartDrag(chart, card, event));
+    const body = el("div", { class: "chart-card-body" });
+    const data = chartData(chart);
+    if (data) body.appendChild(renderChartSvg(chart, data));
+    else body.appendChild(el("div", { class: "chart-empty" }, "Select the chart and enter a data range in Chart settings."));
+    card.append(head, body);
+    card.addEventListener("mousedown", (event) => { event.stopPropagation(); if (selectedChartId !== chart.id) selectChart(chart, card); });
+    chartLayer.appendChild(card);
+    maxX = Math.max(maxX, (chart.x ?? 96) + (chart.width ?? 520) + 30);
+    maxY = Math.max(maxY, (chart.y ?? 44) + (chart.height ?? 320) + 30);
+  }
+  chartLayer.style.width = maxX + "px"; chartLayer.style.height = maxY + "px";
+}
+
+// ===========================================================================
+// Filter rows
+// ===========================================================================
+function filterToken(value) {
+  if (isErr(value)) return "e:" + value.value;
+  if (value == null || value === "") return "z:";
+  if (typeof value === "number") return "n:" + String(value);
+  if (typeof value === "boolean") return "b:" + (value ? "1" : "0");
+  return "s:" + String(value);
+}
+function filterTokenLabel(token) {
+  if (token === "z:") return "(Blanks)";
+  if (token.startsWith("b:")) return token === "b:1" ? "TRUE" : "FALSE";
+  return token.slice(2);
+}
+function filterColumns(filter) {
+  return filter?.columns?.length ? filter.columns : Array.from({ length: curSheet().cols }, (_, column) => column);
+}
+function rowPassesFilter(row) {
+  const filter = curSheet()?.filter;
+  if (!filter || row <= filter.row || row > (filter.endRow ?? curSheet().rows - 1)) return true;
+  for (const [column, selected] of Object.entries(filter.criteria || {})) {
+    if (!selected?.length) continue;
+    const token = filterToken(engine.computeRef(activeSheetId, rcToRef(row, Number(column))));
+    if (!selected.includes(token)) return false;
+  }
+  return true;
+}
+function hasCellData(row, column) {
+  const value = cellRaw(rcToRef(row, column));
+  return value != null && value !== "";
+}
+function detectFilterRange() {
+  const sheet = curSheet();
+  const selection = selRange();
+  const explicit = selection.r2 > selection.r1;
+  if (explicit) {
+    const columns = [];
+    for (let column = selection.c1; column <= selection.c2; column++) {
+      let populated = false;
+      for (let row = selection.r1; row <= selection.r2; row++) if (hasCellData(row, column)) { populated = true; break; }
+      if (populated) columns.push(column);
+    }
+    return columns.length && selection.r2 > selection.r1
+      ? { row: selection.r1, endRow: selection.r2, columns, criteria: {}, rowOrder: Array.from({ length: selection.r2 - selection.r1 }, (_, index) => selection.r1 + 1 + index), sort: null }
+      : null;
+  }
+
+  let minRow = sheet.rows, maxRow = -1, minColumn = sheet.cols, maxColumn = -1;
+  for (const [ref, cell] of Object.entries(curCells())) {
+    if (cell.value == null || cell.value === "") continue;
+    const position = parseRef(ref);
+    if (!position || position.r >= sheet.rows || position.c >= sheet.cols) continue;
+    minRow = Math.min(minRow, position.r); maxRow = Math.max(maxRow, position.r);
+    minColumn = Math.min(minColumn, position.c); maxColumn = Math.max(maxColumn, position.c);
+  }
+  if (maxRow <= minRow || maxColumn < minColumn) return null;
+
+  // Prefer the contiguous table around the active cell when a sheet contains
+  // several independent tables. Fully blank rows/columns act as boundaries.
+  if (focus.r >= minRow && focus.r <= maxRow && focus.c >= minColumn && focus.c <= maxColumn && hasCellData(focus.r, focus.c)) {
+    const rowHasData = (row) => {
+      for (let column = minColumn; column <= maxColumn; column++) if (hasCellData(row, column)) return true;
+      return false;
+    };
+    let tableTop = focus.r, tableBottom = focus.r;
+    while (tableTop > minRow && rowHasData(tableTop - 1)) tableTop--;
+    while (tableBottom < maxRow && rowHasData(tableBottom + 1)) tableBottom++;
+    const columnHasData = (column) => {
+      for (let row = tableTop; row <= tableBottom; row++) if (hasCellData(row, column)) return true;
+      return false;
+    };
+    let tableLeft = focus.c, tableRight = focus.c;
+    while (tableLeft > minColumn && columnHasData(tableLeft - 1)) tableLeft--;
+    while (tableRight < maxColumn && columnHasData(tableRight + 1)) tableRight++;
+    minRow = tableTop; maxRow = tableBottom; minColumn = tableLeft; maxColumn = tableRight;
+  }
+
+  let best = null;
+  const lastCandidate = Math.min(maxRow - 1, minRow + 12);
+  for (let row = minRow; row <= lastCandidate; row++) {
+    let headerCells = 0, supportedColumns = 0;
+    for (let column = minColumn; column <= maxColumn; column++) {
+      if (hasCellData(row, column)) headerCells++;
+      let hasBelow = false;
+      for (let dataRow = row + 1; dataRow <= maxRow; dataRow++) if (hasCellData(dataRow, column)) { hasBelow = true; break; }
+      if (hasBelow) supportedColumns++;
+    }
+    if (!headerCells || !supportedColumns) continue;
+    const score = headerCells * 5 + supportedColumns * 3 - (row - minRow) * 2;
+    if (!best || score > best.score) best = { row, score };
+  }
+  if (!best) return null;
+  const columns = [];
+  for (let column = minColumn; column <= maxColumn; column++) {
+    let populated = false;
+    for (let row = best.row; row <= maxRow; row++) if (hasCellData(row, column)) { populated = true; break; }
+    if (populated) columns.push(column);
+  }
+  return columns.length ? { row: best.row, endRow: maxRow, columns, criteria: {}, rowOrder: Array.from({ length: maxRow - best.row }, (_, index) => best.row + 1 + index), sort: null } : null;
+}
+function resetFilterSortBaseline() {
+  const filter = curSheet()?.filter;
+  if (!filter) return;
+  const endRow = filter.endRow ?? curSheet().rows - 1;
+  filter.rowOrder = Array.from({ length: Math.max(0, endRow - filter.row) }, (_, index) => filter.row + 1 + index);
+  filter.sort = null;
+}
+function toggleFilterRow() {
+  const sheet = curSheet();
+  if (!sheet) return;
+  if (sheet.filter) sheet.filter = null;
+  else {
+    const detected = detectFilterRange();
+    if (!detected) return;
+    sheet.filter = detected;
+  }
+  queueStructure();
+  renderGrid();
+  refreshToolbarState();
+}
+function reorderFilteredRows(compare, nextSort) {
+  const filter = curSheet()?.filter;
+  if (!filter) return;
+  const columns = filterColumns(filter);
+  const rows = [];
+  const endRow = filter.endRow ?? curSheet().rows - 1;
+  const baseline = filter.rowOrder?.length === endRow - filter.row
+    ? filter.rowOrder
+    : Array.from({ length: endRow - filter.row }, (_, index) => filter.row + 1 + index);
+  for (let row = filter.row + 1; row <= endRow; row++) {
+    const rowCells = {};
+    for (const col of columns) {
+      const cell = getCell(rcToRef(row, col));
+      if (cell) rowCells[col] = { ...cell };
+    }
+    const rowComments = sheetComments().filter((comment) => { const position = parseRef(comment.ref); return position?.r === row && columns.includes(position.c); });
+    rows.push({ rowCells, rowComments, originalOrder: baseline[row - filter.row - 1], currentRow: row });
+  }
+  rows.sort(compare);
+  curSheet().comments = sheetComments().filter((comment) => { const position = parseRef(comment.ref); return !position || position.r <= filter.row || position.r > endRow || !columns.includes(position.c); });
+  for (let index = 0; index < rows.length; index++) {
+    const row = filter.row + 1 + index;
+    for (const col of columns) {
+      const ref = rcToRef(row, col), source = rows[index].rowCells[col];
+      if (source) curCells()[ref] = { value: source.value, fmt: source.fmt, version: getCell(ref)?.version || 0 };
+      else delete curCells()[ref];
+    }
+    for (const comment of rows[index].rowComments) {
+      const position = parseRef(comment.ref); if (position) curSheet().comments.push({ ...comment, ref: rcToRef(row, position.c) });
+    }
+  }
+  filter.rowOrder = rows.map((entry) => entry.originalOrder);
+  filter.sort = nextSort;
+  queueStructure(); queueReplacement(activeSheetId); rebuildEngine(); renderGrid();
+  undoStack.length = 0; redoStack.length = 0; updateUndoButtons();
+  schedulePivotRefreshes(activeSheetId);
+}
+function sortFilteredRange(column, ascending) {
+  const values = new Map();
+  const filter = curSheet()?.filter;
+  if (!filter) return;
+  for (let row = filter.row + 1; row <= (filter.endRow ?? curSheet().rows - 1); row++) values.set(row, engine.computeRef(activeSheetId, rcToRef(row, column)));
+  reorderFilteredRows((left, right) => {
+    const a = values.get(left.currentRow) ?? "", b = values.get(right.currentRow) ?? "";
+    const comparison = typeof a === "number" && typeof b === "number"
+      ? a - b
+      : String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: "base" });
+    return ascending ? comparison : -comparison;
+  }, { column, direction: ascending ? "asc" : "desc" });
+}
+function clearFilteredSort() {
+  reorderFilteredRows((left, right) => left.originalOrder - right.originalOrder, null);
+}
+function openFilterMenu(column, trigger) {
+  const filter = curSheet()?.filter;
+  if (!filter) return;
+  const options = new Map();
+  for (let row = filter.row + 1; row <= (filter.endRow ?? curSheet().rows - 1); row++) {
+    const token = filterToken(engine.computeRef(activeSheetId, rcToRef(row, column)));
+    if (!options.has(token)) options.set(token, filterTokenLabel(token));
+  }
+  const sorted = [...options.entries()].sort((a, b) => a[1].localeCompare(b[1], undefined, { numeric: true, sensitivity: "base" }));
+  const current = filter.criteria?.[column] || [];
+  const allSelected = !current.length;
+  const menu = el("div", { class: "ctx filter-menu" });
+  menu.appendChild(el("div", { class: "filter-menu-title" }, `Filter ${colToLetter(column)}`));
+  const sortUp = el("button", {}, "Sort A → Z");
+  const sortDown = el("button", {}, "Sort Z → A");
+  const clearSort = el("button", { title: "Restore the order from when the filter was created" }, "Clear sort");
+  clearSort.disabled = !filter.sort;
+  sortUp.addEventListener("click", () => { closeCtx(); sortFilteredRange(column, true); });
+  sortDown.addEventListener("click", () => { closeCtx(); sortFilteredRange(column, false); });
+  clearSort.addEventListener("click", () => { if (filter.sort) { closeCtx(); clearFilteredSort(); } });
+  menu.appendChild(el("div", { class: "filter-sort" }, [sortUp, sortDown, clearSort]));
+  const list = el("div", { class: "filter-options" });
+  const checks = [];
+  if (!sorted.length) list.appendChild(el("div", { class: "filter-empty" }, "No values below this row"));
+  for (const [token, label] of sorted) {
+    const checkbox = el("input", { type: "checkbox" });
+    checkbox.checked = allSelected || current.includes(token);
+    const option = el("label", { class: "filter-option", title: label }, [checkbox, el("span", {}, label)]);
+    checks.push({ token, label, checkbox, option });
+    list.appendChild(option);
+  }
+  const selectAll = el("button", {}, `Select all ${checks.length}`);
+  const selectNone = el("button", {}, "Clear");
+  selectAll.addEventListener("click", () => checks.forEach((entry) => { entry.checkbox.checked = true; }));
+  selectNone.addEventListener("click", () => checks.forEach((entry) => { entry.checkbox.checked = false; }));
+  menu.appendChild(el("div", { class: "filter-links" }, [selectAll, selectNone]));
+  const search = el("input", { class: "filter-search", type: "search", placeholder: "Search values…", "aria-label": "Search filter values" });
+  search.addEventListener("input", () => {
+    const query = search.value.trim().toLowerCase();
+    for (const entry of checks) entry.option.style.display = !query || entry.label.toLowerCase().includes(query) ? "" : "none";
+  });
+  menu.appendChild(search);
+  menu.appendChild(list);
+  const clear = el("button", {}, "Clear filter");
+  const apply = el("button", { class: "primary" }, "Apply");
+  clear.addEventListener("click", () => {
+    delete filter.criteria[column];
+    closeCtx(); queueStructure(); renderGrid(); refreshToolbarState();
+  });
+  apply.addEventListener("click", () => {
+    const selected = checks.filter((entry) => entry.checkbox.checked).map((entry) => entry.token);
+    if (selected.length === checks.length) delete filter.criteria[column];
+    else filter.criteria[column] = selected.length ? selected : ["x:__none__"];
+    closeCtx(); queueStructure(); renderGrid(); refreshToolbarState();
+  });
+  menu.appendChild(el("div", { class: "filter-actions" }, [clear, apply]));
+  const rect = trigger.getBoundingClientRect();
+  showCtx(menu, rect.left, rect.bottom + 4);
 }
 
 // ===========================================================================
@@ -1699,6 +3022,7 @@ function doRenderGrid() {
   const sh = curSheet();
   if (!sh) return;
   const rng = selRange();
+  const ranges = selectionRanges();
   const frag = document.createDocumentFragment();
 
   // colgroup for widths
@@ -1718,7 +3042,8 @@ function doRenderGrid() {
   hr.appendChild(el("th", { class: "corner" }));
   for (let c = 0; c < sh.cols; c++) {
     const th = el("th", { class: "colhead", "data-col": c }, colToLetter(c));
-    if (c >= rng.c1 && c <= rng.c2) th.classList.add(rng.r1 === 0 && rng.r2 === sh.rows - 1 ? "full" : "hl");
+    const columnRanges = ranges.filter((range) => c >= range.c1 && c <= range.c2);
+    if (columnRanges.length) th.classList.add(columnRanges.some((range) => range.r1 === 0 && range.r2 === sh.rows - 1) ? "full" : "hl");
     const rz = el("div", { class: "col-resize", "data-col": c });
     th.appendChild(rz);
     hr.appendChild(th);
@@ -1729,9 +3054,11 @@ function doRenderGrid() {
   // Body
   const tbody = el("tbody");
   for (let r = 0; r < sh.rows; r++) {
-    const tr = el("tr", { style: `height:${rowHeight(r)}px` });
-    const rh = el("th", { class: "rowhead", "data-row": r }, String(r + 1));
-    if (r >= rng.r1 && r <= rng.r2) rh.classList.add(rng.c1 === 0 && rng.c2 === sh.cols - 1 ? "full" : "hl");
+    const isFilterRow = sh.filter?.row === r;
+    const tr = el("tr", { class: isFilterRow ? "filter-row" : "", style: `height:${rowHeight(r)}px${rowPassesFilter(r) ? "" : ";display:none"}` });
+    const rh = el("th", { class: "rowhead", "data-row": r, title: isFilterRow ? "Filter header row" : "" }, String(r + 1));
+    const rowRanges = ranges.filter((range) => r >= range.r1 && r <= range.r2);
+    if (rowRanges.length) rh.classList.add(rowRanges.some((range) => range.c1 === 0 && range.c2 === sh.cols - 1) ? "full" : "hl");
     const rrz = el("div", { class: "row-resize", "data-row": r });
     rh.appendChild(rrz);
     tr.appendChild(rh);
@@ -1748,6 +3075,79 @@ function doRenderGrid() {
   // sticky offsets for rowhead left
   positionActiveOverlays();
   renderPresence();
+  renderCharts();
+  if (formulaPick) renderFormulaPickHighlight();
+  if (!editing && cellEditor.classList.contains("capture")) armEditorCapture(false);
+}
+
+function isVisuallyEmptyCell(row, column) {
+  const cell = getCell(rcToRef(row, column));
+  if (!cell || cell.value == null || cell.value === "") return true;
+  const value = engine.computeRef(activeSheetId, rcToRef(row, column));
+  return displayValue(value, cell.fmt).text === "";
+}
+function availableOverflowWidth(row, column) {
+  let width = colWidth(column);
+  for (let next = column + 1; next < curSheet().cols; next++) {
+    if (!isVisuallyEmptyCell(row, next)) break;
+    width += colWidth(next);
+  }
+  return width;
+}
+
+function diagnoseFormulaError(formula, errorValue) {
+  let ast = null; try { ast = parseFormula(formula.slice(1)); } catch (error) {
+    return { message: "The formula syntax could not be parsed. Check separators, quotes, and parentheses.", segment: null };
+  }
+  let diagnosis = null;
+  const inspect = (node, parent = null, argumentIndex = -1) => {
+    if (!node || diagnosis) return;
+    if (node.k === "call") {
+      if (!FUNCTIONS[node.name]) diagnosis = { message: `Unknown function ${node.name}.`, segment: node.name };
+      if (!diagnosis && ["VLOOKUP", "HLOOKUP"].includes(node.name) && node.args[3]?.k === "ref" && !parseRef(node.args[3].ref)) {
+        diagnosis = { message: `${node.name}’s fourth argument should usually be TRUE, FALSE, 1, or 0—not unquoted text.`, segment: node.args[3].ref };
+      }
+      if (!diagnosis && ["VLOOKUP", "HLOOKUP"].includes(node.name) && node.args[2]?.k === "num" && node.args[1]?.k === "range") {
+        const first = parseRef(node.args[1].a.split("!").pop()), last = parseRef(node.args[1].b.split("!").pop());
+        const size = first && last ? (node.name === "VLOOKUP" ? Math.abs(last.c - first.c) + 1 : Math.abs(last.r - first.r) + 1) : null;
+        if (size && (node.args[2].v < 1 || node.args[2].v > size)) diagnosis = { message: `${node.name} requests index ${node.args[2].v}, but the lookup range only contains ${size}.`, segment: String(node.args[2].v) };
+      }
+      node.args.forEach((argument, index) => inspect(argument, node, index));
+    } else if (node.k === "ref") {
+      const refText = node.ref, cellPart = refText.split("!").pop();
+      if (!parseRef(cellPart)) diagnosis = { message: `“${refText}” looks like text or an invalid cell reference. Put text in quotes, or choose a valid cell.`, segment: refText };
+      else if (refText.includes("!")) {
+        const sheetName = refText.slice(0, refText.indexOf("!")).replace(/^'|'$/g, "");
+        if (!model.sheetOrder.some((id) => model.sheets[id].name.toLowerCase() === sheetName.toLowerCase())) diagnosis = { message: `The referenced sheet “${sheetName}” does not exist.`, segment: refText.slice(0, refText.indexOf("!")) };
+      }
+    } else if (node.k === "range") {
+      inspect({ k: "ref", ref: node.a }, node); inspect({ k: "ref", ref: node.b }, node);
+    } else { if (node.a) inspect(node.a, node); if (node.b) inspect(node.b, node); }
+  };
+  inspect(ast);
+  if (diagnosis) return diagnosis;
+  const messages = {
+    "#REF!": "A reference is invalid or a lookup index points outside its selected range.",
+    "#DIV/0!": "This formula divides by zero or by an empty value.",
+    "#VALUE!": "One of the highlighted arguments may have the wrong value type.",
+    "#N/A": "No matching value was found. Check the lookup value, range, and match mode.",
+    "#NAME?": "A function or name in this formula is not recognized.",
+    "#NUM!": "A numeric argument is outside the supported range.",
+    "#CYCLE!": "This formula refers back to itself, directly or indirectly.",
+  };
+  return { message: messages[errorValue] || "This formula could not be evaluated.", segment: null };
+}
+function formulaErrorTooltip(formula, errorValue) {
+  const diagnosis = diagnoseFormulaError(formula, errorValue);
+  const tooltip = el("div", { class: "formula-error-tooltip" }, [el("strong", {}, `${errorValue} — Possible issue`), el("div", {}, diagnosis.message)]);
+  const preview = el("div", { class: "formula-error-preview" });
+  if (diagnosis.segment) {
+    const index = formula.toLowerCase().indexOf(String(diagnosis.segment).toLowerCase());
+    if (index >= 0) {
+      preview.append(document.createTextNode(formula.slice(0, index)), el("mark", {}, formula.slice(index, index + String(diagnosis.segment).length)), document.createTextNode(formula.slice(index + String(diagnosis.segment).length)));
+    } else preview.textContent = formula;
+  } else preview.textContent = formula;
+  tooltip.appendChild(preview); return tooltip;
 }
 
 function renderCell(ref, r, c, rng) {
@@ -1756,11 +3156,49 @@ function renderCell(ref, r, c, rng) {
   const fmt = cell?.fmt;
   const computed = (cell && cell.value !== "" && cell.value != null) ? engine.computeRef(activeSheetId, ref) : (cell ? "" : null);
   const disp = displayValue(computed, fmt);
-  const cv = el("span", { class: "cv" });
+  const cv = disp.link
+    ? el("a", { class: "cv cell-link", href: disp.link, target: "_blank", rel: "noopener noreferrer", title: disp.link })
+    : el("span", { class: "cv" });
   cv.textContent = disp.text;
+  if (disp.link) {
+    let openedOnMouseDown = false;
+    cv.addEventListener("mousedown", (event) => {
+      if (event.button !== 0 || !(event.ctrlKey || event.metaKey)) return;
+      event.preventDefault(); event.stopPropagation();
+      openedOnMouseDown = true; openExternalLink(disp.link);
+    });
+    cv.addEventListener("click", (event) => {
+      event.preventDefault(); event.stopPropagation();
+      if ((event.ctrlKey || event.metaKey) && !openedOnMouseDown) openExternalLink(disp.link);
+      openedOnMouseDown = false;
+    });
+  }
   td.appendChild(cv);
+  if (curSheet()?.filter?.row === r && filterColumns(curSheet().filter).includes(c)) {
+    td.classList.add("filter-cell");
+    const active = !!curSheet().filter.criteria?.[c]?.length;
+    const trigger = el("button", { class: "filter-trigger" + (active ? " active" : ""), title: active ? "Change filter" : "Filter this column", "aria-label": `Filter column ${colToLetter(c)}`, html: icon(ICONS.filter) });
+    td.appendChild(trigger);
+  }
+  const cellComments = commentsForRef(ref);
+  if (cellComments.length) {
+    td.classList.add("has-comment");
+    const marker = el("span", { class: "comment-marker", title: `${cellComments.length} comment${cellComments.length === 1 ? "" : "s"}` });
+    const tooltip = el("div", { class: "cell-comment-tooltip" });
+    cellComments.forEach((comment, index) => {
+      if (index) tooltip.appendChild(el("div", { class: "ctx-sep" }));
+      tooltip.appendChild(el("div", {}, comment.text));
+    });
+    td.append(marker, tooltip);
+  }
   if (disp.numeric) td.classList.add("num");
-  if (disp.err) td.classList.add("err");
+  if (disp.err) {
+    td.classList.add("err");
+    if (cell?.value?.startsWith("=")) {
+      td.classList.add("has-error-detail");
+      const detail = formulaErrorTooltip(cell.value, disp.text); td.appendChild(detail);
+    }
+  }
   // formatting styles
   if (fmt) {
     let s = "";
@@ -1774,8 +3212,17 @@ function renderCell(ref, r, c, rng) {
     if (fmt.wrap) td.classList.add("wrap");
     if (disp.center && !fmt.a) cv.style.textAlign = "center";
   } else if (disp.center) cv.style.textAlign = "center";
+  // Like conventional spreadsheets, left-aligned text may flow across empty
+  // cells, but is clipped immediately before the next populated cell.
+  if (disp.text && !disp.numeric && !disp.err && !disp.center && !fmt?.wrap && (!fmt?.a || fmt.a === "l") && curSheet()?.filter?.row !== r) {
+    const overflowWidth = availableOverflowWidth(r, c);
+    if (overflowWidth > colWidth(c)) {
+      td.classList.add("text-overflow");
+      cv.style.width = Math.max(0, overflowWidth - 8) + "px";
+    }
+  }
   // selection classes
-  if (r >= rng.r1 && r <= rng.r2 && c >= rng.c1 && c <= rng.c2) {
+  if (cellInSelection(r, c)) {
     if (r === focus.r && c === focus.c) td.classList.add("active");
     else td.classList.add("sel");
   }
@@ -1882,7 +3329,69 @@ window.matchMedia("print").addEventListener("change", (event) => {
 });
 
 // Position rowheads sticky-left offset already handled by CSS `left:0`.
-function positionActiveOverlays() { /* active box handled via .active class */ }
+function positionActiveOverlays() {
+  if (editing || extraRanges.length) { fillHandle.style.display = "none"; return; }
+  const range = selRange(), target = cellEl(range.r2, range.c2);
+  if (!target || target.offsetParent === null) { fillHandle.style.display = "none"; return; }
+  fillHandle.style.left = (target.offsetLeft + target.offsetWidth - 5) + "px";
+  fillHandle.style.top = (target.offsetTop + target.offsetHeight - 5) + "px";
+  fillHandle.style.display = "block";
+}
+let fillDrag = null;
+function modulo(value, divisor) { return ((value % divisor) + divisor) % divisor; }
+function clearFillPreview() { gridTable.querySelectorAll("td.fill-preview").forEach((cell) => cell.classList.remove("fill-preview")); }
+function updateFillPreview(row, column) {
+  if (!fillDrag) return;
+  const source = fillDrag.source;
+  const rowDistance = row < source.r1 ? source.r1 - row : row > source.r2 ? row - source.r2 : 0;
+  const columnDistance = column < source.c1 ? source.c1 - column : column > source.c2 ? column - source.c2 : 0;
+  if (!rowDistance && !columnDistance) fillDrag.target = { ...source };
+  else if (rowDistance >= columnDistance) fillDrag.target = { r1: Math.min(row, source.r1), c1: source.c1, r2: Math.max(row, source.r2), c2: source.c2 };
+  else fillDrag.target = { r1: source.r1, c1: Math.min(column, source.c1), r2: source.r2, c2: Math.max(column, source.c2) };
+  clearFillPreview();
+  for (let r = fillDrag.target.r1; r <= fillDrag.target.r2; r++) for (let c = fillDrag.target.c1; c <= fillDrag.target.c2; c++) {
+    if (r < source.r1 || r > source.r2 || c < source.c1 || c > source.c2) cellEl(r, c)?.classList.add("fill-preview");
+  }
+}
+function applyFillDrag() {
+  if (!fillDrag) return;
+  const { source, target, snapshots, sheetId } = fillDrag;
+  fillDrag = null; clearFillPreview();
+  if (target.r1 === source.r1 && target.r2 === source.r2 && target.c1 === source.c1 && target.c2 === source.c2) { positionActiveOverlays(); return; }
+  const sourceRows = source.r2 - source.r1 + 1, sourceColumns = source.c2 - source.c1 + 1;
+  beginBatch();
+  for (let row = target.r1; row <= target.r2; row++) for (let column = target.c1; column <= target.c2; column++) {
+    if (row >= source.r1 && row <= source.r2 && column >= source.c1 && column <= source.c2) continue;
+    const sourceRow = source.r1 + modulo(row - source.r1, sourceRows);
+    const sourceColumn = source.c1 + modulo(column - source.c1, sourceColumns);
+    const sourceRef = rcToRef(sourceRow, sourceColumn), destinationRef = rcToRef(row, column);
+    const snapshot = snapshots[sourceRef], existing = (model.cells[sheetId] || {})[destinationRef];
+    recordCell(sheetId, destinationRef);
+    if (snapshot) {
+      const value = shiftedCopyFormula(snapshot.value, sourceRef, destinationRef, false);
+      model.cells[sheetId][destinationRef] = { value, fmt: snapshot.fmt ? { ...snapshot.fmt } : null, version: existing?.version || 0 };
+      queueCellOp(sheetId, destinationRef, value, snapshot.fmt || null);
+    } else clearStoredCell(sheetId, destinationRef);
+  }
+  commitBatch(); rebuildEngine(); setSelection({ r: target.r1, c: target.c1 }, { r: target.r2, c: target.c2 }); renderGrid(); schedulePivotRefreshes(sheetId);
+}
+fillHandle.addEventListener("pointerdown", (event) => {
+  if (event.button !== 0 || editing) return;
+  event.preventDefault(); event.stopPropagation();
+  const source = selRange(), snapshots = {};
+  for (let row = source.r1; row <= source.r2; row++) for (let column = source.c1; column <= source.c2; column++) {
+    const ref = rcToRef(row, column), cell = getCell(ref); snapshots[ref] = cell ? { value: cell.value, fmt: cell.fmt ? { ...cell.fmt } : null } : null;
+  }
+  fillDrag = { source: { ...source }, target: { ...source }, snapshots, sheetId: activeSheetId };
+  fillHandle.setPointerCapture?.(event.pointerId);
+});
+fillHandle.addEventListener("pointermove", (event) => {
+  if (!fillDrag) return;
+  const target = document.elementFromPoint(event.clientX, event.clientY)?.closest?.("td.cell");
+  if (target) updateFillPreview(+target.dataset.r, +target.dataset.c);
+});
+fillHandle.addEventListener("pointerup", (event) => { if (fillDrag) applyFillDrag(); fillHandle.releasePointerCapture?.(event.pointerId); });
+fillHandle.addEventListener("pointercancel", () => { fillDrag = null; clearFillPreview(); positionActiveOverlays(); });
 
 // ===========================================================================
 // Selection & navigation
@@ -1891,15 +3400,16 @@ function clampRC(r, c) {
   const sh = curSheet();
   return { r: Math.max(0, Math.min(sh.rows - 1, r)), c: Math.max(0, Math.min(sh.cols - 1, c)) };
 }
-function moveActive(r, c, extend = false) {
+function moveActive(r, c, extend = false, preserveExtra = false) {
   const p = clampRC(r, c);
   focus = { r: p.r, c: p.c };
-  if (!extend) anchor = { r: p.r, c: p.c };
+  if (!extend) { anchor = { r: p.r, c: p.c }; if (!preserveExtra) extraRanges = []; }
   updateSelectionUI();
   scrollActiveIntoView();
+  armEditorCapture(false);
   sendPresence();
 }
-function setSelection(a, f) { anchor = { ...a }; focus = { ...f }; updateSelectionUI(); sendPresence(); }
+function setSelection(a, f, preserveExtra = false) { if (!preserveExtra) extraRanges = []; anchor = { ...a }; focus = { ...f }; updateSelectionUI(); sendPresence(); }
 
 function updateSelectionUI() {
   const rng = selRange();
@@ -1909,7 +3419,7 @@ function updateSelectionUI() {
   const prevHl = gridTable.querySelectorAll("th.hl, th.full");
   prevHl.forEach((th) => th.classList.remove("hl", "full"));
   const sh = curSheet();
-  for (let r = rng.r1; r <= rng.r2; r++) for (let c = rng.c1; c <= rng.c2; c++) {
+  for (const range of selectionRanges()) for (let r = range.r1; r <= range.r2; r++) for (let c = range.c1; c <= range.c2; c++) {
     const td = cellEl(r, c);
     if (!td) continue;
     if (r === focus.r && c === focus.c) td.classList.add("active");
@@ -1918,18 +3428,20 @@ function updateSelectionUI() {
   // headers
   gridTable.querySelectorAll("th.colhead").forEach((th) => {
     const c = +th.dataset.col;
-    if (c >= rng.c1 && c <= rng.c2) th.classList.add(rng.r1 === 0 && rng.r2 === sh.rows - 1 ? "full" : "hl");
+    const matches = selectionRanges().filter((range) => c >= range.c1 && c <= range.c2);
+    if (matches.length) th.classList.add(matches.some((range) => range.r1 === 0 && range.r2 === sh.rows - 1) ? "full" : "hl");
   });
   gridTable.querySelectorAll("th.rowhead").forEach((th) => {
     const r = +th.dataset.row;
-    if (r >= rng.r1 && r <= rng.r2) th.classList.add(rng.c1 === 0 && rng.c2 === sh.cols - 1 ? "full" : "hl");
+    const matches = selectionRanges().filter((range) => r >= range.r1 && r <= range.r2);
+    if (matches.length) th.classList.add(matches.some((range) => range.c1 === 0 && range.c2 === sh.cols - 1) ? "full" : "hl");
   });
   // name box + formula bar
-  nameBox.value = rng.r1 === rng.r2 && rng.c1 === rng.c2 ? rcToRef(focus.r, focus.c)
-    : rcToRef(rng.r1, rng.c1) + ":" + rcToRef(rng.r2, rng.c2);
+  nameBox.value = extraRanges.length ? `${selectionRanges().length} ranges` : (rng.r1 === rng.r2 && rng.c1 === rng.c2 ? rcToRef(focus.r, focus.c)
+    : rcToRef(rng.r1, rng.c1) + ":" + rcToRef(rng.r2, rng.c2));
   const active = getCell(rcToRef(focus.r, focus.c));
   formulaInput.value = active ? active.value : "";
-  refreshToolbarState();
+  refreshToolbarState(); positionActiveOverlays();
 }
 function cellEl(r, c) { return gridTable.querySelector(`td.cell[data-r="${r}"][data-c="${c}"]`); }
 
@@ -1956,6 +3468,10 @@ function refreshToolbarState() {
   underlineBtn.classList.toggle("active", !!f.u);
   strikeBtn.classList.toggle("active", !!f.s);
   wrapBtn.classList.toggle("active", !!f.wrap);
+  filterBtn.classList.toggle("active", !!curSheet()?.filter);
+  const commentCount = curSheet() ? commentsForRef(rcToRef(focus.r, focus.c)).length : 0;
+  commentBtn.classList.toggle("active", commentCount > 0);
+  commentBtn.title = commentCount ? `${commentCount} active comment${commentCount === 1 ? "" : "s"} on this cell — add another` : "Add a comment to the active cell";
   alignBtns.l.classList.toggle("active", !f.a || f.a === "l");
   alignBtns.c.classList.toggle("active", f.a === "c");
   alignBtns.r.classList.toggle("active", f.a === "r");
@@ -1963,16 +3479,475 @@ function refreshToolbarState() {
 }
 
 // ===========================================================================
-// Cell editing
+// Cell editing + formula guidance
 // ===========================================================================
+let formulaAssistItems = [], formulaAssistIndex = 0, formulaAssistReplaceStart = 0;
+function closeFormulaAssist() { formulaAssist.style.display = "none"; formulaAssist.replaceChildren(); formulaAssistItems = []; }
+function positionFormulaAssist() {
+  const rect = cellEditor.getBoundingClientRect();
+  formulaAssist.style.left = Math.max(8, Math.min(window.innerWidth - formulaAssist.offsetWidth - 8, rect.left)) + "px";
+  formulaAssist.style.top = Math.max(8, Math.min(window.innerHeight - formulaAssist.offsetHeight - 8, rect.bottom + 4)) + "px";
+}
+function activeFormulaCall(text, cursor) {
+  const stack = []; let quote = null;
+  for (let index = 1; index < cursor; index++) {
+    const char = text[index];
+    if (quote) {
+      if (char === "\\" && text[index + 1] === quote) { index++; continue; }
+      if (char === quote) { if (text[index + 1] === quote) { index++; continue; } quote = null; }
+      continue;
+    }
+    if (char === '"' || char === "'") { quote = char; continue; }
+    if (char === "(") {
+      const match = /([A-Za-z][A-Za-z0-9_.]*)\s*$/.exec(text.slice(0, index));
+      stack.push({ name: match ? match[1].toUpperCase() : "", argument: 0 });
+    } else if (char === "," && stack.length) stack[stack.length - 1].argument++;
+    else if (char === ")" && stack.length) stack.pop();
+  }
+  return stack.length ? stack[stack.length - 1] : null;
+}
+function formulaCursorInQuote(value, cursor) {
+  let quote = null;
+  for (let index = 1; index < cursor; index++) {
+    const char = value[index];
+    if (quote) {
+      if (char === "\\" && value[index + 1] === quote) { index++; continue; }
+      if (char === quote) { if (value[index + 1] === quote) { index++; continue; } quote = null; }
+    } else if (char === '"' || char === "'") quote = char;
+  }
+  return !!quote;
+}
+function insertFormulaComma() {
+  const start = cellEditor.selectionStart ?? cellEditor.value.length, end = cellEditor.selectionEnd ?? start;
+  clearFormulaPick();
+  cellEditor.value = cellEditor.value.slice(0, start) + ", " + cellEditor.value.slice(end);
+  const next = start + 2; cellEditor.setSelectionRange(next, next);
+  formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(next, next); syncEditorSize(); updateFormulaAssist();
+}
+function renderFormulaSuggestions(matches) {
+  formulaAssist.replaceChildren(); formulaAssistItems = matches; formulaAssistIndex = Math.min(formulaAssistIndex, matches.length - 1);
+  matches.forEach((name, index) => {
+    const help = functionHelp(name);
+    const item = el("div", { class: "formula-suggestion" + (index === formulaAssistIndex ? " active" : ""), role: "option" }, [el("strong", {}, name), el("span", {}, help[1])]);
+    item.addEventListener("mousedown", (event) => { event.preventDefault(); formulaAssistIndex = index; acceptFormulaSuggestion(); });
+    formulaAssist.appendChild(item);
+  });
+  formulaAssist.style.display = "block"; requestAnimationFrame(positionFormulaAssist);
+}
+function renderFormulaSyntax(call) {
+  const [signature, description] = functionHelp(call.name);
+  const match = /^([^()]+)\((.*)\)$/.exec(signature);
+  const code = el("div", { class: "formula-syntax-code" });
+  if (!match) code.textContent = signature;
+  else {
+    code.appendChild(document.createTextNode(match[1] + "("));
+    const args = match[2] ? match[2].split(/,\s*/) : [];
+    args.forEach((argument, index) => {
+      if (index) code.appendChild(document.createTextNode(", "));
+      code.appendChild(el("span", { class: index === Math.min(call.argument, args.length - 1) ? "current" : "" }, argument));
+    });
+    code.appendChild(document.createTextNode(")"));
+  }
+  formulaAssist.replaceChildren(el("div", { class: "formula-syntax" }, [code, el("div", { class: "formula-syntax-desc" }, description)]));
+  formulaAssistItems = []; formulaAssist.style.display = "block"; requestAnimationFrame(positionFormulaAssist);
+}
+function updateFormulaAssist() {
+  absoluteRefBtn.disabled = !currentFormulaReferenceBounds();
+  if (!editing || imeComposing || !cellEditor.value.startsWith("=")) { closeFormulaAssist(); renderFormulaPickHighlight(); return; }
+  renderFormulaPickHighlight();
+  const cursor = cellEditor.selectionStart ?? cellEditor.value.length;
+  const before = cellEditor.value.slice(0, cursor);
+  if (before === "=") { formulaAssistReplaceStart = 1; formulaAssistIndex = 0; renderFormulaSuggestions(["SUM", "AVERAGE", "IF", "COUNTIF", "VLOOKUP", "HYPERLINK"]); return; }
+  const call = activeFormulaCall(cellEditor.value, cursor);
+  if (formulaReferenceBoundsAtCaret(cellEditor.value, cursor)) {
+    if (call?.name && FUNCTIONS[call.name]) renderFormulaSyntax(call); else closeFormulaAssist();
+    return;
+  }
+  const token = /([A-Za-z][A-Za-z0-9_.]*)$/.exec(before);
+  if (token) {
+    const start = cursor - token[1].length, previous = before[start - 1] || "";
+    if (start === 1 || "(,+-*/^&=<>".includes(previous)) {
+      const query = token[1].toUpperCase();
+      const matches = FUNCTION_NAMES.filter((name) => name.startsWith(query)).slice(0, 7);
+      if (matches.length) { formulaAssistReplaceStart = start; formulaAssistIndex = 0; renderFormulaSuggestions(matches); return; }
+    }
+  }
+  if (call?.name && FUNCTIONS[call.name]) renderFormulaSyntax(call); else closeFormulaAssist();
+}
+function acceptFormulaSuggestion() {
+  const name = formulaAssistItems[formulaAssistIndex]; if (!name || !editing) return;
+  const cursor = cellEditor.selectionStart ?? cellEditor.value.length;
+  cellEditor.value = cellEditor.value.slice(0, formulaAssistReplaceStart) + name + "()" + cellEditor.value.slice(cursor);
+  const next = formulaAssistReplaceStart + name.length + 1;
+  cellEditor.setSelectionRange(next, next); formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(next, next); syncEditorSize(); updateFormulaAssist();
+}
+function moveFormulaSuggestion(delta) {
+  if (!formulaAssistItems.length) return false;
+  formulaAssistIndex = (formulaAssistIndex + delta + formulaAssistItems.length) % formulaAssistItems.length;
+  renderFormulaSuggestions(formulaAssistItems); return true;
+}
+
+let formulaPick = null;
+let formulaPickGestureComplete = false;
+function clearFormulaPick() {
+  formulaPick = null; formulaPickGestureComplete = false; formulaRangeHandle.style.display = "none";
+  gridTable.querySelectorAll("td.formula-ref").forEach((cell) => cell.classList.remove("formula-ref", "formula-ref-top", "formula-ref-bottom", "formula-ref-left", "formula-ref-right"));
+}
+function formulaRangeText(r1, c1, r2, c2) {
+  const first = rcToRef(Math.min(r1, r2), Math.min(c1, c2));
+  const last = rcToRef(Math.max(r1, r2), Math.max(c1, c2));
+  return first === last ? first : first + ":" + last;
+}
+function localFormulaPosition(ref) {
+  const bang = ref.indexOf("!");
+  if (bang >= 0) {
+    const sheetName = ref.slice(0, bang).replace(/^'|'$/g, "").replace(/''/g, "'");
+    if (sheetName.toLowerCase() !== curSheet().name.toLowerCase()) return null;
+    ref = ref.slice(bang + 1);
+  }
+  return parseRef(ref);
+}
+function formulaReferencedRanges(value = cellEditor.value) {
+  const ranges = [];
+  const addRange = (firstRef, lastRef = firstRef) => {
+    const first = localFormulaPosition(firstRef), last = localFormulaPosition(lastRef); if (!first || !last) return;
+    const range = {
+      r1: Math.max(0, Math.min(first.r, last.r)), r2: Math.min(curSheet().rows - 1, Math.max(first.r, last.r)),
+      c1: Math.max(0, Math.min(first.c, last.c)), c2: Math.min(curSheet().cols - 1, Math.max(first.c, last.c)),
+    };
+    if (!ranges.some((item) => item.r1 === range.r1 && item.r2 === range.r2 && item.c1 === range.c1 && item.c2 === range.c2)) ranges.push(range);
+  };
+  let ast;
+  try { ast = parseFormula(value.startsWith("=") ? value.slice(1) : value); }
+  catch (error) {
+    const tokens = tokenize(value.startsWith("=") ? value.slice(1) : value);
+    for (let index = 0; index < tokens.length; index++) {
+      if (tokens[index].t !== "word") continue;
+      if (tokens[index + 1]?.t === "colon" && tokens[index + 2]?.t === "word") { addRange(tokens[index].v, tokens[index + 2].v); index += 2; }
+      else addRange(tokens[index].v);
+    }
+    return ranges;
+  }
+  const visit = (node) => {
+    if (!node) return;
+    if (node.k === "ref") addRange(node.ref);
+    else if (node.k === "range") addRange(node.a, node.b);
+    else if (node.k === "call") node.args.forEach(visit);
+    else { if (node.a) visit(node.a); if (node.b) visit(node.b); }
+  };
+  visit(ast); return ranges;
+}
+function formulaReferencedCells(value = cellEditor.value) {
+  const refs = new Set();
+  for (const range of formulaReferencedRanges(value)) for (let row = range.r1; row <= range.r2; row++) for (let column = range.c1; column <= range.c2; column++) refs.add(rcToRef(row, column));
+  return refs;
+}
+function positionFormulaRangeHandle() {
+  if (!formulaPick || !editing) { formulaRangeHandle.style.display = "none"; return; }
+  const row = Math.max(formulaPick.r1, formulaPick.r2), column = Math.max(formulaPick.c1, formulaPick.c2);
+  const cell = cellEl(row, column);
+  if (!cell || cell.offsetParent === null) { formulaRangeHandle.style.display = "none"; return; }
+  formulaRangeHandle.style.left = (cell.offsetLeft + cell.offsetWidth - 5) + "px";
+  formulaRangeHandle.style.top = (cell.offsetTop + cell.offsetHeight - 5) + "px";
+  formulaRangeHandle.style.display = "block";
+}
+function renderFormulaPickHighlight() {
+  const edgeClasses = ["formula-ref", "formula-ref-top", "formula-ref-bottom", "formula-ref-left", "formula-ref-right"];
+  gridTable.querySelectorAll("td.formula-ref").forEach((cell) => cell.classList.remove(...edgeClasses));
+  const applyRange = (range) => {
+    for (let row = range.r1; row <= range.r2; row++) for (let column = range.c1; column <= range.c2; column++) {
+      const cell = cellEl(row, column); if (!cell) continue;
+      cell.classList.add("formula-ref");
+      if (row === range.r1) cell.classList.add("formula-ref-top");
+      if (row === range.r2) cell.classList.add("formula-ref-bottom");
+      if (column === range.c1) cell.classList.add("formula-ref-left");
+      if (column === range.c2) cell.classList.add("formula-ref-right");
+    }
+  };
+  if (editing && cellEditor.value.startsWith("=")) formulaReferencedRanges().forEach(applyRange);
+  if (formulaPick) applyRange({
+    r1: Math.min(formulaPick.r1, formulaPick.r2), r2: Math.max(formulaPick.r1, formulaPick.r2),
+    c1: Math.min(formulaPick.c1, formulaPick.c2), c2: Math.max(formulaPick.c1, formulaPick.c2),
+  });
+  positionFormulaRangeHandle();
+}
+function formulaReferenceBoundsAtCaret(value, caret) {
+  const pattern = /(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*(?::(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*)?/gi;
+  for (const match of value.matchAll(pattern)) {
+    const start = match.index, end = start + match[0].length;
+    if (caret >= start && caret <= end) return { start, end };
+  }
+  return null;
+}
+function cycleReferenceToken(text) {
+  return text.replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,3})(\$?)([1-9]\d*)(?![A-Z0-9_])/gi, (match, fixedColumn, column, fixedRow, row) => {
+    const state = { column: !!fixedColumn, row: !!fixedRow };
+    let next;
+    if (!state.column && !state.row) next = { column: true, row: true };
+    else if (state.column && state.row) next = { column: false, row: true };
+    else if (!state.column && state.row) next = { column: true, row: false };
+    else next = { column: false, row: false };
+    return (next.column ? "$" : "") + column.toUpperCase() + (next.row ? "$" : "") + row;
+  });
+}
+function formulaEndpointBoundsAtCaret(value, caret) {
+  const pattern = /(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*/gi;
+  for (const match of value.matchAll(pattern)) {
+    if (!match[0].startsWith("'") && formulaCursorInQuote(value, match.index + 1)) continue;
+    const start = match.index, end = start + match[0].length;
+    if (caret >= start && caret <= end) return { start, end };
+  }
+  return null;
+}
+function currentFormulaReferenceBounds() {
+  if (!editing || !cellEditor.value.startsWith("=")) return null;
+  const caret = cellEditor.selectionStart ?? cellEditor.value.length;
+  return formulaEndpointBoundsAtCaret(cellEditor.value, caret);
+}
+function cycleAbsoluteReference() {
+  const bounds = currentFormulaReferenceBounds();
+  if (!bounds) { setStatus("bad", "Place the caret in a cell reference"); return false; }
+  const original = cellEditor.value.slice(bounds.start, bounds.end), replacement = cycleReferenceToken(original);
+  if (replacement === original) { setStatus("bad", "No cell reference selected"); return false; }
+  cellEditor.value = cellEditor.value.slice(0, bounds.start) + replacement + cellEditor.value.slice(bounds.end);
+  const end = bounds.start + replacement.length;
+  cellEditor.setSelectionRange(end, end); formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(end, end);
+  const rangeBounds = formulaReferenceBoundsAtCaret(cellEditor.value, end);
+  formulaPick = formulaReferenceFromBounds(cellEditor.value, rangeBounds); formulaPickGestureComplete = false;
+  syncEditorSize(); updateFormulaAssist(); renderFormulaPickHighlight(); setStatus("saved", "Reference lock changed");
+  return true;
+}
+function formulaReferenceFromBounds(value, bounds) {
+  if (!bounds) return null;
+  const text = value.slice(bounds.start, bounds.end), parts = text.split(":");
+  const first = localFormulaPosition(parts[0]), last = localFormulaPosition(parts[1] || parts[0]);
+  if (!first || !last) return null;
+  return {
+    textStart: bounds.start, textEnd: bounds.end,
+    r1: Math.min(first.r, last.r), r2: Math.max(first.r, last.r),
+    c1: Math.min(first.c, last.c), c2: Math.max(first.c, last.c),
+  };
+}
+function syncFormulaPickFromCaret() {
+  if (!editing || !cellEditor.value.startsWith("=")) { clearFormulaPick(); return; }
+  const start = cellEditor.selectionStart ?? cellEditor.value.length;
+  const end = cellEditor.selectionEnd ?? start;
+  let bounds = formulaReferenceBoundsAtCaret(cellEditor.value, start === end ? start : Math.min(start + 1, end));
+  if (!bounds) {
+    const span = activeFormulaArgumentSpans(cellEditor.value, start).find((item) => start >= item.start && start <= item.end);
+    if (span) {
+      const raw = cellEditor.value.slice(span.start, span.end), leading = raw.length - raw.trimStart().length, trimmed = raw.trim();
+      if (/^(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*(?::(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*)?$/i.test(trimmed)) bounds = { start: span.start + leading, end: span.start + leading + trimmed.length };
+    }
+  }
+  const reference = formulaReferenceFromBounds(cellEditor.value, bounds);
+  if (reference) activateFormulaReference(reference, false);
+  else { formulaPick = null; formulaPickGestureComplete = false; renderFormulaPickHighlight(); }
+}
+function updatePickedFormulaRange(r1, c1, r2 = r1, c2 = c1, reset = false) {
+  if (!editing || !cellEditor.value.startsWith("=")) return;
+  if (!formulaPick || reset) {
+    let start = cellEditor.selectionStart ?? cellEditor.value.length;
+    let end = cellEditor.selectionEnd ?? start;
+    if (start === end) {
+      const bounds = formulaReferenceBoundsAtCaret(cellEditor.value, start);
+      if (bounds) { start = bounds.start; end = bounds.end; }
+    }
+    // Never let point-and-click reference selection replace the formula's
+    // leading '=' or an automatically selected whole formula. In that case,
+    // insert before trailing auto-closed parentheses instead.
+    if (start < 1 || (start === 0 && end === cellEditor.value.length)) {
+      let insertion = cellEditor.value.length;
+      while (insertion > 1 && cellEditor.value[insertion - 1] === ")") insertion--;
+      start = end = insertion;
+    }
+    formulaPick = { textStart: start, textEnd: end, r1, c1, r2, c2 };
+  } else { formulaPick.r2 = r2; formulaPick.c2 = c2; }
+  const reference = formulaRangeText(formulaPick.r1, formulaPick.c1, formulaPick.r2, formulaPick.c2);
+  cellEditor.value = cellEditor.value.slice(0, formulaPick.textStart) + reference + cellEditor.value.slice(formulaPick.textEnd);
+  formulaPick.textEnd = formulaPick.textStart + reference.length;
+  cellEditor.setSelectionRange(formulaPick.textEnd, formulaPick.textEnd);
+  formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(formulaPick.textEnd, formulaPick.textEnd); syncEditorSize(); updateFormulaAssist(); renderFormulaPickHighlight();
+}
+function activeFormulaArgumentSpans(value, cursor) {
+  const opens = []; let quote = null;
+  for (let index = 1; index < cursor; index++) {
+    const char = value[index];
+    if (quote) {
+      if (char === "\\" && value[index + 1] === quote) { index++; continue; }
+      if (char === quote) { if (value[index + 1] === quote) { index++; continue; } quote = null; }
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === "(") opens.push(index);
+    else if (char === ")") opens.pop();
+  }
+  if (!opens.length) return [];
+  const open = opens[opens.length - 1], spans = []; let start = open + 1, depth = 0; quote = null;
+  for (let index = start; index <= value.length; index++) {
+    const char = value[index];
+    if (quote) {
+      if (char === "\\" && value[index + 1] === quote) { index++; continue; }
+      if (char === quote) { if (value[index + 1] === quote) { index++; continue; } quote = null; }
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === "(") depth++;
+    else if (char === ")") { if (depth === 0) { spans.push({ start, end: index }); break; } depth--; }
+    else if (char === "," && depth === 0) { spans.push({ start, end: index }); start = index + 1; }
+    else if (index === value.length) spans.push({ start, end: index });
+  }
+  return spans;
+}
+function removeFormulaReferenceArgument(row, column) {
+  const spans = activeFormulaArgumentSpans(cellEditor.value, cellEditor.selectionStart ?? cellEditor.value.length);
+  const targetRef = rcToRef(row, column);
+  const index = spans.findIndex((span) => {
+    const text = cellEditor.value.slice(span.start, span.end).trim();
+    if (text.includes(":")) return false;
+    const position = localFormulaPosition(text);
+    return position?.r === row && position?.c === column;
+  });
+  if (index < 0) return false;
+  let removeStart = spans[index].start, removeEnd = spans[index].end;
+  if (spans.length > 1 && index < spans.length - 1) {
+    removeEnd = spans[index + 1].start;
+    while (removeEnd < cellEditor.value.length && cellEditor.value[removeEnd] === " ") removeEnd++;
+  } else if (spans.length > 1) removeStart = spans[index - 1].end;
+  const bridge = index > 0 && index < spans.length - 1 ? " " : "";
+  cellEditor.value = cellEditor.value.slice(0, removeStart) + bridge + cellEditor.value.slice(removeEnd);
+  const caret = removeStart + bridge.length;
+  cellEditor.setSelectionRange(caret, caret); formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(caret, caret);
+  clearFormulaPick(); syncEditorSize(); updateFormulaAssist(); return true;
+}
+function beginAdditionalFormulaReference() {
+  let insertion = formulaPick ? formulaPick.textEnd : (cellEditor.selectionStart ?? cellEditor.value.length);
+  if (!formulaPick) while (insertion > 1 && cellEditor.value[insertion - 1] === ")") insertion--;
+  const previous = cellEditor.value[insertion - 1] || "";
+  const separator = previous && previous !== "(" && previous !== "," ? ", " : "";
+  cellEditor.value = cellEditor.value.slice(0, insertion) + separator + cellEditor.value.slice(insertion);
+  insertion += separator.length;
+  clearFormulaPick(); cellEditor.setSelectionRange(insertion, insertion); formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(insertion, insertion);
+}
+function formulaReferenceAtCell(row, column) {
+  const value = cellEditor.value;
+  const pattern = /(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*(?::(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*)?/gi;
+  const matches = [];
+  for (const match of value.matchAll(pattern)) {
+    if (formulaCursorInQuote(value, match.index + 1)) continue;
+    const parts = match[0].split(":");
+    const first = localFormulaPosition(parts[0]), last = localFormulaPosition(parts[1] || parts[0]);
+    if (!first || !last) continue;
+    const range = { r1: Math.min(first.r, last.r), r2: Math.max(first.r, last.r), c1: Math.min(first.c, last.c), c2: Math.max(first.c, last.c) };
+    if (row >= range.r1 && row <= range.r2 && column >= range.c1 && column <= range.c2) matches.push({ ...range, textStart: match.index, textEnd: match.index + match[0].length });
+  }
+  matches.sort((a, b) => (a.r2 - a.r1 + 1) * (a.c2 - a.c1 + 1) - (b.r2 - b.r1 + 1) * (b.c2 - b.c1 + 1));
+  return matches[0] || null;
+}
+function activateFormulaReference(reference, moveCaret = true) {
+  formulaPick = { ...reference }; formulaPickGestureComplete = false;
+  if (moveCaret) {
+    cellEditor.setSelectionRange(reference.textEnd, reference.textEnd);
+    formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(reference.textEnd, reference.textEnd);
+  }
+  renderFormulaPickHighlight(); updateFormulaAssist();
+}
+function startFormulaMousePick(row, column, event) {
+  const modifier = event.ctrlKey || event.metaKey;
+  const caret = cellEditor.selectionStart ?? cellEditor.value.length;
+  // A range selected for an inner function must not remain the active resize
+  // target after the caret moves into an outer function or sibling argument.
+  if (formulaPick && (caret < formulaPick.textStart || caret > formulaPick.textEnd)) clearFormulaPick();
+  const beforeCaret = cellEditor.value.slice(0, caret);
+  const afterSeparator = /[,;(]\s*$/.test(beforeCaret);
+  const call = activeFormulaCall(cellEditor.value, cellEditor.selectionStart ?? cellEditor.value.length);
+  const dedupeSelection = ["SUM", "AVERAGE", "COUNT", "COUNTA", "MIN", "MAX", "PRODUCT", "MEDIAN", "STDEV", "VAR"].includes(call?.name);
+  const existing = formulaReferenceAtCell(row, column);
+  if (modifier && dedupeSelection && existing) {
+    if (removeFormulaReferenceArgument(row, column)) setStatus("saved", `${rcToRef(row, column)} removed from formula`);
+    else setStatus("saved", `${rcToRef(row, column)} is part of an existing range`);
+    renderFormulaPickHighlight(); mouseSelecting = false; return;
+  }
+  if (!modifier && !afterSeparator && existing) { activateFormulaReference(existing); mouseSelecting = false; return; }
+  if (dedupeSelection && afterSeparator && existing) {
+    setStatus("saved", `${rcToRef(row, column)} is already referenced`); renderFormulaPickHighlight(); mouseSelecting = false; return;
+  }
+  if (modifier) beginAdditionalFormulaReference();
+  formulaPickGestureComplete = false;
+  if (formulaPick) {
+    if (!event.shiftKey) { formulaPick.r1 = row; formulaPick.c1 = column; }
+    updatePickedFormulaRange(formulaPick.r1, formulaPick.c1, row, column, false);
+  } else updatePickedFormulaRange(row, column, row, column, true);
+  mouseSelecting = "formula";
+}
+function moveFormulaPickByKeyboard(rowDelta, columnDelta, extend) {
+  if (!formulaPick) {
+    const row = Math.max(0, Math.min(curSheet().rows - 1, editing.r + rowDelta));
+    const column = Math.max(0, Math.min(curSheet().cols - 1, editing.c + columnDelta));
+    updatePickedFormulaRange(row, column, row, column, true);
+  } else {
+    const row = Math.max(0, Math.min(curSheet().rows - 1, formulaPick.r2 + rowDelta));
+    const column = Math.max(0, Math.min(curSheet().cols - 1, formulaPick.c2 + columnDelta));
+    if (extend) updatePickedFormulaRange(formulaPick.r1, formulaPick.c1, row, column, false);
+    else { formulaPick.r1 = row; formulaPick.c1 = column; updatePickedFormulaRange(row, column, row, column, false); }
+  }
+  formulaPickGestureComplete = true;
+  const target = cellEl(formulaPick.r2, formulaPick.c2); if (target) target.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+let resizingFormulaRange = false;
+formulaRangeHandle.addEventListener("pointerdown", (event) => {
+  if (event.button !== 0 || !formulaPick || !editing) return;
+  event.preventDefault(); event.stopPropagation(); resizingFormulaRange = true;
+  const r1 = Math.min(formulaPick.r1, formulaPick.r2), r2 = Math.max(formulaPick.r1, formulaPick.r2);
+  const c1 = Math.min(formulaPick.c1, formulaPick.c2), c2 = Math.max(formulaPick.c1, formulaPick.c2);
+  formulaPick.r1 = r1; formulaPick.c1 = c1; formulaPick.r2 = r2; formulaPick.c2 = c2;
+  formulaRangeHandle.setPointerCapture?.(event.pointerId);
+});
+formulaRangeHandle.addEventListener("pointermove", (event) => {
+  if (!resizingFormulaRange || !formulaPick) return;
+  const target = document.elementsFromPoint(event.clientX, event.clientY).map((element) => element.closest?.("td.cell")).find(Boolean);
+  if (target) {
+    const row = +target.dataset.r, column = +target.dataset.c, rect = target.getBoundingClientRect();
+    const threshold = 7;
+    if (column > formulaPick.c2 && event.clientX < rect.left + threshold) return;
+    if (row > formulaPick.r2 && event.clientY < rect.top + threshold) return;
+    updatePickedFormulaRange(formulaPick.r1, formulaPick.c1, Math.max(formulaPick.r1, row), Math.max(formulaPick.c1, column), false);
+  }
+});
+const finishFormulaRangeResize = (event) => {
+  if (!resizingFormulaRange) return;
+  resizingFormulaRange = false; formulaPickGestureComplete = true;
+  formulaRangeHandle.releasePointerCapture?.(event?.pointerId); renderFormulaPickHighlight();
+};
+formulaRangeHandle.addEventListener("pointerup", finishFormulaRangeResize);
+formulaRangeHandle.addEventListener("pointercancel", finishFormulaRangeResize);
+
 let editing = null; // { ref, r, c, initial }
-function startEdit(ref, replace = false, seed = null) {
+let imeComposing = false;
+function armEditorCapture(focusCapture = false) {
+  if (editing) return;
+  const td = cellEl(focus.r, focus.c);
+  if (!td) return;
+  cellEditor.value = "";
+  cellEditor.style.left = td.offsetLeft + "px";
+  cellEditor.style.top = td.offsetTop + "px";
+  cellEditor.style.display = "block";
+  cellEditor.classList.add("capture");
+  if (focusCapture) cellEditor.focus({ preventScroll: true });
+}
+gridScroll.addEventListener("focus", () => armEditorCapture(true));
+
+function startEdit(ref, replace = false, seed = null, fromCapture = false, keepInputFocus = false) {
+  clearFormulaPick();
+  if (!fromCapture) imeComposing = false;
   const rc = parseRef(ref);
   const td = cellEl(rc.r, rc.c);
   if (!td) return;
   editing = { ref, r: rc.r, c: rc.c };
+  fillHandle.style.display = "none";
   const cell = getCell(ref);
   let text = seed != null ? seed : (replace ? "" : (cell ? cell.value : ""));
+  cellEditor.classList.remove("capture");
   const rect = td.getBoundingClientRect();
   const scRect = gridScroll.getBoundingClientRect();
   cellEditor.style.left = (td.offsetLeft) + "px";
@@ -1980,30 +3955,111 @@ function startEdit(ref, replace = false, seed = null) {
   cellEditor.style.minWidth = td.offsetWidth + "px";
   cellEditor.style.minHeight = td.offsetHeight + "px";
   cellEditor.style.width = td.offsetWidth + "px";
-  cellEditor.value = text;
+  if (!fromCapture) cellEditor.value = text;
+  else text = cellEditor.value;
   cellEditor.style.display = "block";
   // font matches
   const f = cell?.fmt || {};
   cellEditor.style.fontWeight = f.b ? "700" : "400";
   cellEditor.style.fontStyle = f.i ? "italic" : "normal";
   cellEditor.style.textAlign = f.a === "c" ? "center" : f.a === "r" ? "right" : "left";
-  cellEditor.focus();
-  if (replace || seed != null) { const L = cellEditor.value.length; cellEditor.setSelectionRange(L, L); }
-  else cellEditor.select();
+  if (!fromCapture && !keepInputFocus) {
+    cellEditor.focus();
+    if (replace || seed != null || cellEditor.value.startsWith("=")) { const L = cellEditor.value.length; cellEditor.setSelectionRange(L, L); }
+    else cellEditor.select();
+  }
   syncEditorSize();
   formulaInput.value = text;
+  updateFormulaAssist();
 }
+const editorMeasureCanvas = document.createElement("canvas");
 function syncEditorSize() {
+  if (!editing) return;
   cellEditor.style.height = "auto";
   cellEditor.style.height = Math.max(cellEditor.scrollHeight, DEFAULT_ROW_H) + "px";
-  const w = Math.max(cellEditor.scrollWidth + 8, cellEl(editing.r, editing.c)?.offsetWidth || 60);
-  cellEditor.style.width = w + "px";
+  const baseWidth = cellEl(editing.r, editing.c)?.offsetWidth || 60;
+  const context = editorMeasureCanvas.getContext("2d");
+  let measuredWidth = baseWidth;
+  if (context) {
+    const style = getComputedStyle(cellEditor);
+    context.font = style.font || `${style.fontSize} ${style.fontFamily}`;
+    for (const line of cellEditor.value.split("\n")) measuredWidth = Math.max(measuredWidth, Math.ceil(context.measureText(line || " ").width) + 12);
+  }
+  cellEditor.style.width = Math.min(2400, measuredWidth) + "px";
+}
+function completeFormulaParentheses(value) {
+  if (!value.startsWith("=")) return value;
+  const bare = /^=\s*([A-Za-z][A-Za-z0-9_.]*)\s*$/.exec(value);
+  if (bare && FUNCTIONS[bare[1].toUpperCase()] && !["TRUE", "FALSE"].includes(bare[1].toUpperCase())) return `=${bare[1].toUpperCase()}()`;
+  let depth = 0, quote = null;
+  for (let index = 1; index < value.length; index++) {
+    const char = value[index];
+    if (quote) {
+      if (char === "\\" && value[index + 1] === quote) { index++; continue; }
+      if (char === quote) { if (value[index + 1] === quote) { index++; continue; } quote = null; }
+      continue;
+    }
+    if (char === '"' || char === "'") { quote = char; continue; }
+    if (/[A-Za-z_]/.test(char)) {
+      let end = index + 1; while (end < value.length && /[A-Za-z0-9_.]/.test(value[end])) end++;
+      const name = value.slice(index, end).toUpperCase();
+      let next = end; while (next < value.length && /\s/.test(value[next])) next++;
+      if (FUNCTIONS[name] && !["TRUE", "FALSE"].includes(name) && value[next] !== "(" && value[next] !== "!") return null;
+      index = end - 1; continue;
+    }
+    if (char === "(") depth++;
+    else if (char === ")") { depth--; if (depth < 0) return null; }
+  }
+  if (quote) return null;
+  return value + ")".repeat(depth);
+}
+const FORMULA_ARGUMENT_RULES = {
+  VLOOKUP: [3, 4], HLOOKUP: [3, 4], INDEX: [2, 3], MATCH: [2, 3],
+  IF: [2, 3], IFERROR: [2, 2], IFNA: [2, 2], COUNTIF: [2, 2], SUMIF: [2, 3], AVERAGEIF: [2, 3],
+  HYPERLINK: [1, 2], LEFT: [1, 2], RIGHT: [1, 2], MID: [3, 3], ROUND: [2, 2],
+  DATE: [3, 3], DATEDIF: [3, 3], EDATE: [2, 2], CHOOSE: [2, Infinity],
+};
+function validateFormula(value) {
+  if (!value.startsWith("=")) return null;
+  let ast;
+  try { ast = parseFormula(value.slice(1)); }
+  catch (error) { return "This formula has invalid syntax. Check separators, quotes, and parentheses."; }
+  let problem = null;
+  const visit = (node) => {
+    if (!node || problem) return;
+    if (node.k === "call") {
+      if (!FUNCTIONS[node.name]) { problem = `Unknown function ${node.name}.`; return; }
+      const rule = FORMULA_ARGUMENT_RULES[node.name];
+      if (rule && (node.args.length < rule[0] || node.args.length > rule[1])) {
+        const expected = rule[0] === rule[1] ? String(rule[0]) : `${rule[0]}–${rule[1] === Infinity ? "more" : rule[1]}`;
+        problem = `${node.name} expects ${expected} argument${rule[1] === 1 ? "" : "s"}; received ${node.args.length}.`; return;
+      }
+      if (node.name === "SUMIFS" && (node.args.length < 3 || node.args.length % 2 === 0)) { problem = "SUMIFS requires a sum range followed by range/criterion pairs."; return; }
+      if (node.name === "COUNTIFS" && (node.args.length < 2 || node.args.length % 2 !== 0)) { problem = "COUNTIFS requires range/criterion pairs."; return; }
+      if (node.name === "IFS" && (node.args.length < 2 || node.args.length % 2 !== 0)) { problem = "IFS requires condition/value pairs."; return; }
+      node.args.forEach(visit);
+    } else {
+      if (node.a) visit(node.a); if (node.b) visit(node.b);
+    }
+  };
+  visit(ast); return problem;
+}
+function showFormulaError(message) {
+  formulaAssist.replaceChildren(el("div", { class: "formula-error" }, message));
+  formulaAssistItems = []; formulaAssist.style.display = "block"; requestAnimationFrame(positionFormulaAssist);
+  setStatus("bad", "Fix formula error");
 }
 function commitEdit(advance = "down") {
   if (!editing) return;
   const { ref, r, c } = editing;
-  const value = cellEditor.value;
-  editing = null;
+  let value = completeFormulaParentheses(cellEditor.value);
+  if (value == null) { showFormulaError("Formula quotes and parentheses must be balanced."); cellEditor.focus(); return; }
+  cellEditor.value = value;
+  const formulaError = validateFormula(value);
+  if (formulaError) { showFormulaError(formulaError); cellEditor.focus(); return; }
+  imeComposing = false;
+  editing = null; absoluteRefBtn.disabled = true;
+  closeFormulaAssist(); clearFormulaPick();
   cellEditor.style.display = "none";
   beginBatch();
   setCellValue(ref, value === "" ? null : value);
@@ -2020,13 +4076,69 @@ function commitEdit(advance = "down") {
 function cancelEdit() {
   if (!editing) return;
   const { r, c } = editing;
-  editing = null;
+  imeComposing = false;
+  editing = null; absoluteRefBtn.disabled = true;
+  closeFormulaAssist(); clearFormulaPick();
   cellEditor.style.display = "none";
   formulaInput.value = getCell(rcToRef(r, c))?.value || "";
   gridScroll.focus();
 }
-cellEditor.addEventListener("input", () => { syncEditorSize(); formulaInput.value = cellEditor.value; });
+cellEditor.addEventListener("compositionstart", () => {
+  imeComposing = true;
+  if (!editing) startEdit(rcToRef(focus.r, focus.c), true, cellEditor.value, true);
+});
+cellEditor.addEventListener("compositionend", () => {
+  imeComposing = false;
+  if (editing) { syncEditorSize(); formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(cellEditor.selectionStart, cellEditor.selectionEnd); updateFormulaAssist(); }
+});
+cellEditor.addEventListener("input", () => {
+  if (formulaPick) clearFormulaPick();
+  if (!editing && cellEditor.classList.contains("capture")) startEdit(rcToRef(focus.r, focus.c), true, cellEditor.value, true);
+  if (editing) { syncEditorSize(); formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(cellEditor.selectionStart, cellEditor.selectionEnd); updateFormulaAssist(); }
+});
+cellEditor.addEventListener("click", () => { syncFormulaPickFromCaret(); updateFormulaAssist(); });
+cellEditor.addEventListener("keyup", (event) => { if (editing && ["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) { syncFormulaPickFromCaret(); updateFormulaAssist(); } });
 cellEditor.addEventListener("keydown", (e) => {
+  if (imeComposing || e.isComposing || e.keyCode === 229) { e.stopPropagation(); return; }
+  if (!editing) {
+    const meta = e.ctrlKey || e.metaKey;
+    if (e.key.length === 1 && !meta && !e.altKey) return;
+    handleGridKeydown(e);
+    e.stopPropagation();
+    return;
+  }
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "l") { e.preventDefault(); cycleAbsoluteReference(); e.stopPropagation(); return; }
+  if (formulaAssistItems.length && e.key === "ArrowDown") { e.preventDefault(); moveFormulaSuggestion(1); e.stopPropagation(); return; }
+  if (formulaAssistItems.length && e.key === "ArrowUp") { e.preventDefault(); moveFormulaSuggestion(-1); e.stopPropagation(); return; }
+  if (formulaAssistItems.length && (e.key === "Tab" || e.key === "Enter")) { e.preventDefault(); acceptFormulaSuggestion(); e.stopPropagation(); return; }
+  if (cellEditor.value.startsWith("=") && e.key === "," && !formulaCursorInQuote(cellEditor.value, cellEditor.selectionStart)) {
+    e.preventDefault(); insertFormulaComma(); e.stopPropagation(); return;
+  }
+  if (cellEditor.value.startsWith("=") && e.key === "(") {
+    e.preventDefault(); clearFormulaPick();
+    const start = cellEditor.selectionStart, end = cellEditor.selectionEnd;
+    cellEditor.value = cellEditor.value.slice(0, start) + "()" + cellEditor.value.slice(end);
+    cellEditor.setSelectionRange(start + 1, start + 1); formulaInput.value = cellEditor.value; syncEditorSize(); updateFormulaAssist(); e.stopPropagation(); return;
+  }
+  if (cellEditor.value.startsWith("=") && e.key === ")" && cellEditor.value[cellEditor.selectionStart] === ")") {
+    e.preventDefault();
+    const next = cellEditor.selectionStart + 1;
+    cellEditor.setSelectionRange(next, next);
+    formulaInput.setSelectionRange(next, next);
+    // Moving across an auto-inserted closing parenthesis changes the active
+    // nested function/argument. Drop the previous inner reference so the next
+    // grid click targets the outer argument instead of resizing that range.
+    syncFormulaPickFromCaret();
+    updateFormulaAssist();
+    e.stopPropagation();
+    return;
+  }
+  if (!formulaAssistItems.length && cellEditor.value.startsWith("=") && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) {
+    e.preventDefault();
+    const directions = { ArrowUp: [-1, 0], ArrowDown: [1, 0], ArrowLeft: [0, -1], ArrowRight: [0, 1] };
+    moveFormulaPickByKeyboard(directions[e.key][0], directions[e.key][1], e.shiftKey); e.stopPropagation(); return;
+  }
+  if (formulaAssist.style.display !== "none" && e.key === "Escape") { e.preventDefault(); closeFormulaAssist(); e.stopPropagation(); return; }
   if (e.key === "Enter" && !e.shiftKey && !e.altKey) { e.preventDefault(); commitEdit(e.shiftKey ? "up" : "down"); }
   else if (e.key === "Enter" && e.altKey) { e.preventDefault(); const s = cellEditor.selectionStart; cellEditor.value = cellEditor.value.slice(0, s) + "\n" + cellEditor.value.slice(cellEditor.selectionEnd); cellEditor.setSelectionRange(s + 1, s + 1); syncEditorSize(); }
   else if (e.key === "Tab") { e.preventDefault(); commitEdit(e.shiftKey ? "left" : "right"); }
@@ -2041,33 +4153,65 @@ let mouseSelecting = false;
 let resizeState = null;
 
 gridTable.addEventListener("mousedown", (e) => {
+  if (e.button !== 0) return;
+  if (e.target.closest("a.cell-link") && (e.ctrlKey || e.metaKey)) { e.stopPropagation(); return; }
+  const filterTrigger = e.target.closest(".filter-trigger");
+  if (filterTrigger) { e.preventDefault(); e.stopPropagation(); return; }
   // Column/row resize handles
   const colResize = e.target.closest(".col-resize");
   if (colResize) { startColResize(+colResize.dataset.col, e); e.preventDefault(); return; }
   const rowResize = e.target.closest(".row-resize");
   if (rowResize) { startRowResize(+rowResize.dataset.row, e); e.preventDefault(); return; }
 
+  if (editing && cellEditor.value.startsWith("=")) {
+    const formulaCell = e.target.closest("td.cell");
+    const formulaColumn = e.target.closest("th.colhead");
+    const formulaRow = e.target.closest("th.rowhead");
+    if (formulaCell) { startFormulaMousePick(+formulaCell.dataset.r, +formulaCell.dataset.c, e); e.preventDefault(); return; }
+    if (formulaColumn) {
+      if (e.ctrlKey || e.metaKey) beginAdditionalFormulaReference();
+      const column = +formulaColumn.dataset.col, reset = !formulaPick;
+      if (formulaPick) { formulaPick.r1 = 0; formulaPick.c1 = column; }
+      updatePickedFormulaRange(0, column, curSheet().rows - 1, column, reset); formulaPickGestureComplete = true; e.preventDefault(); return;
+    }
+    if (formulaRow) {
+      if (e.ctrlKey || e.metaKey) beginAdditionalFormulaReference();
+      const row = +formulaRow.dataset.row, reset = !formulaPick;
+      if (formulaPick) { formulaPick.r1 = row; formulaPick.c1 = 0; }
+      updatePickedFormulaRange(row, 0, row, curSheet().cols - 1, reset); formulaPickGestureComplete = true; e.preventDefault(); return;
+    }
+  }
+
   const colhead = e.target.closest("th.colhead");
   if (colhead) {
     const c = +colhead.dataset.col; const sh = curSheet();
     if (editing) commitEdit("none");
-    setSelection({ r: 0, c }, { r: sh.rows - 1, c });
-    focus = { r: 0, c }; updateSelectionUI();
+    const additive = e.ctrlKey || e.metaKey;
+    prepareHeaderSelection(additive);
+    const startColumn = e.shiftKey ? anchor.c : c;
+    anchor = { r: 0, c: startColumn };
+    focus = { r: sh.rows - 1, c };
+    updateSelectionUI(); sendPresence();
     mouseSelecting = "col"; e.preventDefault(); return;
   }
   const rowhead = e.target.closest("th.rowhead");
   if (rowhead) {
     const r = +rowhead.dataset.row; const sh = curSheet();
     if (editing) commitEdit("none");
-    setSelection({ r, c: 0 }, { r, c: sh.cols - 1 });
-    focus = { r, c: 0 }; updateSelectionUI();
+    const additive = e.ctrlKey || e.metaKey;
+    prepareHeaderSelection(additive);
+    const startRow = e.shiftKey ? anchor.r : r;
+    anchor = { r: startRow, c: 0 };
+    focus = { r, c: sh.cols - 1 };
+    updateSelectionUI(); sendPresence();
     mouseSelecting = "row"; e.preventDefault(); return;
   }
   const td = e.target.closest("td.cell");
   if (td) {
     const r = +td.dataset.r, c = +td.dataset.c;
     if (editing) commitEdit("none");
-    if (e.shiftKey) { focus = { r, c }; updateSelectionUI(); sendPresence(); }
+    if (e.ctrlKey || e.metaKey) { addCurrentRangeToSelection(); moveActive(r, c, false, true); }
+    else if (e.shiftKey) { focus = { r, c }; updateSelectionUI(); sendPresence(); }
     else moveActive(r, c);
     mouseSelecting = "cell";
     gridScroll.focus();
@@ -2080,15 +4224,34 @@ gridTable.addEventListener("mousemove", (e) => {
   let r, c;
   if (td && td.classList.contains("cell")) { r = +td.dataset.r; c = +td.dataset.c; }
   else return;
+  if (mouseSelecting === "formula" && formulaPick) { updatePickedFormulaRange(formulaPick.r1, formulaPick.c1, r, c, false); return; }
   const sh = curSheet();
   if (mouseSelecting === "col") { focus = { r: sh.rows - 1, c }; anchor = { r: 0, c: anchor.c }; }
   else if (mouseSelecting === "row") { focus = { r, c: sh.cols - 1 }; anchor = { r: anchor.r, c: 0 }; }
   else { focus = { r, c }; }
   updateSelectionUI();
 });
-window.addEventListener("mouseup", () => { if (mouseSelecting) { mouseSelecting = false; sendPresence(); } });
+window.addEventListener("mouseup", () => {
+  if (mouseSelecting) {
+    if (mouseSelecting === "formula" && formulaPick) formulaPickGestureComplete = true;
+    mouseSelecting = false; sendPresence();
+  }
+});
+
+gridTable.addEventListener("click", (e) => {
+  const marker = e.target.closest(".comment-marker");
+  if (marker) {
+    const td = marker.closest("td.cell"); if (td) { const position = parseRef(td.dataset.ref); if (position) moveActive(position.r, position.c); }
+    sidebarView = "comments"; setChartPanelCollapsed(false); renderChartPanel(); return;
+  }
+  const trigger = e.target.closest(".filter-trigger");
+  if (!trigger) return;
+  const td = trigger.closest("td.cell");
+  if (td) openFilterMenu(+td.dataset.c, trigger);
+});
 
 gridTable.addEventListener("dblclick", (e) => {
+  if (e.target.closest(".filter-trigger")) return;
   const td = e.target.closest("td.cell");
   if (td) startEdit(td.dataset.ref, false);
 });
@@ -2123,8 +4286,8 @@ function applyRowHeight(row) {
 // ===========================================================================
 // Keyboard navigation & shortcuts
 // ===========================================================================
-gridScroll.addEventListener("keydown", (e) => {
-  if (editing) return;
+function handleGridKeydown(e) {
+  if (editing || e.isComposing || e.keyCode === 229) return;
   const meta = e.ctrlKey || e.metaKey;
   const r = selRange();
   if (meta) {
@@ -2134,10 +4297,10 @@ gridScroll.addEventListener("keydown", (e) => {
       case "u": e.preventDefault(); toggleFmt("u"); return;
       case "z": e.preventDefault(); e.shiftKey ? redo() : undo(); return;
       case "y": e.preventDefault(); redo(); return;
-      case "c": copySelection(); return;
-      case "x": copySelection(); e._cut = true; return;
-      case "v": return; // handled by paste event
-      case "a": e.preventDefault(); { const sh = curSheet(); setSelection({ r: 0, c: 0 }, { r: sh.rows - 1, c: sh.cols - 1 }); focus = { r: 0, c: 0 }; updateSelectionUI(); } return;
+      case "c": return; // handled by the clipboard copy event
+      case "x": return; // handled by the clipboard cut event
+      case "v": if (e.shiftKey) { pasteWithoutFormattingPending = true; clearTimeout(pasteModeTimer); pasteModeTimer = setTimeout(() => { pasteWithoutFormattingPending = false; }, 1200); } return; // handled by the native paste event
+      case "a": e.preventDefault(); { const sh = curSheet(); setSelection({ r: sh.rows - 1, c: sh.cols - 1 }, { r: 0, c: 0 }); } return;
       case "arrowdown": e.preventDefault(); moveActive(jumpEdge(focus.r, focus.c, 1, 0), focus.c, e.shiftKey); return;
       case "arrowup": e.preventDefault(); moveActive(jumpEdge(focus.r, focus.c, -1, 0), focus.c, e.shiftKey); return;
       case "arrowright": e.preventDefault(); moveActive(focus.r, jumpEdgeCol(focus.r, focus.c, 1), e.shiftKey); return;
@@ -2161,7 +4324,8 @@ gridScroll.addEventListener("keydown", (e) => {
     default:
       if (e.key.length === 1 && !meta && !e.altKey) { e.preventDefault(); startEdit(rcToRef(focus.r, focus.c), true, e.key); }
   }
-});
+}
+gridScroll.addEventListener("keydown", handleGridKeydown);
 function jumpEdge(r, c, dr) {
   const sh = curSheet();
   let nr = r + dr;
@@ -2192,74 +4356,165 @@ function moveWithinSelection(dir, mode) {
   focus = { r, c }; updateSelectionUI(); scrollActiveIntoView(); sendPresence();
 }
 function deleteSelectionContents() {
-  const r = selRange();
+  const seen = new Set();
   beginBatch();
-  for (let row = r.r1; row <= r.r2; row++) for (let col = r.c1; col <= r.c2; col++) {
-    const ref = rcToRef(row, col); const cell = getCell(ref);
-    if (cell) { recordCell(activeSheetId, ref); if (cell.fmt) { setCellValue(ref, null); } else { delete curCells()[ref]; queueCellOp(activeSheetId, ref, null, null); } }
+  for (const range of selectionRanges()) for (let row = range.r1; row <= range.r2; row++) for (let col = range.c1; col <= range.c2; col++) {
+    const ref = rcToRef(row, col); if (seen.has(ref)) continue; seen.add(ref);
+    const cell = getCell(ref);
+    if (cell) { recordCell(activeSheetId, ref); if (cell.fmt) { setCellValue(ref, null); } else { const baseVersion = cell.version || 0; delete curCells()[ref]; queueCellOp(activeSheetId, ref, null, null, baseVersion); } }
   }
-  commitBatch(); rebuildEngine(); renderGrid();
+  commitBatch(); rebuildEngine(); renderGrid(); schedulePivotRefreshes(activeSheetId);
 }
 
 // ===========================================================================
 // Copy / paste (TSV via clipboard)
 // ===========================================================================
 let copyRange = null;
-function copySelection() {
-  const r = selRange();
-  copyRange = { ...r };
-  const lines = [];
-  for (let row = r.r1; row <= r.r2; row++) {
-    const cols = [];
-    for (let col = r.c1; col <= r.c2; col++) {
-      const cell = getCell(rcToRef(row, col));
-      let out = "";
-      if (cell) { const v = engine.computeRef(activeSheetId, rcToRef(row, col)); out = cell.value && cell.value[0] === "=" ? (isErr(v) ? v.value : (v == null ? "" : String(v))) : cell.value; }
-      cols.push(out);
-    }
-    lines.push(cols.join("\t"));
-  }
-  const tsv = lines.join("\n");
-  if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(tsv).catch(() => {});
-  copyFallback = { tsv, cells: snapshotRange(r) };
-}
 let copyFallback = null;
-function snapshotRange(r) {
-  const out = [];
-  for (let row = r.r1; row <= r.r2; row++) { const line = []; for (let col = r.c1; col <= r.c2; col++) { const c = getCell(rcToRef(row, col)); line.push(c ? { value: c.value, fmt: c.fmt } : null); } out.push(line); }
-  return out;
+function clipboardReferenceMatrix() {
+  const ranges = selectionRanges();
+  const sheet = curSheet();
+  const allRows = ranges.every((range) => range.c1 === 0 && range.c2 === sheet.cols - 1);
+  const allColumns = ranges.every((range) => range.r1 === 0 && range.r2 === sheet.rows - 1);
+  if (allRows) {
+    const rows = [...new Set(ranges.flatMap((range) => Array.from({ length: range.r2 - range.r1 + 1 }, (_, index) => range.r1 + index)))].sort((a, b) => a - b);
+    let lastColumn = 0;
+    for (const row of rows) for (let column = 0; column < sheet.cols; column++) if (!isVisuallyEmptyCell(row, column)) lastColumn = Math.max(lastColumn, column);
+    return rows.map((row) => Array.from({ length: lastColumn + 1 }, (_, column) => rcToRef(row, column)));
+  }
+  if (allColumns) {
+    const columns = [...new Set(ranges.flatMap((range) => Array.from({ length: range.c2 - range.c1 + 1 }, (_, index) => range.c1 + index)))].sort((a, b) => a - b);
+    let lastRow = 0;
+    for (const column of columns) for (let row = 0; row < sheet.rows; row++) if (!isVisuallyEmptyCell(row, column)) lastRow = Math.max(lastRow, row);
+    return Array.from({ length: lastRow + 1 }, (_, row) => columns.map((column) => rcToRef(row, column)));
+  }
+  if (ranges.length === 1) {
+    const range = ranges[0];
+    return Array.from({ length: range.r2 - range.r1 + 1 }, (_, row) => Array.from({ length: range.c2 - range.c1 + 1 }, (_, column) => rcToRef(range.r1 + row, range.c1 + column)));
+  }
+  const bounds = ranges.reduce((out, range) => ({ r1: Math.min(out.r1, range.r1), c1: Math.min(out.c1, range.c1), r2: Math.max(out.r2, range.r2), c2: Math.max(out.c2, range.c2) }), { r1: Infinity, c1: Infinity, r2: -1, c2: -1 });
+  return Array.from({ length: bounds.r2 - bounds.r1 + 1 }, (_, row) => Array.from({ length: bounds.c2 - bounds.c1 + 1 }, (_, column) => {
+    const r = bounds.r1 + row, c = bounds.c1 + column;
+    return ranges.some((range) => r >= range.r1 && r <= range.r2 && c >= range.c1 && c <= range.c2) ? rcToRef(r, c) : null;
+  }));
 }
-function clearCopyMarquee() { copyRange = null; }
+function clipboardCellText(ref) {
+  if (!ref) return "";
+  const cell = getCell(ref); if (!cell) return "";
+  const value = engine.computeRef(activeSheetId, ref);
+  return cell.value?.startsWith("=") ? (isErr(value) ? value.value : (value == null ? "" : String(value))) : (cell.value || "");
+}
+function prepareClipboard(cut = false) {
+  const refs = clipboardReferenceMatrix();
+  const cells = refs.map((row) => row.map((ref) => {
+    const cell = ref ? getCell(ref) : null;
+    return cell ? { value: cell.value, fmt: cell.fmt, sourceRef: ref } : (ref ? { value: null, fmt: null, sourceRef: ref } : null);
+  }));
+  const tsv = refs.map((row) => row.map(clipboardCellText).join("\t")).join("\n");
+  copyRange = { ...selRange() };
+  copyFallback = { tsv, cells, refs, sheetId: activeSheetId, cut };
+  return tsv;
+}
+function requestGridClipboard(cut = false) {
+  armEditorCapture(true);
+  try { document.execCommand(cut ? "cut" : "copy"); }
+  catch (error) { setStatus("bad", "Clipboard unavailable"); }
+}
+function pasteFromMenu(keepFormatting) {
+  if (copyFallback?.tsv != null) {
+    pasteText(copyFallback.tsv, { keepFormatting });
+    return;
+  }
+  // Permissions Policy prevents menu-click handlers from reading the system
+  // clipboard. Native keyboard paste still supplies ClipboardEvent data.
+  setStatus("bad", keepFormatting ? "Use Ctrl+V for external content" : "Use Ctrl+Shift+V for external content");
+}
+gridScroll.addEventListener("copy", (event) => {
+  if (editing) return;
+  event.preventDefault(); event.clipboardData.setData("text/plain", prepareClipboard(false));
+});
+gridScroll.addEventListener("cut", (event) => {
+  if (editing) return;
+  event.preventDefault(); event.clipboardData.setData("text/plain", prepareClipboard(true));
+});
+function clearCopyMarquee() { copyRange = null; copyFallback = null; }
 
+let pasteWithoutFormattingPending = false;
+let pasteModeTimer = null;
 gridScroll.addEventListener("paste", (e) => {
   if (editing) return;
   e.preventDefault();
   const text = (e.clipboardData && e.clipboardData.getData("text/plain")) || "";
-  pasteText(text);
+  const keepFormatting = !pasteWithoutFormattingPending;
+  pasteWithoutFormattingPending = false; clearTimeout(pasteModeTimer);
+  pasteText(text, { keepFormatting });
 });
-function pasteText(text) {
-  const start = selRange();
-  const useSnapshot = copyFallback && copyFallback.tsv === text && copyFallback.cells;
-  const rows = text.replace(/\r/g, "").split("\n");
-  if (rows.length && rows[rows.length - 1] === "") rows.pop();
+function shiftedCopyFormula(value, sourceRef, targetRef, isCut) {
+  if (isCut || !value?.startsWith("=") || !sourceRef) return value;
+  const source = parseRef(sourceRef), target = parseRef(targetRef);
+  if (!source || !target) return value;
+  const rowDelta = target.r - source.r, colDelta = target.c - source.c;
+  return value.replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,2})(\$?)([1-9]\d*)(?![A-Z0-9_])/gi, (match, fixedColumn, letters, fixedRow, rowText) => {
+    let row = Number(rowText) - 1, column = letterToCol(letters);
+    if (!fixedRow) row += rowDelta;
+    if (!fixedColumn) column += colDelta;
+    if (row < 0 || column < 0) return "#REF!";
+    return fixedColumn + colToLetter(column) + fixedRow + (row + 1);
+  });
+}
+function clearStoredCell(sheetId, ref) {
+  const cells = model.cells[sheetId] || (model.cells[sheetId] = {});
+  const existing = cells[ref]; if (!existing) return;
+  recordCell(sheetId, ref);
+  const baseVersion = existing.version || 0;
+  delete cells[ref]; queueCellOp(sheetId, ref, null, null, baseVersion);
+}
+function pasteText(text, { keepFormatting = true } = {}) {
+  const normalized = text.replace(/\r/g, "");
+  const useSnapshot = copyFallback && copyFallback.tsv.replace(/\r/g, "") === normalized && copyFallback.cells;
+  const rows = normalized.split("\n");
+  if (rows.length > 1 && rows[rows.length - 1] === "") rows.pop();
+  const values = rows.map((row) => row.split("\t"));
+  const sourceHeight = values.length, sourceWidth = Math.max(1, ...values.map((row) => row.length));
+  const targetRanges = selectionRanges();
+  const destinationRefs = new Set();
   beginBatch();
-  for (let i = 0; i < rows.length; i++) {
-    const cols = rows[i].split("\t");
-    for (let j = 0; j < cols.length; j++) {
-      const rr = start.r1 + i, cc = start.c1 + j;
-      if (rr >= curSheet().rows || cc >= curSheet().cols) continue;
-      const ref = rcToRef(rr, cc);
-      if (useSnapshot && copyFallback.cells[i] && copyFallback.cells[i][j] !== undefined) {
-        const src = copyFallback.cells[i][j];
+  for (const target of targetRanges) {
+    const targetHeight = target.r2 - target.r1 + 1, targetWidth = target.c2 - target.c1 + 1;
+    const repeat = (sourceHeight === 1 && sourceWidth === 1) || (targetHeight >= sourceHeight && targetWidth >= sourceWidth && targetHeight % sourceHeight === 0 && targetWidth % sourceWidth === 0);
+    const pasteHeight = repeat ? targetHeight : sourceHeight;
+    const pasteWidth = repeat ? targetWidth : sourceWidth;
+    for (let i = 0; i < pasteHeight; i++) for (let j = 0; j < pasteWidth; j++) {
+      const row = target.r1 + i, column = target.c1 + j;
+      if (row > target.r2 && targetRanges.length > 1 || column > target.c2 && targetRanges.length > 1) continue;
+      if (row >= curSheet().rows || column >= curSheet().cols) continue;
+      const sourceRow = i % sourceHeight, sourceColumn = j % sourceWidth;
+      const ref = rcToRef(row, column); destinationRefs.add(activeSheetId + "!" + ref);
+      const snapshot = useSnapshot ? copyFallback.cells[sourceRow]?.[sourceColumn] : undefined;
+      if (useSnapshot && keepFormatting) {
         recordCell(activeSheetId, ref);
-        if (src) { curCells()[ref] = { value: src.value, fmt: src.fmt, version: getCell(ref)?.version || 0 }; queueCellOp(activeSheetId, ref, src.value, src.fmt); }
-        else { if (getCell(ref)) { delete curCells()[ref]; queueCellOp(activeSheetId, ref, null, null); } }
+        if (snapshot && snapshot.value != null) {
+          const existing = getCell(ref);
+          const value = shiftedCopyFormula(snapshot.value, snapshot.sourceRef, ref, copyFallback.cut);
+          curCells()[ref] = { value, fmt: snapshot.fmt, version: existing?.version || 0 };
+          queueCellOp(activeSheetId, ref, value, snapshot.fmt);
+        } else clearStoredCell(activeSheetId, ref);
+      } else if (useSnapshot && !keepFormatting) {
+        const value = snapshot && snapshot.value != null ? shiftedCopyFormula(snapshot.value, snapshot.sourceRef, ref, copyFallback.cut) : "";
+        setCellValue(ref, value === "" ? null : value);
       } else {
-        setCellValue(ref, cols[j] === "" ? null : cols[j]);
+        const value = values[sourceRow]?.[sourceColumn] ?? "";
+        setCellValue(ref, value === "" ? null : value);
       }
     }
   }
-  commitBatch(); rebuildEngine(); renderGrid();
+  if (useSnapshot && copyFallback.cut) {
+    for (const row of copyFallback.cells) for (const snapshot of row) {
+      if (snapshot?.sourceRef && !destinationRefs.has(copyFallback.sheetId + "!" + snapshot.sourceRef)) clearStoredCell(copyFallback.sheetId, snapshot.sourceRef);
+    }
+    copyFallback = null; copyRange = null;
+  }
+  commitBatch(); rebuildEngine(); renderGrid(); schedulePivotRefreshes(activeSheetId);
 }
 
 // ===========================================================================
@@ -2275,9 +4530,40 @@ nameBox.addEventListener("keydown", (e) => {
     gridScroll.focus();
   }
 });
-formulaInput.addEventListener("focus", () => { if (!editing) startEdit(rcToRef(focus.r, focus.c), false); });
-formulaInput.addEventListener("input", () => { if (editing) { cellEditor.value = formulaInput.value; syncEditorSize(); } });
+formulaInput.addEventListener("focus", () => { if (!editing) startEdit(rcToRef(focus.r, focus.c), false, null, false, true); });
+function syncFormulaInputCaretToEditor() {
+  if (!editing || document.activeElement !== formulaInput) return;
+  const start = formulaInput.selectionStart ?? formulaInput.value.length;
+  const end = formulaInput.selectionEnd ?? start;
+  cellEditor.setSelectionRange(start, end); syncFormulaPickFromCaret(); updateFormulaAssist();
+}
+formulaInput.addEventListener("input", () => {
+  if (editing) {
+    clearFormulaPick(); cellEditor.value = formulaInput.value;
+    const start = formulaInput.selectionStart ?? formulaInput.value.length, end = formulaInput.selectionEnd ?? start;
+    cellEditor.setSelectionRange(start, end); syncEditorSize(); updateFormulaAssist();
+  }
+});
+formulaInput.addEventListener("click", syncFormulaInputCaretToEditor);
+formulaInput.addEventListener("select", syncFormulaInputCaretToEditor);
+formulaInput.addEventListener("keyup", syncFormulaInputCaretToEditor);
 formulaInput.addEventListener("keydown", (e) => {
+  if (imeComposing || e.isComposing || e.keyCode === 229) return;
+  if (editing && (e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "l") {
+    e.preventDefault(); cellEditor.setSelectionRange(formulaInput.selectionStart, formulaInput.selectionEnd); syncFormulaPickFromCaret(); cycleAbsoluteReference(); return;
+  }
+  if (editing && formulaInput.value.startsWith("=") && e.key === "," && !formulaCursorInQuote(formulaInput.value, formulaInput.selectionStart)) {
+    e.preventDefault(); cellEditor.setSelectionRange(formulaInput.selectionStart, formulaInput.selectionEnd); insertFormulaComma(); return;
+  }
+  if (editing && formulaInput.value.startsWith("=") && e.key === ")" && formulaInput.value[formulaInput.selectionStart] === ")") {
+    e.preventDefault();
+    const next = formulaInput.selectionStart + 1;
+    formulaInput.setSelectionRange(next, next);
+    cellEditor.setSelectionRange(next, next);
+    syncFormulaPickFromCaret();
+    updateFormulaAssist();
+    return;
+  }
   if (e.key === "Enter") { e.preventDefault(); commitEdit("down"); }
   else if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
 });
@@ -2295,25 +4581,85 @@ function openFunctionMenu(e) {
     "Math": ["SUM", "AVERAGE", "COUNT", "MAX", "MIN", "PRODUCT", "ROUND", "ABS", "SQRT", "MOD", "POWER"],
     "Statistical": ["MEDIAN", "STDEV", "VAR", "COUNTA", "COUNTIF", "SUMIF", "SUMIFS", "COUNTIFS", "RANK", "LARGE"],
     "Logical": ["IF", "IFS", "IFERROR", "AND", "OR", "NOT", "SWITCH"],
-    "Text": ["CONCAT", "TEXTJOIN", "LEFT", "RIGHT", "MID", "LEN", "UPPER", "LOWER", "TRIM", "SUBSTITUTE", "TEXT"],
+    "Text": ["CONCAT", "TEXTJOIN", "LEFT", "RIGHT", "MID", "LEN", "UPPER", "LOWER", "TRIM", "SUBSTITUTE", "TEXT", "HYPERLINK"],
     "Lookup": ["VLOOKUP", "HLOOKUP", "INDEX", "MATCH", "CHOOSE", "LOOKUP"],
     "Date": ["TODAY", "NOW", "DATE", "YEAR", "MONTH", "DAY", "WEEKDAY", "EDATE", "DATEDIF"],
   };
-  const menu = el("div", { class: "ctx" });
-  for (const [g, fns] of Object.entries(groups)) {
-    menu.appendChild(el("div", { class: "cmenu-item", style: "color:var(--faint);font-size:11px;pointer-events:none;text-transform:uppercase;letter-spacing:.05em;" }, g));
-    for (const fn of fns) {
-      const it = el("div", { class: "ctx-item" }, [el("span", {}, fn), el("span", { class: "k" }, "ƒ")]);
-      it.addEventListener("click", () => { closeCtx(); insertFunction(fn); });
-      menu.appendChild(it);
+  const menu = el("div", { class: "ctx fn-menu" });
+  const search = el("input", { class: "fn-search", type: "search", placeholder: "Search functions…", "aria-label": "Search functions" });
+  menu.appendChild(el("div", { class: "fn-search-wrap" }, search));
+  const groupRecords = [];
+  for (const [name, functions] of Object.entries(groups)) {
+    const group = el("section", { class: "fn-group" });
+    const header = el("button", { class: "fn-head", type: "button", "aria-expanded": "false" }, [
+      el("span", { class: "fn-head-label" }, name),
+      el("span", { class: "fn-head-count" }, String(functions.length)),
+      el("span", { class: "fn-chev" }, "›"),
+    ]);
+    const items = el("div", { class: "fn-items" });
+    const itemRecords = [];
+    for (const fn of functions) {
+      const item = el("div", { class: "ctx-item" }, [el("span", {}, fn), el("span", { class: "k" }, "ƒ")]);
+      item.addEventListener("click", () => { closeCtx(); insertFunction(fn); });
+      items.appendChild(item); itemRecords.push({ name: fn, element: item });
     }
-    menu.appendChild(el("div", { class: "ctx-sep" }));
+    header.addEventListener("click", () => {
+      if (search.value.trim()) return;
+      const open = !group.classList.contains("open");
+      group.classList.toggle("open", open); header.setAttribute("aria-expanded", String(open));
+    });
+    group.append(header, items); menu.appendChild(group);
+    groupRecords.push({ group, header, items: itemRecords });
   }
-  showCtx(menu, e.clientX, e.clientY);
+  const empty = el("div", { class: "fn-no-results" }, "No matching functions"); empty.style.display = "none"; menu.appendChild(empty);
+  search.addEventListener("input", () => {
+    const query = search.value.trim().toUpperCase(); let matches = 0;
+    for (const record of groupRecords) {
+      let groupMatches = 0;
+      for (const item of record.items) {
+        const visible = !query || item.name.includes(query);
+        item.element.style.display = visible ? "" : "none";
+        if (visible) groupMatches++;
+      }
+      record.group.style.display = groupMatches ? "" : "none";
+      record.group.classList.toggle("open", !!query);
+      record.header.setAttribute("aria-expanded", String(!!query));
+      matches += groupMatches;
+    }
+    empty.style.display = matches ? "none" : "block";
+  });
+  const rect = fxBtn.getBoundingClientRect();
+  showCtx(menu, rect.left, rect.bottom + 4);
+  requestAnimationFrame(() => search.focus({ preventScroll: true }));
 }
 function insertFunction(name) {
   const ref = rcToRef(focus.r, focus.c);
-  startEdit(ref, true, "=" + name + "(");
+  startEdit(ref, true, "=" + name + "()");
+  const cursor = name.length + 2;
+  cellEditor.setSelectionRange(cursor, cursor); updateFormulaAssist();
+}
+
+// ===========================================================================
+// Links + context menu
+// ===========================================================================
+function linkForRef(ref) {
+  const cell = getCell(ref); if (!cell) return null;
+  const value = engine.computeRef(activeSheetId, ref);
+  if (value instanceof HyperlinkValue) return value.url;
+  return typeof value === "string" ? safeHyperlinkUrl(value) : null;
+}
+function openExternalLink(url) {
+  const safe = safeHyperlinkUrl(url); if (!safe) return;
+  const anchor = el("a", { href: safe, target: "_blank", rel: "noopener noreferrer" });
+  document.body.appendChild(anchor); anchor.click(); anchor.remove();
+}
+function copyPlainText(text) {
+  const input = el("textarea", { "aria-hidden": "true" }); input.value = text;
+  input.style.cssText = "position:fixed;left:-10000px;top:0"; document.body.appendChild(input);
+  input.focus(); input.select();
+  let copied = false; try { copied = document.execCommand("copy"); } catch (error) {}
+  input.remove(); armEditorCapture(true);
+  setStatus(copied ? "saved" : "bad", copied ? "Link copied" : "Clipboard unavailable");
 }
 
 // ===========================================================================
@@ -2338,13 +4684,37 @@ gridTable.addEventListener("contextmenu", (e) => {
   const rowhead = e.target.closest("th.rowhead");
   if (!td && !colhead && !rowhead) return;
   e.preventDefault();
-  if (td) { const r = +td.dataset.r, c = +td.dataset.c; const rng = selRange(); if (r < rng.r1 || r > rng.r2 || c < rng.c1 || c > rng.c2) moveActive(r, c); }
+  if (td) {
+    const r = +td.dataset.r, c = +td.dataset.c;
+    if (!cellInSelection(r, c)) moveActive(r, c);
+  } else if (colhead) {
+    const c = +colhead.dataset.col, sheet = curSheet();
+    const selected = selectionRanges().some((range) => range.r1 === 0 && range.r2 === sheet.rows - 1 && c >= range.c1 && c <= range.c2);
+    if (!selected) setSelection({ r: 0, c }, { r: sheet.rows - 1, c });
+  } else if (rowhead) {
+    const r = +rowhead.dataset.row, sheet = curSheet();
+    const selected = selectionRanges().some((range) => range.c1 === 0 && range.c2 === sheet.cols - 1 && r >= range.r1 && r <= range.r2);
+    if (!selected) setSelection({ r, c: 0 }, { r, c: sheet.cols - 1 });
+  }
   const menu = el("div", { class: "ctx" });
   const item = (label, k, fn, danger) => { const it = el("div", { class: "ctx-item" + (danger ? " danger" : "") }, [el("span", {}, label), k ? el("span", { class: "k" }, k) : null]); it.addEventListener("click", () => { closeCtx(); fn(); }); menu.appendChild(it); };
   const sep = () => menu.appendChild(el("div", { class: "ctx-sep" }));
-  item("Cut", "Ctrl+X", () => { copySelection(); deleteSelectionContents(); });
-  item("Copy", "Ctrl+C", () => copySelection());
-  item("Paste", "Ctrl+V", async () => { try { const t = await navigator.clipboard.readText(); pasteText(t); } catch (e) {} });
+  const activeLink = td ? linkForRef(td.dataset.ref) : null;
+  if (activeLink) {
+    item("Open link", "Ctrl+Click", () => openExternalLink(activeLink));
+    item("Copy link", "", () => copyPlainText(activeLink));
+    sep();
+  }
+  item("Cut", "Ctrl+X", () => requestGridClipboard(true));
+  item("Copy", "Ctrl+C", () => requestGridClipboard(false));
+  item("Paste", "Ctrl+V", () => pasteFromMenu(true));
+  item("Paste without formatting", "Ctrl+Shift+V", () => pasteFromMenu(false));
+  sep();
+  item("Comment", "", () => openCommentEditor(rcToRef(focus.r, focus.c)));
+  item("Create pivot table", "", () => createPivotTable());
+  sep();
+  const filter = curSheet().filter;
+  item(filter ? "Remove filter" : "Create filter for data table", "", () => toggleFilterRow());
   sep();
   item("Insert row above", "", () => insertRows(selRange().r1, 1));
   item("Insert row below", "", () => insertRows(selRange().r2 + 1, 1));
@@ -2377,15 +4747,17 @@ function renderTabs() {
 function switchSheet(id) {
   if (editing) commitEdit("none");
   activeSheetId = id;
-  anchor = { r: 0, c: 0 }; focus = { r: 0, c: 0 };
-  renderTabs(); renderGrid(); updateSelectionUI();
+  if (model.sheets[id]?.pivot) refreshPivot(id);
+  anchor = { r: 0, c: 0 }; focus = { r: 0, c: 0 }; extraRanges = [];
+  selectedChartId = null; selectedPivotSheetId = null; sidebarView = "home";
+  renderTabs(); renderGrid(); updateSelectionUI(); renderChartPanel();
   sendPresence();
 }
 function addSheet() {
   const id = "s_" + Math.random().toString(36).slice(2, 8);
   let n = model.sheetOrder.length + 1;
   while (model.sheetOrder.some((sid) => model.sheets[sid].name === "Sheet" + n)) n++;
-  model.sheets[id] = { id, name: "Sheet" + n, rows: 100, cols: 26, colWidths: {}, rowHeights: {}, frozenRows: 0, frozenCols: 0 };
+  model.sheets[id] = { id, name: "Sheet" + n, rows: 100, cols: 26, colWidths: {}, rowHeights: {}, frozenRows: 0, frozenCols: 0, filter: null, charts: [], comments: [], pivot: null };
   model.sheetOrder.push(id);
   model.cells[id] = {};
   activeSheetId = id;
@@ -2489,7 +4861,7 @@ function applyPresence(event) {
   else collaborators.set(event.clientId, { ...event, seenAt: Date.now() });
   renderPresence(); renderPeers();
 }
-gridScroll.addEventListener("scroll", () => { renderPresence(); });
+gridScroll.addEventListener("scroll", () => { renderPresence(); if (formulaAssist.style.display !== "none") positionFormulaAssist(); });
 setInterval(() => {
   sendPresence();
   const cutoff = Date.now() - 12000; let changed = false;
@@ -2515,7 +4887,8 @@ function applyRemoteOperation(event) {
   applyingRemote = false;
   rebuildEngine();
   if (!model.sheets[activeSheetId]) activeSheetId = model.sheetOrder[0];
-  renderTabs(); renderGrid();
+  if (selectedChartId && !(curSheet().charts || []).some((chart) => chart.id === selectedChartId)) selectedChartId = null;
+  renderTabs(); renderGrid(); renderChartPanel();
   setStatus("synced", "Live update");
   setTimeout(() => { if (!saveInFlight && !pendingCellOps.size) setStatus("saved", "Saved"); }, 900);
 }
@@ -2540,7 +4913,7 @@ function applySnapshot(doc) {
   applyingRemote = false;
   rebuildEngine();
   renderTabs(); renderGrid();
-  updateSelectionUI();
+  updateSelectionUI(); renderChartPanel();
 }
 
 class SheetCallbacks extends RpcTarget {

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
@@ -1755,6 +1755,7 @@ function applyHistory(entry, into) {
   into.push(inverse);
   rebuildEngine();
   renderGrid();
+  schedulePivotRefreshes();
   updateUndoButtons();
 }
 function undo() { if (!undoStack.length) return; applyHistory(undoStack.pop(), redoStack); }
@@ -2116,12 +2117,14 @@ function pivotSourceRange() {
 }
 function pivotFields(pivot) {
   const range = parseChartRange(pivot.sourceRange); if (!range || !model.sheets[pivot.sourceSheetId]) return [];
-  const fields = [], used = new Map();
+  const fields = [], used = new Set();
   for (let column = range.c1; column <= range.c2; column++) {
     let name = pivotDisplay(pivotCellValue(pivot.sourceSheetId, range.r1, column));
     if (name === "(Blank)") name = `Column ${colToLetter(column)}`;
-    const count = (used.get(name) || 0) + 1; used.set(name, count);
-    fields.push({ name: count > 1 ? `${name} (${count})` : name, column });
+    // Generated names are reserved too, so headers `A`, `A (2)`, `A` stay distinct.
+    let unique = name; for (let count = 2; used.has(unique); count++) unique = `${name} (${count})`;
+    used.add(unique);
+    fields.push({ name: unique, column });
   }
   return fields;
 }
@@ -2159,9 +2162,11 @@ function buildPivotOutput(pivot) {
   }
   const rowKeys = [...new Set(records.map((record) => record.row))].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   const columnKeys = [...new Set(records.map((record) => record.column))].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-  // The output is the Cartesian product of the two key sets; past this it cannot be materialized
-  // (the sheet also has at most 702 columns), so the pivot reports instead of freezing the browser.
-  if (rowKeys.length * columnKeys.length > MAX_PIVOT_CELLS || columnKeys.length > 699) {
+  // The output is the Cartesian product of the two key sets plus headers and totals; past the cell
+  // cap or the sheet's own limits (50,000 rows, 702 columns) it cannot be materialized, so the
+  // pivot reports instead of freezing the browser.
+  const outputRows = rowKeys.length + 2, outputColumns = columnKeys.length + 2;
+  if (outputRows * outputColumns > MAX_PIVOT_CELLS || outputRows > 50000 || outputColumns > 702) {
     return { cells: { A1: { value: `Pivot table too large: ${rowKeys.length.toLocaleString()} row values × ${columnKeys.length.toLocaleString()} column values. Choose fields with fewer distinct values.`, fmt: { b: true, c: "#b42318" }, version: 1 } }, rows: 20, cols: 8 };
   }
   const states = new Map(), rowTotals = new Map(), columnTotals = new Map(), grandTotal = aggregateState();
@@ -2171,14 +2176,17 @@ function buildPivotOutput(pivot) {
     addAggregate(stateFor(rowTotals, record.row), record.value); addAggregate(stateFor(columnTotals, record.column), record.value); addAggregate(grandTotal, record.value);
   }
   const cells = {}, put = (row, column, value, fmt = null) => { cells[rcToRef(row, column)] = { value: String(value ?? ""), fmt, version: 1 }; };
+  // Labels are text taken from computed values; one that the grid would re-parse (a formula,
+  // a number, a boolean, an apostrophe) is stored with the literal-text prefix.
+  const label = (text) => /^[='+\-$.\d]|^(true|false)$/i.test(text) ? "'" + text : text;
   const headerFmt = { b: true, bg: "#e1632e", c: "#ffffff" };
   const rowHeaderFmt = { b: true, bg: "#fff7f2", c: "#3f332e" };
   const totalFmt = { b: true, bg: "#fde9dc", c: "#3f332e" };
-  put(0, 0, pivot.rowField || "Rows", headerFmt);
-  columnKeys.forEach((key, index) => put(0, index + 1, key, headerFmt));
+  put(0, 0, label(pivot.rowField || "Rows"), headerFmt);
+  columnKeys.forEach((key, index) => put(0, index + 1, label(key), headerFmt));
   if (pivot.showRowTotals !== false) put(0, columnKeys.length + 1, "Grand Total", totalFmt);
   rowKeys.forEach((rowKey, rowIndex) => {
-    put(rowIndex + 1, 0, rowKey, rowHeaderFmt);
+    put(rowIndex + 1, 0, label(rowKey), rowHeaderFmt);
     columnKeys.forEach((columnKey, columnIndex) => put(rowIndex + 1, columnIndex + 1, finishAggregate(states.get(rowKey + "\u0000" + columnKey) || aggregateState(), pivot.aggregate), pivot.aggregate === "average" ? { nf: "number", d: 2 } : null));
     if (pivot.showRowTotals !== false) put(rowIndex + 1, columnKeys.length + 1, finishAggregate(rowTotals.get(rowKey) || aggregateState(), pivot.aggregate), totalFmt);
   });
@@ -2192,7 +2200,8 @@ function buildPivotOutput(pivot) {
 function refreshPivot(sheetId, save = true) {
   const sheet = model.sheets[sheetId]; if (!sheet?.pivot) return;
   const output = buildPivotOutput(sheet.pivot);
-  if (JSON.stringify(output.cells) === JSON.stringify(model.cells[sheetId] || {})) return; // nothing to rematerialize
+  // Settings that leave the cells identical (Sum vs Max over single records) still need saving.
+  if (JSON.stringify(output.cells) === JSON.stringify(model.cells[sheetId] || {})) { if (save) queueStructure(); return; }
   model.cells[sheetId] = output.cells; sheet.rows = Math.max(sheet.rows, output.rows); sheet.cols = Math.max(sheet.cols, output.cols);
   const widths = {};
   for (const [ref, cell] of Object.entries(output.cells)) {
@@ -2258,24 +2267,45 @@ function pivotFilterValues(pivot) {
   const values = []; for (let row = range.r1 + 1; row <= range.r2; row++) values.push(pivotDisplay(pivotCellValue(pivot.sourceSheetId, row, field.column)));
   return [...new Set(values)].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
 }
+// A source column can hold tens of thousands of distinct values; only a page of them is rendered,
+// narrowed by the search box, so the panel never builds an unbounded DOM.
+const MAX_PIVOT_FILTER_OPTIONS = 200;
 function pivotFilterMultiSelect(sheetId, pivot) {
   const options = pivotFilterValues(pivot), selected = pivot.filterValues || (pivot.filterValue ? [pivot.filterValue] : []);
   const allSelected = !selected.length, wrap = el("div", { class: "chart-field" });
   wrap.appendChild(el("span", {}, "Filter values"));
-  const list = el("div", { class: "pivot-filter-values" }), checks = [];
-  for (const value of options) {
-    const input = el("input", { type: "checkbox" }); input.checked = allSelected || selected.includes(value);
-    const option = el("label", { class: "pivot-filter-option" }, [input, el("span", {}, value)]);
-    checks.push({ value, input }); list.appendChild(option);
-  }
+  const chosen = new Set(allSelected ? options : selected);
+  const list = el("div", { class: "pivot-filter-values" });
+  const note = el("div", { class: "pivot-note" });
   const apply = () => {
-    const values = checks.filter((item) => item.input.checked).map((item) => item.value);
-    pivot.filterValues = values.length === options.length ? [] : (values.length ? values : ["__PIVOT_NONE__"]);
+    const next = chosen.size === options.length ? [] : (chosen.size ? [...chosen] : ["__PIVOT_NONE__"]);
+    if (next.length > MAX_FILTER_SELECTIONS) {
+      setStatus("bad", `Select at most ${MAX_FILTER_SELECTIONS} values, or clear the filter instead`);
+      chosen.clear(); for (const value of pivot.filterValues?.length ? pivot.filterValues : options) chosen.add(value);
+      render(); return;
+    }
+    pivot.filterValues = next;
     refreshPivot(sheetId);
   };
-  checks.forEach((item) => item.input.addEventListener("change", apply));
-  if (!options.length) list.appendChild(el("div", { class: "pivot-note" }, "No values available"));
-  wrap.appendChild(list); return wrap;
+  const render = (query = "") => {
+    list.replaceChildren();
+    const matching = query ? options.filter((value) => value.toLowerCase().includes(query)) : options;
+    for (const value of matching.slice(0, MAX_PIVOT_FILTER_OPTIONS)) {
+      const input = el("input", { type: "checkbox" }); input.checked = chosen.has(value);
+      input.addEventListener("change", () => { if (input.checked) chosen.add(value); else chosen.delete(value); apply(); });
+      list.appendChild(el("label", { class: "pivot-filter-option" }, [input, el("span", {}, value)]));
+    }
+    note.textContent = !options.length ? "No values available"
+      : matching.length > MAX_PIVOT_FILTER_OPTIONS ? `Showing ${MAX_PIVOT_FILTER_OPTIONS} of ${matching.length.toLocaleString()} values; search to narrow` : "";
+    note.style.display = note.textContent ? "" : "none";
+  };
+  if (options.length > MAX_PIVOT_FILTER_OPTIONS) {
+    const search = el("input", { class: "filter-search", type: "search", placeholder: "Search values…", "aria-label": "Search pivot filter values" });
+    search.addEventListener("input", () => render(search.value.trim().toLowerCase()));
+    wrap.appendChild(search);
+  }
+  render();
+  wrap.appendChild(list); wrap.appendChild(note); return wrap;
 }
 
 // ===========================================================================
@@ -2412,7 +2442,9 @@ function openCreateChartMenu(event) {
   const rect = chartBtn.getBoundingClientRect();
   showCtx(menu, rect.left, rect.bottom + 4);
 }
+const MAX_CHARTS_PER_SHEET = 50; // the server keeps only this many
 function createChart(type = "line") {
+  if (sheetCharts().length >= MAX_CHARTS_PER_SHEET) { setStatus("bad", `A sheet holds at most ${MAX_CHARTS_PER_SHEET} charts`); return; }
   const range = defaultChartRange();
   const inferred = inferChartLayout(range);
   const chart = {
@@ -2858,6 +2890,14 @@ function rowPassesFilter(row, sheetId = activeSheetId) {
     if (!selected.includes(token)) return false;
   }
   return true;
+}
+// The next row in `step` direction that the filter shows; stays put when none remains, so the
+// keyboard never lands on (and edits) a hidden record.
+function nextVisibleRow(row, step) {
+  const sheet = curSheet();
+  if (!sheet?.filter) return row + step;
+  for (let candidate = row + step; candidate >= 0 && candidate < sheet.rows; candidate += step) if (rowPassesFilter(candidate)) return candidate;
+  return row;
 }
 function hasCellData(row, column) {
   const value = cellRaw(rcToRef(row, column));
@@ -3593,7 +3633,7 @@ function formulaPointModeActive() {
   if (formulaPick?.picked) return true;
   const start = cellEditor.selectionStart ?? cellEditor.value.length;
   if (start !== (cellEditor.selectionEnd ?? start) || formulaCursorInQuote(cellEditor.value, start)) return false;
-  return /[=(,+\-*/^&<>]\s*$/.test(cellEditor.value.slice(0, start));
+  return /[=(,:+\-*/^&<>]\s*$/.test(cellEditor.value.slice(0, start));
 }
 function insertFormulaComma() {
   const start = cellEditor.selectionStart ?? cellEditor.value.length, end = cellEditor.selectionEnd ?? start;
@@ -3655,7 +3695,10 @@ function updateFormulaAssist() {
 function acceptFormulaSuggestion() {
   const name = formulaAssistItems[formulaAssistIndex]; if (!name || !editing) return;
   const cursor = cellEditor.selectionStart ?? cellEditor.value.length;
-  cellEditor.value = cellEditor.value.slice(0, formulaAssistReplaceStart) + name + "()" + cellEditor.value.slice(cursor);
+  // Accepting over an existing call (`=SU|M(A1)`) reuses its parentheses instead of adding a pair.
+  const rest = cellEditor.value.slice(cursor), existingCall = /^[A-Za-z0-9_.]*\s*\(/.exec(rest);
+  const tail = existingCall ? rest.slice(existingCall[0].length) : rest;
+  cellEditor.value = cellEditor.value.slice(0, formulaAssistReplaceStart) + name + (existingCall ? "(" : "()") + tail;
   const next = formulaAssistReplaceStart + name.length + 1;
   cellEditor.setSelectionRange(next, next); formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(next, next); syncEditorSize(); updateFormulaAssist();
 }
@@ -3820,6 +3863,7 @@ function syncFormulaPickFromCaret() {
   const start = cellEditor.selectionStart ?? cellEditor.value.length;
   const end = cellEditor.selectionEnd ?? start;
   let bounds = formulaReferenceBoundsAtCaret(cellEditor.value, start === end ? start : Math.min(start + 1, end));
+  if (bounds && cellEditor.value[bounds.start] !== "'" && formulaCursorInQuote(cellEditor.value, bounds.start + 1)) bounds = null; // text inside a string literal
   if (!bounds) {
     const span = activeFormulaArgumentSpans(cellEditor.value, start).find((item) => start >= item.start && start <= item.end);
     if (span) {
@@ -4159,8 +4203,8 @@ function commitEdit(advance = "down") {
   commitBatch();
   rebuildEngine();
   renderGrid();
-  if (advance === "down") moveActive(r + 1, c);
-  else if (advance === "up") moveActive(r - 1, c);
+  if (advance === "down") moveActive(nextVisibleRow(r, 1), c);
+  else if (advance === "up") moveActive(nextVisibleRow(r, -1), c);
   else if (advance === "right") moveActive(r, c + 1);
   else if (advance === "left") moveActive(r, c - 1);
   else moveActive(r, c);
@@ -4202,6 +4246,13 @@ cellEditor.addEventListener("keydown", (e) => {
     return;
   }
   if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "l") { e.preventDefault(); cycleAbsoluteReference(); e.stopPropagation(); return; }
+  // In point mode (e.g. right after `=`, where the starter suggestions also show) arrows pick cells;
+  // the suggestions stay reachable by Tab/Enter and click.
+  if (cellEditor.value.startsWith("=") && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key) && formulaPointModeActive()) {
+    e.preventDefault();
+    const directions = { ArrowUp: [-1, 0], ArrowDown: [1, 0], ArrowLeft: [0, -1], ArrowRight: [0, 1] };
+    moveFormulaPickByKeyboard(directions[e.key][0], directions[e.key][1], e.shiftKey); e.stopPropagation(); return;
+  }
   if (formulaAssistItems.length && e.key === "ArrowDown") { e.preventDefault(); moveFormulaSuggestion(1); e.stopPropagation(); return; }
   if (formulaAssistItems.length && e.key === "ArrowUp") { e.preventDefault(); moveFormulaSuggestion(-1); e.stopPropagation(); return; }
   if (formulaAssistItems.length && (e.key === "Tab" || e.key === "Enter")) { e.preventDefault(); acceptFormulaSuggestion(); e.stopPropagation(); return; }
@@ -4226,11 +4277,6 @@ cellEditor.addEventListener("keydown", (e) => {
     updateFormulaAssist();
     e.stopPropagation();
     return;
-  }
-  if (!formulaAssistItems.length && cellEditor.value.startsWith("=") && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key) && formulaPointModeActive()) {
-    e.preventDefault();
-    const directions = { ArrowUp: [-1, 0], ArrowDown: [1, 0], ArrowLeft: [0, -1], ArrowRight: [0, 1] };
-    moveFormulaPickByKeyboard(directions[e.key][0], directions[e.key][1], e.shiftKey); e.stopPropagation(); return;
   }
   if (formulaAssist.style.display !== "none" && e.key === "Escape") { e.preventDefault(); closeFormulaAssist(); e.stopPropagation(); return; }
   if (e.key === "Enter" && !e.shiftKey && !e.altKey) { e.preventDefault(); commitEdit(e.shiftKey ? "up" : "down"); }
@@ -4402,8 +4448,8 @@ function handleGridKeydown(e) {
     }
   }
   switch (e.key) {
-    case "ArrowUp": e.preventDefault(); moveActive(focus.r - 1, focus.c, e.shiftKey); break;
-    case "ArrowDown": e.preventDefault(); moveActive(focus.r + 1, focus.c, e.shiftKey); break;
+    case "ArrowUp": e.preventDefault(); moveActive(nextVisibleRow(focus.r, -1), focus.c, e.shiftKey); break;
+    case "ArrowDown": e.preventDefault(); moveActive(nextVisibleRow(focus.r, 1), focus.c, e.shiftKey); break;
     case "ArrowLeft": e.preventDefault(); moveActive(focus.r, focus.c - 1, e.shiftKey); break;
     case "ArrowRight": e.preventDefault(); moveActive(focus.r, focus.c + 1, e.shiftKey); break;
     case "Tab": e.preventDefault(); moveWithinSelection(e.shiftKey ? -1 : 1, "h"); break;
@@ -4478,13 +4524,13 @@ function clipboardReferences(ranges, sheet, allRows, allColumns) {
   if (allRows) {
     const rows = [...new Set(ranges.flatMap((range) => Array.from({ length: range.r2 - range.r1 + 1 }, (_, index) => range.r1 + index)))].sort((a, b) => a - b);
     let lastColumn = 0;
-    for (const row of rows) for (let column = 0; column < sheet.cols; column++) if (!isVisuallyEmptyCell(row, column)) lastColumn = Math.max(lastColumn, column);
+    for (const row of rows) for (let column = 0; column < sheet.cols; column++) if (getCell(rcToRef(row, column))) lastColumn = Math.max(lastColumn, column);
     return rows.map((row) => Array.from({ length: lastColumn + 1 }, (_, column) => rcToRef(row, column)));
   }
   if (allColumns) {
     const columns = [...new Set(ranges.flatMap((range) => Array.from({ length: range.c2 - range.c1 + 1 }, (_, index) => range.c1 + index)))].sort((a, b) => a - b);
     let lastRow = 0;
-    for (const column of columns) for (let row = 0; row < sheet.rows; row++) if (!isVisuallyEmptyCell(row, column)) lastRow = Math.max(lastRow, row);
+    for (const column of columns) for (let row = 0; row < sheet.rows; row++) if (getCell(rcToRef(row, column))) lastRow = Math.max(lastRow, row);
     return Array.from({ length: lastRow + 1 }, (_, row) => columns.map((column) => rcToRef(row, column)));
   }
   if (ranges.length === 1) {
@@ -4625,7 +4671,7 @@ function pasteText(text, { keepFormatting = true, token = null } = {}) {
       const sourceRow = i % sourceHeight, sourceColumn = j % sourceWidth;
       const ref = rcToRef(row, column); destinationRefs.add(activeSheetId + "!" + ref);
       const snapshot = useSnapshot ? copyFallback.cells[sourceRow]?.[sourceColumn] : undefined;
-      if (moving && snapshot?.sourceRef && !moves.has(snapshot.sourceRef)) moves.set(snapshot.sourceRef, { sheetId: activeSheetId, ref });
+      if (moving && snapshot?.sourceRef && !moves.has(snapshot.sourceRef)) moves.set(snapshot.sourceRef, { sheetId: activeSheetId, ref, snapshot });
       if (useSnapshot && keepFormatting) {
         recordCell(activeSheetId, ref);
         if (snapshot && snapshot.value != null) {
@@ -4649,7 +4695,7 @@ function pasteText(text, { keepFormatting = true, token = null } = {}) {
     const sourceSheet = model.sheets[copyFallback.sheetId];
     let movedComments = false;
     for (const [sourceRef, destination] of moves) {
-      const snapshot = copyFallback.cells.flat().find((entry) => entry?.sourceRef === sourceRef);
+      const { snapshot } = destination;
       if (destinationRefs.has(copyFallback.sheetId + "!" + sourceRef) || !cutSourceUnchanged(copyFallback.sheetId, snapshot)) continue;
       clearStoredCell(copyFallback.sheetId, sourceRef);
       const comments = sourceSheet?.comments?.filter((comment) => comment.ref === sourceRef) || [];
@@ -5046,6 +5092,7 @@ function applyRemoteOperation(event) {
   if (!model.sheets[activeSheetId]) { if (editing) cancelEdit(); activeSheetId = model.sheetOrder[0]; }
   if (selectedChartId && !(curSheet().charts || []).some((chart) => chart.id === selectedChartId)) selectedChartId = null;
   renderTabs(); renderGrid(); renderChartPanel();
+  schedulePivotRefreshes(); // a remote source edit re-materializes the pivots reading it
   setStatus("synced", "Live update");
   setTimeout(() => { if (!saveInFlight && !pendingCellOps.size) setStatus("saved", "Saved"); }, 900);
 }

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
@@ -506,7 +506,7 @@ class CellError {
   toString() { return this.value; }
 }
 class HyperlinkValue {
-  constructor(url, label) { this.url = url; this.label = label || url; }
+  constructor(url, label) { this.url = url; this.label = label == null ? url : String(label); }
   toString() { return this.label; }
 }
 function safeHyperlinkUrl(value) {
@@ -537,6 +537,7 @@ function tokenize(src) {
     const singleQuotedSheet = ch === "'" && (() => {
       let j = i + 1;
       while (j < n) {
+        if (src[j] === "\\" && src[j + 1] === "'") { j += 2; continue; }
         if (src[j] === "'") { if (src[j + 1] === "'") { j += 2; continue; } return src[j + 1] === "!"; }
         j++;
       }
@@ -1618,6 +1619,7 @@ function queueCellOp(sheetId, ref, value, fmt, baseVersion) {
 // Structure is saved as a whole-workbook snapshot, so `ackedStructure` (what the server last held)
 // lets a remote update be merged with the local changes still pending.
 let ackedStructure = null;
+let inFlightStructure = null; // structure sent in the save awaiting its response
 function structureSnapshot() {
   return { title: model.title, sheetOrder: model.sheetOrder.slice(), sheets: JSON.parse(JSON.stringify(model.sheets)) };
 }
@@ -1648,6 +1650,7 @@ async function doSave() {
     cellOps.push({ sheetId: op.sheetId, ref: op.ref, value: op.value, fmt: op.fmt, baseVersion: op.baseVersion ?? (cur ? cur.version : 0) });
   }
   const structure = pendingStructure;
+  inFlightStructure = structure;
   const sheetReplacements = Array.from(pendingReplacements.entries()).map(([sheetId, cells]) => ({ sheetId, cells }));
   pendingCellOps = new Map();
   pendingStructure = null;
@@ -1707,7 +1710,7 @@ async function doSave() {
     console.error(e);
     setStatus("bad", "Save failed");
   } finally {
-    saveInFlight = false;
+    saveInFlight = false; inFlightStructure = null;
     if (pendingCellOps.size || pendingStructure || pendingReplacements.size) scheduleSave(40);
   }
 }
@@ -1962,7 +1965,10 @@ function insertCols(at, count) {
     const next = {};
     for (const [column, values] of Object.entries(sh.filter.criteria || {})) next[Number(column) >= at ? Number(column) + count : Number(column)] = values;
     sh.filter.criteria = next;
-    sh.filter.columns = filterColumns(sh.filter).map((column) => column >= at ? column + count : column);
+    const shifted = filterColumns(sh.filter).map((column) => column >= at ? column + count : column);
+    // Columns inserted inside the table belong to its records.
+    const inside = at > Math.min(...shifted) && at <= Math.max(...shifted);
+    sh.filter.columns = inside ? [...shifted, ...Array.from({ length: count }, (_, index) => at + index)].sort((a, b) => a - b) : shifted;
   }
   rewriteAllFormulas(0, 0, at, count);
   rebuildSheetCells((r) => r, (c) => c >= at ? c + count : c);
@@ -2088,6 +2094,7 @@ function sortSelection(asc) {
 // Pivot tables
 // ===========================================================================
 let pivotRefreshTimer = null;
+const MAX_PIVOT_CELLS = 100000;
 function pivotSheets() { return model.sheetOrder.filter((id) => model.sheets[id]?.pivot); }
 function pivotCellValue(sheetId, row, column) { return engine.computeRef(sheetId, rcToRef(row, column)); }
 function pivotDisplay(value) { return value == null || value === "" ? "(Blank)" : (isErr(value) ? value.value : String(value)); }
@@ -2152,6 +2159,11 @@ function buildPivotOutput(pivot) {
   }
   const rowKeys = [...new Set(records.map((record) => record.row))].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   const columnKeys = [...new Set(records.map((record) => record.column))].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  // The output is the Cartesian product of the two key sets; past this it cannot be materialized
+  // (the sheet also has at most 702 columns), so the pivot reports instead of freezing the browser.
+  if (rowKeys.length * columnKeys.length > MAX_PIVOT_CELLS || columnKeys.length > 699) {
+    return { cells: { A1: { value: `Pivot table too large: ${rowKeys.length.toLocaleString()} row values × ${columnKeys.length.toLocaleString()} column values. Choose fields with fewer distinct values.`, fmt: { b: true, c: "#b42318" }, version: 1 } }, rows: 20, cols: 8 };
+  }
   const states = new Map(), rowTotals = new Map(), columnTotals = new Map(), grandTotal = aggregateState();
   const stateFor = (map, key) => { if (!map.has(key)) map.set(key, aggregateState()); return map.get(key); };
   for (const record of records) {
@@ -2180,6 +2192,7 @@ function buildPivotOutput(pivot) {
 function refreshPivot(sheetId, save = true) {
   const sheet = model.sheets[sheetId]; if (!sheet?.pivot) return;
   const output = buildPivotOutput(sheet.pivot);
+  if (JSON.stringify(output.cells) === JSON.stringify(model.cells[sheetId] || {})) return; // nothing to rematerialize
   model.cells[sheetId] = output.cells; sheet.rows = Math.max(sheet.rows, output.rows); sheet.cols = Math.max(sheet.cols, output.cols);
   const widths = {};
   for (const [ref, cell] of Object.entries(output.cells)) {
@@ -2193,15 +2206,14 @@ function refreshPivot(sheetId, save = true) {
   rebuildEngine();
   if (activeSheetId === sheetId) renderGrid();
 }
-// Edits to several source sheets inside the debounce window refresh every one of their pivots.
-const pendingPivotSources = new Set();
-function schedulePivotRefreshes(sourceSheetId) {
-  pendingPivotSources.add(sourceSheetId);
+// A pivot's source may itself hold formulas reading other sheets, so any edit refreshes every
+// pivot after the debounce rather than tracing dependencies. Refreshing writes only pivot sheets and
+// does not reschedule itself.
+function schedulePivotRefreshes() {
   clearTimeout(pivotRefreshTimer);
   pivotRefreshTimer = setTimeout(() => {
-    const sources = new Set(pendingPivotSources); pendingPivotSources.clear();
     rebuildEngine();
-    for (const id of pivotSheets()) if (sources.has(model.sheets[id].pivot.sourceSheetId)) refreshPivot(id);
+    for (const id of pivotSheets()) refreshPivot(id);
   }, 320);
 }
 function createPivotTable() {
@@ -2275,11 +2287,15 @@ function activeComments() { return sheetComments().filter((comment) => !comment.
 function commentsForRef(ref) { return activeComments().filter((comment) => comment.ref === ref); }
 function closeCommentEditor() { if (commentPopover) { commentPopover.remove(); commentPopover = null; } }
 document.addEventListener("mousedown", (event) => { if (commentPopover && !commentPopover.contains(event.target)) closeCommentEditor(); });
+// The popover is bound to the sheet it opened on: a remote deletion of that sheet switches the
+// grid elsewhere, and the comment must not land there.
+const MAX_COMMENT_LENGTH = 4000; // the server truncates beyond this
 function openCommentEditor(ref) {
   closeCommentEditor();
   const cell = gridTable.querySelector(`td.cell[data-ref="${ref}"]`);
   if (!cell) return;
-  const textarea = el("textarea", { placeholder: `Comment on ${ref}`, "aria-label": `Comment on ${ref}` });
+  const sheetId = activeSheetId;
+  const textarea = el("textarea", { placeholder: `Comment on ${ref}`, "aria-label": `Comment on ${ref}`, maxlength: String(MAX_COMMENT_LENGTH) });
   const cancel = el("button", {}, "Cancel");
   const save = el("button", { class: "primary" }, "Comment");
   const popover = el("div", { class: "comment-popover" }, [textarea, el("div", { class: "comment-popover-actions" }, [cancel, save])]);
@@ -2291,7 +2307,10 @@ function openCommentEditor(ref) {
   const done = () => {
     const text = textarea.value.trim();
     if (!text) return;
-    sheetComments().push({ id: "comment_" + Math.random().toString(36).slice(2, 10), ref, text, createdAt: Date.now(), resolved: false });
+    const sheet = model.sheets[sheetId];
+    if (!sheet || !model.sheetOrder.includes(sheetId)) { closeCommentEditor(); setStatus("bad", "That sheet was deleted"); return; }
+    if (text.length > MAX_COMMENT_LENGTH) { setStatus("bad", `Comments are limited to ${MAX_COMMENT_LENGTH.toLocaleString()} characters`); return; }
+    (sheet.comments || (sheet.comments = [])).push({ id: "comment_" + Math.random().toString(36).slice(2, 10), ref, text, createdAt: Date.now(), resolved: false });
     closeCommentEditor(); sidebarView = "comments"; queueStructure(); renderGrid(); renderChartPanel(); setChartPanelCollapsed(false); refreshToolbarState();
   };
   cancel.addEventListener("click", closeCommentEditor); save.addEventListener("click", done);
@@ -2574,15 +2593,16 @@ function chartData(chart) {
   const dataRow = range.r1 + (chart.firstRowHeaders && range.r2 > range.r1 ? 1 : 0);
   let seriesColumn = range.c1 + (chart.firstColLabels && range.c2 > range.c1 ? 1 : 0);
   if (seriesColumn > range.c2 || dataRow > range.r2) return null;
-  const labels = [];
-  for (let row = dataRow; row <= range.r2; row++) labels.push(chart.firstColLabels ? chartCellLabel(row, range.c1) : String(row - dataRow + 1));
+  // Rows the filter hides are left out, as Excel does for an exported chart (plotVisOnly).
+  const rows = [];
+  for (let row = dataRow; row <= range.r2; row++) if (rowPassesFilter(row)) rows.push(row);
+  const labels = rows.map((row) => chart.firstColLabels ? chartCellLabel(row, range.c1) : String(row - dataRow + 1));
   const series = [];
   for (let column = seriesColumn; column <= range.c2; column++) {
-    const values = [];
-    for (let row = dataRow; row <= range.r2; row++) {
+    const values = rows.map((row) => {
       const value = engine.computeRef(activeSheetId, rcToRef(row, column));
-      values.push(typeof value === "number" && Number.isFinite(value) ? value : null);
-    }
+      return typeof value === "number" && Number.isFinite(value) ? value : null;
+    });
     if (values.some((value) => value != null)) series.push({
       name: chart.firstRowHeaders ? (chartCellLabel(range.r1, column) || colToLetter(column)) : colToLetter(column), values,
     });
@@ -2675,22 +2695,30 @@ function renderStackedBarChartSvg(chart, data) {
   const svg = svgNode("svg", { viewBox: "0 0 520 270", role: "img", "aria-label": chart.title || "Stacked bar chart" });
   const left = 78, top = 18, right = chart.legend ? 112 : 24, bottom = 42;
   const width = 520 - left - right, height = 270 - top - bottom;
-  const totals = data.labels.map((_, index) => data.series.reduce((sum, series) => sum + Math.max(0, series.values[index] || 0), 0));
-  const max = Math.max(...totals, 1);
+  // Positive values stack to the right of the zero line and negative ones to the left, as Excel
+  // draws them, so the axis spans the largest negative and positive totals.
+  const positiveTotals = data.labels.map((_, index) => data.series.reduce((sum, series) => sum + Math.max(0, series.values[index] || 0), 0));
+  const negativeTotals = data.labels.map((_, index) => data.series.reduce((sum, series) => sum + Math.min(0, series.values[index] || 0), 0));
+  const max = Math.max(...positiveTotals, 0), min = Math.min(...negativeTotals, 0);
+  const span = max - min || 1;
+  const x = (value) => left + (value - min) / span * width;
   const rowHeight = height / Math.max(1, data.labels.length);
   for (let tick = 0; tick <= 4; tick++) {
-    const xx = left + width * tick / 4;
+    const value = min + span * tick / 4, xx = x(value);
     svg.appendChild(svgNode("line", { x1: xx, y1: top, x2: xx, y2: top + height, stroke: "#e4e4e1" }));
-    svg.appendChild(svgNode("text", { x: xx, y: top + height + 15, "text-anchor": "middle", fill: "#77777f", "font-size": 10 }, fmtGeneral(max * tick / 4)));
+    svg.appendChild(svgNode("text", { x: xx, y: top + height + 15, "text-anchor": "middle", fill: "#77777f", "font-size": 10 }, fmtGeneral(value)));
   }
+  if (min < 0) svg.appendChild(svgNode("line", { x1: x(0), y1: top, x2: x(0), y2: top + height, stroke: "#9a9aa2" }));
   data.labels.forEach((label, row) => {
     const barY = top + row * rowHeight + rowHeight * .18, barHeight = Math.max(3, rowHeight * .64);
     svg.appendChild(svgNode("text", { x: left - 7, y: barY + barHeight / 2 + 4, "text-anchor": "end", fill: "#66666e", "font-size": 10 }, String(label).slice(0, 12)));
-    let offset = 0;
+    let positive = 0, negative = 0;
     data.series.forEach((series, index) => {
-      const value = Math.max(0, series.values[row] || 0), barWidth = value / max * width;
-      svg.appendChild(svgNode("rect", { x: left + offset, y: barY, width: barWidth, height: barHeight, fill: CHART_COLORS[index % CHART_COLORS.length] }));
-      offset += barWidth;
+      const value = series.values[row] || 0;
+      if (!value) return;
+      const start = value > 0 ? positive : negative + value, barWidth = Math.abs(value) / span * width;
+      svg.appendChild(svgNode("rect", { x: x(start), y: barY, width: barWidth, height: barHeight, fill: CHART_COLORS[index % CHART_COLORS.length] }));
+      if (value > 0) positive += value; else negative += value;
     });
   });
   if (chart.legend) data.series.forEach((series, index) => {
@@ -2805,6 +2833,7 @@ function renderCharts() {
 // ===========================================================================
 // Filter rows
 // ===========================================================================
+const MAX_FILTER_SELECTIONS = 500; // mirrors the server's per-column criteria bound
 function filterToken(value) {
   if (isErr(value)) return "e:" + value.value;
   if (value == null || value === "") return "z:";
@@ -3029,9 +3058,15 @@ function openFilterMenu(column, trigger) {
     queueStructure(); renderGrid(); refreshToolbarState();
   });
   apply.addEventListener("click", () => {
-    const current = liveFilter(); closeCtx();
-    if (!current) return;
+    const current = liveFilter();
+    if (!current) { closeCtx(); return; }
     const selected = checks.filter((entry) => entry.checkbox.checked).map((entry) => entry.token);
+    // The server keeps at most MAX_FILTER_SELECTIONS tokens per column and drops larger criteria
+    // outright, so a selection it would not keep is refused here instead of silently changing.
+    if (selected.length !== checks.length && selected.length > MAX_FILTER_SELECTIONS) {
+      setStatus("bad", `Select at most ${MAX_FILTER_SELECTIONS} values, or deselect fewer values instead`); return;
+    }
+    closeCtx();
     if (selected.length === checks.length) delete current.criteria[column];
     else current.criteria[column] = selected.length ? selected : ["x:__none__"];
     queueStructure(); renderGrid(); refreshToolbarState();
@@ -3714,8 +3749,14 @@ function renderFormulaPickHighlight() {
   });
   positionFormulaRangeHandle();
 }
+// Cell references in editor text, optionally sheet-qualified. Bounded on both sides so a function
+// name such as `LOG10` (letters and digits followed by `(`) or the tail of an identifier is not one.
+const SHEET_PREFIX_SOURCE = "(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?";
+const CELL_SOURCE = "(?<![A-Za-z0-9_.$])\\$?[A-Z]{1,3}\\$?[1-9]\\d*(?![A-Za-z0-9_]|\\s*\\()";
+const ENDPOINT_SOURCE = SHEET_PREFIX_SOURCE + CELL_SOURCE;
+const REFERENCE_SOURCE = `${ENDPOINT_SOURCE}(?::${ENDPOINT_SOURCE})?`;
 function formulaReferenceBoundsAtCaret(value, caret) {
-  const pattern = /(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*(?::(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*)?/gi;
+  const pattern = new RegExp(REFERENCE_SOURCE, "gi");
   for (const match of value.matchAll(pattern)) {
     const start = match.index, end = start + match[0].length;
     if (caret >= start && caret <= end) return { start, end };
@@ -3737,7 +3778,7 @@ function cycleReferenceToken(text) {
   });
 }
 function formulaEndpointBoundsAtCaret(value, caret) {
-  const pattern = /(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*/gi;
+  const pattern = new RegExp(ENDPOINT_SOURCE, "gi");
   for (const match of value.matchAll(pattern)) {
     if (!match[0].startsWith("'") && formulaCursorInQuote(value, match.index + 1)) continue;
     const start = match.index, end = start + match[0].length;
@@ -3783,7 +3824,7 @@ function syncFormulaPickFromCaret() {
     const span = activeFormulaArgumentSpans(cellEditor.value, start).find((item) => start >= item.start && start <= item.end);
     if (span) {
       const raw = cellEditor.value.slice(span.start, span.end), leading = raw.length - raw.trimStart().length, trimmed = raw.trim();
-      if (/^(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*(?::(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*)?$/i.test(trimmed)) bounds = { start: span.start + leading, end: span.start + leading + trimmed.length };
+      if (new RegExp(`^${REFERENCE_SOURCE}$`, "i").test(trimmed)) bounds = { start: span.start + leading, end: span.start + leading + trimmed.length };
     }
   }
   const reference = formulaReferenceFromBounds(cellEditor.value, bounds);
@@ -3877,7 +3918,7 @@ function beginAdditionalFormulaReference() {
 }
 function formulaReferenceAtCell(row, column) {
   const value = cellEditor.value;
-  const pattern = /(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*(?::(?:(?:'(?:[^']|'')+'|[A-Za-z_][A-Za-z0-9_.]*)!)?\$?[A-Z]{1,3}\$?[1-9]\d*)?/gi;
+  const pattern = new RegExp(REFERENCE_SOURCE, "gi");
   const matches = [];
   for (const match of value.matchAll(pattern)) {
     if (formulaCursorInQuote(value, match.index + 1)) continue;
@@ -4470,7 +4511,7 @@ function prepareClipboard(cut = false) {
   }));
   const tsv = refs.map((row) => row.map(clipboardCellText).join("\t")).join("\n");
   copyRange = { ...selRange() };
-  copyFallback = { tsv, cells, refs, trimmed, sheetId: activeSheetId, cut };
+  copyFallback = { tsv, cells, refs, trimmed, sheetId: activeSheetId, cut, token: Math.random().toString(36).slice(2) };
   return tsv;
 }
 function requestGridClipboard(cut = false) {
@@ -4478,23 +4519,26 @@ function requestGridClipboard(cut = false) {
   try { document.execCommand(cut ? "cut" : "copy"); }
   catch (error) { setStatus("bad", "Clipboard unavailable"); }
 }
+// Own clipboard writes carry a token in a private type; a paste whose text merely equals the last
+// cut is not enough to make that cut destructive.
+const CLIPBOARD_TOKEN_TYPE = "application/x-workspace-sheets";
 function pasteFromMenu(keepFormatting) {
   if (copyFallback?.tsv != null) {
-    pasteText(copyFallback.tsv, { keepFormatting });
+    pasteText(copyFallback.tsv, { keepFormatting, token: copyFallback.token });
     return;
   }
   // Permissions Policy prevents menu-click handlers from reading the system
   // clipboard. Native keyboard paste still supplies ClipboardEvent data.
   setStatus("bad", keepFormatting ? "Use Ctrl+V for external content" : "Use Ctrl+Shift+V for external content");
 }
-gridScroll.addEventListener("copy", (event) => {
+function writeGridClipboard(event, cut) {
   if (editing) return;
-  event.preventDefault(); event.clipboardData.setData("text/plain", prepareClipboard(false));
-});
-gridScroll.addEventListener("cut", (event) => {
-  if (editing) return;
-  event.preventDefault(); event.clipboardData.setData("text/plain", prepareClipboard(true));
-});
+  event.preventDefault();
+  event.clipboardData.setData("text/plain", prepareClipboard(cut));
+  try { event.clipboardData.setData(CLIPBOARD_TOKEN_TYPE, copyFallback.token); } catch (error) { /* custom types unsupported */ }
+}
+gridScroll.addEventListener("copy", (event) => writeGridClipboard(event, false));
+gridScroll.addEventListener("cut", (event) => writeGridClipboard(event, true));
 function clearCopyMarquee() { copyRange = null; copyFallback = null; }
 
 let pasteWithoutFormattingPending = false;
@@ -4503,9 +4547,10 @@ gridScroll.addEventListener("paste", (e) => {
   if (editing) return;
   e.preventDefault();
   const text = (e.clipboardData && e.clipboardData.getData("text/plain")) || "";
+  const token = (e.clipboardData && e.clipboardData.getData(CLIPBOARD_TOKEN_TYPE)) || null;
   const keepFormatting = !pasteWithoutFormattingPending;
   pasteWithoutFormattingPending = false; clearTimeout(pasteModeTimer);
-  pasteText(text, { keepFormatting });
+  pasteText(text, { keepFormatting, token });
 });
 // Applies `rewrite` to the parts of a formula outside string literals and quoted sheet names, so
 // text such as `="A1"` is never mistaken for a reference.
@@ -4548,9 +4593,13 @@ function clearStoredCell(sheetId, ref) {
   const baseVersion = existing.version || 0;
   delete cells[ref]; queueCellOp(sheetId, ref, null, null, baseVersion);
 }
-function pasteText(text, { keepFormatting = true } = {}) {
+function pasteText(text, { keepFormatting = true, token = null } = {}) {
   const normalized = text.replace(/\r/g, "");
-  const useSnapshot = copyFallback && copyFallback.tsv.replace(/\r/g, "") === normalized && copyFallback.cells;
+  // Text equality identifies a copy; a cut (which deletes its source) needs the token.
+  const useSnapshot = !!copyFallback?.cells && (token ? token === copyFallback.token
+    : !copyFallback.cut && copyFallback.tsv.replace(/\r/g, "") === normalized);
+  const moving = useSnapshot && copyFallback.cut;
+  const moves = new Map(); // source ref -> where its snapshot was pasted
   const rows = normalized.split("\n");
   if (rows.length > 1 && rows[rows.length - 1] === "") rows.pop();
   const values = rows.map((row) => row.split("\t"));
@@ -4565,7 +4614,8 @@ function pasteText(text, { keepFormatting = true } = {}) {
     const trimmedRows = useSnapshot && copyFallback.trimmed === "rows", trimmedColumns = useSnapshot && copyFallback.trimmed === "columns";
     const widthFits = trimmedRows || (targetWidth >= sourceWidth && targetWidth % sourceWidth === 0);
     const heightFits = trimmedColumns || (targetHeight >= sourceHeight && targetHeight % sourceHeight === 0);
-    const repeat = (sourceHeight === 1 && sourceWidth === 1 && !trimmedRows && !trimmedColumns) || (widthFits && heightFits);
+    // A cut moves its cells once; it never tiles them across a larger destination.
+    const repeat = !moving && ((sourceHeight === 1 && sourceWidth === 1 && !trimmedRows && !trimmedColumns) || (widthFits && heightFits));
     const pasteHeight = repeat && !trimmedColumns ? targetHeight : sourceHeight;
     const pasteWidth = repeat && !trimmedRows ? targetWidth : sourceWidth;
     for (let i = 0; i < pasteHeight; i++) for (let j = 0; j < pasteWidth; j++) {
@@ -4575,6 +4625,7 @@ function pasteText(text, { keepFormatting = true } = {}) {
       const sourceRow = i % sourceHeight, sourceColumn = j % sourceWidth;
       const ref = rcToRef(row, column); destinationRefs.add(activeSheetId + "!" + ref);
       const snapshot = useSnapshot ? copyFallback.cells[sourceRow]?.[sourceColumn] : undefined;
+      if (moving && snapshot?.sourceRef && !moves.has(snapshot.sourceRef)) moves.set(snapshot.sourceRef, { sheetId: activeSheetId, ref });
       if (useSnapshot && keepFormatting) {
         recordCell(activeSheetId, ref);
         if (snapshot && snapshot.value != null) {
@@ -4592,13 +4643,27 @@ function pasteText(text, { keepFormatting = true } = {}) {
       }
     }
   }
-  if (useSnapshot && copyFallback.cut) {
-    for (const row of copyFallback.cells) for (const snapshot of row) {
-      if (snapshot?.sourceRef && !destinationRefs.has(copyFallback.sheetId + "!" + snapshot.sourceRef) && cutSourceUnchanged(copyFallback.sheetId, snapshot)) clearStoredCell(copyFallback.sheetId, snapshot.sourceRef);
+  if (moving) {
+    // Only sources whose snapshot was actually pasted are cleared (a discontiguous destination
+    // may have received part of the block), and their comments travel with them.
+    const sourceSheet = model.sheets[copyFallback.sheetId];
+    let movedComments = false;
+    for (const [sourceRef, destination] of moves) {
+      const snapshot = copyFallback.cells.flat().find((entry) => entry?.sourceRef === sourceRef);
+      if (destinationRefs.has(copyFallback.sheetId + "!" + sourceRef) || !cutSourceUnchanged(copyFallback.sheetId, snapshot)) continue;
+      clearStoredCell(copyFallback.sheetId, sourceRef);
+      const comments = sourceSheet?.comments?.filter((comment) => comment.ref === sourceRef) || [];
+      if (comments.length) {
+        sourceSheet.comments = sourceSheet.comments.filter((comment) => comment.ref !== sourceRef);
+        const targetSheet = model.sheets[destination.sheetId];
+        (targetSheet.comments || (targetSheet.comments = [])).push(...comments.map((comment) => ({ ...comment, ref: destination.ref })));
+        movedComments = true;
+      }
     }
+    if (movedComments) { queueStructure(); renderChartPanel(); refreshToolbarState(); }
     copyFallback = null; copyRange = null;
   }
-  commitBatch(); rebuildEngine(); renderGrid(); schedulePivotRefreshes(activeSheetId);
+  commitBatch(); rebuildEngine(); renderGrid(); schedulePivotRefreshes();
 }
 
 // ===========================================================================
@@ -4647,6 +4712,11 @@ formulaInput.addEventListener("keydown", (e) => {
     syncFormulaPickFromCaret();
     updateFormulaAssist();
     return;
+  }
+  if (editing && formulaAssistItems.length && (e.key === "ArrowDown" || e.key === "ArrowUp")) { e.preventDefault(); moveFormulaSuggestion(e.key === "ArrowDown" ? 1 : -1); return; }
+  if (editing && formulaAssistItems.length && (e.key === "Tab" || e.key === "Enter")) {
+    e.preventDefault(); cellEditor.setSelectionRange(formulaInput.selectionStart, formulaInput.selectionEnd); acceptFormulaSuggestion();
+    formulaInput.setSelectionRange(cellEditor.selectionStart, cellEditor.selectionEnd); return;
   }
   if (e.key === "Enter") { e.preventDefault(); commitEdit("down"); }
   else if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
@@ -4760,7 +4830,8 @@ function showCtx(menu, x, y) {
 }
 function closeCtx() { if (ctxEl) { ctxEl.remove(); ctxEl = null; } }
 document.addEventListener("mousedown", (e) => { if (ctxEl && !ctxEl.contains(e.target)) closeCtx(); });
-window.addEventListener("scroll", closeCtx, true);
+// Scrolling inside the menu itself (a long filter value list) must not dismiss it.
+window.addEventListener("scroll", (event) => { if (!ctxEl || !ctxEl.contains(event.target)) closeCtx(); }, true);
 
 gridTable.addEventListener("contextmenu", (e) => {
   const td = e.target.closest("td.cell");
@@ -4794,7 +4865,7 @@ gridTable.addEventListener("contextmenu", (e) => {
   item("Paste", "Ctrl+V", () => pasteFromMenu(true));
   item("Paste without formatting", "Ctrl+Shift+V", () => pasteFromMenu(false));
   sep();
-  item("Comment", "", () => openCommentEditor(rcToRef(focus.r, focus.c)));
+  item("Comment", "", () => openCommentEditor(td ? td.dataset.ref : rcToRef(focus.r, focus.c)));
   item("Create pivot table", "", () => createPivotTable());
   sep();
   const filter = curSheet().filter;
@@ -4982,7 +5053,10 @@ function applyRemoteOperation(event) {
 // that are still pending are diffed against `ackedStructure` and replayed on top, per sheet field,
 // so a remote chart and a local comment on the same sheet both survive.
 function applyStructure(s) {
-  const local = pendingStructure ? localStructureChanges() : null;
+  // A structure awaiting its save response is local too: the server applies it after this remote
+  // one, so it must be replayed here as well (and re-saved merged, since the server holds only ours).
+  const localSource = pendingStructure || inFlightStructure;
+  const local = localSource ? localStructureChanges(localSource) : null;
   if (s.title != null && document.activeElement !== titleInput) { model.title = s.title; titleInput.value = s.title; }
   else if (s.title != null) model.title = s.title;
   model.sheetOrder = s.sheetOrder.slice();
@@ -5007,17 +5081,17 @@ function applyStructure(s) {
   }
   pendingStructure = structureSnapshot();
 }
-function localStructureChanges() {
-  const base = ackedStructure || { title: pendingStructure.title, sheetOrder: [], sheets: {} };
+function localStructureChanges(snapshot) {
+  const base = ackedStructure || { title: snapshot.title, sheetOrder: [], sheets: {} };
   const same = (a, b) => JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
   const changes = {
-    title: pendingStructure.title !== base.title ? pendingStructure.title : null,
-    sheetOrder: same(pendingStructure.sheetOrder, base.sheetOrder) ? null : pendingStructure.sheetOrder,
-    added: Object.keys(pendingStructure.sheets).filter((id) => !base.sheets[id]),
-    removed: base.sheetOrder.filter((id) => !pendingStructure.sheets[id]),
+    title: snapshot.title !== base.title ? snapshot.title : null,
+    sheetOrder: same(snapshot.sheetOrder, base.sheetOrder) ? null : snapshot.sheetOrder,
+    added: Object.keys(snapshot.sheets).filter((id) => !base.sheets[id]),
+    removed: base.sheetOrder.filter((id) => !snapshot.sheets[id]),
     sheets: {},
   };
-  for (const [id, sheet] of Object.entries(pendingStructure.sheets)) {
+  for (const [id, sheet] of Object.entries(snapshot.sheets)) {
     const baseSheet = base.sheets[id];
     if (!baseSheet) { changes.sheets[id] = sheet; continue; }
     const fields = {};

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/client.js
@@ -1293,12 +1293,12 @@ const FUNCTION_HELP = {
   MIN: ["MIN(value1, [value2, …])", "Returns the smallest number."],
   MAX: ["MAX(value1, [value2, …])", "Returns the largest number."],
   MEDIAN: ["MEDIAN(value1, [value2, …])", "Returns the median value."],
-  ROUND: ["ROUND(value, places)", "Rounds a number to a specified precision."],
+  ROUND: ["ROUND(value, [places])", "Rounds a number to a specified precision (default 0)."],
   ROUNDUP: ["ROUNDUP(value, places)", "Rounds a number away from zero."],
   ROUNDDOWN: ["ROUNDDOWN(value, places)", "Rounds a number toward zero."],
   IF: ["IF(condition, value_if_true, [value_if_false])", "Returns values based on a condition."],
   IFS: ["IFS(condition1, value1, [condition2, value2, …])", "Tests multiple conditions in order."],
-  IFERROR: ["IFERROR(value, fallback)", "Returns a fallback when a value is an error."],
+  IFERROR: ["IFERROR(value, [fallback])", "Returns a fallback (default blank) when a value is an error."],
   IFNA: ["IFNA(value, fallback)", "Returns a fallback for #N/A."],
   AND: ["AND(condition1, [condition2, …])", "Returns TRUE when every condition is true."],
   OR: ["OR(condition1, [condition2, …])", "Returns TRUE when any condition is true."],
@@ -1679,15 +1679,20 @@ async function doSave() {
       }
     }
     if (result.status === "conflict" && result.conflicts) {
-      // Rebase each rejected local intent onto the latest server version.
+      // Rebase each rejected local intent onto the latest server version. An edit queued while
+      // this save was in flight is the newer intent: the model already shows it, so only its base
+      // version moves.
       const intents = new Map(cellOps.map((op) => [op.sheetId + "!" + op.ref, op]));
       for (const cf of result.conflicts) {
+        const key = cf.sheetId + "!" + cf.ref;
+        const newer = pendingCellOps.get(key);
+        if (newer) { newer.baseVersion = cf.cell?.version || 0; continue; }
         const cells = model.cells[cf.sheetId] || (model.cells[cf.sheetId] = {});
-        const intent = intents.get(cf.sheetId + "!" + cf.ref);
+        const intent = intents.get(key);
         if (!intent) { cells[cf.ref] = { ...cf.cell }; continue; }
         if (intent.value == null && intent.fmt == null) delete cells[cf.ref];
         else cells[cf.ref] = { value: intent.value ?? "", fmt: intent.fmt ?? null, version: cf.cell?.version || 0 };
-        pendingCellOps.set(cf.sheetId + "!" + cf.ref, { ...intent, baseVersion: cf.cell?.version || 0 });
+        pendingCellOps.set(key, { ...intent, baseVersion: cf.cell?.version || 0 });
       }
       setStatus("synced", "Resolving edit…");
       scheduleSave(40);
@@ -2939,6 +2944,8 @@ function sortFilteredRange(column, ascending) {
   for (let row = filter.row + 1; row <= (filter.endRow ?? curSheet().rows - 1); row++) values.set(row, engine.computeRef(activeSheetId, rcToRef(row, column)));
   reorderFilteredRows((left, right) => {
     const a = values.get(left.currentRow) ?? "", b = values.get(right.currentRow) ?? "";
+    // Blank rows (the unused tail of the filter range) stay after populated rows in both directions.
+    if (a === "" || b === "") return a === b ? 0 : a === "" ? 1 : -1;
     const comparison = typeof a === "number" && typeof b === "number"
       ? a - b
       : String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: "base" });
@@ -3517,6 +3524,15 @@ function formulaCursorInQuote(value, cursor) {
   }
   return !!quote;
 }
+// Arrow keys pick grid references only in "point mode": right after a reference chosen through
+// the grid, or with the caret just after an operator, separator or `(`. Elsewhere they move the
+// caret, so an existing formula can be edited as text.
+function formulaPointModeActive() {
+  if (formulaPick?.picked) return true;
+  const start = cellEditor.selectionStart ?? cellEditor.value.length;
+  if (start !== (cellEditor.selectionEnd ?? start) || formulaCursorInQuote(cellEditor.value, start)) return false;
+  return /[=(,+\-*/^&<>]\s*$/.test(cellEditor.value.slice(0, start));
+}
 function insertFormulaComma() {
   const start = cellEditor.selectionStart ?? cellEditor.value.length, end = cellEditor.selectionEnd ?? start;
   clearFormulaPick();
@@ -3680,7 +3696,10 @@ function formulaReferenceBoundsAtCaret(value, caret) {
   return null;
 }
 function cycleReferenceToken(text) {
-  return text.replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,3})(\$?)([1-9]\d*)(?![A-Z0-9_])/gi, (match, fixedColumn, column, fixedRow, row) => {
+  // A sheet name such as `Q1` looks like a cell; only the endpoint after `!` cycles.
+  const bang = text.lastIndexOf("!");
+  const prefix = text.slice(0, bang + 1);
+  return prefix + text.slice(bang + 1).replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,3})(\$?)([1-9]\d*)(?![A-Z0-9_])/gi, (match, fixedColumn, column, fixedRow, row) => {
     const state = { column: !!fixedColumn, row: !!fixedRow };
     let next;
     if (!state.column && !state.row) next = { column: true, row: true };
@@ -3761,8 +3780,8 @@ function updatePickedFormulaRange(r1, c1, r2 = r1, c2 = c1, reset = false) {
       while (insertion > 1 && cellEditor.value[insertion - 1] === ")") insertion--;
       start = end = insertion;
     }
-    formulaPick = { textStart: start, textEnd: end, r1, c1, r2, c2 };
-  } else { formulaPick.r2 = r2; formulaPick.c2 = c2; }
+    formulaPick = { textStart: start, textEnd: end, r1, c1, r2, c2, picked: true };
+  } else { formulaPick.r2 = r2; formulaPick.c2 = c2; formulaPick.picked = true; }
   const reference = formulaRangeText(formulaPick.r1, formulaPick.c1, formulaPick.r2, formulaPick.c2);
   cellEditor.value = cellEditor.value.slice(0, formulaPick.textStart) + reference + cellEditor.value.slice(formulaPick.textEnd);
   formulaPick.textEnd = formulaPick.textStart + reference.length;
@@ -3844,8 +3863,10 @@ function formulaReferenceAtCell(row, column) {
   matches.sort((a, b) => (a.r2 - a.r1 + 1) * (a.c2 - a.c1 + 1) - (b.r2 - b.r1 + 1) * (b.c2 - b.c1 + 1));
   return matches[0] || null;
 }
+// `picked` marks a reference placed or chosen through the grid; a reference merely under the text
+// caret leaves the arrow keys to caret navigation.
 function activateFormulaReference(reference, moveCaret = true) {
-  formulaPick = { ...reference }; formulaPickGestureComplete = false;
+  formulaPick = { ...reference, picked: moveCaret }; formulaPickGestureComplete = false;
   if (moveCaret) {
     cellEditor.setSelectionRange(reference.textEnd, reference.textEnd);
     formulaInput.value = cellEditor.value; formulaInput.setSelectionRange(reference.textEnd, reference.textEnd);
@@ -4013,10 +4034,11 @@ function completeFormulaParentheses(value) {
   if (quote) return null;
   return value + ")".repeat(depth);
 }
+// Argument counts the evaluator accepts; a rule is omitted where any count evaluates.
 const FORMULA_ARGUMENT_RULES = {
   VLOOKUP: [3, 4], HLOOKUP: [3, 4], INDEX: [2, 3], MATCH: [2, 3],
-  IF: [2, 3], IFERROR: [2, 2], IFNA: [2, 2], COUNTIF: [2, 2], SUMIF: [2, 3], AVERAGEIF: [2, 3],
-  HYPERLINK: [1, 2], LEFT: [1, 2], RIGHT: [1, 2], MID: [3, 3], ROUND: [2, 2],
+  IF: [2, 3], IFERROR: [1, 2], IFNA: [2, 2], COUNTIF: [2, 2], SUMIF: [2, 3], AVERAGEIF: [2, 3],
+  HYPERLINK: [1, 2], LEFT: [1, 2], RIGHT: [1, 2], MID: [3, 3], ROUND: [1, 2],
   DATE: [3, 3], DATEDIF: [3, 3], EDATE: [2, 2], CHOOSE: [2, Infinity],
 };
 function validateFormula(value) {
@@ -4114,13 +4136,13 @@ cellEditor.addEventListener("keydown", (e) => {
   if (cellEditor.value.startsWith("=") && e.key === "," && !formulaCursorInQuote(cellEditor.value, cellEditor.selectionStart)) {
     e.preventDefault(); insertFormulaComma(); e.stopPropagation(); return;
   }
-  if (cellEditor.value.startsWith("=") && e.key === "(") {
+  if (cellEditor.value.startsWith("=") && e.key === "(" && !formulaCursorInQuote(cellEditor.value, cellEditor.selectionStart)) {
     e.preventDefault(); clearFormulaPick();
     const start = cellEditor.selectionStart, end = cellEditor.selectionEnd;
     cellEditor.value = cellEditor.value.slice(0, start) + "()" + cellEditor.value.slice(end);
     cellEditor.setSelectionRange(start + 1, start + 1); formulaInput.value = cellEditor.value; syncEditorSize(); updateFormulaAssist(); e.stopPropagation(); return;
   }
-  if (cellEditor.value.startsWith("=") && e.key === ")" && cellEditor.value[cellEditor.selectionStart] === ")") {
+  if (cellEditor.value.startsWith("=") && e.key === ")" && cellEditor.value[cellEditor.selectionStart] === ")" && !formulaCursorInQuote(cellEditor.value, cellEditor.selectionStart)) {
     e.preventDefault();
     const next = cellEditor.selectionStart + 1;
     cellEditor.setSelectionRange(next, next);
@@ -4133,7 +4155,7 @@ cellEditor.addEventListener("keydown", (e) => {
     e.stopPropagation();
     return;
   }
-  if (!formulaAssistItems.length && cellEditor.value.startsWith("=") && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) {
+  if (!formulaAssistItems.length && cellEditor.value.startsWith("=") && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key) && formulaPointModeActive()) {
     e.preventDefault();
     const directions = { ArrowUp: [-1, 0], ArrowDown: [1, 0], ArrowLeft: [0, -1], ArrowRight: [0, 1] };
     moveFormulaPickByKeyboard(directions[e.key][0], directions[e.key][1], e.shiftKey); e.stopPropagation(); return;
@@ -4449,18 +4471,38 @@ gridScroll.addEventListener("paste", (e) => {
   pasteWithoutFormattingPending = false; clearTimeout(pasteModeTimer);
   pasteText(text, { keepFormatting });
 });
+// Applies `rewrite` to the parts of a formula outside string literals and quoted sheet names, so
+// text such as `="A1"` is never mistaken for a reference.
+function rewriteFormulaOutsideQuotes(value, rewrite) {
+  let result = value[0], segment = "", quote = null;
+  for (let index = 1; index < value.length; index++) {
+    const char = value[index];
+    if (quote) {
+      result += char;
+      if ((char === "\\" || char === quote) && value[index + 1] === quote) result += value[++index];
+      else if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") { result += rewrite(segment) + char; segment = ""; quote = char; }
+    else segment += char;
+  }
+  return result + rewrite(segment);
+}
 function shiftedCopyFormula(value, sourceRef, targetRef, isCut) {
   if (isCut || !value?.startsWith("=") || !sourceRef) return value;
   const source = parseRef(sourceRef), target = parseRef(targetRef);
   if (!source || !target) return value;
   const rowDelta = target.r - source.r, colDelta = target.c - source.c;
-  return value.replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,2})(\$?)([1-9]\d*)(?![A-Z0-9_])/gi, (match, fixedColumn, letters, fixedRow, rowText) => {
+  return rewriteFormulaOutsideQuotes(value, (segment) => segment.replace(/(?<![A-Z0-9_])(\$?)([A-Z]{1,2})(\$?)([1-9]\d*)(?![A-Z0-9_])/gi, (match, fixedColumn, letters, fixedRow, rowText) => {
     let row = Number(rowText) - 1, column = letterToCol(letters);
     if (!fixedRow) row += rowDelta;
     if (!fixedColumn) column += colDelta;
     if (row < 0 || column < 0) return "#REF!";
     return fixedColumn + colToLetter(column) + fixedRow + (row + 1);
-  });
+  }));
+}
+// A cut source is only removed while it still holds what was cut; an edit made in between wins.
+function cutSourceUnchanged(sheetId, snapshot) {
+  const current = model.cells[sheetId]?.[snapshot.sourceRef];
+  return (current?.value ?? null) === snapshot.value && JSON.stringify(current?.fmt ?? null) === JSON.stringify(snapshot.fmt ?? null);
 }
 function clearStoredCell(sheetId, ref) {
   const cells = model.cells[sheetId] || (model.cells[sheetId] = {});
@@ -4510,7 +4552,7 @@ function pasteText(text, { keepFormatting = true } = {}) {
   }
   if (useSnapshot && copyFallback.cut) {
     for (const row of copyFallback.cells) for (const snapshot of row) {
-      if (snapshot?.sourceRef && !destinationRefs.has(copyFallback.sheetId + "!" + snapshot.sourceRef)) clearStoredCell(copyFallback.sheetId, snapshot.sourceRef);
+      if (snapshot?.sourceRef && !destinationRefs.has(copyFallback.sheetId + "!" + snapshot.sourceRef) && cutSourceUnchanged(copyFallback.sheetId, snapshot)) clearStoredCell(copyFallback.sheetId, snapshot.sourceRef);
     }
     copyFallback = null; copyRange = null;
   }

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
@@ -106,6 +106,10 @@ export class Gadget extends DurableObject {
           rowHeights: incoming.rowHeights ?? existing.rowHeights,
           frozenRows: incoming.frozenRows ?? existing.frozenRows,
           frozenCols: incoming.frozenCols ?? existing.frozenCols,
+          filter: Object.prototype.hasOwnProperty.call(incoming, "filter") ? incoming.filter : existing.filter,
+          charts: Object.prototype.hasOwnProperty.call(incoming, "charts") ? incoming.charts : existing.charts,
+          comments: Object.prototype.hasOwnProperty.call(incoming, "comments") ? incoming.comments : existing.comments,
+          pivot: Object.prototype.hasOwnProperty.call(incoming, "pivot") ? incoming.pivot : existing.pivot,
         });
         if (!(await this.ctx.storage.get("cells:" + id))) {
           await this.ctx.storage.put("cells:" + id, {});
@@ -301,7 +305,90 @@ function sheetMeta(s) {
     rowHeights: sanitizeDims(s.rowHeights),
     frozenRows: clampInt(s.frozenRows, 0, 50, 0),
     frozenCols: clampInt(s.frozenCols, 0, 50, 0),
+    filter: sanitizeFilter(s.filter, clampInt(s.rows, 1, 50000, DEFAULT_ROWS), clampInt(s.cols, 1, 702, DEFAULT_COLS)),
+    charts: sanitizeCharts(s.charts),
+    comments: sanitizeComments(s.comments),
+    pivot: sanitizePivot(s.pivot),
   };
+}
+
+function sanitizePivot(pivot) {
+  if (!pivot || typeof pivot !== "object") return null;
+  const aggregates = new Set(["sum", "count", "average", "min", "max"]);
+  return {
+    sourceSheetId: String(pivot.sourceSheetId || "").slice(0, 80),
+    sourceRange: /^([A-Z]+[1-9]\d*):([A-Z]+[1-9]\d*)$/.test(String(pivot.sourceRange || "").toUpperCase()) ? String(pivot.sourceRange).toUpperCase() : "",
+    rowField: String(pivot.rowField || "").slice(0, 200),
+    columnField: String(pivot.columnField || "").slice(0, 200),
+    valueField: String(pivot.valueField || "").slice(0, 200),
+    aggregate: aggregates.has(pivot.aggregate) ? pivot.aggregate : "sum",
+    showRowTotals: pivot.showRowTotals !== false,
+    showColumnTotals: pivot.showColumnTotals !== false,
+    filterField: String(pivot.filterField || "").slice(0, 200),
+    filterValues: Array.isArray(pivot.filterValues)
+      ? [...new Set(pivot.filterValues.map((value) => String(value).slice(0, 1000)))].slice(0, 500)
+      : (pivot.filterValue ? [String(pivot.filterValue).slice(0, 1000)] : []),
+  };
+}
+
+function sanitizeComments(comments) {
+  if (!Array.isArray(comments)) return [];
+  return comments.slice(0, 2000).map((comment, index) => ({
+    id: String(comment?.id || "comment_" + index).slice(0, 80),
+    ref: /^[A-Z]+[1-9]\d*$/.test(String(comment?.ref || "").toUpperCase()) ? String(comment.ref).toUpperCase() : "A1",
+    text: String(comment?.text || "").slice(0, 4000),
+    createdAt: Math.max(0, Math.round(Number(comment?.createdAt)) || Date.now()),
+    resolved: comment?.resolved === true,
+  })).filter((comment) => comment.text.trim());
+}
+
+function sanitizeCharts(charts) {
+  if (!Array.isArray(charts)) return [];
+  return charts.slice(0, 50).map((chart, index) => ({
+    id: String(chart?.id || "chart_" + index).slice(0, 80),
+    type: ["line", "pie", "area", "stackedBar"].includes(chart?.type) ? chart.type : "line",
+    range: /^([A-Z]+[1-9]\d*)(:([A-Z]+[1-9]\d*))?$/.test(String(chart?.range || "").toUpperCase()) ? String(chart.range).toUpperCase() : "",
+    title: String(chart?.title || "").slice(0, 200),
+    xAxisTitle: String(chart?.xAxisTitle || "").slice(0, 120),
+    yAxisTitle: String(chart?.yAxisTitle || "").slice(0, 120),
+    legend: chart?.legend !== false,
+    firstRowHeaders: chart?.firstRowHeaders !== false,
+    firstColLabels: chart?.firstColLabels !== false,
+    smooth: chart?.smooth === true,
+    x: clampInt(chart?.x, 48, 5000, 96),
+    y: clampInt(chart?.y, 28, 5000, 44),
+    width: clampInt(chart?.width, 280, 1200, 520),
+    height: clampInt(chart?.height, 200, 900, 320),
+  }));
+}
+
+function sanitizeFilter(filter, rows, cols) {
+  if (!filter || typeof filter !== "object") return null;
+  const row = clampInt(filter.row, 0, Math.max(0, rows - 1), 0);
+  const criteria = {};
+  if (filter.criteria && typeof filter.criteria === "object") {
+    for (const [column, values] of Object.entries(filter.criteria)) {
+      if (!/^\d+$/.test(column)) continue;
+      const col = Number(column);
+      if (col < 0 || col >= cols || !Array.isArray(values)) continue;
+      const clean = [...new Set(values.map((value) => String(value).slice(0, 8192)))].slice(0, 500);
+      if (clean.length) criteria[col] = clean;
+    }
+  }
+  const endRow = clampInt(filter.endRow, row, Math.max(row, rows - 1), rows - 1);
+  const columns = Array.isArray(filter.columns)
+    ? [...new Set(filter.columns.map(Number).filter((column) => Number.isInteger(column) && column >= 0 && column < cols))].slice(0, cols)
+    : Array.from({ length: cols }, (_, column) => column);
+  const expectedRows = Math.max(0, endRow - row);
+  const incomingOrder = Array.isArray(filter.rowOrder) ? filter.rowOrder.map(Number) : [];
+  const rowOrder = incomingOrder.length === expectedRows && incomingOrder.every(Number.isFinite)
+    ? incomingOrder.map((value) => Math.round(value))
+    : Array.from({ length: expectedRows }, (_, index) => row + 1 + index);
+  const sortColumn = Number(filter.sort?.column);
+  const sort = Number.isInteger(sortColumn) && columns.includes(sortColumn) && (filter.sort?.direction === "asc" || filter.sort?.direction === "desc")
+    ? { column: sortColumn, direction: filter.sort.direction }
+    : null;
+  return { row, endRow, columns, criteria, rowOrder, sort };
 }
 
 const FMT_KEYS = new Set(["b", "i", "u", "s", "c", "bg", "a", "nf", "d", "fs", "wrap"]);

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
@@ -111,6 +111,14 @@ export class Gadget extends DurableObject {
           comments: Object.prototype.hasOwnProperty.call(incoming, "comments") ? incoming.comments : existing.comments,
           pivot: Object.prototype.hasOwnProperty.call(incoming, "pivot") ? incoming.pivot : existing.pivot,
         });
+      }
+      // A pivot's range lives on its source sheet, which may appear later in the order.
+      for (const sheet of Object.values(nextSheets)) {
+        if (!sheet.pivot) continue;
+        const source = nextSheets[sheet.pivot.sourceSheetId];
+        sheet.pivot.sourceRange = source ? sanitizeRange(sheet.pivot.sourceRange, source.rows, source.cols, false) : "";
+      }
+      for (const id of order) {
         if (!(await this.ctx.storage.get("cells:" + id))) {
           await this.ctx.storage.put("cells:" + id, {});
         }
@@ -283,6 +291,21 @@ function clampInt(v, lo, hi, dflt) {
   return Math.max(lo, Math.min(hi, n));
 }
 
+// Clients walk chart and pivot ranges cell by cell, so a range outside the sheet or beyond this
+// many cells would hang every client that opens the workbook. It is clamped to the sheet and
+// rejected (empty) when still too large.
+const MAX_RANGE_CELLS = 200000;
+function sanitizeRange(text, rows, cols, allowSingle) {
+  const match = /^([A-Z]+)([1-9]\d*)(?::([A-Z]+)([1-9]\d*))?$/.exec(String(text || "").toUpperCase());
+  if (!match || (!match[3] && !allowSingle)) return "";
+  const first = parseCsvCellRef(match[1] + match[2]);
+  const last = match[3] ? parseCsvCellRef(match[3] + match[4]) : first;
+  const top = Math.min(first.row, last.row), left = Math.min(first.column, last.column);
+  const bottom = Math.min(Math.max(first.row, last.row), rows - 1), right = Math.min(Math.max(first.column, last.column), cols - 1);
+  if (top > bottom || left > right || (bottom - top + 1) * (right - left + 1) > MAX_RANGE_CELLS) return "";
+  return csvCellRef(top, left) + (match[3] ? ":" + csvCellRef(bottom, right) : "");
+}
+
 function sanitizeDims(dims) {
   const out = {};
   if (dims && typeof dims === "object") {
@@ -296,17 +319,18 @@ function sanitizeDims(dims) {
 }
 
 function sheetMeta(s) {
+  const rows = clampInt(s.rows, 1, 50000, DEFAULT_ROWS), cols = clampInt(s.cols, 1, 702, DEFAULT_COLS);
   return {
     id: String(s.id),
     name: String(s.name || "Sheet").slice(0, 60),
-    rows: clampInt(s.rows, 1, 50000, DEFAULT_ROWS),
-    cols: clampInt(s.cols, 1, 702, DEFAULT_COLS),
+    rows,
+    cols,
     colWidths: sanitizeDims(s.colWidths),
     rowHeights: sanitizeDims(s.rowHeights),
     frozenRows: clampInt(s.frozenRows, 0, 50, 0),
     frozenCols: clampInt(s.frozenCols, 0, 50, 0),
-    filter: sanitizeFilter(s.filter, clampInt(s.rows, 1, 50000, DEFAULT_ROWS), clampInt(s.cols, 1, 702, DEFAULT_COLS)),
-    charts: sanitizeCharts(s.charts),
+    filter: sanitizeFilter(s.filter, rows, cols),
+    charts: sanitizeCharts(s.charts, rows, cols),
     comments: sanitizeComments(s.comments),
     pivot: sanitizePivot(s.pivot),
   };
@@ -317,6 +341,7 @@ function sanitizePivot(pivot) {
   const aggregates = new Set(["sum", "count", "average", "min", "max"]);
   return {
     sourceSheetId: String(pivot.sourceSheetId || "").slice(0, 80),
+    // Shape only; applyOperationLocked bounds it against the source sheet.
     sourceRange: /^([A-Z]+[1-9]\d*):([A-Z]+[1-9]\d*)$/.test(String(pivot.sourceRange || "").toUpperCase()) ? String(pivot.sourceRange).toUpperCase() : "",
     rowField: String(pivot.rowField || "").slice(0, 200),
     columnField: String(pivot.columnField || "").slice(0, 200),
@@ -342,12 +367,12 @@ function sanitizeComments(comments) {
   })).filter((comment) => comment.text.trim());
 }
 
-function sanitizeCharts(charts) {
+function sanitizeCharts(charts, rows, cols) {
   if (!Array.isArray(charts)) return [];
   return charts.slice(0, 50).map((chart, index) => ({
     id: String(chart?.id || "chart_" + index).slice(0, 80),
     type: ["line", "pie", "area", "stackedBar"].includes(chart?.type) ? chart.type : "line",
-    range: /^([A-Z]+[1-9]\d*)(:([A-Z]+[1-9]\d*))?$/.test(String(chart?.range || "").toUpperCase()) ? String(chart.range).toUpperCase() : "",
+    range: sanitizeRange(chart?.range, rows, cols, true),
     title: String(chart?.title || "").slice(0, 200),
     xAxisTitle: String(chart?.xAxisTitle || "").slice(0, 120),
     yAxisTitle: String(chart?.yAxisTitle || "").slice(0, 120),

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
@@ -351,9 +351,11 @@ function sanitizePivot(pivot) {
     showRowTotals: pivot.showRowTotals !== false,
     showColumnTotals: pivot.showColumnTotals !== false,
     filterField: String(pivot.filterField || "").slice(0, 8192),
-    filterValues: Array.isArray(pivot.filterValues)
-      ? [...new Set(pivot.filterValues.map((value) => String(value).slice(0, 1000)))].slice(0, 500)
-      : (pivot.filterValue ? [String(pivot.filterValue).slice(0, 1000)] : []),
+    // Compared exactly to cell values, so they keep the cell limit; an oversized set is dropped
+    // whole rather than trimmed into a different filter.
+    filterValues: ((values) => values.length <= MAX_FILTER_SELECTIONS ? values : [])(Array.isArray(pivot.filterValues)
+      ? [...new Set(pivot.filterValues.map((value) => String(value).slice(0, 8192)))]
+      : (pivot.filterValue ? [String(pivot.filterValue).slice(0, 8192)] : [])),
   };
 }
 

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/server.js
@@ -343,13 +343,14 @@ function sanitizePivot(pivot) {
     sourceSheetId: String(pivot.sourceSheetId || "").slice(0, 80),
     // Shape only; applyOperationLocked bounds it against the source sheet.
     sourceRange: /^([A-Z]+[1-9]\d*):([A-Z]+[1-9]\d*)$/.test(String(pivot.sourceRange || "").toUpperCase()) ? String(pivot.sourceRange).toUpperCase() : "",
-    rowField: String(pivot.rowField || "").slice(0, 200),
-    columnField: String(pivot.columnField || "").slice(0, 200),
-    valueField: String(pivot.valueField || "").slice(0, 200),
+    // Fields are keyed by their header cell's text, so they share the cell value limit.
+    rowField: String(pivot.rowField || "").slice(0, 8192),
+    columnField: String(pivot.columnField || "").slice(0, 8192),
+    valueField: String(pivot.valueField || "").slice(0, 8192),
     aggregate: aggregates.has(pivot.aggregate) ? pivot.aggregate : "sum",
     showRowTotals: pivot.showRowTotals !== false,
     showColumnTotals: pivot.showColumnTotals !== false,
-    filterField: String(pivot.filterField || "").slice(0, 200),
+    filterField: String(pivot.filterField || "").slice(0, 8192),
     filterValues: Array.isArray(pivot.filterValues)
       ? [...new Set(pivot.filterValues.map((value) => String(value).slice(0, 1000)))].slice(0, 500)
       : (pivot.filterValue ? [String(pivot.filterValue).slice(0, 1000)] : []),
@@ -386,6 +387,7 @@ function sanitizeCharts(charts, rows, cols) {
     height: clampInt(chart?.height, 200, 900, 320),
   }));
 }
+const MAX_FILTER_SELECTIONS = 500; // the client's filter menu refuses larger selections
 
 function sanitizeFilter(filter, rows, cols) {
   if (!filter || typeof filter !== "object") return null;
@@ -396,8 +398,10 @@ function sanitizeFilter(filter, rows, cols) {
       if (!/^\d+$/.test(column)) continue;
       const col = Number(column);
       if (col < 0 || col >= cols || !Array.isArray(values)) continue;
-      const clean = [...new Set(values.map((value) => String(value).slice(0, 8192)))].slice(0, 500);
-      if (clean.length) criteria[col] = clean;
+      // Trimming a selection would change which rows it hides; an oversized one is dropped whole.
+      // (Values are compared to cell values, which the server caps at 8,192 characters.)
+      const clean = [...new Set(values.map((value) => String(value).slice(0, 8192)))];
+      if (clean.length && clean.length <= MAX_FILTER_SELECTIONS) criteria[col] = clean;
     }
   }
   const endRow = clampInt(filter.endRow, row, Math.max(row, rows - 1), rows - 1);

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/xlsx.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/xlsx.js
@@ -440,7 +440,8 @@ function literalFilterToken(value) {
 
 // Sorting in the grid reorders the stored cells, so only the header row, the criteria and the sort
 // indicator need exporting. Rows are hidden by the literal values in the criteria columns; a row
-// whose criteria cell holds a formula stays visible, since formulas are not evaluated here.
+// whose criteria cell holds a formula stays visible, since formulas are not evaluated here - unless
+// the column selects nothing (`x:` tokens only), which no value can pass.
 function prepareFilter(sheet) {
   const filter = sheet.metadata.filter;
   if (!filter || typeof filter !== "object") return null;
@@ -458,7 +459,7 @@ function prepareFilter(sheet) {
   for (const [key, tokens] of Object.entries(source)) {
     const column = /^(0|[1-9]\d*)$/.test(key) ? Number(key) : null;
     if (column == null || !columns.includes(column) || !Array.isArray(tokens) || !tokens.length) continue;
-    const criterion = {tokens: new Set(tokens), values: [], blank: false};
+    const criterion = {tokens: new Set(tokens), values: [], blank: false, selectsNothing: tokens.every(token => typeof token === "string" && token.startsWith("x:"))};
     for (const token of tokens) {
       const parsed = filterCriterion(token);
       if (parsed?.blank) criterion.blank = true;
@@ -479,7 +480,7 @@ function prepareFilter(sheet) {
         const cell = sheet.sourceCells[columnName(column + 1) + (row + 1)];
         const value = cell && typeof cell === "object" && cell.value != null ? String(cell.value) : "";
         const token = literalFilterToken(value);
-        if (token != null && !criterion.tokens.has(token)) {
+        if (criterion.selectsNothing || (token != null && !criterion.tokens.has(token))) {
           hiddenRows.push(row + 1);
           break;
         }
@@ -536,6 +537,17 @@ function anchorPosition(pixels, sizes, defaultPixels, maximum) {
   }
 }
 
+// The grid's chartData() drops a column with no numeric value before building its series. Only
+// literals can be judged here, so a column is usable when it holds a number or a formula.
+function usableSeriesColumns(sheet, range, firstColumn) {
+  const usable = new Set();
+  for (const cell of sheet.cells) {
+    if (cell.column < firstColumn || cell.column > range.lastColumn || cell.row < range.firstRow || cell.row > range.lastRow) continue;
+    if (cell.value[0] === "=" || parsedCellValue(cell.value, null).type === "number") usable.add(cell.column);
+  }
+  return [...usable].sort((a, b) => a - b);
+}
+
 // Mirrors the grid's chartData(): with header and label rows on, each remaining column is a series
 // named by its first cell, categorized by the first column. Charts without a usable range are
 // skipped, as the grid draws only a placeholder for them.
@@ -552,7 +564,8 @@ function prepareCharts(sheet) {
     const seriesColumn = range.firstColumn + (firstColumnLabels && range.lastColumn > range.firstColumn ? 1 : 0);
     if (dataRow > range.lastRow || seriesColumn > range.lastColumn) continue;
     const type = CHART_TYPES.has(chart.type) ? chart.type : "line";
-    const seriesCount = Math.min(type === "pie" ? 1 : MAX_SERIES, range.lastColumn - seriesColumn + 1);
+    const columns = usableSeriesColumns(sheet, {...range, firstRow: dataRow}, seriesColumn).slice(0, type === "pie" ? 1 : MAX_SERIES);
+    if (!columns.length) continue;
     const width = count(chart.width, 520, 1200);
     const height = count(chart.height, 320, 900);
     charts.push({
@@ -565,7 +578,7 @@ function prepareCharts(sheet) {
       categoryColumn: seriesColumn > range.firstColumn ? range.firstColumn : null,
       firstRow: dataRow,
       lastRow: range.lastRow,
-      columns: Array.from({length: seriesCount}, (_, index) => seriesColumn + index),
+      columns,
       column: anchorPosition(Number(chart.x ?? 96) - ROW_HEADER_PIXELS, sheet.metadata.colWidths, DEFAULT_COLUMN_PIXELS, MAX_COLUMNS),
       row: anchorPosition(Number(chart.y ?? 44) - COLUMN_HEADER_PIXELS, sheet.metadata.rowHeights, DEFAULT_ROW_PIXELS, MAX_ROWS),
       extent: {cx: width * EMU_PER_PIXEL, cy: height * EMU_PER_PIXEL},

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/xlsx.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/xlsx.js
@@ -4,6 +4,9 @@ const encoder = new TextEncoder();
 const MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
 const REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 const PACKAGE_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships";
+const DRAWING_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
+const SPREADSHEET_DRAWING_NS = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+const CHART_NS = "http://schemas.openxmlformats.org/drawingml/2006/chart";
 const MAX_ROWS = 1048576;
 const MAX_COLUMNS = 16384;
 const DEFAULT_ROWS = 100;
@@ -15,6 +18,18 @@ const MAX_FILLS = 256;
 const MAX_CELL_FORMATS = 65490;
 const MAX_FORMULA_CHARACTERS = 8192;
 const TEXT_CHUNK_SIZE = 64 * 1024;
+const MAX_SERIES = 255;
+const MAX_HYPERLINKS = 65530;
+const MAX_HYPERLINK_CHARACTERS = 2079;
+const MAX_COMMENT_CHARACTERS = 32767;
+const EMU_PER_PIXEL = 9525;
+// The grid positions charts over its scroll area, so stored coordinates include the row-header
+// column and the column-header row.
+const ROW_HEADER_PIXELS = 44;
+const COLUMN_HEADER_PIXELS = 22;
+const CHART_TYPES = new Set(["line", "area", "pie", "stackedBar"]);
+const CHART_COLORS = ["E1632E", "3478C7", "1F9D77", "8B5FBF", "C49324", "C4566A"];
+const HYPERLINK_FMT = {c: "#1967d2", u: true};
 const FUTURE_FUNCTIONS = new Set([
   "CONCAT", "DAYS", "IFNA", "IFS", "SWITCH", "TEXTJOIN", "UNICHAR", "UNICODE", "XOR",
 ]);
@@ -69,6 +84,13 @@ function formulaXml(value) {
 function xmlAttribute(value) {
   return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;")
     .replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+// DrawingML text has no `_xHHHH_` escapes: characters XML 1.0 forbids are dropped instead.
+function plainXml(value) {
+  return String(value).replace(/[\0-\x08\x0b\x0c\x0e-\x1f\ufffe\uffff]/g, "")
+    .replace(/[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/g, "\ufffd")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 // Encodes a string generator into ~64 KiB byte chunks. Cell-sized chunks would make the ZIP's
@@ -374,6 +396,197 @@ function sourceSheets(document) {
   return result;
 }
 
+function integerIn(value, minimum, maximum) {
+  const number = Number(value);
+  return Number.isInteger(number) && number >= minimum && number <= maximum ? number : null;
+}
+
+function parseRangeReference(value) {
+  const match = /^([A-Z]+[1-9]\d*)(?::([A-Z]+[1-9]\d*))?$/.exec(typeof value === "string" ? value : "");
+  const first = match && parseCellReference(match[1]);
+  const last = match && parseCellReference(match[2] ?? match[1]);
+  if (!first || !last) return null;
+  return {
+    firstRow: Math.min(first.row, last.row), lastRow: Math.max(first.row, last.row),
+    firstColumn: Math.min(first.column, last.column), lastColumn: Math.max(first.column, last.column),
+  };
+}
+
+function absoluteReference(sheetName, firstColumn, firstRow, lastColumn, lastRow) {
+  const first = `$${columnName(firstColumn)}$${firstRow}`;
+  const last = `$${columnName(lastColumn)}$${lastRow}`;
+  return `'${sheetName.replace(/'/g, "''")}'!${first}${first === last ? "" : ":" + last}`;
+}
+
+// The grid's filter criteria are tokens of its computed values: `s:` text, `n:` number, `b:1`/`b:0`
+// booleans, `e:` an error code, `z:` blank, and `x:__none__` when nothing was selected.
+function filterCriterion(token) {
+  if (typeof token !== "string") return null;
+  const kind = token.slice(0, 2);
+  const text = token.slice(2);
+  if (kind === "z:") return {blank: true};
+  if (kind === "b:") return {value: text === "1" ? "TRUE" : "FALSE"};
+  return kind === "s:" || kind === "n:" || kind === "e:" ? {value: text} : null;
+}
+
+// The token the grid derives from a literal cell, or null for a formula, whose value it computes.
+function literalFilterToken(value) {
+  if (value[0] === "=") return null;
+  const parsed = parsedCellValue(value, null);
+  if (parsed.type === "blank") return "z:";
+  if (parsed.type === "boolean") return parsed.value ? "b:1" : "b:0";
+  return (parsed.type === "number" ? "n:" : "s:") + String(parsed.value);
+}
+
+// Sorting in the grid reorders the stored cells, so only the header row, the criteria and the sort
+// indicator need exporting. Rows are hidden by the literal values in the criteria columns; a row
+// whose criteria cell holds a formula stays visible, since formulas are not evaluated here.
+function prepareFilter(sheet) {
+  const filter = sheet.metadata.filter;
+  if (!filter || typeof filter !== "object") return null;
+  const headerRow = integerIn(filter.row, 0, MAX_ROWS - 1);
+  const endRow = headerRow == null ? null : integerIn(filter.endRow, headerRow, MAX_ROWS - 1);
+  const columns = Array.isArray(filter.columns)
+    ? [...new Set(filter.columns.map(column => integerIn(column, 0, MAX_COLUMNS - 1)))]
+      .filter(column => column != null).sort((a, b) => a - b)
+    : [];
+  if (endRow == null || !columns.length) return null;
+  const first = columns[0];
+  const last = columns[columns.length - 1];
+  const criteria = new Map();
+  const source = filter.criteria && typeof filter.criteria === "object" ? filter.criteria : {};
+  for (const [key, tokens] of Object.entries(source)) {
+    const column = /^(0|[1-9]\d*)$/.test(key) ? Number(key) : null;
+    if (column == null || !columns.includes(column) || !Array.isArray(tokens) || !tokens.length) continue;
+    const criterion = {tokens: new Set(tokens), values: [], blank: false};
+    for (const token of tokens) {
+      const parsed = filterCriterion(token);
+      if (parsed?.blank) criterion.blank = true;
+      else if (parsed) criterion.values.push(parsed.value);
+    }
+    criteria.set(column, criterion);
+  }
+  const filterColumns = [];
+  for (let column = first; column <= last; ++column) {
+    const criterion = criteria.get(column);
+    if (!columns.includes(column)) filterColumns.push({offset: column - first, hiddenButton: true});
+    else if (criterion?.values.length || criterion?.blank) filterColumns.push({offset: column - first, ...criterion});
+  }
+  const hiddenRows = [];
+  if (criteria.size) {
+    for (let row = headerRow + 1; row <= endRow; ++row) {
+      for (const [column, criterion] of criteria) {
+        const cell = sheet.sourceCells[columnName(column + 1) + (row + 1)];
+        const value = cell && typeof cell === "object" && cell.value != null ? String(cell.value) : "";
+        const token = literalFilterToken(value);
+        if (token != null && !criterion.tokens.has(token)) {
+          hiddenRows.push(row + 1);
+          break;
+        }
+      }
+    }
+  }
+  const sortColumn = filter.sort && typeof filter.sort === "object" ? integerIn(filter.sort.column, 0, MAX_COLUMNS - 1) : null;
+  const direction = filter.sort?.direction;
+  const sort = sortColumn != null && columns.includes(sortColumn) && endRow > headerRow &&
+      (direction === "asc" || direction === "desc")
+    ? {
+        ref: `${columnName(first + 1)}${headerRow + 2}:${columnName(last + 1)}${endRow + 1}`,
+        column: `${columnName(sortColumn + 1)}${headerRow + 2}:${columnName(sortColumn + 1)}${endRow + 1}`,
+        descending: direction === "desc",
+      }
+    : null;
+  return {
+    ref: `${columnName(first + 1)}${headerRow + 1}:${columnName(last + 1)}${endRow + 1}`,
+    definedName: absoluteReference(sheet.name, first + 1, headerRow + 1, last + 1, endRow + 1),
+    columns: filterColumns,
+    hiddenRows,
+    sort,
+  };
+}
+
+// Resolved comments are hidden in the grid, so only open ones export. Excel allows one note per
+// cell; several comments on a cell are joined.
+function prepareComments(sheet) {
+  const source = Array.isArray(sheet.metadata.comments) ? sheet.metadata.comments : [];
+  const byReference = new Map();
+  for (const comment of source) {
+    if (!comment || typeof comment !== "object" || comment.resolved === true ||
+        typeof comment.text !== "string" || !comment.text.trim()) continue;
+    const position = typeof comment.ref === "string" ? parseCellReference(comment.ref) : null;
+    if (!position) continue;
+    const existing = byReference.get(comment.ref);
+    if (existing) existing.text = (existing.text + "\n\n" + comment.text).slice(0, MAX_COMMENT_CHARACTERS);
+    else byReference.set(comment.ref, {reference: comment.ref, ...position, text: comment.text.slice(0, MAX_COMMENT_CHARACTERS)});
+  }
+  return [...byReference.values()].sort((a, b) => a.row - b.row || a.column - b.column);
+}
+
+// Walks the grid's pixel sizes to the cell under `pixels`, for a drawing anchor.
+function anchorPosition(pixels, sizes, defaultPixels, maximum) {
+  const source = sizes && typeof sizes === "object" ? sizes : {};
+  let index = 0;
+  // The grid stores positions up to 5000px; anything else is malformed and lands at the origin.
+  let remaining = Number.isFinite(pixels) && pixels <= 5000 ? Math.max(0, Math.round(pixels)) : 0;
+  for (;;) {
+    const size = pixelDimension(source[index]) ?? defaultPixels;
+    if (remaining < size || index >= maximum - 1) return {index, offset: Math.min(remaining, size - 1) * EMU_PER_PIXEL};
+    remaining -= size;
+    ++index;
+  }
+}
+
+// Mirrors the grid's chartData(): with header and label rows on, each remaining column is a series
+// named by its first cell, categorized by the first column. Charts without a usable range are
+// skipped, as the grid draws only a placeholder for them.
+function prepareCharts(sheet) {
+  const source = Array.isArray(sheet.metadata.charts) ? sheet.metadata.charts : [];
+  const charts = [];
+  for (const chart of source) {
+    if (!chart || typeof chart !== "object") continue;
+    const range = parseRangeReference(chart.range);
+    if (!range) continue;
+    const firstRowHeaders = chart.firstRowHeaders !== false;
+    const firstColumnLabels = chart.firstColLabels !== false;
+    const dataRow = range.firstRow + (firstRowHeaders && range.lastRow > range.firstRow ? 1 : 0);
+    const seriesColumn = range.firstColumn + (firstColumnLabels && range.lastColumn > range.firstColumn ? 1 : 0);
+    if (dataRow > range.lastRow || seriesColumn > range.lastColumn) continue;
+    const type = CHART_TYPES.has(chart.type) ? chart.type : "line";
+    const seriesCount = Math.min(type === "pie" ? 1 : MAX_SERIES, range.lastColumn - seriesColumn + 1);
+    const width = count(chart.width, 520, 1200);
+    const height = count(chart.height, 320, 900);
+    charts.push({
+      type,
+      title: typeof chart.title === "string" ? chart.title : "",
+      xAxisTitle: typeof chart.xAxisTitle === "string" ? chart.xAxisTitle : "",
+      yAxisTitle: typeof chart.yAxisTitle === "string" ? chart.yAxisTitle : "",
+      legend: chart.legend !== false,
+      headerRow: firstRowHeaders && range.lastRow > range.firstRow ? range.firstRow : null,
+      categoryColumn: seriesColumn > range.firstColumn ? range.firstColumn : null,
+      firstRow: dataRow,
+      lastRow: range.lastRow,
+      columns: Array.from({length: seriesCount}, (_, index) => seriesColumn + index),
+      column: anchorPosition(Number(chart.x ?? 96) - ROW_HEADER_PIXELS, sheet.metadata.colWidths, DEFAULT_COLUMN_PIXELS, MAX_COLUMNS),
+      row: anchorPosition(Number(chart.y ?? 44) - COLUMN_HEADER_PIXELS, sheet.metadata.rowHeights, DEFAULT_ROW_PIXELS, MAX_ROWS),
+      extent: {cx: width * EMU_PER_PIXEL, cy: height * EMU_PER_PIXEL},
+    });
+  }
+  return charts;
+}
+
+// The grid links any literal whose text is an absolute http(s) URL, unless formatted as text.
+function hyperlinkTarget(value, fmt) {
+  const text = value[0] === "'" ? value.slice(1) : value;
+  if (fmt?.nf === "text" || !/^\s*https?:/i.test(text)) return null;
+  try {
+    const url = new URL(text);
+    const external = url.protocol === "http:" || url.protocol === "https:";
+    return external && url.href.length <= MAX_HYPERLINK_CHARACTERS ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
 function prepareWorkbook(document) {
   const sheets = sourceSheets(document);
   const formulaNames = new Map();
@@ -382,6 +595,7 @@ function prepareWorkbook(document) {
     if (!formulaNames.has(key)) formulaNames.set(key, sheet.name);
   }
   const styles = new Styles();
+  const parts = {drawings: 0, charts: 0, comments: 0, vmlShapeBlocks: 0};
   for (const sheet of sheets) {
     sheet.rows = count(sheet.metadata.rows, DEFAULT_ROWS, MAX_ROWS);
     sheet.columns = count(sheet.metadata.cols, DEFAULT_COLUMNS, MAX_COLUMNS);
@@ -390,18 +604,46 @@ function prepareWorkbook(document) {
     sheet.columnWidths = dimensions(sheet.metadata.colWidths, sheet.columns, columnWidth);
     sheet.rowHeights = dimensions(sheet.metadata.rowHeights, sheet.rows, rowPoints);
     sheet.cells = [];
+    sheet.hyperlinks = [];
     for (const [reference, sourceCell] of Object.entries(sheet.sourceCells)) {
       const position = parseCellReference(reference);
       if (!position || !sourceCell || typeof sourceCell !== "object") continue;
-      const style = styles.style(sourceCell.fmt);
       const value = sourceCell.value == null ? "" : String(sourceCell.value);
+      const target = sheet.hyperlinks.length < MAX_HYPERLINKS ? hyperlinkTarget(value, sourceCell.fmt) : null;
+      if (target) sheet.hyperlinks.push({reference, ...position, target, relationshipId: `rId${sheet.hyperlinks.length + 1}`});
+      const style = styles.style(target ? {...sourceCell.fmt, ...HYPERLINK_FMT} : sourceCell.fmt);
       if (value === "" && !style) continue;
       sheet.cells.push({reference, ...position, value, style});
     }
+    sheet.filter = prepareFilter(sheet);
+    sheet.hiddenRows = sheet.filter?.hiddenRows ?? [];
     delete sheet.sourceCells;
     sheet.cells.sort((a, b) => a.row - b.row || a.column - b.column);
+    sheet.hyperlinks.sort((a, b) => a.row - b.row || a.column - b.column);
+
+    let relationships = sheet.hyperlinks.length;
+    const charts = prepareCharts(sheet);
+    if (charts.length) {
+      sheet.drawing = {
+        index: ++parts.drawings,
+        relationshipId: `rId${++relationships}`,
+        charts: charts.map(chart => ({...chart, index: ++parts.charts})),
+      };
+    }
+    const comments = prepareComments(sheet);
+    if (comments.length) {
+      sheet.comments = {
+        index: ++parts.comments,
+        vmlRelationshipId: `rId${++relationships}`,
+        relationshipId: `rId${++relationships}`,
+        // VML shape ids are allotted in blocks of 1024 per `o:idmap` entry, unique across the workbook.
+        firstShapeBlock: parts.vmlShapeBlocks + 1,
+        list: comments,
+      };
+      parts.vmlShapeBlocks += Math.ceil(comments.length / 1024);
+    }
   }
-  return {sheets, styles, formulaNames};
+  return {sheets, styles, formulaNames, parts};
 }
 
 function formulaReferenceAt(formula, offset) {
@@ -483,53 +725,82 @@ function formulaFunctionAt(formula, offset) {
   return parenthesis > end ? {end: parenthesis, text: formula.slice(offset, end)} : null;
 }
 
-// Rewrites sheet and function names for Excel. Returns null when the formula is unbalanced
-// (unterminated string or quoted name, mismatched parentheses or brackets): the grid's parser
-// tolerates those, but one such `<f>` makes Excel report the whole workbook as damaged.
+// Mirrors the grid's tokenizer: inside a string a doubled quote, or a backslash before the quote,
+// is a literal quote. Emits the Excel form (double quotes, doubled inside) or null when unterminated.
+function stringLiteralAt(formula, offset) {
+  const quote = formula[offset];
+  let text = "";
+  for (let i = offset + 1; i < formula.length; ++i) {
+    const character = formula[i];
+    const escaped = formula[i + 1] === quote && (character === quote || character === "\\");
+    if (escaped) {
+      text += quote;
+      ++i;
+    } else if (character === quote) {
+      return {end: i + 1, text: `"${text.replace(/"/g, '""')}"`};
+    } else {
+      text += character;
+    }
+  }
+  return null;
+}
+
+// The grid reads a single-quoted run as a sheet name only when its closing quote is followed by
+// `!`; any other run is a string literal. A run followed by `:` is also left alone here so an
+// Excel 3-D reference such as 'Jan':'Mar'!A1 survives verbatim (see isThreeDimensionalReference).
+function quotedSheetNameAt(formula, offset) {
+  for (let i = offset + 1; i < formula.length; ++i) {
+    if (formula[i] !== "'") continue;
+    if (formula[i + 1] === "'") {
+      ++i;
+      continue;
+    }
+    return formula[i + 1] === "!" || formula[i + 1] === ":";
+  }
+  return false;
+}
+
+// Rewrites strings, sheet names and function names for Excel. Returns null when the formula is
+// unbalanced (unterminated string or quoted name, mismatched parentheses or brackets): the grid's
+// parser tolerates those, but one such `<f>` makes Excel report the whole workbook as damaged.
 function rewriteFormula(formula, names) {
   const result = [];
-  let stringLiteral = false;
   let parentheses = 0;
   let structuredReferenceDepth = 0;
   for (let i = 0; i < formula.length;) {
     const character = formula[i];
-    if (character === '"') {
-      result.push(character);
-      if (stringLiteral && formula[i + 1] === '"') {
-        result.push(formula[i + 1]);
-        i += 2;
-        continue;
-      }
-      stringLiteral = !stringLiteral;
-      ++i;
+    if (character === '"' ||
+        (character === "'" && !structuredReferenceDepth && !quotedSheetNameAt(formula, i))) {
+      const literal = stringLiteralAt(formula, i);
+      if (!literal) return null;
+      result.push(literal.text);
+      i = literal.end;
       continue;
     }
-    if (!stringLiteral) {
-      let apostrophes = 0;
-      if (structuredReferenceDepth && (character === "[" || character === "]")) {
-        for (let j = i - 1; formula[j] === "'"; --j) ++apostrophes;
-      }
-      const escapedBracket = apostrophes % 2 === 1;
-      if (character === "[" && !escapedBracket) ++structuredReferenceDepth;
-      else if (character === "]" && !escapedBracket && --structuredReferenceDepth < 0) return null;
-      if (!structuredReferenceDepth) {
-        if (character === "(") ++parentheses;
-        else if (character === ")" && --parentheses < 0) return null;
-        const reference = character === "'"
-          ? quotedSheetReference(formula, i, names)
-          : formulaFunctionAt(formula, i) || unquotedSheetReference(formula, i, names);
-        if (character === "'" && !reference) return null;
-        if (reference) {
-          result.push(reference.text);
-          i = reference.end;
-          continue;
-        }
+    let apostrophes = 0;
+    if (structuredReferenceDepth && (character === "[" || character === "]")) {
+      for (let j = i - 1; formula[j] === "'"; --j) ++apostrophes;
+    }
+    const escapedBracket = apostrophes % 2 === 1;
+    if (character === "[" && !escapedBracket) ++structuredReferenceDepth;
+    else if (character === "]" && !escapedBracket && --structuredReferenceDepth < 0) return null;
+    if (!structuredReferenceDepth) {
+      if (character === "(") ++parentheses;
+      else if (character === ")" && --parentheses < 0) return null;
+      const reference = character === "'"
+        ? quotedSheetReference(formula, i, names)
+        : formulaFunctionAt(formula, i) || unquotedSheetReference(formula, i, names);
+      if (character === "'" && !reference) return null;
+      if (reference) {
+        result.push(reference.text);
+        i = reference.end;
+        continue;
       }
     }
     result.push(character);
     ++i;
   }
-  return stringLiteral || parentheses || structuredReferenceDepth ? null : result.join("");
+  return parentheses || structuredReferenceDepth ? null : result.join("");
 }
 
 function parsedCellValue(value, formulaNames) {
@@ -594,8 +865,27 @@ function worksheetDimension(cells) {
   return first === last ? first : first + ":" + last;
 }
 
+function autoFilterXml(filter) {
+  let xml = `<autoFilter ref="${filter.ref}">`;
+  for (const column of filter.columns) {
+    if (column.hiddenButton) {
+      xml += `<filterColumn colId="${column.offset}" hiddenButton="1"/>`;
+      continue;
+    }
+    xml += `<filterColumn colId="${column.offset}"><filters${column.blank ? ' blank="1"' : ""}>`;
+    for (const value of column.values) xml += `<filter val="${spreadsheetXml(value, true)}"/>`;
+    xml += "</filters></filterColumn>";
+  }
+  // A sort applied through the filter dropdown lives inside the autoFilter, as Excel writes it.
+  if (filter.sort) {
+    xml += `<sortState ref="${filter.sort.ref}"><sortCondition ref="${filter.sort.column}"` +
+      `${filter.sort.descending ? ' descending="1"' : ""}/></sortState>`;
+  }
+  return xml + "</autoFilter>";
+}
+
 function* worksheetXml(sheet, formulaNames) {
-  yield `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet xmlns="${MAIN_NS}">`;
+  yield `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet xmlns="${MAIN_NS}" xmlns:r="${REL_NS}">`;
   yield `<dimension ref="${worksheetDimension(sheet.cells)}"/>`;
   yield `<sheetViews><sheetView workbookViewId="0">${frozenPane(sheet)}</sheetView></sheetViews>`;
   yield `<sheetFormatPr defaultColWidth="${columnWidth(DEFAULT_COLUMN_PIXELS)}" defaultRowHeight="${rowPoints(DEFAULT_ROW_PIXELS)}"/>`;
@@ -609,16 +899,178 @@ function* worksheetXml(sheet, formulaNames) {
   yield "<sheetData>";
   let cellIndex = 0;
   let heightIndex = 0;
-  while (cellIndex < sheet.cells.length || heightIndex < sheet.rowHeights.length) {
+  let hiddenIndex = 0;
+  for (;;) {
     const cellRow = sheet.cells[cellIndex]?.row ?? Infinity;
     const heightRow = (sheet.rowHeights[heightIndex]?.index ?? Infinity) + 1;
-    const row = Math.min(cellRow, heightRow);
+    const hiddenRow = sheet.hiddenRows[hiddenIndex] ?? Infinity;
+    const row = Math.min(cellRow, heightRow, hiddenRow);
+    if (row === Infinity) break;
     const height = heightRow === row ? sheet.rowHeights[heightIndex++] : null;
-    yield `<row r="${row}"${height ? ` ht="${height.value}" customHeight="1"` : ""}>`;
+    const hidden = hiddenRow === row && ++hiddenIndex;
+    yield `<row r="${row}"${height ? ` ht="${height.value}" customHeight="1"` : ""}${hidden ? ' hidden="1"' : ""}>`;
     while (sheet.cells[cellIndex]?.row === row) yield cellXml(sheet.cells[cellIndex++], formulaNames);
     yield "</row>";
   }
-  yield "</sheetData></worksheet>";
+  yield "</sheetData>";
+  if (sheet.filter) yield autoFilterXml(sheet.filter);
+  if (sheet.hyperlinks.length) {
+    yield "<hyperlinks>";
+    for (const link of sheet.hyperlinks) yield `<hyperlink ref="${link.reference}" r:id="${link.relationshipId}"/>`;
+    yield "</hyperlinks>";
+  }
+  if (sheet.drawing) yield `<drawing r:id="${sheet.drawing.relationshipId}"/>`;
+  if (sheet.comments) yield `<legacyDrawing r:id="${sheet.comments.vmlRelationshipId}"/>`;
+  yield "</worksheet>";
+}
+
+function worksheetRelationships(sheet) {
+  let xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="${PACKAGE_REL_NS}">`;
+  for (const link of sheet.hyperlinks) {
+    xml += `<Relationship Id="${link.relationshipId}" Type="${REL_NS}/hyperlink" Target="${xmlAttribute(link.target)}" TargetMode="External"/>`;
+  }
+  if (sheet.drawing) {
+    xml += `<Relationship Id="${sheet.drawing.relationshipId}" Type="${REL_NS}/drawing" Target="../drawings/drawing${sheet.drawing.index}.xml"/>`;
+  }
+  if (sheet.comments) {
+    xml += `<Relationship Id="${sheet.comments.vmlRelationshipId}" Type="${REL_NS}/vmlDrawing" Target="../drawings/vmlDrawing${sheet.comments.index}.vml"/>`;
+    xml += `<Relationship Id="${sheet.comments.relationshipId}" Type="${REL_NS}/comments" Target="../comments${sheet.comments.index}.xml"/>`;
+  }
+  return xml + "</Relationships>";
+}
+
+function* commentsXml(comments) {
+  yield `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><comments xmlns="${MAIN_NS}">`;
+  yield "<authors><author>Workspace Sheets</author></authors><commentList>";
+  for (const comment of comments.list) {
+    yield `<comment ref="${comment.reference}" authorId="0"><text><t xml:space="preserve">${spreadsheetXml(comment.text)}</t></text></comment>`;
+  }
+  yield "</commentList></comments>";
+}
+
+// Excel shows a legacy note only through its VML shape; the anchor places the hidden popup beside
+// the cell and Excel sizes it on open.
+function* vmlDrawingXml(comments) {
+  const blocks = Array.from({length: Math.ceil(comments.list.length / 1024)}, (_, i) => comments.firstShapeBlock + i);
+  yield '<xml xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel">';
+  yield `<o:shapelayout v:ext="edit"><o:idmap v:ext="edit" data="${blocks.join(",")}"/></o:shapelayout>`;
+  yield '<v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202" path="m,l,21600r21600,l21600,xe"><v:stroke joinstyle="miter"/><v:path gradientshapeok="t" o:connecttype="rect"/></v:shapetype>';
+  for (let i = 0; i < comments.list.length; ++i) {
+    const comment = comments.list[i];
+    const row = comment.row - 1;
+    const column = comment.column - 1;
+    const anchor = [
+      Math.min(column + 1, MAX_COLUMNS - 1), 15, Math.max(0, row - 1), 10,
+      Math.min(column + 3, MAX_COLUMNS - 1), 15, Math.min(row + 3, MAX_ROWS - 1), 4,
+    ];
+    yield `<v:shape id="_x0000_s${comments.firstShapeBlock * 1024 + i + 1}" type="#_x0000_t202" ` +
+      `style="position:absolute;margin-left:59.25pt;margin-top:1.5pt;width:108pt;height:59.25pt;z-index:${i + 1};visibility:hidden" ` +
+      'fillcolor="#ffffe1" o:insetmode="auto"><v:fill color2="#ffffe1"/><v:shadow on="t" color="black" obscured="t"/>' +
+      '<v:path o:connecttype="none"/><v:textbox style="mso-direction-alt:auto"><div style="text-align:left"></div></v:textbox>' +
+      `<x:ClientData ObjectType="Note"><x:MoveWithCells/><x:SizeWithCells/><x:Anchor>${anchor.join(", ")}</x:Anchor>` +
+      `<x:AutoFill>False</x:AutoFill><x:Row>${row}</x:Row><x:Column>${column}</x:Column></x:ClientData></v:shape>`;
+  }
+  yield "</xml>";
+}
+
+function drawingXml(drawing) {
+  let xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xdr:wsDr xmlns:xdr="${SPREADSHEET_DRAWING_NS}" xmlns:a="${DRAWING_NS}">`;
+  drawing.charts.forEach((chart, i) => {
+    xml += `<xdr:oneCellAnchor><xdr:from><xdr:col>${chart.column.index}</xdr:col><xdr:colOff>${chart.column.offset}</xdr:colOff>` +
+      `<xdr:row>${chart.row.index}</xdr:row><xdr:rowOff>${chart.row.offset}</xdr:rowOff></xdr:from>` +
+      `<xdr:ext cx="${chart.extent.cx}" cy="${chart.extent.cy}"/>` +
+      `<xdr:graphicFrame macro=""><xdr:nvGraphicFramePr><xdr:cNvPr id="${i + 2}" name="Chart ${i + 1}"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr>` +
+      '<xdr:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></xdr:xfrm>' +
+      `<a:graphic><a:graphicData uri="${CHART_NS}"><c:chart xmlns:c="${CHART_NS}" xmlns:r="${REL_NS}" r:id="rId${i + 1}"/></a:graphicData></a:graphic>` +
+      "</xdr:graphicFrame><xdr:clientData/></xdr:oneCellAnchor>";
+  });
+  return xml + "</xdr:wsDr>";
+}
+
+function drawingRelationships(drawing) {
+  let xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="${PACKAGE_REL_NS}">`;
+  drawing.charts.forEach((chart, i) => {
+    xml += `<Relationship Id="rId${i + 1}" Type="${REL_NS}/chart" Target="../charts/chart${chart.index}.xml"/>`;
+  });
+  return xml + "</Relationships>";
+}
+
+function chartTitleXml(text) {
+  return `<c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>${plainXml(text)}</a:t></a:r></a:p></c:rich></c:tx><c:overlay val="0"/></c:title>`;
+}
+
+function solidFill(color, alpha) {
+  const rgb = alpha ? `<a:srgbClr val="${color}"><a:alpha val="${alpha}"/></a:srgbClr>` : `<a:srgbClr val="${color}"/>`;
+  return `<a:solidFill>${rgb}</a:solidFill>`;
+}
+
+function chartSeriesXml(chart, sheetName, index) {
+  const column = chart.columns[index];
+  const color = CHART_COLORS[index % CHART_COLORS.length];
+  const reference = (firstRow, lastRow) => plainXml(absoluteReference(sheetName, column, firstRow, column, lastRow));
+  let xml = `<c:ser><c:idx val="${index}"/><c:order val="${index}"/>`;
+  xml += chart.headerRow
+    ? `<c:tx><c:strRef><c:f>${reference(chart.headerRow, chart.headerRow)}</c:f></c:strRef></c:tx>`
+    : `<c:tx><c:v>${columnName(column)}</c:v></c:tx>`;
+  if (chart.type === "line") {
+    xml += `<c:spPr><a:ln w="28575" cap="rnd">${solidFill(color)}<a:round/></a:ln></c:spPr>`;
+    xml += `<c:marker><c:symbol val="circle"/><c:size val="5"/><c:spPr>${solidFill(color)}<a:ln>${solidFill(color)}</a:ln></c:spPr></c:marker>`;
+  } else if (chart.type === "area") {
+    xml += `<c:spPr>${solidFill(color, 18000)}<a:ln w="28575">${solidFill(color)}</a:ln></c:spPr>`;
+  } else if (chart.type === "stackedBar") {
+    xml += `<c:spPr>${solidFill(color)}</c:spPr><c:invertIfNegative val="0"/>`;
+  } else {
+    const points = Math.min(chart.lastRow - chart.firstRow + 1, 64);
+    for (let point = 0; point < points; ++point) {
+      xml += `<c:dPt><c:idx val="${point}"/><c:bubble3D val="0"/><c:spPr>${solidFill(CHART_COLORS[point % CHART_COLORS.length])}` +
+        `<a:ln w="19050">${solidFill("FFFFFF")}</a:ln></c:spPr></c:dPt>`;
+    }
+  }
+  if (chart.categoryColumn) {
+    const categories = absoluteReference(sheetName, chart.categoryColumn, chart.firstRow, chart.categoryColumn, chart.lastRow);
+    xml += `<c:cat><c:strRef><c:f>${plainXml(categories)}</c:f></c:strRef></c:cat>`;
+  }
+  xml += `<c:val><c:numRef><c:f>${reference(chart.firstRow, chart.lastRow)}</c:f></c:numRef></c:val>`;
+  if (chart.type === "line") xml += '<c:smooth val="0"/>';
+  return xml + "</c:ser>";
+}
+
+function chartAxisXml(kind, id, crossId, position, title, {reversed = false, crossesMax = false} = {}) {
+  return `<c:${kind}><c:axId val="${id}"/><c:scaling><c:orientation val="${reversed ? "maxMin" : "minMax"}"/></c:scaling>` +
+    `<c:delete val="0"/><c:axPos val="${position}"/>${kind === "valAx" ? "<c:majorGridlines/>" : ""}${title ? chartTitleXml(title) : ""}` +
+    '<c:numFmt formatCode="General" sourceLinked="1"/><c:majorTickMark val="out"/><c:minorTickMark val="none"/><c:tickLblPos val="nextTo"/>' +
+    `<c:crossAx val="${crossId}"/><c:crosses val="${crossesMax ? "max" : "autoZero"}"/>` +
+    (kind === "catAx" ? '<c:auto val="1"/><c:lblAlgn val="ctr"/><c:lblOffset val="100"/><c:noMultiLvlLbl val="0"/>' : '<c:crossBetween val="between"/>') +
+    `</c:${kind}>`;
+}
+
+// Series references point at the worksheet without cached values; Excel reads them on open, like
+// formulas. Palette and layout follow the grid's SVG renderer.
+function chartXml(chart, sheetName) {
+  let xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><c:chartSpace xmlns:c="${CHART_NS}" xmlns:a="${DRAWING_NS}" xmlns:r="${REL_NS}">`;
+  xml += '<c:roundedCorners val="0"/><c:chart>';
+  xml += chart.title ? chartTitleXml(chart.title) + '<c:autoTitleDeleted val="0"/>' : '<c:autoTitleDeleted val="1"/>';
+  xml += "<c:plotArea><c:layout/>";
+  const series = chart.columns.map((_, index) => chartSeriesXml(chart, sheetName, index)).join("");
+  if (chart.type === "pie") {
+    xml += `<c:pieChart><c:varyColors val="1"/>${series}<c:firstSliceAng val="0"/></c:pieChart>`;
+  } else {
+    const axes = '<c:axId val="1"/><c:axId val="2"/>';
+    if (chart.type === "stackedBar") {
+      xml += `<c:barChart><c:barDir val="bar"/><c:grouping val="stacked"/><c:varyColors val="0"/>${series}<c:gapWidth val="56"/><c:overlap val="100"/>${axes}</c:barChart>`;
+      // Categories run top-down as in the grid, which puts the value axis at the category maximum.
+      xml += chartAxisXml("catAx", 1, 2, "l", chart.yAxisTitle, {reversed: true}) +
+        chartAxisXml("valAx", 2, 1, "b", chart.xAxisTitle, {crossesMax: true});
+    } else {
+      xml += chart.type === "area"
+        ? `<c:areaChart><c:grouping val="standard"/><c:varyColors val="0"/>${series}${axes}</c:areaChart>`
+        : `<c:lineChart><c:grouping val="standard"/><c:varyColors val="0"/>${series}<c:marker val="1"/>${axes}</c:lineChart>`;
+      xml += chartAxisXml("catAx", 1, 2, "b", chart.xAxisTitle) + chartAxisXml("valAx", 2, 1, "l", chart.yAxisTitle);
+    }
+  }
+  xml += "</c:plotArea>";
+  if (chart.legend) xml += '<c:legend><c:legendPos val="r"/><c:overlay val="0"/></c:legend>';
+  return xml + '<c:plotVisOnly val="1"/><c:dispBlanksAs val="gap"/></c:chart></c:chartSpace>';
 }
 
 function* stylesXml(styles) {
@@ -666,15 +1118,25 @@ function* stylesXml(styles) {
   yield '</cellXfs><cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles></styleSheet>';
 }
 
-function contentTypes(sheetCount) {
+function contentTypes(sheets, parts) {
   let xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
   xml += '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">';
   xml += '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>';
   xml += '<Default Extension="xml" ContentType="application/xml"/>';
+  if (parts.comments) xml += '<Default Extension="vml" ContentType="application/vnd.openxmlformats-officedocument.vmlDrawing"/>';
   xml += '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>';
   xml += '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>';
-  for (let i = 1; i <= sheetCount; ++i) {
+  for (let i = 1; i <= sheets.length; ++i) {
     xml += `<Override PartName="/xl/worksheets/sheet${i}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`;
+  }
+  for (let i = 1; i <= parts.comments; ++i) {
+    xml += `<Override PartName="/xl/comments${i}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml"/>`;
+  }
+  for (let i = 1; i <= parts.drawings; ++i) {
+    xml += `<Override PartName="/xl/drawings/drawing${i}.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>`;
+  }
+  for (let i = 1; i <= parts.charts; ++i) {
+    xml += `<Override PartName="/xl/charts/chart${i}.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>`;
   }
   return xml + "</Types>";
 }
@@ -685,8 +1147,18 @@ function workbookXml(sheets) {
   for (let i = 0; i < sheets.length; ++i) {
     xml += `<sheet name="${spreadsheetXml(sheets[i].name, true)}" sheetId="${i + 1}" r:id="rId${i + 1}"/>`;
   }
+  xml += "</sheets>";
+  // Excel records each sheet's autofilter range under this reserved hidden name.
+  const filtered = sheets.filter(sheet => sheet.filter);
+  if (filtered.length) {
+    xml += "<definedNames>";
+    for (const sheet of filtered) {
+      xml += `<definedName name="_xlnm._FilterDatabase" localSheetId="${sheets.indexOf(sheet)}" hidden="1">${plainXml(sheet.filter.definedName)}</definedName>`;
+    }
+    xml += "</definedNames>";
+  }
   // Formulas are written without cached results, so ask for one full recalculation on open.
-  return xml + '</sheets><calcPr calcId="0" fullCalcOnLoad="1"/></workbook>';
+  return xml + '<calcPr calcId="0" fullCalcOnLoad="1"/></workbook>';
 }
 
 function workbookRelationships(sheetCount) {
@@ -697,19 +1169,35 @@ function workbookRelationships(sheetCount) {
   return xml + `<Relationship Id="rId${sheetCount + 1}" Type="${REL_NS}/styles" Target="styles.xml"/></Relationships>`;
 }
 
+function sheetParts(sheet, index, formulaNames) {
+  const entries = [{name: `xl/worksheets/sheet${index + 1}.xml`, data: textStream(worksheetXml(sheet, formulaNames))}];
+  if (sheet.hyperlinks.length || sheet.drawing || sheet.comments) {
+    entries.push({name: `xl/worksheets/_rels/sheet${index + 1}.xml.rels`, data: worksheetRelationships(sheet)});
+  }
+  if (sheet.drawing) {
+    entries.push({name: `xl/drawings/drawing${sheet.drawing.index}.xml`, data: drawingXml(sheet.drawing)});
+    entries.push({name: `xl/drawings/_rels/drawing${sheet.drawing.index}.xml.rels`, data: drawingRelationships(sheet.drawing)});
+    for (const chart of sheet.drawing.charts) {
+      entries.push({name: `xl/charts/chart${chart.index}.xml`, data: chartXml(chart, sheet.name)});
+    }
+  }
+  if (sheet.comments) {
+    entries.push({name: `xl/comments${sheet.comments.index}.xml`, data: textStream(commentsXml(sheet.comments))});
+    entries.push({name: `xl/drawings/vmlDrawing${sheet.comments.index}.vml`, data: textStream(vmlDrawingXml(sheet.comments))});
+  }
+  return entries;
+}
+
 /** Streams `document` (a complete `Gadget.getDocument()` snapshot) as an XLSX workbook. */
 export function workbookToXlsx(document) {
-  const {sheets, styles, formulaNames} = prepareWorkbook(document);
+  const {sheets, styles, formulaNames, parts} = prepareWorkbook(document);
   const entries = [
-    {name: "[Content_Types].xml", data: contentTypes(sheets.length)},
+    {name: "[Content_Types].xml", data: contentTypes(sheets, parts)},
     {name: "_rels/.rels", data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="${PACKAGE_REL_NS}"><Relationship Id="rId1" Type="${REL_NS}/officeDocument" Target="xl/workbook.xml"/></Relationships>`},
     {name: "xl/workbook.xml", data: workbookXml(sheets)},
     {name: "xl/_rels/workbook.xml.rels", data: workbookRelationships(sheets.length)},
     {name: "xl/styles.xml", data: textStream(stylesXml(styles))},
-    ...sheets.map((sheet, i) => ({
-      name: `xl/worksheets/sheet${i + 1}.xml`,
-      data: textStream(worksheetXml(sheet, formulaNames)),
-    })),
+    ...sheets.flatMap((sheet, i) => sheetParts(sheet, i, formulaNames)),
   ];
   return createZip(entries);
 }

--- a/packages/workshop-backend/format-blueprints/workspace-sheets/files/xlsx.js
+++ b/packages/workshop-backend/format-blueprints/workspace-sheets/files/xlsx.js
@@ -537,12 +537,14 @@ function anchorPosition(pixels, sizes, defaultPixels, maximum) {
   }
 }
 
-// The grid's chartData() drops a column with no numeric value before building its series. Only
-// literals can be judged here, so a column is usable when it holds a number or a formula.
+// The grid's chartData() drops a column with no numeric value before building its series and
+// skips filter-hidden rows. Only literals can be judged here, so a visible cell makes its column
+// usable when it holds a number or a formula.
 function usableSeriesColumns(sheet, range, firstColumn) {
+  const hidden = new Set(sheet.hiddenRows);
   const usable = new Set();
   for (const cell of sheet.cells) {
-    if (cell.column < firstColumn || cell.column > range.lastColumn || cell.row < range.firstRow || cell.row > range.lastRow) continue;
+    if (cell.column < firstColumn || cell.column > range.lastColumn || cell.row < range.firstRow || cell.row > range.lastRow || hidden.has(cell.row)) continue;
     if (cell.value[0] === "=" || parsedCellValue(cell.value, null).type === "number") usable.add(cell.column);
   }
   return [...usable].sort((a, b) => a - b);
@@ -763,6 +765,11 @@ function stringLiteralAt(formula, offset) {
 // Excel 3-D reference such as 'Jan':'Mar'!A1 survives verbatim (see isThreeDimensionalReference).
 function quotedSheetNameAt(formula, offset) {
   for (let i = offset + 1; i < formula.length; ++i) {
+    // Same escape rules as stringLiteralAt(): `''` and `\'` are quotes inside the run.
+    if (formula[i] === "\\" && formula[i + 1] === "'") {
+      ++i;
+      continue;
+    }
     if (formula[i] !== "'") continue;
     if (formula[i + 1] === "'") {
       ++i;


### PR DESCRIPTION
Upstream several different enhancements that an internal user made to the built-in sheets blueprint:
- Filter rows with per-column criteria and sorting
- Line, area, pie, and stacked bar charts
- Cell comments
- Pivot tables
- Clickable URLs and `HYPERLINK()` formulas
- Drag-to-fill handles
- Absolute and mixed references (`$A$1`, `$A1`, `A$1`)
- Formula autocomplete, syntax guidance, and validation errors
- Paste without formatting
- Single-quoted formula strings
- Expanded formula/function support
- Improved formatting and spreadsheet editing controls
