### PR TITLE
Add shared UI package and hierarchical list

### DIFF
--- a/.agents/skills/frontend-conventions/SKILL.md
+++ b/.agents/skills/frontend-conventions/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: frontend-conventions
+description: Use for creating, modifying, moving, or reviewing React frontend code anywhere in packages/*, including Workshop pages, gatekeeper management apps, shared UI, components, hooks, forms, interactions, styling, accessibility, and frontend tests.
+---
+
+# Frontend Conventions
+
+Apply these conventions to the Workshop SPA, gatekeeper management SPAs, and `@gadgets/ui`.
+Package-level `AGENTS.md` files add product-specific rules but do not replace this guidance.
+
+## Ownership And Organization
+
+Organize code by product ownership before implementation type. Feature directories own product
+behavior and may contain components, hooks, tests, and utilities that change for the same reason.
+
+Start directories flat. Do not introduce `components/`, `hooks/`, `helpers/`, or `tests/`
+subdirectories merely to classify files. Introduce a responsibility-named subsystem directory only
+when several files form a coherent unit or the flat directory becomes difficult to scan.
+
+Use PascalCase filenames for components and camelCase filenames for hooks and non-component
+modules. Colocate `*.test.ts(x)` files with their subject. Feature organization does not replace
+the one-component-per-file model.
+
+Keep product behavior with its product even when another feature consumes it. Promote code only as
+high as its ownership requires:
+
+- Code shared within one feature belongs at the nearest common feature directory.
+- Feature-independent code shared across unrelated areas of one app may live in that app's
+  `components/` or `hooks/` directory.
+- Runtime UI shared by independent frontends belongs in `@gadgets/ui`.
+- Do not merge components merely because they look similar. Avoid generic prop-heavy abstractions
+  that erase domain behavior.
+
+## Components And Hooks
+
+Create a separate component when it owns meaningful state, effects, interactions, accessibility
+behavior, or reusable responsibility; represents a distinct UI concern; or obscures its parent's
+main flow. Keep small stateless render helpers private until they develop an independent concern.
+
+Extract a hook when it owns a coherent behavior or external synchronization lifecycle, not simply
+to shorten a file. Keep code together when an extracted child would mostly forward markup or depend
+on the parent's refs, setters, and synchronization callbacks.
+
+Prefer named arrow-function components and hooks. Type props directly rather than using `React.FC`.
+Give wrappers such as `memo` and `forwardRef` stable DevTools names.
+
+## Component APIs
+
+Represent props that are valid only together as an object or discriminated union. A controlled
+value requires a change callback; otherwise expose an uncontrolled initial value. Do not copy a
+controlled prop into local state with an Effect.
+
+Name callbacks `on<Action>` and pass domain values rather than React setters or browser events.
+Add `children`, slots, variants, `className`, DOM passthrough, and imperative refs only for current
+callers, not speculative reuse.
+
+Use context for genuinely application-wide values such as authentication, theme, and toasts. Pass
+instance-specific feature data and actions through props.
+
+## Kumo And Styling
+
+Use Kumo components and semantic tokens by default. Check Kumo and `@gadgets/ui` before creating a
+control or interaction pattern. A shared Gadgets component should compose Kumo behavior, not merely
+rename or restyle a primitive.
+
+Do not add custom color literals, arbitrary Tailwind colors, feature-local token systems, or local
+replacements for Kumo surfaces, borders, text, status, focus, and interaction tokens unless the user
+explicitly requests them. Existing legacy colors are not precedent.
+
+Tailwind is appropriate for structure, spacing, sizing, positioning, responsive behavior, and
+typography. Use custom CSS only for technical behavior Kumo and utilities cannot express. Global
+Kumo token theming is an application-level decision and must not be changed during ordinary feature
+work.
+
+When Kumo is unsuitable, identify the concrete behavioral or accessibility gap before introducing
+a shared abstraction.
+
+## React
+
+Treat Effects as synchronization with external systems, not as derived-state machinery or a way to
+sequence user interactions. Calculate render data during render, keep state near its owner, prefer a
+component `key` for identity resets, and use `useSyncExternalStore` for suitable external stores.
+
+Effects that fetch or subscribe must clean up stale work and remain correct when restarted. Avoid
+chains of Effects and do not synchronize two pieces of React state when one can be derived.
+
+Do not add `useMemo` or `useCallback` without a concrete identity or performance need. Preserve
+keyboard behavior, focus management, accessible names, announcements, and mouse/touch/hybrid input
+parity. RPC stubs must follow the disposal and React state rules in the root `AGENTS.md`.
+
+## Comments
+
+Prefer names and types that communicate intent. Comments should explain non-obvious constraints,
+security or performance reasons, and deliberate departures from conventions. Do not narrate the
+next line. Remove or update comments when their constraint changes.
+
+## Tests
+
+Tests should protect observable behavior, product rules, accessibility, state transitions, races,
+and failure paths. Do not test React, JavaScript, Kumo, or another framework's own behavior merely
+for coverage. Avoid assertions coupled only to implementation details or trivial passthrough.
+
+Behavior-preserving moves should keep tests unchanged apart from imports. Add focused coverage only
+when an extraction exposes important previously untested logic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ The project structure is:
     * The RPC protocol is Cap'n Web, which has similar semantics to Cloudflare's Worker-to-Worker RPC system, while being able to run in a browser over WebSocket. Read the readme for details.
 * packages/configurator-ui: Type-only component helpers used by optional gatekeeper resource configurator UI modules.
     * Gatekeeper configurator UI modules are compiled by `scripts/build-gatekeeper-configurator.ts` as part of package builds.
+* packages/ui: Shared runtime React UI used across the Workshop and gatekeeper management apps.
+    * Kumo remains the primitive and token foundation. Reusable Gadgets interaction patterns and composed controls belong here rather than being reimplemented in individual apps.
 * packages/gatekeeper-*: Gatekeeper workers for external service integrations.
     * Each gatekeeper runs as a separate Cloudflare Worker — with one exception the prefix does not capture: a `gatekeeper-*` package with **no `wrangler.jsonc` is a library, not a worker** (`gatekeeper-kit` here; `gatekeeper-shared` in the internal repo). Deployable discovery is config-gated, not name-gated — `readDeployablePackages` in `scripts/release/manifest-lib.ts` keys solely on the presence of `wrangler.jsonc`, and `run-dev-server.ts` requires it too — so adding one to a library package is what would make it deployable, at which point `workerKind` would classify it a gatekeeper by prefix and the deploy wizard would demand `CLIENT_ID`/`CLIENT_SECRET` for it. `manifest-lib.test.ts` fails first if that ever happens.
     * Gatekeepers handle OAuth flows and provide sandboxed access to external APIs. A connect URL is a bearer capability, so every connect/reconnect flow ends on the kit's `connectHandoffPageHtml`, which sends the popup to the Workshop's `/connect/handoff` page, and that page redeems the single-use ticket over the popup's own session together with a per-flow nonce (see `docs/connect-handoff.md`); a reconnect stages its new credentials via `gatekeeper-kit/credential-stage` until the Workshop calls `GatekeeperUser.commitReconnect(stageId)` with the id that completion reported; completion is confirmed through the ticket, never through the URL alone.
@@ -39,6 +41,24 @@ The project structure is:
     * Tests are two vitest projects: `vitest.config.ts` (Node, pure logic) and `vitest.worker.config.ts` (workerd, for `RpcTarget`/`RpcStub`/Durable Objects). The workerd suite reaches the gatekeeper through a `TestHooks` Durable Object because a `DurableObjectClass` carrying `ctx.props` is only reachable via `ctx.facets` — the way the overseer instantiates it.
     * `src/configurator/*.tsx` duplicate the resource-URL grammar from `resources.ts` and **must**: `build-gatekeeper-configurator.mjs` transpiles each per-file, stripping only `@gadgets/configurator-ui` and type-only imports, so they cannot import runtime helpers. `__tests__/configurator-url.test.ts` keeps the copies in step, and `configurator-fields.test.ts` drives `render` against a mocked runtime — the runtime's `clearFields` only drops an autocomplete's typed query, so a dependent field must *also* be nulled through `setValues` or the stale value silently survives into the resource URL.
 * packages/router: The public origin of a deployed gadgets instance. Serves the workshop-frontend assets and routes by path prefix: `/api/*` and `/blueprint-screenshot/*` to the workshop backend, `/gatekeeper/<name>/*` to whichever gatekeepers are bound (discovered by scanning its own `GATEKEEPER_*` service bindings, so installing a gatekeeper is purely a binding change). The same worker doubles as the dev router (`pnpm dev-server`): with no `ASSETS` binding it proxies frontend requests to the Vite dev server instead.
+
+Frontend conventions (Workshop, gatekeeper management apps, and shared UI):
+
+* IMPORTANT: Load the `frontend-conventions` skill before creating, materially changing, moving, or reviewing React frontend code anywhere under `packages/`. The bullets below are the mandatory summary; the skill contains the complete conventions and examples.
+
+* Organize code by product ownership before implementation type. Keep feature-owned components, hooks, tests, and utilities together; start directories flat and introduce responsibility-named subdirectories only when a subsystem grows.
+* Use PascalCase filenames for components and camelCase filenames for hooks and non-component modules. Colocate `*.test.ts(x)` files with their subject.
+* Keep small stateless render helpers private. Extract a component or hook when it owns meaningful state, effects, interactions, accessibility behavior, or a reusable responsibility.
+* Cross-application UI belongs in `@gadgets/ui`. An app's local `components/` directory is shared only within that app. Product-specific compositions stay with the product even when they use shared primitives.
+* Use Kumo components and semantic Kumo tokens by default. Check Kumo and `@gadgets/ui` before creating a control or interaction pattern. Do not add custom color literals, feature-local token systems, or wrappers that only restyle Kumo.
+* Tailwind is appropriate for structure, spacing, sizing, positioning, responsive behavior, and typography. Custom CSS is for technical behavior Kumo and utilities cannot express.
+* Represent props that are valid only together as an object or discriminated union. Controlled values require a change callback. Name callbacks `on<Action>` and pass domain values rather than React setters or browser events.
+* Add slots, variants, DOM passthrough, imperative refs, and other customization surface only for current callers. Do not generalize based on speculative reuse.
+* Treat Effects as synchronization with external systems, not as derived-state machinery. Keep state close to its owner, calculate render data during render, clean up subscriptions, and avoid chains of Effects.
+* Prefer named arrow-function components and hooks. Do not add `useMemo` or `useCallback` without a concrete identity or performance need.
+* Preserve keyboard behavior, focus management, accessible names, and announcements when building or extracting interactions.
+* Tests should protect observable behavior, product rules, accessibility, state transitions, races, and failure paths. Do not test framework behavior or implementation details merely for coverage.
+* Prefer code that communicates intent through names and types. Comments should explain non-obvious constraints and reasons, not narrate the next line.
 
 Deployment admin settings (the `/admin` panel) follow a few conventions worth knowing when extending them:
 

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,23 @@
+# Shared UI
+
+`@gadgets/ui` is the shared runtime React UI layer for the Workshop and gatekeeper management apps.
+Kumo owns low-level controls and semantic tokens; this package owns reusable Gadgets interaction
+patterns and composed components.
+
+## Ownership
+
+- Add a component here when at least two independent frontends need the same feature-independent
+  behavior or when consistency across those frontends is an explicit product requirement.
+- Keep product data fetching, routing, RPC, permissions, and domain workflows in the consuming app.
+- Check Kumo before adding a primitive. Do not wrap Kumo solely to restyle or rename it.
+- Export source directly. This package has no publish or emitted-build step and is marked private.
+- Keep React and Kumo as peer dependencies so consumers use one runtime and design-system version.
+- A Tailwind consumer must include `packages/ui/src` as an `@source`, because the shared components'
+  utility classes are compiled by the consuming app.
+
+## APIs And Tests
+
+- Prefer a headless behavior primitive plus a Kumo adapter when both are real consumers' needs.
+- Keep the headless model free of presentation policy and styled-only fields where practical.
+- Preserve accessibility and input parity across mouse, keyboard, touch, and hybrid devices.
+- Colocate tests and test observable contracts rather than package boundaries or framework behavior.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@gadgets/ui",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./hierarchical-list": {
+      "types": "./src/HierarchicalList/index.ts",
+      "import": "./src/HierarchicalList/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test:run": "vitest run"
+  },
+  "peerDependencies": {
+    "@cloudflare/kumo": "^2.12.0",
+    "react": "^19.2.8"
+  },
+  "dependencies": {
+    "@phosphor-icons/react": "^2.1.10",
+    "motion": "^13.2.0"
+  },
+  "devDependencies": {
+    "@cloudflare/kumo": "^2.12.0",
+    "@gadgets/scripts": "workspace:*",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.5",
+    "jsdom": "^26.1.0",
+    "motion": "^13.2.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/ui/src/HierarchicalList/HierarchicalList.test.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalList.test.tsx
@@ -320,6 +320,7 @@ describe("HierarchicalList", () => {
       item: HierarchicalListItem,
       destination: HierarchicalListDropDestination,
     ) => void>();
+    const onItemClick = vi.fn<(item: HierarchicalListItem) => void>();
     const touchItems: HierarchicalListItem[] = [
       { id: "source", name: "Source", draggable: true },
       { id: "target", name: "Target" },
@@ -330,6 +331,7 @@ describe("HierarchicalList", () => {
         label="Files"
         dragAndDrop={{ onMove }}
         interaction={{ touchDragThresholdPx: 16 }}
+        onItemClick={onItemClick}
       />,
     );
     const source = rowFor("Source")!;
@@ -355,6 +357,10 @@ describe("HierarchicalList", () => {
 
     expect(onMove).toHaveBeenCalledWith(touchItems[0], { parent: null, index: 1 });
     expect(container!.querySelector("[data-touch-drag-preview]")).toBeNull();
+    act(() => source.click());
+    expect(onItemClick).not.toHaveBeenCalled();
+    act(() => source.click());
+    expect(onItemClick).toHaveBeenCalledWith(touchItems[0]);
   });
 
   it("disables touch scrolling on draggable rows when the primary pointer is fine", () => {
@@ -374,6 +380,8 @@ describe("HierarchicalList", () => {
     const row = rowFor("Source")!;
     expect(row.draggable).toBe(true);
     expect(row.className).toContain("touch-none");
+    expect(row.style.touchAction).toBe("none");
+    expect(row.style.paddingLeft).toBe("12px");
   });
 
   it("opens an item's action menu from a right click", () => {

--- a/packages/ui/src/HierarchicalList/HierarchicalList.test.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalList.test.tsx
@@ -1,0 +1,454 @@
+// @vitest-environment jsdom
+
+import { DropdownMenu } from "@cloudflare/kumo";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HierarchicalList,
+  type HierarchicalListDropDestination,
+  type HierarchicalListItem,
+} from ".";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const items: HierarchicalListItem[] = [
+  {
+    id: "collection",
+    name: "Engineering",
+    metadata: "2 skills",
+    droppable: true,
+    children: [
+      { id: "review", name: "Review code", draggable: true },
+      { id: "deploy", name: "Deploy service", draggable: true },
+    ],
+  },
+];
+
+describe("HierarchicalList", () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  const render = (element: React.ReactNode) => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => root?.render(element));
+  };
+
+  const buttonFor = (name: string) => Array.from(container!.querySelectorAll("button"))
+    .find((button) => button.textContent?.includes(name));
+
+  const rowFor = (name: string) => buttonFor(name);
+
+  const dataTransfer = () => ({
+    effectAllowed: "none",
+    dropEffect: "none",
+    setData: vi.fn<(format: string, data: string) => void>(),
+  });
+
+  const dispatchDrag = (
+    target: HTMLElement,
+    type: string,
+    transfer: ReturnType<typeof dataTransfer>,
+    clientY = 0,
+  ) => {
+    const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientY });
+    Object.defineProperty(event, "dataTransfer", { value: transfer });
+    act(() => target.dispatchEvent(event));
+  };
+
+  const setRect = (
+    element: Element,
+    { top, left = 0, width = 400, height = 40 }: {
+      top: number;
+      left?: number;
+      width?: number;
+      height?: number;
+    },
+  ) => {
+    element.getBoundingClientRect = () => DOMRect.fromRect({ x: left, y: top, width, height });
+  };
+
+  const dispatchTouchPointer = (
+    target: HTMLElement,
+    type: string,
+    clientX: number,
+    clientY: number,
+  ) => {
+    const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY });
+    Object.defineProperties(event, {
+      isPrimary: { value: true },
+      pointerType: { value: "touch" },
+    });
+    act(() => target.dispatchEvent(event));
+  };
+
+  it("expands branches and selects leaf items", () => {
+    const onItemClick = vi.fn<(item: HierarchicalListItem) => void>();
+    render(
+      <HierarchicalList items={items} label="Skills" onItemClick={onItemClick} />,
+    );
+
+    expect(container?.querySelector("ul")?.getAttribute("aria-label")).toBe("Skills");
+    expect(buttonFor("Review code")).toBeUndefined();
+
+    act(() => buttonFor("Engineering")?.click());
+
+    const skillButton = buttonFor("Review code");
+    expect(skillButton).toBeDefined();
+    expect(skillButton?.className).toContain("w-full");
+    expect(skillButton?.className).toContain("focus-visible:z-20");
+    expect(rowFor("Review code")?.draggable).toBe(false);
+    act(() => skillButton?.focus());
+    act(() => skillButton?.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    })));
+    expect(document.activeElement).toBe(buttonFor("Deploy service"));
+    act(() => document.activeElement?.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowUp",
+      bubbles: true,
+      cancelable: true,
+    })));
+    expect(document.activeElement).toBe(skillButton);
+    act(() => skillButton?.click());
+    expect(onItemClick).toHaveBeenCalledWith(items[0].children?.[0]);
+  });
+
+  it("reports valid drops and rejects drops into descendants", () => {
+    const onMove = vi.fn<(
+      item: HierarchicalListItem,
+      destination: HierarchicalListDropDestination,
+    ) => void>();
+    const nestedItems: HierarchicalListItem[] = [
+      {
+        id: "source",
+        name: "Source",
+        draggable: true,
+        droppable: true,
+        children: [{ id: "child", name: "Child", droppable: true, children: [] }],
+      },
+      { id: "destination", name: "Destination", droppable: true, children: [] },
+    ];
+    render(
+      <HierarchicalList items={nestedItems} label="Files" expandAll dragAndDrop={{ onMove }} />,
+    );
+
+    const source = rowFor("Source")!;
+    const child = rowFor("Child")!;
+    const destination = rowFor("Destination")!;
+    const dataTransfer = {
+      effectAllowed: "none",
+      dropEffect: "none",
+      setData: vi.fn<(format: string, data: string) => void>(),
+    };
+    const dispatchDrag = (target: HTMLElement, type: string) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+      act(() => target.dispatchEvent(event));
+    };
+
+    dispatchDrag(source, "dragstart");
+    dispatchDrag(child, "dragover");
+    dispatchDrag(child, "drop");
+    expect(onMove).not.toHaveBeenCalled();
+
+    dispatchDrag(destination, "dragover");
+    dispatchDrag(destination, "drop");
+    expect(onMove).toHaveBeenCalledWith(nestedItems[0], {
+      parent: nestedItems[1],
+      index: 0,
+    });
+  });
+
+  it("uses the row midpoint for before and after insertion", () => {
+    const onMove = vi.fn<(
+      item: HierarchicalListItem,
+      destination: HierarchicalListDropDestination,
+    ) => void>();
+    const reorderItems: HierarchicalListItem[] = [
+      { id: "source", name: "Source", draggable: true },
+      { id: "target", name: "Target" },
+    ];
+    render(<HierarchicalList items={reorderItems} label="Files" dragAndDrop={{ onMove }} />);
+    const source = rowFor("Source")!;
+    const target = rowFor("Target")!;
+    setRect(container!.firstElementChild!, { top: 0 });
+    setRect(source, { top: 0 });
+    setRect(target, { top: 40 });
+    const transfer = dataTransfer();
+
+    dispatchDrag(source, "dragstart", transfer);
+    dispatchDrag(target, "dragover", transfer, 59);
+    dispatchDrag(target, "drop", transfer, 59);
+    expect(onMove).toHaveBeenLastCalledWith(reorderItems[0], { parent: null, index: 0 });
+
+    dispatchDrag(source, "dragstart", transfer);
+    dispatchDrag(target, "dragover", transfer, 60);
+    dispatchDrag(target, "drop", transfer, 60);
+    expect(onMove).toHaveBeenLastCalledWith(reorderItems[0], { parent: null, index: 1 });
+  });
+
+  it("uses thirds of a closed folder for before, inside, and after", () => {
+    const onMove = vi.fn<(
+      item: HierarchicalListItem,
+      destination: HierarchicalListDropDestination,
+    ) => void>();
+    const folderItems: HierarchicalListItem[] = [
+      { id: "source", name: "Source", draggable: true },
+      { id: "folder", name: "Folder", droppable: true, children: [] },
+    ];
+    render(<HierarchicalList items={folderItems} label="Files" dragAndDrop={{ onMove }} />);
+    const source = rowFor("Source")!;
+    const folder = rowFor("Folder")!;
+    setRect(container!.firstElementChild!, { top: 0 });
+    setRect(source, { top: 0, height: 60 });
+    setRect(folder, { top: 60, height: 60 });
+    const transfer = dataTransfer();
+
+    const dropAt = (clientY: number) => {
+      dispatchDrag(source, "dragstart", transfer);
+      dispatchDrag(folder, "dragover", transfer, clientY);
+      dispatchDrag(folder, "drop", transfer, clientY);
+    };
+
+    dropAt(70);
+    expect(onMove).toHaveBeenLastCalledWith(folderItems[0], { parent: null, index: 0 });
+    dropAt(90);
+    expect(onMove).toHaveBeenLastCalledWith(folderItems[0], { parent: folderItems[1], index: 0 });
+    dropAt(110);
+    expect(onMove).toHaveBeenLastCalledWith(folderItems[0], { parent: null, index: 1 });
+  });
+
+  it("only inserts into an expanded folder directly below its row", () => {
+    const onMove = vi.fn<(
+      item: HierarchicalListItem,
+      destination: HierarchicalListDropDestination,
+    ) => void>();
+    const folderItems: HierarchicalListItem[] = [
+      { id: "source", name: "Source", draggable: true },
+      {
+        id: "folder",
+        name: "Folder",
+        droppable: true,
+        children: [{ id: "child", name: "Child" }],
+      },
+    ];
+    render(
+      <HierarchicalList items={folderItems} label="Files" expandAll dragAndDrop={{ onMove }} />,
+    );
+    const source = rowFor("Source")!;
+    const folder = rowFor("Folder")!;
+    const child = rowFor("Child")!;
+    setRect(container!.firstElementChild!, { top: 0 });
+    setRect(source, { top: 0 });
+    setRect(folder, { top: 40 });
+    setRect(child, { top: 80 });
+    const transfer = dataTransfer();
+
+    dispatchDrag(source, "dragstart", transfer);
+    dispatchDrag(folder, "dragover", transfer, 75);
+    dispatchDrag(folder, "drop", transfer, 75);
+    expect(onMove).toHaveBeenLastCalledWith(folderItems[0], {
+      parent: folderItems[1],
+      index: 0,
+    });
+
+    dispatchDrag(source, "dragstart", transfer);
+    dispatchDrag(child, "dragover", transfer, 101);
+    dispatchDrag(child, "drop", transfer, 101);
+    expect(onMove).toHaveBeenLastCalledWith(folderItems[0], {
+      parent: folderItems[1],
+      index: 1,
+    });
+  });
+
+  it("moves one persistent fixed-thickness indicator between insertion targets", () => {
+    const movementItems: HierarchicalListItem[] = [
+      { id: "source", name: "Source", draggable: true },
+      { id: "target", name: "Target" },
+    ];
+    render(
+      <HierarchicalList
+        items={movementItems}
+        label="Files"
+        dragAndDrop={{ onMove: () => {} }}
+      />,
+    );
+    const source = rowFor("Source")!;
+    const target = rowFor("Target")!;
+    setRect(container!.firstElementChild!, { top: 0 });
+    setRect(source, { top: 0 });
+    setRect(target, { top: 40 });
+    const transfer = dataTransfer();
+
+    dispatchDrag(source, "dragstart", transfer);
+    const indicator = container!.querySelector<HTMLElement>("[data-drop-indicator]");
+    const dropZones = container!.querySelectorAll<HTMLElement>("[data-hierarchical-list-drop-zone]");
+    expect(indicator).not.toBeNull();
+    expect(indicator?.className).toContain("h-[1.5px]");
+    expect(dropZones.length).toBeGreaterThan(0);
+    expect([...dropZones].every((zone) => zone.className.includes("absolute"))).toBe(true);
+    expect([...dropZones].every((zone) => !zone.className.includes("-my-"))).toBe(true);
+
+    dispatchDrag(target, "dragover", transfer, 59);
+    expect(container!.querySelectorAll("[data-drop-indicator]")).toHaveLength(1);
+    expect(container!.querySelector("[data-drop-indicator]")).toBe(indicator);
+
+    dispatchDrag(target, "dragover", transfer, 60);
+    expect(container!.querySelectorAll("[data-drop-indicator]")).toHaveLength(1);
+    expect(container!.querySelector("[data-drop-indicator]")).toBe(indicator);
+  });
+
+  it("moves items by touch without native scrolling or drag events", () => {
+    vi.stubGlobal("matchMedia", vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    })));
+    const onMove = vi.fn<(
+      item: HierarchicalListItem,
+      destination: HierarchicalListDropDestination,
+    ) => void>();
+    const touchItems: HierarchicalListItem[] = [
+      { id: "source", name: "Source", draggable: true },
+      { id: "target", name: "Target" },
+    ];
+    render(
+      <HierarchicalList
+        items={touchItems}
+        label="Files"
+        dragAndDrop={{ onMove }}
+        interaction={{ touchDragThresholdPx: 16 }}
+      />,
+    );
+    const source = rowFor("Source")!;
+    const target = rowFor("Target")!;
+    setRect(container!.firstElementChild!, { top: 0 });
+    setRect(source, { top: 0 });
+    setRect(target, { top: 40 });
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn<(x: number, y: number) => Element | null>(() => target),
+    });
+
+    expect(source.draggable).toBe(false);
+    expect(source.className).toContain("touch-none");
+    expect(source.className).toContain("hover:!bg-transparent");
+    dispatchTouchPointer(source, "pointerdown", 10, 10);
+    dispatchTouchPointer(source, "pointermove", 20, 20);
+    expect(container!.querySelector("[data-touch-drag-preview]")).toBeNull();
+    dispatchTouchPointer(source, "pointermove", 30, 30);
+    expect(container!.querySelector("[data-touch-drag-preview]")?.textContent).toContain("Source");
+    dispatchTouchPointer(source, "pointermove", 20, 60);
+    dispatchTouchPointer(source, "pointerup", 20, 60);
+
+    expect(onMove).toHaveBeenCalledWith(touchItems[0], { parent: null, index: 1 });
+    expect(container!.querySelector("[data-touch-drag-preview]")).toBeNull();
+  });
+
+  it("disables touch scrolling on draggable rows when the primary pointer is fine", () => {
+    vi.stubGlobal("matchMedia", vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    })));
+    render(
+      <HierarchicalList
+        items={[{ id: "source", name: "Source", draggable: true }]}
+        label="Files"
+        dragAndDrop={{ onMove: () => {} }}
+      />,
+    );
+
+    const row = rowFor("Source")!;
+    expect(row.draggable).toBe(true);
+    expect(row.className).toContain("touch-none");
+  });
+
+  it("opens an item's action menu from a right click", () => {
+    render(
+      <HierarchicalList
+        items={[{ id: "skill", name: "Review code" }]}
+        label="Skills"
+        renderContextMenu={() => <DropdownMenu.Item>Delete</DropdownMenu.Item>}
+      />,
+    );
+
+    const row = rowFor("Review code")!;
+    act(() => row.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    })));
+
+    expect(document.body.textContent).toContain("Delete");
+    expect(container?.querySelectorAll("button")).toHaveLength(1);
+  });
+
+  it("opens an item's action drawer from a long press on touch devices", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    })));
+    render(
+      <HierarchicalList
+        items={[{ id: "skill", name: "Review code" }]}
+        label="Skills"
+        interaction={{ longPressDelayMs: 100, actionDrawerMaxWidthPx: 800 }}
+        renderContextMenu={() => <DropdownMenu.Item>Delete</DropdownMenu.Item>}
+      />,
+    );
+
+    const pointerDown = new MouseEvent("pointerdown", { bubbles: true, clientX: 20, clientY: 30 });
+    Object.defineProperties(pointerDown, {
+      isPrimary: { value: true },
+      pointerType: { value: "touch" },
+    });
+    act(() => rowFor("Review code")?.dispatchEvent(pointerDown));
+    act(() => vi.advanceTimersByTime(99));
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+
+    expect(document.body.textContent).toContain("Delete");
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+  });
+
+  it("does not suppress clicks when an item has no context actions", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    })));
+    const item: HierarchicalListItem = { id: "skill", name: "Review code" };
+    const onItemClick = vi.fn<(item: HierarchicalListItem) => void>();
+    render(
+      <HierarchicalList
+        items={[item]}
+        label="Skills"
+        onItemClick={onItemClick}
+        renderContextMenu={() => null}
+      />,
+    );
+
+    const row = rowFor("Review code")!;
+    dispatchTouchPointer(row, "pointerdown", 20, 30);
+    act(() => vi.advanceTimersByTime(500));
+    act(() => row.click());
+
+    expect(onItemClick).toHaveBeenCalledWith(item);
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+});

--- a/packages/ui/src/HierarchicalList/HierarchicalList.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalList.tsx
@@ -108,7 +108,7 @@ const StyledRow = ({
             : "hover:!bg-transparent data-[popup-open]:!bg-kumo-recessed"
         ),
       )}
-      style={{ paddingLeft: `${itemPadding(depth)}px` }}
+      style={{ ...rowProps.style, paddingLeft: `${itemPadding(depth)}px` }}
     >
       {itemIcon(item)}
       {collapsible && (

--- a/packages/ui/src/HierarchicalList/HierarchicalList.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalList.tsx
@@ -1,0 +1,297 @@
+import { Button, DropdownMenu, LayerCard, Text } from "@cloudflare/kumo";
+import { ContextMenu } from "@cloudflare/kumo/primitives/context-menu";
+import { Drawer } from "@cloudflare/kumo/primitives/drawer";
+import { Menu } from "@cloudflare/kumo/primitives/menu";
+import { cn } from "@cloudflare/kumo/utils";
+import { CaretDownIcon, FolderIcon } from "@phosphor-icons/react";
+import { AnimatePresence, motion } from "motion/react";
+import React, { useRef, useState, type ReactNode } from "react";
+import {
+  HierarchicalListPrimitive,
+  type HierarchicalListPrimitiveRowProps,
+  type HierarchicalListPrimitiveRowState,
+} from "./HierarchicalListPrimitive";
+import type { HierarchicalListDragAndDropOptions } from "./HierarchicalListDragAndDrop";
+import {
+  useHierarchicalListActionDrawer,
+  type HierarchicalListActionPresentationOptions,
+  type HierarchicalListTouchInteractionOptions,
+} from "./useHierarchicalListTouchInteractions";
+import type {
+  HierarchicalListExpansionProps,
+  HierarchicalListItem,
+} from "./HierarchicalList.types";
+
+const DRAG_PREVIEW_CLASS_NAME = cn(
+  "inline-flex h-9 max-w-64 items-center gap-2 overflow-hidden rounded-lg",
+  "bg-kumo-control px-3 text-sm font-medium text-kumo-default shadow-lg",
+  "ring-1 ring-kumo-line",
+);
+const itemPadding = (depth: number) => 12 + depth * 24;
+const itemIcon = (item: HierarchicalListItem) => item.icon ?? (
+  item.children !== undefined
+    ? <FolderIcon aria-hidden="true" size={18} className="shrink-0 text-kumo-subtle" />
+    : null
+);
+
+/** Touch behavior and responsive action presentation settings for the styled list. */
+export type HierarchicalListInteractionOptions = HierarchicalListTouchInteractionOptions
+  & HierarchicalListActionPresentationOptions;
+
+/** Props for {@link HierarchicalList}. */
+export type HierarchicalListProps = HierarchicalListExpansionProps & {
+  items: readonly HierarchicalListItem[];
+  label: string;
+  selectedId?: string;
+  /** Forces every branch open and disables individual expansion toggles. */
+  expandAll?: boolean;
+  /** Enables item movement and its mouse and touch drag interactions. */
+  dragAndDrop?: HierarchicalListDragAndDropOptions;
+  /** Customizes touch gesture thresholds and the action-drawer breakpoint. */
+  interaction?: HierarchicalListInteractionOptions;
+  onItemClick?: (item: HierarchicalListItem) => void;
+  onSelectionClear?: () => void;
+  renderContextMenu?: (item: HierarchicalListItem) => ReactNode;
+};
+
+type StyledRowProps = {
+  rowProps: HierarchicalListPrimitiveRowProps;
+  state: HierarchicalListPrimitiveRowState;
+  actionsOpen: boolean;
+  useActionDrawer: boolean;
+  onActionsOpenChange: (open: boolean) => void;
+  renderContextMenu?: (item: HierarchicalListItem) => ReactNode;
+};
+
+const StyledRow = ({
+  rowProps,
+  state,
+  actionsOpen,
+  useActionDrawer,
+  onActionsOpenChange,
+  renderContextMenu,
+}: StyledRowProps) => {
+  const drawerPopupRef = useRef<HTMLDivElement>(null);
+  const {
+    item,
+    depth,
+    collapsible,
+    expanded,
+    selected,
+    pressed,
+    coarsePointer,
+  } = state;
+  const highlighted = selected || actionsOpen || pressed;
+  const contextMenu = renderContextMenu?.(item);
+  const row = (
+    <Button
+      {...rowProps as React.ComponentProps<typeof Button>}
+      type="button"
+      variant="ghost"
+      size="base"
+      aria-current={selected ? "true" : undefined}
+      aria-expanded={collapsible ? expanded : undefined}
+      onClick={(event) => {
+        rowProps.onClick?.(event);
+        if (!event.defaultPrevented && collapsible) state.toggleExpanded();
+      }}
+      className={cn(
+        rowProps.className,
+        "group relative focus-visible:z-20",
+        "!flex !h-auto w-full min-h-11 min-w-0 justify-start gap-2 pr-3 text-left active:!bg-kumo-recessed",
+        state.draggable && "cursor-grab active:cursor-grabbing",
+        state.draggable && "touch-none",
+        highlighted && "bg-kumo-recessed",
+        coarsePointer && (
+          highlighted
+            ? "hover:!bg-kumo-recessed"
+            : "hover:!bg-transparent data-[popup-open]:!bg-kumo-recessed"
+        ),
+      )}
+      style={{ paddingLeft: `${itemPadding(depth)}px` }}
+    >
+      {itemIcon(item)}
+      {collapsible && (
+        <CaretDownIcon
+          aria-hidden="true"
+          size={14}
+          className={cn(
+            "shrink-0 text-kumo-inactive transition-transform duration-100 ease-out motion-reduce:transition-none",
+            !expanded && "-rotate-90",
+          )}
+        />
+      )}
+      <Text as="span" size="sm" truncate DANGEROUS_className="min-w-0 flex-1">
+        {item.name}
+      </Text>
+      {item.metadata && (
+        <Text
+          as="span"
+          size="xs"
+          variant="secondary"
+          truncate
+          DANGEROUS_className="min-w-0 max-w-1/2 shrink tabular-nums"
+        >
+          {item.metadata}
+        </Text>
+      )}
+      <AnimatePresence>
+        {state.insideDropTarget && (
+          <motion.span
+            data-folder-drop-outline=""
+            className="pointer-events-none absolute inset-0 z-20 rounded-lg border-[1.5px] border-black"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.22, ease: [0.25, 0.1, 0.25, 1] }}
+          />
+        )}
+      </AnimatePresence>
+    </Button>
+  );
+
+  if (!contextMenu) return row;
+  if (!useActionDrawer) {
+    return (
+      <ContextMenu.Root open={actionsOpen} onOpenChange={onActionsOpenChange}>
+        <ContextMenu.Trigger render={row} />
+        <DropdownMenu.Content>{contextMenu}</DropdownMenu.Content>
+      </ContextMenu.Root>
+    );
+  }
+
+  return (
+    <>
+      {row}
+      <Drawer.Root open={actionsOpen} onOpenChange={onActionsOpenChange}>
+        <Drawer.Portal>
+          <Drawer.Backdrop
+            onClick={() => onActionsOpenChange(false)}
+            className={cn(
+              "fixed inset-0 z-40 bg-kumo-recessed",
+              "[opacity:calc(0.8*(1-var(--drawer-swipe-progress)))]",
+              "transition-opacity duration-300 ease-out motion-reduce:transition-none",
+              "data-ending-style:opacity-0 data-starting-style:opacity-0",
+            )}
+          />
+          <Drawer.Viewport className="pointer-events-none fixed inset-0 z-50 flex items-end">
+            <Drawer.Popup
+              ref={drawerPopupRef}
+              className={cn(
+                "pointer-events-auto w-full rounded-t-2xl bg-kumo-control px-2 pt-2",
+                "pb-[max(0.5rem,env(safe-area-inset-bottom))] text-kumo-default shadow-xl",
+                "ring-1 ring-kumo-line",
+                "[transform:translateY(var(--drawer-swipe-movement-y))]",
+                "transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]",
+                "motion-reduce:transition-none data-swiping:transition-none",
+                "data-ending-style:translate-y-full data-starting-style:translate-y-full",
+              )}
+            >
+              <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-kumo-line" />
+              <Drawer.Title className="px-2 pb-2 text-xs text-kumo-subtle">
+                {item.name}
+              </Drawer.Title>
+              <Menu.Root open={actionsOpen} modal={false} onOpenChange={onActionsOpenChange}>
+                <Menu.Trigger className="sr-only" tabIndex={-1} aria-hidden="true" />
+                <Menu.Portal container={drawerPopupRef}>
+                  <Menu.Positioner className="!static !block !w-full !transform-none" sideOffset={0}>
+                    <Menu.Popup className="flex w-full flex-col gap-1">
+                      {contextMenu}
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+            </Drawer.Popup>
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      </Drawer.Root>
+    </>
+  );
+};
+
+/** A nested Kumo resource list with optional context-menu and drag-and-drop behaviors. */
+export const HierarchicalList = ({
+  renderContextMenu,
+  ...props
+}: HierarchicalListProps) => {
+  const [contextMenuId, setContextMenuId] = useState<string | null>(null);
+  const useActionDrawer = useHierarchicalListActionDrawer(props.interaction);
+
+  return (
+    <LayerCard className="p-1">
+      <HierarchicalListPrimitive
+        {...props}
+        hasLongPressAction={renderContextMenu && useActionDrawer
+          ? (item) => Boolean(renderContextMenu(item))
+          : undefined}
+        onItemLongPress={renderContextMenu && useActionDrawer
+          ? (item) => setContextMenuId(item.id)
+          : undefined}
+        getDropIndicatorInset={itemPadding}
+        slots={{
+          root: { className: "relative" },
+          item: { className: "relative" },
+          dropZone: {
+            className: cn(
+              "absolute inset-x-0 z-10 h-3",
+              "data-[edge=before]:-top-1.5 data-[edge=after]:-bottom-1.5",
+            ),
+          },
+        }}
+        createDragImage={(item, row, event) => {
+          if (!event.dataTransfer.setDragImage) return;
+          const rect = row.getBoundingClientRect();
+          const dragImage = document.createElement("div");
+          dragImage.className = DRAG_PREVIEW_CLASS_NAME;
+          const icon = row.querySelector("svg")?.cloneNode(true);
+          if (icon) dragImage.append(icon);
+          const label = document.createElement("span");
+          label.className = "min-w-0 truncate";
+          label.textContent = item.name;
+          dragImage.append(label);
+          Object.assign(dragImage.style, {
+            position: "fixed",
+            top: "-1000px",
+            left: "-1000px",
+            maxWidth: `${Math.min(rect.width, 256)}px`,
+          });
+          document.body.append(dragImage);
+          event.dataTransfer.setDragImage(dragImage, 18, 18);
+          requestAnimationFrame(() => dragImage.remove());
+        }}
+        renderRow={(rowProps, state) => (
+          <StyledRow
+            rowProps={rowProps}
+            state={state}
+            actionsOpen={contextMenuId === state.item.id}
+            useActionDrawer={useActionDrawer}
+            onActionsOpenChange={(open) => setContextMenuId(open ? state.item.id : null)}
+            renderContextMenu={renderContextMenu}
+          />
+        )}
+        renderDropIndicator={(indicator) => (
+          <motion.div
+            data-drop-indicator=""
+            className="pointer-events-none absolute z-20 h-[1.5px] rounded-full bg-black"
+            style={{ borderRadius: 9999, transformOrigin: "center" }}
+            initial={{ ...indicator, opacity: 0 }}
+            animate={{ ...indicator, opacity: indicator.visible ? 1 : 0 }}
+            transition={{ duration: 0.14, ease: [0.25, 0.1, 0.25, 1] }}
+          />
+        )}
+        renderTouchDragPreview={(item, position) => (
+          <div
+            data-touch-drag-preview=""
+            className={cn("pointer-events-none fixed z-[100]", DRAG_PREVIEW_CLASS_NAME)}
+            style={{ left: position.x + 12, top: position.y + 12 }}
+          >
+            {itemIcon(item)}
+            <span className="min-w-0 truncate">{item.name}</span>
+          </div>
+        )}
+      />
+    </LayerCard>
+  );
+};
+
+export type { HierarchicalListItem } from "./HierarchicalList.types";

--- a/packages/ui/src/HierarchicalList/HierarchicalList.types.ts
+++ b/packages/ui/src/HierarchicalList/HierarchicalList.types.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+/** One row in a hierarchical list. Defining `children` makes the row collapsible. */
+export type HierarchicalListItem = {
+  id: string;
+  name: string;
+  icon?: ReactNode;
+  metadata?: ReactNode;
+  children?: readonly HierarchicalListItem[];
+  draggable?: boolean;
+  droppable?: boolean;
+};
+
+/** Controlled or uncontrolled expansion configuration for a hierarchical list. */
+export type HierarchicalListExpansionProps =
+  | {
+      expandedIds: ReadonlySet<string>;
+      onExpandedChange: (expandedIds: ReadonlySet<string>) => void;
+      initialExpandedIds?: never;
+    }
+  | {
+      expandedIds?: never;
+      onExpandedChange?: never;
+      initialExpandedIds?: Iterable<string>;
+    };

--- a/packages/ui/src/HierarchicalList/HierarchicalListDragAndDrop.test.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalListDragAndDrop.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { HierarchicalListItem } from "./HierarchicalList";
+import {
+  getKeyboardMoveDestination,
+  getRowDropTarget,
+  normalizeDropDestination,
+} from "./HierarchicalListDragAndDrop";
+
+const source: HierarchicalListItem = { id: "source", name: "Source", draggable: true };
+const target: HierarchicalListItem = { id: "target", name: "Target" };
+
+const rowTarget = (
+  item: HierarchicalListItem,
+  clientY: number,
+  options: {
+    source?: HierarchicalListItem;
+    parent?: HierarchicalListItem | null;
+    open?: boolean;
+  } = {},
+) => getRowDropTarget({
+  source: options.source ?? source,
+  item,
+  parent: options.parent ?? null,
+  index: 1,
+  depth: 0,
+  open: options.open ?? false,
+  clientY,
+  rowTop: 40,
+  rowHeight: 60,
+});
+
+describe("hierarchical list drag-and-drop targeting", () => {
+  it("inserts before or after a row at its midpoint", () => {
+    expect(rowTarget(target, 69)?.destination).toEqual({ parent: null, index: 1 });
+    expect(rowTarget(target, 70)?.destination).toEqual({ parent: null, index: 2 });
+  });
+
+  it("targets the middle third of a closed folder", () => {
+    const folder: HierarchicalListItem = {
+      id: "folder",
+      name: "Folder",
+      droppable: true,
+      children: [{ id: "child", name: "Child" }],
+    };
+
+    expect(rowTarget(folder, 50)?.destination).toEqual({ parent: null, index: 1 });
+    expect(rowTarget(folder, 70)?.destination).toEqual({ parent: folder, index: 1 });
+    expect(rowTarget(folder, 110)?.destination).toEqual({ parent: null, index: 2 });
+  });
+
+  it("inserts at the start of an expanded folder", () => {
+    const folder: HierarchicalListItem = {
+      id: "folder",
+      name: "Folder",
+      droppable: true,
+      children: [{ id: "child", name: "Child" }],
+    };
+
+    expect(rowTarget(folder, 80, { open: true })?.destination).toEqual({ parent: folder, index: 0 });
+  });
+
+  it("rejects moving a folder into its descendant", () => {
+    const child: HierarchicalListItem = { id: "child", name: "Child", droppable: true, children: [] };
+    const folder: HierarchicalListItem = {
+      id: "folder",
+      name: "Folder",
+      droppable: true,
+      children: [child],
+    };
+
+    expect(rowTarget(child, 70, { source: folder, parent: folder })).toBeNull();
+  });
+
+  it("normalizes same-parent destinations after removing the source", () => {
+    const items = [source, target];
+    expect(normalizeDropDestination(items, source, { parent: null, index: 2 })).toEqual({
+      parent: null,
+      index: 1,
+    });
+    expect(normalizeDropDestination(items, target, { parent: null, index: 0 })).toEqual({
+      parent: null,
+      index: 0,
+    });
+  });
+
+  it("derives keyboard reorder and indentation destinations", () => {
+    const folder: HierarchicalListItem = {
+      id: "folder",
+      name: "Folder",
+      droppable: true,
+      children: [],
+    };
+    const items = [folder, source, target];
+
+    expect(getKeyboardMoveDestination(items, source, "up")).toEqual({ parent: null, index: 0 });
+    expect(getKeyboardMoveDestination(items, source, "down")).toEqual({ parent: null, index: 3 });
+    expect(getKeyboardMoveDestination(items, source, "right")).toEqual({ parent: folder, index: 0 });
+  });
+
+  it("rejects keyboard unindent into a non-droppable grandparent", () => {
+    const nestedSource: HierarchicalListItem = { id: "nested", name: "Nested", draggable: true };
+    const parent: HierarchicalListItem = {
+      id: "parent",
+      name: "Parent",
+      droppable: true,
+      children: [nestedSource],
+    };
+    const grandparent: HierarchicalListItem = {
+      id: "grandparent",
+      name: "Grandparent",
+      children: [parent],
+    };
+
+    expect(getKeyboardMoveDestination([grandparent], nestedSource, "left")).toBeNull();
+    const droppableGrandparent = { ...grandparent, droppable: true };
+    expect(getKeyboardMoveDestination([droppableGrandparent], nestedSource, "left")).toEqual({
+      parent: droppableGrandparent,
+      index: 1,
+    });
+  });
+});

--- a/packages/ui/src/HierarchicalList/HierarchicalListDragAndDrop.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalListDragAndDrop.tsx
@@ -1,0 +1,374 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import type { HierarchicalListItem } from "./HierarchicalList.types";
+
+const EDGE_SIZE_PX = 72;
+const MAX_PX_PER_FRAME = 14;
+
+/** An insertion position after the moved item has been removed from its original parent. */
+export type HierarchicalListDropDestination = {
+  /** Parent that will contain the item, or `null` for the root list. */
+  parent: HierarchicalListItem | null;
+  /** Insertion index after the moved item has been removed from its previous parent. */
+  index: number;
+};
+
+type RawDropDestination = {
+  parent: HierarchicalListItem | null;
+  index: number;
+};
+
+type DragPosition = { x: number; y: number };
+
+type DragAutoScrollOptions = {
+  enabled?: boolean;
+  position: DragPosition | null;
+  onScroll?: (position: DragPosition) => void;
+};
+
+/** Optional drag-and-drop behavior for a hierarchical list. */
+export type HierarchicalListDragAndDropOptions = {
+  /** Enables edge-triggered scrolling during mouse and touch dragging. */
+  autoScroll?: boolean;
+  /** Applies a move to the supplied post-removal destination. */
+  onMove: (item: HierarchicalListItem, destination: HierarchicalListDropDestination) => void;
+};
+
+type DropIndicatorEdge = "top" | "center" | "bottom";
+
+/** Calculated list-relative geometry supplied to an indicator renderer. */
+export type DropIndicatorPosition = {
+  left: number;
+  top: number;
+  width: number;
+  visible: boolean;
+};
+
+/** Mutable drag session state shared by primitive rows. @internal */
+export type HierarchicalListDragAndDropController = {
+  draggedItem: HierarchicalListItem | null;
+  dropIndicator: DropIndicatorPosition | null;
+  dropTargetId: string | null;
+  touchDragPosition: DragPosition | null;
+  setDraggedItem: (item: HierarchicalListItem | null) => void;
+  setDropTargetId: (id: string | null) => void;
+  setTouchDragPosition: (position: DragPosition | null) => void;
+  updateDropIndicator: (
+    element: HTMLElement,
+    inset: number,
+    edge: DropIndicatorEdge,
+    visible: boolean,
+  ) => void;
+};
+
+const containsItem = (item: HierarchicalListItem, id: string): boolean =>
+  item.children?.some((child) => child.id === id || containsItem(child, id)) ?? false;
+
+/** Returns whether a source can move inside a destination item. @internal */
+export const canDrop = (
+  source: HierarchicalListItem,
+  destination: HierarchicalListItem,
+): boolean => source.id !== destination.id && !containsItem(source, destination.id);
+
+/** Returns whether a source can be inserted among a parent's children. @internal */
+export const canInsertInto = (
+  source: HierarchicalListItem,
+  parent: HierarchicalListItem | null,
+): boolean => !parent || (
+  (Boolean(parent.droppable) || Boolean(parent.children?.some((child) => child.id === source.id)))
+  && parent.id !== source.id
+  && !containsItem(source, parent.id)
+);
+
+/** Builds the stable internal identity of an insertion target. @internal */
+export const insertionTargetId = (parent: HierarchicalListItem | null, index: number) =>
+  `between:${parent?.id ?? "root"}:${index}`;
+
+/** Builds the stable internal identity of an inside-item target. @internal */
+export const insideTargetId = (item: HierarchicalListItem) => `inside:${item.id}`;
+
+const findItemPosition = (
+  items: readonly HierarchicalListItem[],
+  id: string,
+  parent: HierarchicalListItem | null = null,
+): { parent: HierarchicalListItem | null; index: number } | null => {
+  for (const [index, item] of items.entries()) {
+    if (item.id === id) return { parent, index };
+    const nested = item.children && findItemPosition(item.children, id, item);
+    if (nested) return nested;
+  }
+  return null;
+};
+
+type HierarchicalListKeyboardMove = "up" | "down" | "left" | "right";
+
+/** Returns a pre-removal destination for one keyboard movement step. @internal */
+export const getKeyboardMoveDestination = (
+  items: readonly HierarchicalListItem[],
+  source: HierarchicalListItem,
+  direction: HierarchicalListKeyboardMove,
+): RawDropDestination | null => {
+  const position = findItemPosition(items, source.id);
+  if (!position) return null;
+  const siblings = position.parent?.children ?? items;
+
+  if (direction === "up") {
+    return position.index > 0 ? { parent: position.parent, index: position.index - 1 } : null;
+  }
+  if (direction === "down") {
+    return position.index < siblings.length - 1
+      ? { parent: position.parent, index: position.index + 2 }
+      : null;
+  }
+  if (direction === "left") {
+    if (!position.parent) return null;
+    const parentPosition = findItemPosition(items, position.parent.id);
+    if (!parentPosition || !canInsertInto(source, parentPosition.parent)) return null;
+    return { parent: parentPosition.parent, index: parentPosition.index + 1 };
+  }
+
+  const previousSibling = siblings[position.index - 1];
+  return previousSibling?.droppable && canDrop(source, previousSibling)
+    ? { parent: previousSibling, index: previousSibling.children?.length ?? 0 }
+    : null;
+};
+
+/** Converts a DOM drop position into the public post-removal insertion position. @internal */
+export const normalizeDropDestination = (
+  items: readonly HierarchicalListItem[],
+  source: HierarchicalListItem,
+  destination: RawDropDestination,
+): HierarchicalListDropDestination => {
+  const sourcePosition = findItemPosition(items, source.id);
+  if (
+    sourcePosition
+    && sourcePosition.parent?.id === destination.parent?.id
+    && sourcePosition.index < destination.index
+  ) {
+    return { ...destination, index: destination.index - 1 };
+  }
+  return destination;
+};
+
+type RowDropTarget = {
+  id: string;
+  destination: RawDropDestination;
+  indicatorDepth: number;
+  edge: "top" | "bottom";
+  showIndicator: boolean;
+};
+
+/** Resolves pointer geometry into before, inside, or after movement semantics. @internal */
+export const getRowDropTarget = ({
+  source,
+  item,
+  parent,
+  index,
+  depth,
+  open,
+  clientY,
+  rowTop,
+  rowHeight,
+}: {
+  source: HierarchicalListItem | null;
+  item: HierarchicalListItem;
+  parent: HierarchicalListItem | null;
+  index: number;
+  depth: number;
+  open: boolean;
+  clientY: number;
+  rowTop: number;
+  rowHeight: number;
+}): RowDropTarget | null => {
+  if (!source) return null;
+  const verticalRatio = rowHeight > 0 ? (clientY - rowTop) / rowHeight : 0.5;
+  const insideFolder = open
+    ? verticalRatio >= 1 / 3
+    : verticalRatio >= 1 / 3 && verticalRatio <= 2 / 3;
+  if (item.droppable && canDrop(source, item) && insideFolder) {
+    return {
+      id: insideTargetId(item),
+      destination: { parent: item, index: open ? 0 : item.children?.length ?? 0 },
+      indicatorDepth: depth + 1,
+      edge: "bottom",
+      showIndicator: false,
+    };
+  }
+  if (!canInsertInto(source, parent)) return null;
+
+  const after = verticalRatio >= 0.5;
+  const destinationIndex = index + (after ? 1 : 0);
+  return {
+    id: insertionTargetId(parent, destinationIndex),
+    destination: { parent, index: destinationIndex },
+    indicatorDepth: depth,
+    edge: after ? "bottom" : "top",
+    showIndicator: true,
+  };
+};
+
+/** Bridges touch pointer movement to the primitive's shared drag event path. @internal */
+export const dispatchTouchDragEvent = (
+  type: "dragover" | "drop",
+  clientX: number,
+  clientY: number,
+) => {
+  const target = document.elementFromPoint(clientX, clientY);
+  if (!target) return;
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY });
+  Object.defineProperty(event, "dataTransfer", {
+    value: {
+      effectAllowed: "move",
+      dropEffect: "move",
+      setData() {},
+      setDragImage() {},
+    },
+  });
+  target.dispatchEvent(event);
+};
+
+const scrollableAncestorAtPoint = (position: DragPosition) => {
+  let element = document.elementFromPoint(position.x, position.y) as HTMLElement | null;
+  while (element) {
+    const overflowY = getComputedStyle(element).overflowY;
+    if (
+      (overflowY === "auto" || overflowY === "scroll")
+      && element.scrollHeight > element.clientHeight
+    ) return element;
+    element = element.parentElement;
+  }
+  return document.scrollingElement instanceof HTMLElement ? document.scrollingElement : null;
+};
+
+const edgeScrollDelta = (clientY: number, top: number, bottom: number) => {
+  const edge = Math.min(EDGE_SIZE_PX, (bottom - top) / 4);
+  if (edge <= 0) return 0;
+  if (clientY < top + edge) {
+    const progress = (top + edge - clientY) / edge;
+    return -Math.ceil(MAX_PX_PER_FRAME * Math.min(1, progress) ** 2);
+  }
+  if (clientY > bottom - edge) {
+    const progress = (clientY - (bottom - edge)) / edge;
+    return Math.ceil(MAX_PX_PER_FRAME * Math.min(1, progress) ** 2);
+  }
+  return 0;
+};
+
+/** Continuously scrolls the nearest vertical scroll container while a drag is near its edge. */
+const useDragAutoScroll = ({
+  enabled = true,
+  position,
+  onScroll,
+}: DragAutoScrollOptions) => {
+  const positionRef = useRef(position);
+  const onScrollRef = useRef(onScroll);
+  const active = position !== null;
+  positionRef.current = position;
+  onScrollRef.current = onScroll;
+
+  useEffect(() => {
+    if (!enabled || !position) return;
+    let frameId = 0;
+
+    const autoScroll = () => {
+      const currentPosition = positionRef.current;
+      if (!currentPosition) return;
+      const scrollable = scrollableAncestorAtPoint(currentPosition);
+      if (scrollable) {
+        const rect = scrollable === document.scrollingElement
+          ? { top: 0, bottom: window.innerHeight }
+          : scrollable.getBoundingClientRect();
+        const delta = edgeScrollDelta(currentPosition.y, rect.top, rect.bottom);
+        if (delta !== 0) {
+          const previousScrollTop = scrollable.scrollTop;
+          scrollable.scrollTop += delta;
+          if (scrollable.scrollTop !== previousScrollTop) onScrollRef.current?.(currentPosition);
+        }
+      }
+      frameId = requestAnimationFrame(autoScroll);
+    };
+
+    frameId = requestAnimationFrame(autoScroll);
+    return () => cancelAnimationFrame(frameId);
+  }, [active, enabled]);
+};
+
+/** Owns the active drag session and indicator geometry for a primitive list. @internal */
+export const useHierarchicalListDragAndDrop = (
+  options: HierarchicalListDragAndDropOptions | undefined,
+  listRef: RefObject<HTMLDivElement | null>,
+): HierarchicalListDragAndDropController => {
+  const [draggedItem, setDraggedItemState] = useState<HierarchicalListItem | null>(null);
+  const [dragPosition, setDragPosition] = useState<DragPosition | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<DropIndicatorPosition | null>(null);
+  const [touchDragPosition, setTouchDragPosition] = useState<DragPosition | null>(null);
+
+  const setDraggedItem = (item: HierarchicalListItem | null) => {
+    setDraggedItemState(item);
+    if (!item) {
+      setDropIndicator(null);
+      setDragPosition(null);
+      setTouchDragPosition(null);
+    }
+  };
+
+  const updateDropIndicator: HierarchicalListDragAndDropController["updateDropIndicator"] = (
+    element,
+    inset,
+    edge,
+    visible,
+  ) => {
+    if (!visible) {
+      setDropIndicator((current) => current ? { ...current, visible: false } : null);
+      return;
+    }
+
+    const list = listRef.current;
+    if (!list) return;
+    const listRect = list.getBoundingClientRect();
+    const targetRect = element.getBoundingClientRect();
+    const edgeY = edge === "top"
+      ? targetRect.top
+      : edge === "bottom"
+        ? targetRect.bottom
+        : targetRect.top + targetRect.height / 2;
+    const left = targetRect.left - listRect.left + inset;
+    setDropIndicator({
+      left,
+      top: edgeY - listRect.top - 0.75,
+      width: Math.max(0, targetRect.right - listRect.left - 8 - left),
+      visible,
+    });
+  };
+
+  useDragAutoScroll({
+    enabled: options?.autoScroll ?? false,
+    position: dragPosition,
+    onScroll: (position) => dispatchTouchDragEvent("dragover", position.x, position.y),
+  });
+
+  useEffect(() => {
+    if (!draggedItem) return;
+    const updatePosition = (event: DragEvent) => {
+      setDragPosition({ x: event.clientX, y: event.clientY });
+    };
+    document.addEventListener("dragover", updatePosition, true);
+    return () => document.removeEventListener("dragover", updatePosition, true);
+  }, [draggedItem]);
+
+  const updateTouchDragPosition = (position: DragPosition | null) => {
+    setTouchDragPosition(position);
+    setDragPosition(position);
+  };
+
+  return {
+    draggedItem,
+    dropIndicator,
+    dropTargetId,
+    touchDragPosition,
+    setDraggedItem,
+    setDropTargetId,
+    setTouchDragPosition: updateTouchDragPosition,
+    updateDropIndicator,
+  };
+};

--- a/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.test.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.test.tsx
@@ -177,6 +177,7 @@ describe("HierarchicalListPrimitive", () => {
     );
 
     const [source, target] = Array.from(container!.querySelectorAll("button"));
+    expect(source.style.touchAction).toBe("none");
     source.getBoundingClientRect = () => DOMRect.fromRect({ y: 0, width: 300, height: 40 });
     target.getBoundingClientRect = () => DOMRect.fromRect({ y: 40, width: 300, height: 40 });
     const transfer = {
@@ -240,6 +241,49 @@ describe("HierarchicalListPrimitive", () => {
     expect(container!.querySelector('[role="status"]')?.textContent).toBe(
       "Movable moved to position 1 in Folder.",
     );
+  });
+
+  it("focuses a collapsed destination when the moved item becomes hidden", () => {
+    const folder: HierarchicalListItem = {
+      id: "folder",
+      name: "Folder",
+      droppable: true,
+      children: [],
+    };
+    const movable: HierarchicalListItem = { id: "movable", name: "Movable", draggable: true };
+    const Example = () => {
+      const [tree, setTree] = React.useState<readonly HierarchicalListItem[]>([folder, movable]);
+      return (
+        <HierarchicalListPrimitive
+          items={tree}
+          label="Resources"
+          dragAndDrop={{
+            onMove: (item, destination) => {
+              if (destination.parent?.id !== folder.id) return;
+              setTree([{ ...folder, children: [item] }]);
+            },
+          }}
+          renderRow={disclosureRow}
+        />
+      );
+    };
+    render(<Example />);
+
+    const movableRow = [...container!.querySelectorAll("button")]
+      .find((button) => button.textContent === "Movable")!;
+    act(() => movableRow.focus());
+    act(() => movableRow.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    })));
+
+    expect(container!.querySelector("[data-item-id='movable']")).toBeNull();
+    expect(document.activeElement?.textContent).toBe("Folder");
+    act(() => (document.activeElement as HTMLButtonElement).click());
+    expect(container!.querySelector("[data-item-id='movable']")).not.toBeNull();
+    expect(document.activeElement?.textContent).toBe("Folder");
   });
 
   it("uses primary coarse-pointer capability for native dragging", () => {

--- a/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.test.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.test.tsx
@@ -1,0 +1,562 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HierarchicalListDropDestination } from "./HierarchicalListDragAndDrop";
+import {
+  HierarchicalListPrimitive,
+  type HierarchicalListPrimitiveRowProps,
+  type HierarchicalListPrimitiveRowState,
+} from "./HierarchicalListPrimitive";
+import type { HierarchicalListItem } from "./HierarchicalList.types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const items: HierarchicalListItem[] = [{
+  id: "folder",
+  name: "Folder",
+  children: [{ id: "document", name: "Document" }],
+}];
+
+const disclosureRow = (
+  rowProps: HierarchicalListPrimitiveRowProps,
+  state: HierarchicalListPrimitiveRowState,
+) => (
+  <button
+    {...rowProps}
+    onClick={(event) => {
+      rowProps.onClick?.(event);
+      if (!event.defaultPrevented) state.toggleExpanded();
+    }}
+  >
+    {state.item.name}
+  </button>
+);
+
+describe("HierarchicalListPrimitive", () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  const render = (element: React.ReactNode) => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => root?.render(element));
+  };
+
+  it("renders caller-owned row markup and styling with stable state attributes", () => {
+    render(
+      <HierarchicalListPrimitive
+        items={items}
+        label="Custom resources"
+        selectedId="folder"
+        renderRow={(rowProps, { item, depth, selected, expanded }) => (
+          <article
+            {...rowProps}
+            className="caller-markup"
+            data-render-depth={depth}
+          >
+            {item.name}:{selected ? "selected" : "idle"}:{expanded ? "open" : "closed"}
+          </article>
+        )}
+      />,
+    );
+
+    const row = container!.querySelector<HTMLElement>("[data-hierarchical-list-row]")!;
+    expect(row.className).toContain("caller-markup");
+    expect(row.getAttribute("data-selected")).toBe("");
+    expect(row.getAttribute("data-collapsed")).toBe("");
+    expect(row.getAttribute("data-depth")).toBe("0");
+    expect(row.textContent).toBe("Folder:selected:closed");
+    expect(container!.querySelector("[data-item-id='folder']")?.getAttribute("data-depth")).toBe("0");
+    expect(container!.textContent).not.toContain("Document");
+  });
+
+  it("owns uncontrolled expansion and reports controlled expansion", () => {
+    const onExpandedChange = vi.fn<(ids: ReadonlySet<string>) => void>();
+    render(
+      <HierarchicalListPrimitive
+        items={items}
+        label="Resources"
+        renderRow={disclosureRow}
+      />,
+    );
+    act(() => container!.querySelector<HTMLElement>("[data-item-id='folder'] [data-hierarchical-list-row]")!.click());
+    expect(container!.textContent).toContain("Document");
+
+    act(() => root!.render(
+      <HierarchicalListPrimitive
+        items={items}
+        label="Resources"
+        expandedIds={new Set()}
+        onExpandedChange={onExpandedChange}
+        renderRow={disclosureRow}
+      />,
+    ));
+    act(() => container!.querySelector<HTMLElement>("[data-item-id='folder'] [data-hierarchical-list-row]")!.click());
+    expect(onExpandedChange).toHaveBeenCalledOnce();
+    expect([...onExpandedChange.mock.calls[0][0]]).toEqual(["folder"]);
+    expect(container!.textContent).not.toContain("Document");
+  });
+
+  it("keeps activation separate from expansion", () => {
+    const onItemClick = vi.fn<(item: HierarchicalListItem) => void>();
+    render(
+      <HierarchicalListPrimitive
+        items={items}
+        label="Resources"
+        onItemClick={onItemClick}
+        renderRow={(rowProps, { item }) => <button {...rowProps}>{item.name}</button>}
+      />,
+    );
+
+    act(() => container!.querySelector<HTMLButtonElement>("button")!.click());
+    expect(onItemClick).toHaveBeenCalledWith(items[0]);
+    expect(container!.textContent).not.toContain("Document");
+  });
+
+  it("does not toggle expansion state for leaf items", () => {
+    const onExpandedChange = vi.fn<(ids: ReadonlySet<string>) => void>();
+    render(
+      <HierarchicalListPrimitive
+        items={[{ id: "leaf", name: "Leaf" }]}
+        label="Resources"
+        expandedIds={new Set()}
+        onExpandedChange={onExpandedChange}
+        renderRow={disclosureRow}
+      />,
+    );
+
+    act(() => container!.querySelector<HTMLButtonElement>("button")!.click());
+    expect(onExpandedChange).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate hidden expansion state while expandAll is active", () => {
+    render(
+      <HierarchicalListPrimitive
+        items={items}
+        label="Resources"
+        expandAll
+        renderRow={disclosureRow}
+      />,
+    );
+    expect(container!.textContent).toContain("Document");
+    act(() => container!.querySelector<HTMLElement>("[data-item-id='folder'] button")!.click());
+
+    act(() => root!.render(
+      <HierarchicalListPrimitive items={items} label="Resources" renderRow={disclosureRow} />,
+    ));
+    expect(container!.textContent).not.toContain("Document");
+  });
+
+  it("provides drag-and-drop behavior to custom row elements", () => {
+    const movableItems: HierarchicalListItem[] = [
+      { id: "source", name: "Source", draggable: true },
+      { id: "target", name: "Target" },
+    ];
+    const onMove = vi.fn<(
+      item: HierarchicalListItem,
+      destination: HierarchicalListDropDestination,
+    ) => void>();
+    render(
+      <HierarchicalListPrimitive
+        items={movableItems}
+        label="Movable resources"
+        dragAndDrop={{ onMove }}
+        renderRow={(rowProps, { item }) => <button {...rowProps}>{item.name}</button>}
+      />,
+    );
+
+    const [source, target] = Array.from(container!.querySelectorAll("button"));
+    source.getBoundingClientRect = () => DOMRect.fromRect({ y: 0, width: 300, height: 40 });
+    target.getBoundingClientRect = () => DOMRect.fromRect({ y: 40, width: 300, height: 40 });
+    const transfer = {
+      effectAllowed: "none",
+      dropEffect: "none",
+      setData: vi.fn<(format: string, data: string) => void>(),
+    };
+    const dispatchDrag = (element: Element, type: string, clientY: number) => {
+      const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientY });
+      Object.defineProperty(event, "dataTransfer", { value: transfer });
+      act(() => element.dispatchEvent(event));
+    };
+
+    dispatchDrag(source, "dragstart", 10);
+    expect(source.closest("[data-hierarchical-list-item]")?.getAttribute("data-dragging")).toBe("");
+    dispatchDrag(target, "dragover", 70);
+    dispatchDrag(target, "drop", 70);
+
+    expect(onMove).toHaveBeenCalledWith(movableItems[0], { parent: null, index: 1 });
+  });
+
+  it("keeps keyboard focus on an item moved to another branch", () => {
+    const folder: HierarchicalListItem = {
+      id: "folder",
+      name: "Folder",
+      droppable: true,
+      children: [],
+    };
+    const movable: HierarchicalListItem = { id: "movable", name: "Movable", draggable: true };
+    const Example = () => {
+      const [tree, setTree] = React.useState<readonly HierarchicalListItem[]>([folder, movable]);
+      return (
+        <HierarchicalListPrimitive
+          items={tree}
+          label="Resources"
+          initialExpandedIds={[folder.id]}
+          dragAndDrop={{
+            onMove: (item, destination) => {
+              if (destination.parent?.id !== folder.id) return;
+              setTree([{ ...folder, children: [item] }]);
+            },
+          }}
+          renderRow={(rowProps, { item }) => <button {...rowProps}>{item.name}</button>}
+        />
+      );
+    };
+    render(<Example />);
+
+    const movableRow = [...container!.querySelectorAll("button")]
+      .find((button) => button.textContent === "Movable")!;
+    act(() => movableRow.focus());
+    act(() => movableRow.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    })));
+
+    expect(document.activeElement?.textContent).toBe("Movable");
+    expect(document.activeElement?.closest("[data-item-id='folder']")).not.toBeNull();
+    expect(container!.querySelector('[role="status"]')?.textContent).toBe(
+      "Movable moved to position 1 in Folder.",
+    );
+  });
+
+  it("uses primary coarse-pointer capability for native dragging", () => {
+    const matchMedia = vi.fn<(query: string) => {
+      matches: boolean;
+      addEventListener: () => void;
+      removeEventListener: () => void;
+    }>((query) => ({
+      matches: query === "(pointer: coarse)",
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    }));
+    vi.stubGlobal("matchMedia", matchMedia);
+    const draggableItem: HierarchicalListItem = {
+      id: "touch-item",
+      name: "Touch item",
+      draggable: true,
+    };
+    render(
+      <HierarchicalListPrimitive
+        items={[draggableItem]}
+        label="Resources"
+        dragAndDrop={{ onMove: () => {} }}
+        renderRow={(rowProps, state) => (
+          <button
+            {...rowProps}
+            data-coarse-pointer={state.coarsePointer ? "" : undefined}
+          >
+            {state.item.name}
+          </button>
+        )}
+      />,
+    );
+
+    const row = container!.querySelector<HTMLButtonElement>("button")!;
+    expect(row.draggable).toBe(false);
+    expect(row.getAttribute("data-coarse-pointer")).toBe("");
+    expect(matchMedia).toHaveBeenCalledWith("(pointer: coarse)");
+  });
+
+  it("handles touch gestures when the primary pointer is fine", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", vi.fn((query: string) => ({
+      matches: query === "(any-pointer: coarse)",
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    })));
+    const item: HierarchicalListItem = {
+      id: "hybrid-item",
+      name: "Hybrid item",
+      draggable: true,
+    };
+    const onItemLongPress = vi.fn<(pressedItem: HierarchicalListItem) => void>();
+    render(
+      <HierarchicalListPrimitive
+        items={[item]}
+        label="Resources"
+        dragAndDrop={{ onMove: () => {} }}
+        hasLongPressAction={() => true}
+        onItemLongPress={onItemLongPress}
+        interaction={{ longPressDelayMs: 100 }}
+        renderRow={(rowProps, { item: rowItem }) => (
+          <button {...rowProps}>{rowItem.name}</button>
+        )}
+      />,
+    );
+    const row = container!.querySelector("button")!;
+    expect(row.draggable).toBe(true);
+    const pointerDown = new MouseEvent("pointerdown", {
+      bubbles: true,
+      clientX: 20,
+      clientY: 30,
+    });
+    Object.defineProperties(pointerDown, {
+      isPrimary: { value: true },
+      pointerType: { value: "touch" },
+    });
+
+    act(() => row.dispatchEvent(pointerDown));
+    act(() => vi.advanceTimersByTime(100));
+    expect(onItemLongPress).toHaveBeenCalledWith(item);
+  });
+
+  it("reports a long press", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", vi.fn((query: string) => ({
+      matches: query === "(pointer: coarse)" || query.startsWith("(max-width:"),
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    })));
+    const item: HierarchicalListItem = { id: "touch-item", name: "Touch item" };
+    const onItemLongPress = vi.fn<(pressedItem: HierarchicalListItem) => void>();
+    render(
+      <HierarchicalListPrimitive
+        items={[item]}
+        label="Resources"
+        hasLongPressAction={() => true}
+        onItemLongPress={onItemLongPress}
+        interaction={{ longPressDelayMs: 100 }}
+        renderRow={(rowProps, { item: rowItem }) => (
+          <button {...rowProps}>{rowItem.name}</button>
+        )}
+      />,
+    );
+
+    const event = new MouseEvent("pointerdown", {
+      bubbles: true,
+      clientX: 20,
+      clientY: 30,
+    });
+    Object.defineProperties(event, {
+      isPrimary: { value: true },
+      pointerType: { value: "touch" },
+    });
+    act(() => container!.querySelector("button")!.dispatchEvent(event));
+    act(() => vi.advanceTimersByTime(100));
+
+    expect(onItemLongPress).toHaveBeenCalledWith(item);
+  });
+
+  it("lets row slots cancel internal click and keyboard behavior", () => {
+    const folder: HierarchicalListItem = {
+      id: "folder",
+      name: "Folder",
+      draggable: true,
+      children: [{ id: "child", name: "Child" }],
+    };
+    const onItemClick = vi.fn<(item: HierarchicalListItem) => void>();
+    const onMove = vi.fn<(
+      item: HierarchicalListItem,
+      destination: HierarchicalListDropDestination,
+    ) => void>();
+    const onClick = vi.fn<(event: React.MouseEvent<HTMLElement>) => void>((event) => {
+      event.preventDefault();
+    });
+    const onKeyDown = vi.fn<(event: React.KeyboardEvent<HTMLElement>) => void>((event) => {
+      event.preventDefault();
+    });
+    render(
+      <HierarchicalListPrimitive
+        items={[folder, { id: "target", name: "Target" }]}
+        label="Resources"
+        dragAndDrop={{ onMove }}
+        onItemClick={onItemClick}
+        renderRow={(rowProps, { item }) => (
+          <button
+            {...rowProps}
+            onClick={(event) => {
+              onClick(event);
+              rowProps.onClick?.(event);
+            }}
+            onKeyDown={(event) => {
+              onKeyDown(event);
+              rowProps.onKeyDown?.(event);
+            }}
+          >
+            {item.name}
+          </button>
+        )}
+      />,
+    );
+
+    const row = [...container!.querySelectorAll("button")]
+      .find((button) => button.textContent === "Folder")!;
+    act(() => row.click());
+    act(() => row.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    })));
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(onKeyDown).toHaveBeenCalledOnce();
+    expect(onItemClick).not.toHaveBeenCalled();
+    expect(onMove).not.toHaveBeenCalled();
+    expect(container!.textContent).not.toContain("Child");
+  });
+
+  it("clears drag state even when a row slot cancels drag end", () => {
+    const item: HierarchicalListItem = { id: "source", name: "Source", draggable: true };
+    render(
+      <HierarchicalListPrimitive
+        items={[item]}
+        label="Resources"
+        dragAndDrop={{ onMove: () => {} }}
+        renderRow={(rowProps, { item: rowItem }) => (
+          <button
+            {...rowProps}
+            onDragEnd={(event) => {
+              event.preventDefault();
+              rowProps.onDragEnd?.(event);
+            }}
+          >
+            {rowItem.name}
+          </button>
+        )}
+      />,
+    );
+    const row = container!.querySelector("button")!;
+    const dragStart = new MouseEvent("dragstart", { bubbles: true, cancelable: true });
+    Object.defineProperty(dragStart, "dataTransfer", {
+      value: {
+        effectAllowed: "none",
+        setData: vi.fn<(format: string, data: string) => void>(),
+      },
+    });
+
+    act(() => row.dispatchEvent(dragStart));
+    expect(row.closest("[data-hierarchical-list-item]")?.getAttribute("data-dragging")).toBe("");
+    act(() => row.dispatchEvent(new Event("dragend", { bubbles: true, cancelable: true })));
+    expect(row.closest("[data-hierarchical-list-item]")?.hasAttribute("data-dragging")).toBe(false);
+  });
+
+  it("suppresses only the click immediately following a long press", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+    })));
+    const item: HierarchicalListItem = { id: "touch-item", name: "Touch item" };
+    const onItemClick = vi.fn<(clickedItem: HierarchicalListItem) => void>();
+    render(
+      <HierarchicalListPrimitive
+        items={[item]}
+        label="Resources"
+        hasLongPressAction={() => true}
+        onItemLongPress={() => {}}
+        onItemClick={onItemClick}
+        interaction={{ longPressDelayMs: 100 }}
+        renderRow={(rowProps, { item: rowItem }) => (
+          <button {...rowProps}>{rowItem.name}</button>
+        )}
+      />,
+    );
+    const row = container!.querySelector("button")!;
+    const pointerDown = new MouseEvent("pointerdown", {
+      bubbles: true,
+      clientX: 20,
+      clientY: 30,
+    });
+    Object.defineProperties(pointerDown, {
+      isPrimary: { value: true },
+      pointerType: { value: "touch" },
+    });
+
+    act(() => row.dispatchEvent(pointerDown));
+    act(() => vi.advanceTimersByTime(100));
+    act(() => row.click());
+    expect(onItemClick).not.toHaveBeenCalled();
+    act(() => row.click());
+    expect(onItemClick).toHaveBeenCalledOnce();
+    expect(onItemClick).toHaveBeenCalledWith(item);
+  });
+
+  it("auto-scrolls in both directions from desktop row drag events", () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", vi.fn<(callback: FrameRequestCallback) => number>(
+      (callback) => frames.push(callback),
+    ));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn<(id: number) => void>());
+    const scrollContainer = document.createElement("div");
+    scrollContainer.style.overflowY = "auto";
+    scrollContainer.scrollTop = 100;
+    Object.defineProperties(scrollContainer, {
+      clientHeight: { value: 200 },
+      scrollHeight: { value: 1000 },
+    });
+    scrollContainer.getBoundingClientRect = () => DOMRect.fromRect({ width: 300, height: 200 });
+    container = scrollContainer;
+    document.body.append(container);
+    root = createRoot(container);
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn<(x: number, y: number) => Element | null>(() => scrollContainer),
+    });
+    const draggableItem: HierarchicalListItem = {
+      id: "source",
+      name: "Source",
+      draggable: true,
+    };
+    act(() => root?.render(
+      <HierarchicalListPrimitive
+        items={[draggableItem]}
+        label="Resources"
+        dragAndDrop={{ onMove: () => {}, autoScroll: true }}
+        renderRow={(rowProps, { item }) => <button {...rowProps}>{item.name}</button>}
+      />,
+    ));
+    const row = container.querySelector("button")!;
+    const transfer = {
+      effectAllowed: "none",
+      dropEffect: "none",
+      setData: vi.fn<(format: string, data: string) => void>(),
+    };
+    const dragStart = new MouseEvent("dragstart", { bubbles: true, cancelable: true });
+    Object.defineProperty(dragStart, "dataTransfer", { value: transfer });
+    act(() => row.dispatchEvent(dragStart));
+    const dragOver = (clientY: number) => {
+      const event = new MouseEvent("dragover", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY,
+      });
+      Object.defineProperty(event, "dataTransfer", { value: transfer });
+      act(() => row.dispatchEvent(event));
+    };
+
+    dragOver(1);
+    act(() => frames.shift()?.(0));
+    expect(scrollContainer.scrollTop).toBeLessThan(100);
+
+    scrollContainer.scrollTop = 100;
+    dragOver(199);
+    act(() => frames.shift()?.(0));
+    expect(scrollContainer.scrollTop).toBeGreaterThan(100);
+  });
+});

--- a/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.tsx
@@ -1,0 +1,426 @@
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import {
+  canInsertInto,
+  insertionTargetId,
+  normalizeDropDestination,
+  useHierarchicalListDragAndDrop,
+  type DropIndicatorPosition,
+  type HierarchicalListDragAndDropController,
+  type HierarchicalListDragAndDropOptions,
+} from "./HierarchicalListDragAndDrop";
+import {
+  useHierarchicalListCoarsePointer,
+  type HierarchicalListTouchInteractionOptions,
+} from "./useHierarchicalListTouchInteractions";
+import {
+  useHierarchicalListRowInteractions,
+  type HierarchicalListPrimitiveRowProps,
+} from "./useHierarchicalListRowInteractions";
+
+export type { DropIndicatorPosition } from "./HierarchicalListDragAndDrop";
+export type { HierarchicalListTouchInteractionOptions } from "./useHierarchicalListTouchInteractions";
+import type {
+  HierarchicalListExpansionProps,
+  HierarchicalListItem,
+} from "./HierarchicalList.types";
+
+/** Stable behavioral state passed to a primitive row renderer. */
+export type HierarchicalListPrimitiveRowState = {
+  item: HierarchicalListItem;
+  parent: HierarchicalListItem | null;
+  index: number;
+  depth: number;
+  collapsible: boolean;
+  expanded: boolean;
+  selected: boolean;
+  draggable: boolean;
+  dragging: boolean;
+  insideDropTarget: boolean;
+  pressed: boolean;
+  coarsePointer: boolean;
+  /** Toggles this branch without activating the item. No-op while `expandAll` is true. */
+  toggleExpanded: () => void;
+};
+
+export type { HierarchicalListPrimitiveRowProps } from "./useHierarchicalListRowInteractions";
+
+/** Visual props accepted by a structural primitive slot. */
+type HierarchicalListPrimitiveSlotProps<T> = Pick<HTMLAttributes<T>, "className" | "style">;
+
+/** Visual slots supplied by a consumer of the headless primitive. */
+export type HierarchicalListPrimitiveSlots = {
+  root?: HierarchicalListPrimitiveSlotProps<HTMLDivElement>;
+  list?: HierarchicalListPrimitiveSlotProps<HTMLUListElement>;
+  item?: HierarchicalListPrimitiveSlotProps<HTMLLIElement>;
+  group?: HierarchicalListPrimitiveSlotProps<HTMLUListElement>;
+  dropZone?: HierarchicalListPrimitiveSlotProps<HTMLDivElement>;
+};
+
+/** Props for the behavior-only hierarchical list primitive. */
+export type HierarchicalListPrimitiveProps = HierarchicalListExpansionProps & {
+  items: readonly HierarchicalListItem[];
+  label: string;
+  selectedId?: string;
+  /** Forces every branch open and disables individual expansion toggles. */
+  expandAll?: boolean;
+  dragAndDrop?: HierarchicalListDragAndDropOptions;
+  interaction?: HierarchicalListTouchInteractionOptions;
+  onItemClick?: (item: HierarchicalListItem) => void;
+  onSelectionClear?: () => void;
+  hasLongPressAction?: (item: HierarchicalListItem) => boolean;
+  onItemLongPress?: (item: HierarchicalListItem) => void;
+  renderRow: (
+    props: HierarchicalListPrimitiveRowProps,
+    state: HierarchicalListPrimitiveRowState,
+  ) => ReactNode;
+  renderDropIndicator?: (indicator: DropIndicatorPosition) => ReactNode;
+  renderTouchDragPreview?: (
+    item: HierarchicalListItem,
+    position: { x: number; y: number },
+  ) => ReactNode;
+  createDragImage?: (
+    item: HierarchicalListItem,
+    row: HTMLElement,
+    event: React.DragEvent<HTMLElement>,
+  ) => void;
+  /** Computes the visual inset of an insertion indicator. Defaults to no inset. */
+  getDropIndicatorInset?: (depth: number) => number;
+  slots?: HierarchicalListPrimitiveSlots;
+};
+
+type BranchProps = Omit<HierarchicalListPrimitiveProps, keyof HierarchicalListExpansionProps | "items" | "label"> & {
+  item: HierarchicalListItem;
+  parent: HierarchicalListItem | null;
+  index: number;
+  isLast: boolean;
+  depth: number;
+  expandedIds: ReadonlySet<string>;
+  dragController: HierarchicalListDragAndDropController;
+  coarsePointer: boolean;
+  rootItems: readonly HierarchicalListItem[];
+  onToggle: (id: string) => void;
+};
+
+const PrimitiveDropZone = ({
+  parent,
+  index,
+  depth,
+  edge,
+  controller,
+  onMove,
+  inset,
+  slot,
+}: {
+  parent: HierarchicalListItem | null;
+  index: number;
+  depth: number;
+  edge: "before" | "after";
+  controller: HierarchicalListDragAndDropController;
+  onMove?: HierarchicalListDragAndDropOptions["onMove"];
+  inset: (depth: number) => number;
+  slot?: HierarchicalListPrimitiveSlotProps<HTMLDivElement>;
+}) => {
+  const { draggedItem, dropTargetId, setDraggedItem, setDropTargetId, updateDropIndicator } = controller;
+  if (!draggedItem || !onMove || !canInsertInto(draggedItem, parent)) return null;
+  const targetId = insertionTargetId(parent, index);
+
+  return (
+    <div
+      {...slot}
+      aria-hidden="true"
+      data-hierarchical-list-drop-zone=""
+      data-edge={edge}
+      data-active={dropTargetId === targetId ? "" : undefined}
+      onDragOver={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        event.dataTransfer.dropEffect = "move";
+        setDropTargetId(targetId);
+        updateDropIndicator(event.currentTarget, inset(depth), "center", true);
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onMove(draggedItem, { parent, index });
+        setDraggedItem(null);
+        setDropTargetId(null);
+      }}
+    />
+  );
+};
+
+const PrimitiveBranch = ({
+  item,
+  parent,
+  index,
+  isLast,
+  depth,
+  expandedIds,
+  expandAll = false,
+  selectedId,
+  dragAndDrop,
+  interaction,
+  onItemClick,
+  onSelectionClear,
+  hasLongPressAction,
+  onItemLongPress,
+  renderRow,
+  createDragImage,
+  getDropIndicatorInset = () => 0,
+  slots,
+  dragController,
+  coarsePointer,
+  rootItems,
+  onToggle,
+}: BranchProps) => {
+  const collapsible = item.children !== undefined;
+  const expanded = collapsible && (expandAll || expandedIds.has(item.id));
+  const selected = selectedId === item.id;
+  const rowInteractions = useHierarchicalListRowInteractions({
+    item,
+    parent,
+    index,
+    depth,
+    collapsible,
+    expanded,
+    selected,
+    coarsePointer,
+    rootItems,
+    dragAndDrop,
+    interaction,
+    dragController,
+    hasLongPressAction,
+    onItemLongPress,
+    onItemClick,
+    onSelectionClear,
+    createDragImage,
+    getDropIndicatorInset,
+  });
+  const state: HierarchicalListPrimitiveRowState = {
+    item,
+    parent,
+    index,
+    depth,
+    collapsible,
+    expanded,
+    selected,
+    draggable: rowInteractions.draggable,
+    dragging: rowInteractions.dragging,
+    insideDropTarget: rowInteractions.insideDropTarget,
+    pressed: rowInteractions.pressed,
+    coarsePointer,
+    toggleExpanded: () => {
+      if (collapsible && !expandAll) onToggle(item.id);
+    },
+  };
+
+  return (
+    <li
+      {...slots?.item}
+      data-hierarchical-list-item=""
+      data-item-id={item.id}
+      data-depth={depth}
+      data-expanded={collapsible ? (expanded ? "" : undefined) : undefined}
+      data-collapsed={collapsible && !expanded ? "" : undefined}
+      data-selected={state.selected ? "" : undefined}
+      data-dragging={state.dragging ? "" : undefined}
+    >
+      <PrimitiveDropZone
+        parent={parent}
+        index={index}
+        depth={depth}
+        edge="before"
+        controller={dragController}
+        onMove={dragAndDrop?.onMove}
+        inset={getDropIndicatorInset}
+        slot={slots?.dropZone}
+      />
+      {renderRow(rowInteractions.rowProps, state)}
+      {collapsible && expanded && (
+        <ul {...slots?.group} data-hierarchical-list-group="">
+          {item.children?.map((child, childIndex) => (
+            <PrimitiveBranch
+              key={child.id}
+              {...{
+                item: child,
+                parent: item,
+                index: childIndex,
+                isLast: childIndex === item.children!.length - 1,
+                depth: depth + 1,
+                expandedIds,
+                expandAll,
+                selectedId,
+                dragAndDrop,
+                interaction,
+                onItemClick,
+                onSelectionClear,
+                hasLongPressAction,
+                onItemLongPress,
+                renderRow,
+                createDragImage,
+                getDropIndicatorInset,
+                slots,
+                dragController,
+                coarsePointer,
+                rootItems,
+                onToggle,
+              }}
+            />
+          ))}
+        </ul>
+      )}
+      {isLast && (
+        <PrimitiveDropZone
+          parent={parent}
+          index={index + 1}
+          depth={depth}
+          edge="after"
+          controller={dragController}
+          onMove={dragAndDrop?.onMove}
+          inset={getDropIndicatorInset}
+          slot={slots?.dropZone}
+        />
+      )}
+    </li>
+  );
+};
+
+/** A headless hierarchical list that owns expansion, selection, and drag-and-drop behavior. */
+export const HierarchicalListPrimitive = ({
+  items,
+  label,
+  selectedId,
+  expandAll = false,
+  dragAndDrop,
+  onSelectionClear,
+  renderDropIndicator,
+  renderTouchDragPreview,
+  slots,
+  ...props
+}: HierarchicalListPrimitiveProps) => {
+  const [internalExpandedIds, setInternalExpandedIds] = useState<ReadonlySet<string>>(
+    () => new Set(props.initialExpandedIds),
+  );
+  const [moveAnnouncement, setMoveAnnouncement] = useState<{ id: number; text: string } | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const pendingFocusIdRef = useRef<string | null>(null);
+  const announcementIdRef = useRef(0);
+  const normalizedDragAndDrop = dragAndDrop && {
+    ...dragAndDrop,
+    onMove: (
+      item: HierarchicalListItem,
+      destination: Parameters<typeof normalizeDropDestination>[2],
+    ) => {
+      const focusedItemId = document.activeElement
+        ?.closest("[data-hierarchical-list-item]")
+        ?.getAttribute("data-item-id");
+      if (focusedItemId === item.id) pendingFocusIdRef.current = item.id;
+      const normalizedDestination = normalizeDropDestination(items, item, destination);
+      setMoveAnnouncement({
+        id: ++announcementIdRef.current,
+        text: `${item.name} moved to position ${normalizedDestination.index + 1} in ${
+          normalizedDestination.parent?.name ?? label
+        }.`,
+      });
+      dragAndDrop.onMove(item, normalizedDestination);
+    },
+  };
+  const dragController = useHierarchicalListDragAndDrop(normalizedDragAndDrop, listRef);
+  const expandedIds = props.expandedIds ?? internalExpandedIds;
+  const coarsePointer = useHierarchicalListCoarsePointer();
+
+  useLayoutEffect(() => {
+    const pendingFocusId = pendingFocusIdRef.current;
+    if (!pendingFocusId) return;
+    const rows = listRef.current?.querySelectorAll<HTMLElement>("[data-hierarchical-list-row]");
+    const row = rows && [...rows].find((candidate) => candidate
+      .closest("[data-hierarchical-list-item]")
+      ?.getAttribute("data-item-id") === pendingFocusId);
+    if (!row) return;
+    row.focus();
+    pendingFocusIdRef.current = null;
+  });
+
+  useEffect(() => {
+    if (!selectedId || !onSelectionClear) return;
+    const clearOutsideRow = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Element
+        && listRef.current?.contains(target)
+        && target.closest("[data-hierarchical-list-row]")) return;
+      onSelectionClear();
+    };
+    document.addEventListener("pointerdown", clearOutsideRow, true);
+    return () => document.removeEventListener("pointerdown", clearOutsideRow, true);
+  }, [onSelectionClear, selectedId]);
+
+  const toggle = (id: string) => {
+    const next = new Set(expandedIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    if (props.onExpandedChange) props.onExpandedChange(next);
+    else setInternalExpandedIds(next);
+  };
+
+  return (
+    <div {...slots?.root} ref={listRef} data-hierarchical-list-root="">
+      <ul {...slots?.list} aria-label={label} data-hierarchical-list="">
+        {items.map((item, index) => (
+          <PrimitiveBranch
+            key={item.id}
+            {...props}
+            item={item}
+            parent={null}
+            index={index}
+            isLast={index === items.length - 1}
+            depth={0}
+            expandedIds={expandedIds}
+            expandAll={expandAll}
+            selectedId={selectedId}
+            dragAndDrop={normalizedDragAndDrop}
+            onSelectionClear={onSelectionClear}
+            slots={slots}
+            dragController={dragController}
+            coarsePointer={coarsePointer}
+            rootItems={items}
+            onToggle={toggle}
+          />
+        ))}
+      </ul>
+      {moveAnnouncement && (
+        <span
+          key={moveAnnouncement.id}
+          role="status"
+          aria-live="polite"
+          style={{
+            position: "absolute",
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: "hidden",
+            clip: "rect(0, 0, 0, 0)",
+            whiteSpace: "nowrap",
+            border: 0,
+          }}
+        >
+          {moveAnnouncement.text}
+        </span>
+      )}
+      {dragController.draggedItem && dragController.dropIndicator
+        && renderDropIndicator?.(dragController.dropIndicator)}
+      {dragController.draggedItem && dragController.touchDragPosition
+        && renderTouchDragPreview?.(
+          dragController.draggedItem,
+          dragController.touchDragPosition,
+        )}
+    </div>
+  );
+};

--- a/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.tsx
+++ b/packages/ui/src/HierarchicalList/HierarchicalListPrimitive.tsx
@@ -310,7 +310,7 @@ export const HierarchicalListPrimitive = ({
   );
   const [moveAnnouncement, setMoveAnnouncement] = useState<{ id: number; text: string } | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const pendingFocusIdRef = useRef<string | null>(null);
+  const pendingFocusRef = useRef<{ itemId: string; fallbackId: string | null } | null>(null);
   const announcementIdRef = useRef(0);
   const normalizedDragAndDrop = dragAndDrop && {
     ...dragAndDrop,
@@ -321,8 +321,13 @@ export const HierarchicalListPrimitive = ({
       const focusedItemId = document.activeElement
         ?.closest("[data-hierarchical-list-item]")
         ?.getAttribute("data-item-id");
-      if (focusedItemId === item.id) pendingFocusIdRef.current = item.id;
       const normalizedDestination = normalizeDropDestination(items, item, destination);
+      if (focusedItemId === item.id) {
+        pendingFocusRef.current = {
+          itemId: item.id,
+          fallbackId: normalizedDestination.parent?.id ?? null,
+        };
+      }
       setMoveAnnouncement({
         id: ++announcementIdRef.current,
         text: `${item.name} moved to position ${normalizedDestination.index + 1} in ${
@@ -337,15 +342,17 @@ export const HierarchicalListPrimitive = ({
   const coarsePointer = useHierarchicalListCoarsePointer();
 
   useLayoutEffect(() => {
-    const pendingFocusId = pendingFocusIdRef.current;
-    if (!pendingFocusId) return;
+    const pendingFocus = pendingFocusRef.current;
+    if (!pendingFocus) return;
     const rows = listRef.current?.querySelectorAll<HTMLElement>("[data-hierarchical-list-row]");
-    const row = rows && [...rows].find((candidate) => candidate
-      .closest("[data-hierarchical-list-item]")
-      ?.getAttribute("data-item-id") === pendingFocusId);
-    if (!row) return;
-    row.focus();
-    pendingFocusIdRef.current = null;
+    const rowFor = (id: string | null) => id
+      ? [...rows ?? []].find((candidate) => candidate
+        .closest("[data-hierarchical-list-item]")
+        ?.getAttribute("data-item-id") === id)
+      : undefined;
+    const row = rowFor(pendingFocus.itemId) || rowFor(pendingFocus.fallbackId);
+    row?.focus();
+    pendingFocusRef.current = null;
   });
 
   useEffect(() => {

--- a/packages/ui/src/HierarchicalList/index.ts
+++ b/packages/ui/src/HierarchicalList/index.ts
@@ -1,3 +1,4 @@
+export * from "./HierarchicalList";
 export * from "./HierarchicalListPrimitive";
 export type {
   HierarchicalListDragAndDropOptions,

--- a/packages/ui/src/HierarchicalList/index.ts
+++ b/packages/ui/src/HierarchicalList/index.ts
@@ -1,0 +1,5 @@
+export * from "./HierarchicalListPrimitive";
+export type {
+  HierarchicalListDragAndDropOptions,
+  HierarchicalListDropDestination,
+} from "./HierarchicalListDragAndDrop";

--- a/packages/ui/src/HierarchicalList/useHierarchicalListRowInteractions.ts
+++ b/packages/ui/src/HierarchicalList/useHierarchicalListRowInteractions.ts
@@ -14,7 +14,7 @@ import {
 } from "./useHierarchicalListTouchInteractions";
 import type { HierarchicalListItem } from "./HierarchicalList.types";
 
-/** Props that must be applied to the consumer-rendered row element. */
+/** Props that must be applied to the consumer-rendered row element, composing any overrides. */
 export type HierarchicalListPrimitiveRowProps = HTMLAttributes<HTMLElement> & {
   draggable?: boolean;
   "data-hierarchical-list-row": string;
@@ -109,6 +109,7 @@ export const useHierarchicalListRowInteractions = ({
   };
 
   const rowProps: HierarchicalListPrimitiveRowProps = {
+    style: draggable ? { touchAction: "none" } : undefined,
     onPointerDown: (event) => {
       if (!event.defaultPrevented) pointerProps.onPointerDown?.(event);
     },

--- a/packages/ui/src/HierarchicalList/useHierarchicalListRowInteractions.ts
+++ b/packages/ui/src/HierarchicalList/useHierarchicalListRowInteractions.ts
@@ -1,0 +1,224 @@
+import type { DragEvent as ReactDragEvent, HTMLAttributes } from "react";
+import {
+  canDrop,
+  getKeyboardMoveDestination,
+  getRowDropTarget,
+  insideTargetId,
+  insertionTargetId,
+  type HierarchicalListDragAndDropController,
+  type HierarchicalListDragAndDropOptions,
+} from "./HierarchicalListDragAndDrop";
+import {
+  useHierarchicalListTouchInteractions,
+  type HierarchicalListTouchInteractionOptions,
+} from "./useHierarchicalListTouchInteractions";
+import type { HierarchicalListItem } from "./HierarchicalList.types";
+
+/** Props that must be applied to the consumer-rendered row element. */
+export type HierarchicalListPrimitiveRowProps = HTMLAttributes<HTMLElement> & {
+  draggable?: boolean;
+  "data-hierarchical-list-row": string;
+  "data-depth": number;
+  "data-expanded"?: string;
+  "data-collapsed"?: string;
+  "data-selected"?: string;
+  "data-pressed"?: string;
+  "data-drop-target"?: "inside";
+};
+
+type RowInteractionOptions = {
+  item: HierarchicalListItem;
+  parent: HierarchicalListItem | null;
+  index: number;
+  depth: number;
+  collapsible: boolean;
+  expanded: boolean;
+  selected: boolean;
+  coarsePointer: boolean;
+  rootItems: readonly HierarchicalListItem[];
+  dragAndDrop?: HierarchicalListDragAndDropOptions;
+  interaction?: HierarchicalListTouchInteractionOptions;
+  dragController: HierarchicalListDragAndDropController;
+  hasLongPressAction?: (item: HierarchicalListItem) => boolean;
+  onItemLongPress?: (item: HierarchicalListItem) => void;
+  onItemClick?: (item: HierarchicalListItem) => void;
+  onSelectionClear?: () => void;
+  createDragImage?: (
+    item: HierarchicalListItem,
+    row: HTMLElement,
+    event: ReactDragEvent<HTMLElement>,
+  ) => void;
+  getDropIndicatorInset: (depth: number) => number;
+};
+
+/** Owns one primitive row's pointer, keyboard, and drag interactions. @internal */
+export const useHierarchicalListRowInteractions = ({
+  item,
+  parent,
+  index,
+  depth,
+  collapsible,
+  expanded,
+  selected,
+  coarsePointer,
+  rootItems,
+  dragAndDrop,
+  interaction,
+  dragController,
+  hasLongPressAction,
+  onItemLongPress,
+  onItemClick,
+  onSelectionClear,
+  createDragImage,
+  getDropIndicatorInset,
+}: RowInteractionOptions) => {
+  const draggable = Boolean(item.draggable && dragAndDrop?.onMove);
+  const longPressAction = Boolean(hasLongPressAction?.(item) && onItemLongPress);
+  const { draggedItem, dropTargetId } = dragController;
+  const { pressed, pointerProps, consumeSuppressedClick } = useHierarchicalListTouchInteractions({
+    enabled: longPressAction || draggable,
+    item,
+    parent,
+    index,
+    depth,
+    draggable,
+    longPressAction,
+    dragController,
+    getDropIndicatorInset,
+    onItemLongPress,
+    onSelectionClear,
+    interaction,
+  });
+  const dragging = draggedItem?.id === item.id;
+  const insideDropTarget = dropTargetId === insideTargetId(item)
+    && Boolean(item.droppable && draggedItem && canDrop(draggedItem, item));
+
+  const rowDropTarget = (clientY: number, row: HTMLElement) => {
+    const rect = row.getBoundingClientRect();
+    return getRowDropTarget({
+      source: draggedItem,
+      item,
+      parent,
+      index,
+      depth,
+      open: expanded,
+      clientY,
+      rowTop: rect.top,
+      rowHeight: rect.height,
+    });
+  };
+
+  const rowProps: HierarchicalListPrimitiveRowProps = {
+    onPointerDown: (event) => {
+      if (!event.defaultPrevented) pointerProps.onPointerDown?.(event);
+    },
+    onPointerMove: (event) => {
+      if (!event.defaultPrevented) pointerProps.onPointerMove?.(event);
+    },
+    onPointerUp: (event) => {
+      if (!event.defaultPrevented) pointerProps.onPointerUp?.(event);
+    },
+    onPointerCancel: (event) => {
+      if (!event.defaultPrevented) pointerProps.onPointerCancel?.(event);
+    },
+    "data-hierarchical-list-row": "",
+    "data-depth": depth,
+    "data-expanded": collapsible ? (expanded ? "" : undefined) : undefined,
+    "data-collapsed": collapsible && !expanded ? "" : undefined,
+    "data-selected": selected ? "" : undefined,
+    "data-pressed": pressed ? "" : undefined,
+    "data-drop-target": insideDropTarget ? "inside" : undefined,
+    draggable: draggable && !coarsePointer || undefined,
+    "aria-keyshortcuts": draggable
+      ? "Alt+ArrowUp Alt+ArrowDown Alt+ArrowLeft Alt+ArrowRight"
+      : undefined,
+    "aria-description": draggable ? "Move with Alt plus an arrow key." : undefined,
+    onClick: (event) => {
+      if (event.defaultPrevented) return;
+      if (consumeSuppressedClick()) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      onItemClick?.(item);
+    },
+    onDragStart: (event) => {
+      if (event.defaultPrevented || !draggable) return;
+      onSelectionClear?.();
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", item.id);
+      createDragImage?.(item, event.currentTarget, event);
+      dragController.setDropTargetId(insertionTargetId(parent, index));
+      dragController.updateDropIndicator(
+        event.currentTarget,
+        getDropIndicatorInset(depth),
+        "top",
+        true,
+      );
+      dragController.setDraggedItem(item);
+    },
+    onKeyDown: (event) => {
+      if (event.defaultPrevented) return;
+      if (!event.altKey && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
+        const root = event.currentTarget.closest("[data-hierarchical-list-root]");
+        const rows = root
+          ? [...root.querySelectorAll<HTMLElement>("[data-hierarchical-list-row]")]
+          : [];
+        const currentIndex = rows.indexOf(event.currentTarget);
+        const nextIndex = currentIndex + (event.key === "ArrowDown" ? 1 : -1);
+        const nextRow = rows[nextIndex];
+        if (nextRow) {
+          event.preventDefault();
+          nextRow.focus();
+        }
+        return;
+      }
+      if (!draggable || !event.altKey) return;
+      const direction = event.key === "ArrowUp"
+        ? "up"
+        : event.key === "ArrowDown"
+          ? "down"
+          : event.key === "ArrowLeft"
+            ? "left"
+            : event.key === "ArrowRight"
+              ? "right"
+              : null;
+      if (!direction) return;
+      const destination = getKeyboardMoveDestination(rootItems, item, direction);
+      if (!destination) return;
+      event.preventDefault();
+      dragAndDrop?.onMove(item, destination);
+    },
+    onDragEnd: () => {
+      dragController.setDraggedItem(null);
+      dragController.setDropTargetId(null);
+    },
+    onDragOver: (event) => {
+      if (event.defaultPrevented) return;
+      const target = rowDropTarget(event.clientY, event.currentTarget);
+      if (!target) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "move";
+      dragController.setDropTargetId(target.id);
+      dragController.updateDropIndicator(
+        event.currentTarget,
+        getDropIndicatorInset(target.indicatorDepth),
+        target.edge,
+        target.showIndicator,
+      );
+    },
+    onDrop: (event) => {
+      if (event.defaultPrevented || !draggedItem) return;
+      const target = rowDropTarget(event.clientY, event.currentTarget);
+      if (!target) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragAndDrop?.onMove(draggedItem, target.destination);
+      dragController.setDraggedItem(null);
+      dragController.setDropTargetId(null);
+    },
+  };
+
+  return { draggable, dragging, insideDropTarget, pressed, rowProps };
+};

--- a/packages/ui/src/HierarchicalList/useHierarchicalListTouchInteractions.ts
+++ b/packages/ui/src/HierarchicalList/useHierarchicalListTouchInteractions.ts
@@ -143,6 +143,7 @@ export const useHierarchicalListTouchInteractions = ({
       onPointerUp: (event) => {
         if (touchDraggingRef.current) {
           event.preventDefault();
+          suppressClickRef.current = true;
           dispatchTouchDragEvent("drop", event.clientX, event.clientY);
           touchDraggingRef.current = false;
           dragController.setTouchDragPosition(null);

--- a/packages/ui/src/HierarchicalList/useHierarchicalListTouchInteractions.ts
+++ b/packages/ui/src/HierarchicalList/useHierarchicalListTouchInteractions.ts
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState, type PointerEventHandler } from "react";
+import {
+  dispatchTouchDragEvent,
+  insertionTargetId,
+  type HierarchicalListDragAndDropController,
+} from "./HierarchicalListDragAndDrop";
+import type { HierarchicalListItem } from "./HierarchicalList.types";
+
+const LONG_PRESS_DELAY_MS = 500;
+const DRAG_MOVE_TOLERANCE_PX = 8;
+
+/** Optional thresholds for touch gestures. */
+export type HierarchicalListTouchInteractionOptions = {
+  /** Delay before a touch press opens item actions. Defaults to 500ms. */
+  longPressDelayMs?: number;
+  /** Pointer travel that starts touch dragging and cancels long press. Defaults to 8px. */
+  touchDragThresholdPx?: number;
+};
+
+/** Styled action presentation settings. */
+export type HierarchicalListActionPresentationOptions = {
+  /** Maximum width at which item actions use a drawer. Defaults to 639px. */
+  actionDrawerMaxWidthPx?: number;
+};
+
+const useMediaQuery = (queryText: string) => {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (!window.matchMedia) return;
+    const query = window.matchMedia(queryText);
+    const update = () => setMatches(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, [queryText]);
+
+  return matches;
+};
+
+/** Whether item actions should use the narrow-layout drawer presentation. */
+export const useHierarchicalListActionDrawer = (
+  options?: HierarchicalListActionPresentationOptions,
+) => useMediaQuery(
+  `(max-width: ${Math.max(0, options?.actionDrawerMaxWidthPx ?? 639)}px)`,
+);
+
+/** Whether the primary pointer has coarse precision. */
+export const useHierarchicalListCoarsePointer = () => useMediaQuery("(pointer: coarse)");
+
+/** Coordinates long press and touch dragging for one row. */
+export const useHierarchicalListTouchInteractions = ({
+  enabled,
+  item,
+  parent,
+  index,
+  depth,
+  draggable,
+  longPressAction,
+  dragController,
+  getDropIndicatorInset,
+  onItemLongPress,
+  onSelectionClear,
+  interaction,
+}: {
+  enabled: boolean;
+  item: HierarchicalListItem;
+  parent: HierarchicalListItem | null;
+  index: number;
+  depth: number;
+  draggable: boolean;
+  longPressAction: boolean;
+  dragController: HierarchicalListDragAndDropController;
+  getDropIndicatorInset: (depth: number) => number;
+  onItemLongPress?: (item: HierarchicalListItem) => void;
+  onSelectionClear?: () => void;
+  interaction?: HierarchicalListTouchInteractionOptions;
+}) => {
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressStartRef = useRef<{ x: number; y: number } | null>(null);
+  const suppressClickRef = useRef(false);
+  const touchDraggingRef = useRef(false);
+  const [pressed, setPressed] = useState(false);
+
+  const cancelLongPress = () => {
+    if (longPressTimerRef.current !== null) clearTimeout(longPressTimerRef.current);
+    longPressTimerRef.current = null;
+    longPressStartRef.current = null;
+  };
+  useEffect(() => cancelLongPress, []);
+
+  const pointerProps: {
+    onPointerDown?: PointerEventHandler<HTMLElement>;
+    onPointerMove?: PointerEventHandler<HTMLElement>;
+    onPointerUp?: PointerEventHandler<HTMLElement>;
+    onPointerCancel?: PointerEventHandler<HTMLElement>;
+  } = enabled ? {
+      onPointerDown: (event) => {
+        if (event.pointerType !== "touch" || !event.isPrimary) return;
+        cancelLongPress();
+        if (longPressAction) setPressed(true);
+        longPressStartRef.current = { x: event.clientX, y: event.clientY };
+        if (longPressAction) {
+          longPressTimerRef.current = setTimeout(() => {
+            suppressClickRef.current = true;
+            longPressStartRef.current = null;
+            onItemLongPress?.(item);
+            longPressTimerRef.current = null;
+          }, Math.max(0, interaction?.longPressDelayMs ?? LONG_PRESS_DELAY_MS));
+        }
+      },
+      onPointerMove: (event) => {
+        if (event.pointerType !== "touch" || !event.isPrimary) return;
+        if (touchDraggingRef.current) {
+          event.preventDefault();
+          dragController.setTouchDragPosition({ x: event.clientX, y: event.clientY });
+          dispatchTouchDragEvent("dragover", event.clientX, event.clientY);
+          return;
+        }
+        const start = longPressStartRef.current;
+        if (!start || (
+          Math.abs(event.clientX - start.x)
+            <= Math.max(0, interaction?.touchDragThresholdPx ?? DRAG_MOVE_TOLERANCE_PX)
+          && Math.abs(event.clientY - start.y)
+            <= Math.max(0, interaction?.touchDragThresholdPx ?? DRAG_MOVE_TOLERANCE_PX)
+        )) return;
+        setPressed(false);
+        cancelLongPress();
+        if (!draggable) return;
+        event.preventDefault();
+        touchDraggingRef.current = true;
+        onSelectionClear?.();
+        dragController.setDropTargetId(insertionTargetId(parent, index));
+        dragController.updateDropIndicator(
+          event.currentTarget,
+          getDropIndicatorInset(depth),
+          "top",
+          true,
+        );
+        dragController.setTouchDragPosition({ x: event.clientX, y: event.clientY });
+        dragController.setDraggedItem(item);
+      },
+      onPointerUp: (event) => {
+        if (touchDraggingRef.current) {
+          event.preventDefault();
+          dispatchTouchDragEvent("drop", event.clientX, event.clientY);
+          touchDraggingRef.current = false;
+          dragController.setTouchDragPosition(null);
+          dragController.setDraggedItem(null);
+          dragController.setDropTargetId(null);
+        }
+        setPressed(false);
+        cancelLongPress();
+      },
+      onPointerCancel: () => {
+        if (touchDraggingRef.current) {
+          touchDraggingRef.current = false;
+          dragController.setTouchDragPosition(null);
+          dragController.setDraggedItem(null);
+          dragController.setDropTargetId(null);
+        }
+        setPressed(false);
+        cancelLongPress();
+      },
+    } : {};
+
+  const consumeSuppressedClick = () => {
+    if (!suppressClickRef.current) return false;
+    suppressClickRef.current = false;
+    return true;
+  };
+
+  return { pressed, pointerProps, consumeSuppressedClick };
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./HierarchicalList";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,0 +1,3 @@
+import vitestTaskViteConfig from '@gadgets/scripts/vitest-task'
+
+export default vitestTaskViteConfig('vitest run')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1142,9 +1142,6 @@ importers:
       '@gadgets/error-reporting':
         specifier: workspace:*
         version: link:../error-reporting
-      '@gadgets/ui':
-        specifier: workspace:*
-        version: link:../ui
       '@gadgets/workshop-shared':
         specifier: workspace:*
         version: link:../workshop-shared

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,6 +927,46 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
 
+  packages/ui:
+    dependencies:
+      '@phosphor-icons/react':
+        specifier: ^2.1.10
+        version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      motion:
+        specifier: ^13.2.0
+        version: 13.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+    devDependencies:
+      '@cloudflare/kumo':
+        specifier: ^2.12.0
+        version: 2.12.0(@date-fns/tz@1.5.0)(@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      '@gadgets/scripts':
+        specifier: workspace:*
+        version: link:../../scripts
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.5
+        version: 19.2.5(@types/react@19.2.18)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0(supports-color@10.2.2)
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: 7.3.6
+        version: 7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))
+
   packages/workshop-backend:
     dependencies:
       '@cloudflare/puppeteer':
@@ -1102,6 +1142,9 @@ importers:
       '@gadgets/error-reporting':
         specifier: workspace:*
         version: link:../error-reporting
+      '@gadgets/ui':
+        specifier: workspace:*
+        version: link:../ui
       '@gadgets/workshop-shared':
         specifier: workspace:*
         version: link:../workshop-shared
@@ -3830,6 +3873,17 @@ packages:
       react-dom:
         optional: true
 
+  framer-motion@13.2.0:
+    resolution: {integrity: sha512-9E33ebgMaO33w1nN/jEdW8z3/GO483fMi4rqbMG9rt83XgW9QLKRe4NcmJ8s+fQ3O34++UHrIQwlIWGIWTITjA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4419,8 +4473,14 @@ packages:
   motion-dom@12.43.0:
     resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
 
+  motion-dom@13.2.0:
+    resolution: {integrity: sha512-N6gdSoWRDk0Rh/fVtlqUtLs+fEN3ELFZI3cn3IQE9Mnf3E+Mh8wjO6MstzCOPFh4Yf0L1as5m2eUyYWj8ylVSQ==}
+
   motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion-utils@13.0.0:
+    resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
 
   motion@12.43.0:
     resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
@@ -4431,6 +4491,17 @@ packages:
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  motion@13.2.0:
+    resolution: {integrity: sha512-4Hrb5vD6HhjFstLUiCmWvtpsw+WTpP4R+QXfSDYZBz7+uxE/LrRg3aV0ReJxHrTRffHhbIE6svEqnotngXvesQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
       react:
         optional: true
       react-dom:
@@ -7742,6 +7813,15 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  framer-motion@13.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 13.2.0
+      motion-utils: 13.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   fsevents@2.3.3:
     optional: true
 
@@ -8544,11 +8624,25 @@ snapshots:
     dependencies:
       motion-utils: 12.39.0
 
+  motion-dom@13.2.0:
+    dependencies:
+      motion-utils: 13.0.0
+
   motion-utils@12.39.0: {}
+
+  motion-utils@13.0.0: {}
 
   motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       framer-motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  motion@13.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      framer-motion: 13.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.8


### PR DESCRIPTION
## Summary

This is the foundation PR for shared hierarchical navigation. It introduces the reusable UI layer and component without adopting it in an application yet.

### Shared UI package

- add the private, source-exported `@gadgets/ui` workspace package for runtime UI shared by the Workshop and gatekeeper management apps
- keep React and Kumo as peer dependencies so consumers share one runtime and design-system instance
- add package-level TypeScript and Vitest configuration, root and subpath exports, ownership guidance, and lockfile entries

### Hierarchical list

- add a headless `HierarchicalListPrimitive` that recursively renders semantic nested lists while leaving row presentation to the consumer
- support controlled or uncontrolled expansion, forced expand-all behavior, consumer-controlled selection, selection clearing, and custom structural/rendering slots
- add the Kumo `HierarchicalList` adapter using Kumo controls and tokens, Phosphor icons, and Motion-powered insertion indicators and drag previews
- support desktop context menus and configurable narrow-screen action drawers opened by touch long press
- support native mouse dragging and touch-pointer dragging, optional edge auto-scroll, root/sibling/folder insertion, post-removal index normalization, and rejection of self/descendant moves
- support Arrow Up/Down focus movement and accessible Alt+Arrow reordering, indenting, and unindenting for draggable rows
- preserve focus after consumer-applied moves and announce successful moves through a polite live region
- expose item flags for draggable and droppable behavior while leaving tree mutation in the consuming application

### Frontend conventions

- define `@gadgets/ui` as the shared runtime UI ownership boundary while keeping Kumo as the primitive and token foundation
- add repository guidance for feature-oriented organization, component APIs, React effects/state, styling, accessibility, and behavior-focused tests
- add the `frontend-conventions` skill with the full conventions for React work under `packages/`
- add package-specific guidance for source exports, peer dependencies, Tailwind source scanning, and the headless-primitive/Kumo-adapter split

## Scope

- this PR adds the package and reusable component only; application adoption follows separately
- consumers continue to own selected state and applying `onMove` results to their tree data

## Testing

- `pnpm --filter @gadgets/ui test:run` (32 tests)
- `pnpm install --lockfile-only --frozen-lockfile`
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/cloudflare-os/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->