### PR TITLE
integration-tests: check a deleted workspace's listing over a fresh session

### DIFF
--- a/packages/integration-tests/__tests__/workshop-lifecycle.test.ts
+++ b/packages/integration-tests/__tests__/workshop-lifecycle.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import { type Harness, startHarness } from "../src/harness.js";
 import { mockChatCompletion } from "../src/mock-model.js";
 import { NetworkInterceptor } from "../src/network-interceptor.js";
-import { connect, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
+import { connect, logIn, nextUsernames, signUp, waitFor } from "../src/rpc-client.js";
 
 let harness: Harness | undefined;
 const network = new NetworkInterceptor({ handlers: [mockChatCompletion("Test chat")] });
@@ -33,8 +33,9 @@ function username(): string {
 }
 
 it.concurrent("lists workspace metadata after activity and removes it after deletion", async () => {
+  const owner = username();
   using publicApi = connect(requireHarness().url);
-  using authenticated = await signUp(publicApi, username());
+  using authenticated = await signUp(publicApi, owner);
   using workspace = await authenticated.newGadget();
   const { id } = await workspace.getMetadata();
   expect(await authenticated.listGadgets()).not.toContainEqual(expect.objectContaining({ id }));
@@ -55,8 +56,16 @@ it.concurrent("lists workspace metadata after activity and removes it after dele
 
   await workspace.deleteSelf();
   workspace[Symbol.dispose]();
+  // Deleting schedules the workspace DO's abort about 100ms out (Overseer.scheduleAccessRestart),
+  // and an abort severs every session that still has the workspace open: the session's
+  // `notifyClosed` stub is dropped uncalled, which AuthenticatedApiImpl reads as a lost DO and
+  // answers by closing the WebSocket. The dispose above usually reaches the DO first, but not
+  // always, so nothing below may depend on `authenticated` surviving. A browser would reconnect
+  // and log in again; so does this.
+  using reconnected = connect(requireHarness().url);
+  using relisted = await logIn(reconnected, owner);
   await waitFor("the deleted workspace to disappear from the user's list", async () =>
-    (await authenticated.listGadgets()).some(entry => entry.id === id) ? null : true);
+    (await relisted.listGadgets()).some(entry => entry.id === id) ? null : true);
 });
 
 it.concurrent("persists an ordered human-only chat without starting an agent", async () => {


### PR DESCRIPTION
Fixes an intermittent CI failure in `workshop-lifecycle.test.ts` ("lists workspace metadata after activity and removes it after deletion"):

```
Error: Peer closed WebSocket: 3000 RPC session was shut down by disposing the main stub
```

Seen on unrelated branches on Sept 4 (`nathan/create-external-resource`), Sept 8 (`nathan/gatekeeper-kit-replayable-refresh`) and in my PR on Sept 10 (#473).

**Cause.** `deleteSelf()` ends with `Overseer.scheduleAccessRestart`, which aborts the workspace DO about 100ms later. An abort severs every session that still has the workspace open: the `notifyClosed` stub handed to `open()` is dropped without being called, `AuthenticatedApiImpl` reads that as a lost DO connection and calls `abortSession`, which disposes the session's main stub and closes the WebSocket with the reason above.

**Fix.** After deletion the test no longer depends on the original session surviving: it logs in over a fresh session for the "workspace is gone" check, as a reconnecting client would.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->