### PR TITLE
Download all gadget files as a ZIP

### DIFF
--- a/packages/workshop-frontend/src/FileSidebar.tsx
+++ b/packages/workshop-frontend/src/FileSidebar.tsx
@@ -19,6 +19,7 @@ interface FileSidebarProps {
   onFileDelete: (filename: string) => void
   onFileRename: (oldName: string, newName: string) => void
   onFileDownload: (filename: string) => void
+  onFilesDownload: () => void
   className?: string
   onRequestClose?: () => void
   ref?: Ref<FileSidebarHandle>
@@ -44,6 +45,7 @@ export default function FileSidebar({
   onFileDelete,
   onFileRename,
   onFileDownload,
+  onFilesDownload,
   className = '',
   onRequestClose,
   ref,
@@ -125,6 +127,15 @@ export default function FileSidebar({
           Files
         </span>
         <div className="flex items-center gap-1">
+          <WorkshopIconButton
+            onClick={onFilesDownload}
+            disabled={files.length === 0}
+            aria-label="Download all files"
+            title="Download all files"
+            className="!h-8 !w-8 text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default md:!h-6 md:!w-6"
+          >
+            <DownloadSimple size={14} weight="bold" />
+          </WorkshopIconButton>
           <WorkshopIconButton
             onClick={() => setIsCreateModalOpen(true)}
             disabled={editLocked}

--- a/packages/workshop-frontend/src/GadgetCodeInterface.tsx
+++ b/packages/workshop-frontend/src/GadgetCodeInterface.tsx
@@ -14,7 +14,7 @@ import type {
 } from './ChatInterface'
 import { ChatOtClient, type RemoteFileEvent } from './otClient'
 import { reportIssue } from './errorReporting'
-import { saveTextToFile } from './fileTransfers'
+import { makeExportFilename, saveFilesToZip, saveTextToFile } from './fileTransfers'
 import { isTransientRpcError } from './rpcErrors'
 
 // The code view over git-backed gadget code.
@@ -44,6 +44,7 @@ interface GadgetCodeInterfaceProps {
   overseer: RpcStub<Overseer>
   // The selected workpiece: the gadget whose files the editor shows.
   workpieceId: WorkpieceId
+  workpieceTitle: string
   // The selected workpiece's head commit (WorkpieceSummary.commitId). Absent while the gadget
   // is still pending in a chat, which reads as an empty committed file set.
   headCommitId?: string
@@ -169,7 +170,7 @@ function replaceSpanTextChange(
 }
 
 export default function GadgetCodeInterface({
-  overseer, workpieceId, headCommitId, height = '100%', selectedChatId = null, chatChanges,
+  overseer, workpieceId, workpieceTitle, headCommitId, height = '100%', selectedChatId = null, chatChanges,
   liveRows, liveEditPreviews, pendingGadgetIds, streamingActiveFile, isAgentActive,
   isVisible = true, onHasCodeChange,
 }: GadgetCodeInterfaceProps) {
@@ -1000,6 +1001,15 @@ export default function GadgetCodeInterface({
     saveTextToFile(filename, text)
   }, [displayFiles, toasts])
 
+  const handleFilesDownload = useCallback(() => {
+    if (!displayFiles || displayFiles.size === 0) return
+    try {
+      saveFilesToZip(makeExportFilename(workpieceTitle, '.zip'), displayFiles)
+    } catch {
+      toasts.add({ title: 'Could not download gadget files', variant: 'error' })
+    }
+  }, [displayFiles, toasts, workpieceTitle])
+
   // ---- render ------------------------------------------------------------------------------
 
   // Outside a chat, ready means the committed files have loaded; within one, the chat's
@@ -1129,6 +1139,7 @@ export default function GadgetCodeInterface({
             onFileDelete={handleFileDelete}
             onFileRename={handleFileRename}
             onFileDownload={handleFileDownload}
+            onFilesDownload={handleFilesDownload}
             onRequestClose={() => setFileDrawerOpen(false)}
             className="max-md:!w-full"
           />

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -1881,6 +1881,7 @@ export default function GadgetEditor() {
                 <GadgetCodeInterface
                   overseer={overseer.stub}
                   workpieceId={selectedGadgetSummary.id}
+                  workpieceTitle={selectedGadgetSummary.title}
                   headCommitId={selectedGadgetSummary.commitId}
                   height="100%"
                   selectedChatId={effectiveSelectedChatId}

--- a/packages/workshop-frontend/src/fileTransfers.test.ts
+++ b/packages/workshop-frontend/src/fileTransfers.test.ts
@@ -1,16 +1,63 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { makeExportFilename, saveStreamToFile } from './fileTransfers'
+import { createFilesZip, makeExportFilename, saveStreamToFile } from './fileTransfers'
 
 afterEach(() => {
   delete (window as Window & { showSaveFilePicker?: unknown }).showSaveFilePicker
 })
 
+function readBlob(blob: Blob): Promise<ArrayBuffer> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.addEventListener('load', () => resolve(reader.result as ArrayBuffer), { once: true })
+    reader.addEventListener('error', () => reject(reader.error), { once: true })
+    reader.readAsArrayBuffer(blob)
+  })
+}
+
 describe('export file transfers', () => {
   it('builds a safe filename with the advertised extension', () => {
     expect(makeExportFilename('Quarterly report / 2026', '.csv'))
       .toBe('Quarterly-report-2026.csv')
+  })
+
+  it('creates a ZIP containing every file and its path', async () => {
+    const blob = createFilesZip(new Map([
+      ['server/index.ts', 'export default {}'],
+      ['client.js', 'console.log("hello")'],
+    ]))
+    const bytes = new Uint8Array(await readBlob(blob))
+    const view = new DataView(bytes.buffer)
+    const decoder = new TextDecoder()
+    const files = new Map<string, string>()
+    let offset = 0
+
+    while (view.getUint32(offset, true) === 0x04034b50) {
+      const size = view.getUint32(offset + 18, true)
+      const nameLength = view.getUint16(offset + 26, true)
+      const extraLength = view.getUint16(offset + 28, true)
+      const nameStart = offset + 30
+      const dataStart = nameStart + nameLength + extraLength
+      files.set(
+        decoder.decode(bytes.subarray(nameStart, nameStart + nameLength)),
+        decoder.decode(bytes.subarray(dataStart, dataStart + size)),
+      )
+      offset = dataStart + size
+    }
+
+    expect(blob.type).toBe('application/zip')
+    expect(files).toEqual(new Map([
+      ['client.js', 'console.log("hello")'],
+      ['server/index.ts', 'export default {}'],
+    ]))
+    expect(view.getUint32(bytes.byteLength - 22, true)).toBe(0x06054b50)
+    expect(view.getUint16(bytes.byteLength - 12, true)).toBe(2)
+  })
+
+  it('refuses paths that could escape the archive directory', () => {
+    expect(() => createFilesZip(new Map([['../outside.txt', 'nope']]))).toThrow('unsafe file path')
+    expect(() => createFilesZip(new Map([['..\\outside.txt', 'nope']]))).toThrow('unsafe file path')
   })
 
   it('opens the picker before starting the export stream', async () => {

--- a/packages/workshop-frontend/src/fileTransfers.ts
+++ b/packages/workshop-frontend/src/fileTransfers.ts
@@ -1,5 +1,20 @@
 export const BLUEPRINT_ARCHIVE_EXTENSION = '.gadget'
 
+const ZIP_UTF8_FLAG = 0x0800
+const ZIP_STORE_METHOD = 0
+const ZIP_DOS_DATE = 33 // 1980-01-01
+const ZIP_MAX_UINT16 = 0xffff
+const ZIP_MAX_UINT32 = 0xffffffff
+
+const CRC32_TABLE = new Uint32Array(256)
+for (let i = 0; i < CRC32_TABLE.length; i++) {
+  let value = i
+  for (let bit = 0; bit < 8; bit++) {
+    value = (value & 1) ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+  }
+  CRC32_TABLE[i] = value >>> 0
+}
+
 function makeFilename(title: string, fallback: string): string {
   return title
     .trim()
@@ -41,6 +56,110 @@ function triggerBlobDownload(blob: Blob, filename: string): void {
   } finally {
     window.setTimeout(() => URL.revokeObjectURL(url), 100)
   }
+}
+
+function zipRecord(size: number, write: (view: DataView) => void): Uint8Array {
+  const bytes = new Uint8Array(size)
+  write(new DataView(bytes.buffer))
+  return bytes
+}
+
+function crc32(bytes: Uint8Array): number {
+  let value = 0xffffffff
+  for (const byte of bytes) {
+    value = CRC32_TABLE[(value ^ byte) & 0xff] ^ (value >>> 8)
+  }
+  return (value ^ 0xffffffff) >>> 0
+}
+
+type ZipEntry = {
+  name: Uint8Array
+  data: Uint8Array
+  crc: number
+  localOffset: number
+}
+
+function assertSafeZipPath(path: string): void {
+  const segments = path.split('/')
+  if (path.startsWith('/') || path.includes('\\') || /^[A-Za-z]:/.test(path)
+      || segments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error(`Cannot archive unsafe file path: ${path}`)
+  }
+}
+
+export function createFilesZip(files: ReadonlyMap<string, string>): Blob {
+  if (files.size > ZIP_MAX_UINT16) throw new Error('Too many files to create a ZIP archive')
+
+  const encoder = new TextEncoder()
+  const chunks: Uint8Array[] = []
+  const entries: ZipEntry[] = []
+  let offset = 0
+  const append = (bytes: Uint8Array) => {
+    chunks.push(bytes)
+    offset += bytes.byteLength
+    if (offset > ZIP_MAX_UINT32) throw new Error('Files are too large to create a ZIP archive')
+  }
+
+  for (const [path, text] of [...files].toSorted(([a], [b]) => a.localeCompare(b))) {
+    assertSafeZipPath(path)
+    const name = encoder.encode(path)
+    const data = encoder.encode(text)
+    if (name.byteLength > ZIP_MAX_UINT16) throw new Error(`File path is too long: ${path}`)
+    const crc = crc32(data)
+    const localOffset = offset
+    append(zipRecord(30, view => {
+      view.setUint32(0, 0x04034b50, true)
+      view.setUint16(4, 20, true)
+      view.setUint16(6, ZIP_UTF8_FLAG, true)
+      view.setUint16(8, ZIP_STORE_METHOD, true)
+      view.setUint16(12, ZIP_DOS_DATE, true)
+      view.setUint32(14, crc, true)
+      view.setUint32(18, data.byteLength, true)
+      view.setUint32(22, data.byteLength, true)
+      view.setUint16(26, name.byteLength, true)
+    }))
+    append(name)
+    append(data)
+    entries.push({ name, data, crc, localOffset })
+  }
+
+  const centralOffset = offset
+  for (const entry of entries) {
+    append(zipRecord(46, view => {
+      view.setUint32(0, 0x02014b50, true)
+      view.setUint16(4, 20, true)
+      view.setUint16(6, 20, true)
+      view.setUint16(8, ZIP_UTF8_FLAG, true)
+      view.setUint16(10, ZIP_STORE_METHOD, true)
+      view.setUint16(14, ZIP_DOS_DATE, true)
+      view.setUint32(16, entry.crc, true)
+      view.setUint32(20, entry.data.byteLength, true)
+      view.setUint32(24, entry.data.byteLength, true)
+      view.setUint16(28, entry.name.byteLength, true)
+      view.setUint32(42, entry.localOffset, true)
+    }))
+    append(entry.name)
+  }
+  const centralSize = offset - centralOffset
+  append(zipRecord(22, view => {
+    view.setUint32(0, 0x06054b50, true)
+    view.setUint16(8, entries.length, true)
+    view.setUint16(10, entries.length, true)
+    view.setUint32(12, centralSize, true)
+    view.setUint32(16, centralOffset, true)
+  }))
+
+  const archive = new Uint8Array(offset)
+  let cursor = 0
+  for (const chunk of chunks) {
+    archive.set(chunk, cursor)
+    cursor += chunk.byteLength
+  }
+  return new Blob([archive.buffer], { type: 'application/zip' })
+}
+
+export function saveFilesToZip(filename: string, files: ReadonlyMap<string, string>): void {
+  triggerBlobDownload(createFilesZip(files), filename)
 }
 
 export async function saveStreamToFile(


### PR DESCRIPTION
Adds a Download all files action to the gadget editor that creates a title-based ZIP while preserving file paths.

Includes archive path validation and focused ZIP tests.

Tests: full workspace test suite, frontend tests, lint, build, and type checks.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->