### PR TITLE
Preserve Cloudflare connections and credential updates across sign-in

### DIFF
--- a/packages/workshop-backend/__tests__/login-account-preservation.test.ts
+++ b/packages/workshop-backend/__tests__/login-account-preservation.test.ts
@@ -1,0 +1,71 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
+import type { GatekeeperUser } from "@gadgets/workshop-shared/gatekeeper";
+import { UserDurableObject } from "../src/user.js";
+
+function setup(ctx: DurableObjectState, hasResources = true) {
+  const description = {
+    uniqueName: "person@example.com",
+    grantedResourceUrlPatterns: hasResources
+      ? ["https://dash.cloudflare.com/:accountId/notifications"]
+      : [],
+  };
+  const existing = { describe: vi.fn(), revoke: vi.fn() };
+  const fresh = {
+    describe: vi.fn(async () => ({ uniqueName: description.uniqueName })),
+    revoke: vi.fn(),
+  };
+  const record = { id: 0, vendorId: "cloudflare", account: existing, description };
+  const put = vi.fn();
+  const user = new UserDurableObject(ctx, {} as Cloudflare.Env);
+  Object.assign(user, {
+    storage: {
+      nextAccountId: { get: () => 1 },
+      connectedAccounts: { get: () => record, put },
+    },
+  });
+  return { user, existing, fresh, record, put };
+}
+
+it.each([false, true])(
+  "preserves resource grants during sign-in, including expired credentials (%s)",
+  async (expired) => {
+    await runInDurableObject(
+      env.TEST_OVERSEER.getByName(crypto.randomUUID()),
+      async (_instance, ctx) => {
+        const { user, existing, fresh, record } = setup(ctx);
+        Object.assign(record, { credentialsExpired: expired });
+        expect(
+          await user.linkConnectedAccountFromLogin(
+            fresh as unknown as Fetcher<GatekeeperUser>,
+            "cloudflare",
+          ),
+        ).toBe(0);
+        expect(existing.describe).not.toHaveBeenCalled();
+        expect(existing.revoke).not.toHaveBeenCalled();
+        expect(fresh.revoke).toHaveBeenCalledOnce();
+        expect(record.account).toBe(existing);
+        expect(record).toHaveProperty("credentialsExpired", expired);
+      },
+    );
+  },
+);
+
+it("refreshes billing-only credentials in place on sign-in", async () => {
+  await runInDurableObject(
+    env.TEST_OVERSEER.getByName(crypto.randomUUID()),
+    async (_instance, ctx) => {
+      const { user, existing, fresh, record } = setup(ctx, false);
+      expect(
+        await user.linkConnectedAccountFromLogin(
+          fresh as unknown as Fetcher<GatekeeperUser>,
+          "cloudflare",
+        ),
+      ).toBe(0);
+      expect(existing.revoke).toHaveBeenCalledOnce();
+      expect(fresh.revoke).not.toHaveBeenCalled();
+      expect(record.account).toBe(fresh);
+    },
+  );
+});

--- a/packages/workshop-backend/__tests__/login-credential-callback.test.ts
+++ b/packages/workshop-backend/__tests__/login-credential-callback.test.ts
@@ -1,0 +1,39 @@
+import { expect, it, vi } from "vitest";
+import { PendingLogin } from "../src/auth/login-flow.js";
+
+function loginWithStorage(values: Map<string, unknown>) {
+  const login = Object.create(PendingLogin.prototype) as PendingLogin;
+  Object.assign(login, {
+    ctx: {
+      storage: {
+        kv: {
+          get: (key: string) => values.get(key),
+          put: (key: string, value: unknown) => values.set(key, value),
+        },
+      },
+    },
+  });
+  return login;
+}
+
+it("forwards persisted login-grant lifecycle updates after the login instance is replaced", async () => {
+  const values = new Map<string, unknown>();
+  const callback = { credentialsExpired: vi.fn(), credentialsRestored: vi.fn() };
+  await loginWithStorage(values).setAccountCallback(
+    callback as unknown as Parameters<PendingLogin["setAccountCallback"]>[0],
+  );
+  const restored = loginWithStorage(values);
+  const expiry = new Date("2030-01-01");
+  await restored.credentialsRestored(expiry);
+  await restored.credentialsExpired();
+  expect(callback.credentialsRestored).toHaveBeenCalledWith(expiry);
+  expect(callback.credentialsExpired).toHaveBeenCalledOnce();
+});
+
+it("does not persist or forward lifecycle updates for transient login grants", async () => {
+  const values = new Map<string, unknown>();
+  const login = loginWithStorage(values);
+  await login.credentialsRestored();
+  await login.credentialsExpired();
+  expect(values.size).toBe(0);
+});

--- a/packages/workshop-backend/src/auth/login-flow.ts
+++ b/packages/workshop-backend/src/auth/login-flow.ts
@@ -14,10 +14,9 @@
 //      verified email, resolve/create the email-keyed user DO, mint a session, and deliver the token
 //      to the PendingLogin DO, which resolves the awaiting RPC.
 //
-// Sign-in only requests minimal scopes and the gatekeeper grant is transient (it self-destructs
-// shortly after we read the email) — so login does NOT create a persistent connected account.
-// Capability access (repos, docs, billing) is granted later when the user explicitly connects the
-// gatekeeper, which requests the full scopes and persists the connection.
+// Most sign-in grants are minimal and transient. Cloudflare also links its billing grant as a
+// persistent connected account; its lifecycle callback remains durable so later resource grants
+// and credential expiry update that connection. Gadget resource access is authorized separately.
 
 import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
 import { GatekeeperConnectCallback, GatekeeperUser } from "@gadgets/workshop-shared/gatekeeper";
@@ -32,12 +31,25 @@ type PendingResult = { token: string } | { error: string };
 /**
  * Bridges a login result from the (separate) OAuth-callback invocation back to the waiting browser.
  *
- * This DO holds no durable storage: a login normally completes within seconds, and the in-flight
+ * The login result stays in memory: a login normally completes within seconds, and the in-flight
  * awaitResult() request keeps the DO alive so the in-memory waiter is reachable when deliver()/fail()
  * fire. If the attempt is abandoned, the client disposes the awaiting RPC (the `attempt` stub) and
  * the DO is simply evicted — no alarm or cleanup needed.
  */
 export class PendingLogin extends DurableObject<Cloudflare.Env> {
+  /** Retain the account callback so Cloudflare scope upgrades and expiry outlive the login. */
+  async setAccountCallback(callback: Fetcher<GatekeeperConnectCallback>): Promise<void> {
+    this.ctx.storage.kv.put("accountCallback", callback);
+  }
+
+  async credentialsExpired(): Promise<void> {
+    await this.ctx.storage.kv.get<Fetcher<GatekeeperConnectCallback>>("accountCallback")?.credentialsExpired();
+  }
+
+  async credentialsRestored(expiresAt?: Date): Promise<void> {
+    await this.ctx.storage.kv.get<Fetcher<GatekeeperConnectCallback>>("accountCallback")?.credentialsRestored(expiresAt);
+  }
+
   // Awaiters from in-flight awaitResult() calls, resolved/rejected when the result arrives.
   #waiters: { resolve: (token: string) => void; reject: (err: Error) => void }[] = [];
   // Stash for the rare case deliver()/fail() arrives before awaitResult() registers a waiter.
@@ -124,7 +136,10 @@ export class LoginConnectCallbackImpl
       // requested full (non-transient) scopes, so persist the grant as a connected account before
       // handing back the session. Other providers use minimal, transient sign-in grants (no persist).
       if (this.ctx.props.vendorId === CLOUDFLARE_VENDOR_ID) {
-        await userStub.linkConnectedAccountFromLogin(account, this.ctx.props.vendorId, expiresAt);
+        const accountId = await userStub.linkConnectedAccountFromLogin(account, this.ctx.props.vendorId, expiresAt);
+        await pending.setAccountCallback(this.ctx.exports.GatekeeperConnectCallbackImpl({ props: {
+          userId: userStub.id.toString(), accountId, vendorId: this.ctx.props.vendorId,
+        } }));
       }
       // Session tokens are "<doName>:<secret>"; PublicApi.authenticate() routes via idFromName of
       // the first part. The user DO is keyed by email, so the prefix must be the email.
@@ -143,13 +158,6 @@ export class LoginConnectCallbackImpl
     }
   }
 
-  /**
-   * No-ops: for transient sign-in grants there's nothing persisted to update. For the Cloudflare
-   * billing connection (persisted on login) these would ideally flip the account's credential flag,
-   * but the callback doesn't carry the user/account identity (it's only learned in complete()). The
-   * billing path degrades gracefully regardless — getUsableAccessToken() returns null on expiry and
-   * the user falls back to the free tier / a reconnect prompt.
-   */
-  async credentialsExpired(): Promise<void> {}
-  async credentialsRestored(_expiresAt?: Date): Promise<void> {}
+  async credentialsExpired(): Promise<void> { await this.#pending().credentialsExpired(); }
+  async credentialsRestored(expiresAt?: Date): Promise<void> { await this.#pending().credentialsRestored(expiresAt); }
 }

--- a/packages/workshop-backend/src/user.ts
+++ b/packages/workshop-backend/src/user.ts
@@ -1560,18 +1560,19 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
    * requests no gadget-facing resources, so any later resource access is authorized separately.
    */
   async linkConnectedAccountFromLogin(
-      account: Fetcher<GatekeeperUser>, vendorId: string, expiresAt?: Date): Promise<void> {
+      account: Fetcher<GatekeeperUser>, vendorId: string, expiresAt?: Date): Promise<number> {
     let description = await account.describe();
     let uniqueName = description.uniqueName;
 
-    // A repeated sign-in is a re-authorization, so the *fresh* grant is the one we want. If this
-    // identity is already connected for this vendor, refresh that record in place rather than letting
-    // putConnectedAccount's dedup discard the new grant: keeping the stale record would leave billing
-    // broken whenever the old token had expired or was rotated out by this very re-auth — the
-    // opposite of what signing in again should accomplish.
+    // Sign-in grants billing access only. Resource grants own persistent bindings and subscriptions;
+    // preserve them even if expired. Their existing reconnect flow refreshes credentials in place.
     if (uniqueName) {
       let existing = this.#findConnectedAccountByIdentity(vendorId, uniqueName);
       if (existing) {
+        if (existing.description.grantedResourceUrlPatterns?.length) {
+          await account.revoke();
+          return existing.id;
+        }
         // Drop the now-stale grant (a separate gatekeeper-side object from the fresh one), then point
         // the existing record — keeping its id, so UI references stay stable — at the fresh grant.
         try {
@@ -1587,7 +1588,7 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
         existing.credentialExpiresAt = expiresAt;
         existing.credentialsExpired = false;
         this.storage.connectedAccounts.put(existing);
-        return;
+        return existing.id;
       }
     }
 
@@ -1600,6 +1601,7 @@ export class UserDurableObject extends DurableObject<Cloudflare.Env> {
       vendorId,
       credentialExpiresAt: expiresAt,
     });
+    return id;
   }
 
   // Find an existing connected account for the given vendor + identity (uniqueName), excluding


### PR DESCRIPTION
### Problems

1. **Signing in again could replace the more powerful connection with the basic one**, breaking features you had already connected.
2. **Later credential changes weren’t passed along**, so Cloudflare OS could miss that the connection had expired or been restored.

### Fix

Keep existing connections with resource permissions when users sign in again. Billing-only connections still refresh during sign-in; connections with resource permissions use the existing reconnect flow, including when their credentials have expired.

Forward credential expiry and restoration updates to the connected account after login finishes, so its status stays up to date.

Includes regression tests for repeat sign-in and credential updates. Lint/build, 775 backend tests, and 3 integration tests pass (4 existing integration tests skipped).
