### PR TITLE
Restricted mode: every action pends for manual approval; approver reviews the full text

### DIFF
--- a/docs/observers.md
+++ b/docs/observers.md
@@ -34,9 +34,11 @@ The mechanism is a per-user, gatekeeper-mediated check — "this data may be sha
 people who *also* have access to it". (Maximally sensitive data gets an extra layer: an
 observation marked **`containsRestrictedData`**
 (`ObservationDescription.containsRestrictedData` in `packages/workshop-shared/src/gatekeeper.ts`)
-latches the workspace into a restricted mode — no actions, no web fetches. Its coverage rests on
-admission: nobody can open the workspace without being verified against the producing gatekeeper,
-and anything that widens what they must be verified against restarts every live session.)
+latches the workspace into a restricted mode — no web fetches, and every action requires manual
+approval (auto-approval rules are suspended), the approver checking the action text for restricted
+data. Its coverage rests on admission: nobody can open the workspace without being verified
+against the producing gatekeeper, and anything that widens what they must be verified against
+restarts every live session.)
 
 The check works as follows:
 
@@ -668,7 +670,8 @@ already in the JSDoc in `gatekeeper.ts`; add anything missing there rather than 
    at every `open()`, so nobody can be in the workspace without having passed the producing
    gatekeeper's `addObserver()`, and anything that widens what they must pass restarts every live
    session (see "Restarting when verification scope widens"). The flag also latches the workspace
-   into a restricted mode that blocks actions and web fetches.
+   into a restricted mode: no web fetches, and every action requires manual approval
+   (auto-approval rules are suspended), the approver checking the action text for restricted data.
    Verification is held to each collaborator's own role scope, because `ensureObserver` can
    never verify beyond it: a `use` collaborator can't be covered for a gatekeeper outside their
    scope (one no gadget binds and no enabled hook feeds — see `#useScopeGatekeeperIds`).
@@ -775,8 +778,10 @@ its resource types.
 
 - **A — Private-only.** Non-owner observers are refused: `addObserver()` unconditionally throws.
   For data that must additionally never leak back out, the `containsRestrictedData` restricted
-  mode (no actions, no web fetches) is available separately; combined with strategy A it makes
-  the workspace effectively private once sensitive data is observed.
+  mode (no web fetches, and every action requires manual approval — auto-approval rules are
+  suspended — the approver checking the action text for restricted data) is available separately;
+  combined with strategy A it makes the workspace effectively private once sensitive data is
+  observed.
   `getVerifier()` must still exist (the overseer mints one on every open) but is never consulted.
 
 - **B — ACL check (single unit).** The resource is treated as one atomic unit.

--- a/packages/integration-tests/__tests__/auto-approval-policy.test.ts
+++ b/packages/integration-tests/__tests__/auto-approval-policy.test.ts
@@ -1,0 +1,150 @@
+// Tests for the auto-approval policy gate around sensitive data.
+//
+// Auto-approval requires the author's per-action `autoApprovable` verdict AND a user-enabled rule
+// for the action's kind. The restricted-data latch must additionally force manual approval no
+// matter what -- even when the rule was enabled before the data was read. (The web-fetch
+// restriction has no client-reachable surface, so it is not asserted here.)
+//
+// The fixture gatekeeper's session drives this through the real ApprovalQueue funnel:
+// `writeValue()` submits a `set-value` action with the given verdict and resolves once the action
+// is decided, and `applyAction` succeeds, so the drain's submit -> auto-approve -> apply round
+// trip is the real one.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { RpcStub } from "capnweb";
+import type {
+  ActionLogEntry, AuthenticatedApi, Overseer, PublicApi,
+} from "@gadgets/workshop-shared/api";
+import { startTestGatekeeperHarness, TEST_VENDOR_ID, type Harness } from "../src/harness.js";
+import type { TestSession } from "../fixtures/gatekeeper-test/src/test-gatekeeper.js";
+import {
+  connect, listConnectedAccounts, nextUsernames, signUp, waitFor, type ConnectedAccount,
+} from "../src/rpc-client.js";
+import { NetworkInterceptor } from "../src/network-interceptor.js";
+
+// The kind the fixture tags every write with (and advertises via getAutoApprovableActions).
+const SET_VALUE = { tag: "set-value", label: "Set value" };
+
+let harness: Harness;
+let interceptor: NetworkInterceptor;
+
+beforeAll(async () => {
+  interceptor = new NetworkInterceptor();
+  interceptor.install();
+  harness = await startTestGatekeeperHarness();
+});
+
+afterAll(async () => {
+  const unmocked = interceptor.getUnmockedCalls();
+  await harness?.server.close();
+  interceptor.uninstall();
+  interceptor.reset();
+  expect(unmocked).toEqual([]);
+});
+
+async function withSession<T>(body: (api: RpcStub<PublicApi>) => Promise<T>): Promise<T> {
+  const publicApi = connect(harness.url);
+  try {
+    return await body(publicApi);
+  } finally {
+    publicApi[Symbol.dispose]();
+  }
+}
+
+async function provisionAccount(api: RpcStub<AuthenticatedApi>): Promise<ConnectedAccount> {
+  await api.provisionAmbientAccount(TEST_VENDOR_ID);
+  return waitFor("the test account to be provisioned", async () => {
+    const accounts = await listConnectedAccounts(api);
+    return accounts.find(a => a.vendorId === TEST_VENDOR_ID) ?? null;
+  });
+}
+
+type Workspace = {
+  overseer: RpcStub<Overseer>;
+  session: RpcStub<TestSession>;
+  gatekeeperId: number;
+};
+
+async function newWorkspace(publicApi: RpcStub<PublicApi>, thingName: string): Promise<Workspace> {
+  const [alice] = nextUsernames("alice");
+  const aliceApi = await signUp(publicApi, alice);
+  const account = await provisionAccount(aliceApi);
+  const overseer = await aliceApi.newGadget();
+  const gatekeeper = await overseer.newGatekeeper(
+      account.id, `https://gadgets-test.example/things/${thingName}`);
+  if (!gatekeeper) throw new Error("Failed to create the test connection");
+  return {
+    overseer,
+    session: await gatekeeper.openSession() as RpcStub<TestSession>,
+    gatekeeperId: await gatekeeper.getId(),
+  };
+}
+
+async function listWrites(ws: Workspace): Promise<Array<ActionLogEntry & { type: "action" }>> {
+  // listActions pages newest-first; sort back to creation order, which the tests reason in.
+  const { entries } = await ws.overseer.listActions();
+  return entries.filter(
+      (a): a is ActionLogEntry & { type: "action" } =>
+          a.type === "action" && a.gatekeeperId === ws.gatekeeperId)
+      .toSorted((a, b) => a.id - b.id);
+}
+
+// The drain runs via ctx.waitUntil after submit, so "did not auto-approve" needs a settle window.
+// One further RPC round trip plus a beat is far beyond the drain's synchronous storage work.
+async function settle(ws: Workspace): Promise<void> {
+  await ws.overseer.listActions();
+  await new Promise(resolve => setTimeout(resolve, 300));
+}
+
+describe("auto-approval policy", () => {
+  it.concurrent("auto-approves a rule-enabled, author-approvable action", async () => {
+    await withSession(async publicApi => {
+      const ws = await newWorkspace(publicApi, "auto-happy");
+      await ws.overseer.setAutoApprovedActionKind(ws.gatekeeperId, SET_VALUE);
+      // Resolves once the action is decided -- here, by the drain, with no human involved.
+      await expect(ws.session.writeValue(1, { autoApprovable: true }))
+          .resolves.toEqual(expect.any(Number));
+
+      const applied = await waitFor("the write to be auto-approved", async () => {
+        const [write] = await listWrites(ws);
+        return write?.state === "approved" ? write : null;
+      });
+      expect(applied.autoApproved).toBe(true);
+    });
+  });
+
+  it.concurrent("a pre-latch auto-approval rule stops firing once the workspace reads sensitive data",
+      async () => {
+    await withSession(async publicApi => {
+      const ws = await newWorkspace(publicApi, "pre-latch");
+      // The catalog lists only connections some gadget binds (pure storage writes; no gadget code
+      // runs), so bind this one to make its rule visible below. Unshared, so no restart.
+      using gadget = await ws.overseer.createGadget("Test Gadget", undefined, "TEST_GADGET");
+      await gadget.bind("TEST_THING", ws.gatekeeperId);
+      await ws.overseer.setAutoApprovedActionKind(ws.gatekeeperId, SET_VALUE);
+      await ws.session.readValue(true);
+
+      // Actions still pend, but the rule the user enabled before the latch must not fire.
+      // The write resolves only once decided, so it is held rather than awaited here.
+      const write = ws.session.writeValue(2, { autoApprovable: true });
+      await settle(ws);
+      const [held] = await listWrites(ws);
+      expect(held.state).toBe("pending");
+
+      // The catalog still names each existing rule's connection so it stays identifiable and
+      // revocable in the UI.
+      await expect(ws.overseer.listPreApprovableActions()).resolves.toEqual([
+        expect.objectContaining({
+          gatekeeperId: ws.gatekeeperId, actionKind: SET_VALUE, alreadyEnabled: true,
+        }),
+      ]);
+
+      // Manual approval still works: the human is the intended path.
+      await ws.overseer.approveAction(held.id);
+      await expect(write).resolves.toEqual(expect.any(Number));
+      const [approved] = await listWrites(ws);
+      expect(approved.state).toBe("approved");
+      expect(approved.autoApproved).toBeFalsy();
+    });
+  });
+});

--- a/packages/integration-tests/__tests__/sensitive-observations.test.ts
+++ b/packages/integration-tests/__tests__/sensitive-observations.test.ts
@@ -5,8 +5,8 @@
 // anything that widens what they must pass restarts the workspace so every live session re-opens
 // against the new scope. So sensitive observations are not blocked by an unverified collaborator,
 // and sharing stays available. The observation also latches the workspace into a restricted mode:
-// once latched, the workspace may not perform actions (nor fetch from the web, which has no
-// client-reachable surface to assert here).
+// once latched, every action pends for manual approval and is never auto-approved; the workspace
+// may not fetch from the web (no client-reachable surface to assert here).
 //
 // The fixture gatekeeper's session drives all of this through the real ApprovalQueue funnel:
 // `readValue(true)` records a `containsRestrictedData` observation, `writeValue()` submits an
@@ -217,7 +217,8 @@ async function bobHolds(ws: Workspace, bob: Bob): Promise<HeldSession> {
 }
 
 describe("sensitive observations", () => {
-  it.concurrent("latch restricted mode: actions are blocked and metadata reports it", async () => {
+  it.concurrent("latch restricted mode: actions pend for manual approval and metadata reports it",
+      async () => {
     await withSession(async publicApi => {
       const ws = await newWorkspace(publicApi, "latch");
 
@@ -235,7 +236,33 @@ describe("sensitive observations", () => {
       await expect(ws.session.readValue(true)).resolves.toBe(42);
 
       expect((await ws.overseer.getMetadata()).containsRestrictedData).toBe(true);
-      await expect(ws.session.writeValue(8)).rejects.toThrow(/prohibited from performing actions/i);
+
+      // A write back to the producing connection is held for approval and goes through once
+      // approved...
+      const latchedWrite = ws.session.writeValue(8);
+      const [pending] = await waitFor("the latched write to be held for approval", async () => {
+        const { entries } = await ws.overseer.listActions({ filter: "pending" });
+        return entries.length > 0 ? entries : null;
+      });
+      await ws.overseer.approveAction(pending.id);
+      await expect(latchedWrite).resolves.toEqual(expect.any(Number));
+
+      // ...and so is a write to any other connection: the latch does not distinguish targets, it
+      // only insists on a human decision.
+      const accounts = await listConnectedAccounts(ws.aliceApi);
+      const account = accounts.find(a => a.vendorId === TEST_VENDOR_ID)!;
+      const other = await ws.overseer.newGatekeeper(account.id, thingUrl("latch-other"));
+      if (!other) throw new Error("Failed to create the second test connection");
+      const otherSession = await other.openSession() as RpcStub<TestSession>;
+      const otherWrite = otherSession.writeValue(9);
+      const [otherPending] = await waitFor("the other connection's write to be held for approval",
+          async () => {
+        const { entries } = await ws.overseer.listActions({ filter: "pending" });
+        return entries.length > 0 ? entries : null;
+      });
+      await ws.overseer.rejectAction(otherPending.id);
+      await expect(otherWrite).rejects.toThrow();
+
       // Reads -- sensitive or not -- keep working.
       await expect(ws.session.readValue()).resolves.toBe(42);
       await expect(ws.session.readValue(true)).resolves.toBe(42);

--- a/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
+++ b/packages/integration-tests/fixtures/gatekeeper-test/src/test-gatekeeper.ts
@@ -301,10 +301,15 @@ export class TestVerifier
 // ---------------------------------------------------------------------------
 // Gatekeeper (one per bound resource, running as a facet under the gadget's Overseer)
 
+/**
+ * A live session against a Test Thing, opened via `GatekeeperClient.openSession()`. `readValue()`
+ * records an observation (optionally `containsRestrictedData`); `writeValue()` submits a
+ * `set-value` action whose `autoApprovable` verdict and warnings the caller chooses.
+ */
 export interface TestSession {
   /** `restricted` marks the observation `containsRestrictedData`. */
   readValue(restricted?: boolean): Promise<number>;
-  writeValue(value: number): Promise<number>;
+  writeValue(value: number, opts?: { autoApprovable?: boolean }): Promise<number>;
   writeValues(values: number[]): Promise<number[]>;
 }
 
@@ -329,7 +334,7 @@ class TestSessionTarget extends RpcTarget implements TestSession {
     return 42;
   }
 
-  async writeValue(value: number): Promise<number> {
+  async writeValue(value: number, opts?: { autoApprovable?: boolean }): Promise<number> {
     const id = await this.state.stageAction(this.label, value);
     try {
       await this.approvalQueue.submitAction(id, {
@@ -337,7 +342,8 @@ class TestSessionTarget extends RpcTarget implements TestSession {
         description: `Set the deterministic integration-test value to **${value}**.`,
         implementsRevert: false,
         awaitDecision: true,
-        actionKind: { tag: "set-value", label: "Set value" },
+        actionKind: SET_VALUE_ACTION_KIND,
+        ...(opts?.autoApprovable ? { autoApprovable: true } : {}),
       });
       return id;
     } catch (error) {
@@ -354,6 +360,8 @@ class TestSessionTarget extends RpcTarget implements TestSession {
     this.approvalQueue[Symbol.dispose]();
   }
 }
+
+const SET_VALUE_ACTION_KIND: ActionKind = { tag: "set-value", label: "Set value" };
 
 @validateRpc()
 export class TestGatekeeper
@@ -384,7 +392,7 @@ export class TestGatekeeper
   }
 
   async getAutoApprovableActions(): Promise<ActionKind[]> {
-    return [];
+    return [SET_VALUE_ACTION_KIND];
   }
 
   async startSession(approvalQueue: RpcStub<ApprovalQueue>): Promise<TestSession> {

--- a/packages/workshop-backend/__tests__/auto-approval.test.ts
+++ b/packages/workshop-backend/__tests__/auto-approval.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { AutoApprovalDrainer, AutoApprovalStorage, ApplyPendingActionFn }
+import { AutoApprovalDrainer, AutoApprovalStorage, ApplyPendingActionFn, autoApprovalRule }
     from "../src/auto-approval.js";
 import type { ActionRecord } from "../src/overseer.js";
 import type { AiChatAuthorInfo } from "@gadgets/workshop-shared/api";
+import type { ActionDescription } from "@gadgets/workshop-shared/gatekeeper";
 import { makeMockStorage } from "./mock-storage.js";
 import { makeActionStorage, makePreIndexActionStorage, putAction } from "./fixtures.js";
 
@@ -279,5 +280,75 @@ describe("AutoApprovalDrainer.drain", () => {
 
     expect(apply.calls).toEqual([1]);
     expect(getAction(storage, 2).state).toBe("pending");
+  });
+
+  it("applies nothing while the workspace is latched, even with a matching rule", async () => {
+    let storage = makeStorage();
+    enableRule(storage);
+    putAction(storage, 1);
+    storage.containsRestrictedData.put(true);
+
+    let apply = makeImmediateApply(storage);
+    await new AutoApprovalDrainer(storage, apply.applyFn).drain(GK);
+
+    expect(apply.calls).toEqual([]);
+    expect(getAction(storage, 1).state).toBe("pending");
+  });
+});
+
+// A description that passes every gate, for the predicate tests to knock single gates out of.
+function eligibleDescription(overrides: Partial<ActionDescription> = {}): ActionDescription {
+  return {
+    title: "Edit the thing",
+    description: "Edits the thing.",
+    implementsRevert: true,
+    actionKind: { tag: "edit", label: "Edits" },
+    autoApprovable: true,
+    ...overrides,
+  };
+}
+
+describe("autoApprovalRule", () => {
+  it("returns the enabling rule when every gate passes", () => {
+    let storage = makeStorage();
+    enableRule(storage);
+    let rule = autoApprovalRule(storage, GK, eligibleDescription());
+    expect(rule?.enabledBy).toEqual(ENABLER);
+  });
+
+  it("requires the author's autoApprovable verdict", () => {
+    let storage = makeStorage();
+    enableRule(storage);
+    expect(autoApprovalRule(storage, GK, eligibleDescription({ autoApprovable: undefined })))
+        .toBeUndefined();
+    expect(autoApprovalRule(storage, GK, eligibleDescription({ autoApprovable: false })))
+        .toBeUndefined();
+  });
+
+  it("requires an actionKind", () => {
+    let storage = makeStorage();
+    enableRule(storage);
+    expect(autoApprovalRule(storage, GK, eligibleDescription({ actionKind: undefined })))
+        .toBeUndefined();
+  });
+
+  it("requires a user-enabled rule for the kind on this gatekeeper", () => {
+    let storage = makeStorage();
+    expect(autoApprovalRule(storage, GK, eligibleDescription())).toBeUndefined();
+    enableRule(storage, "edit", GK + 1);  // right tag, wrong gatekeeper
+    expect(autoApprovalRule(storage, GK, eligibleDescription())).toBeUndefined();
+    enableRule(storage, "delete", GK);    // right gatekeeper, wrong tag
+    expect(autoApprovalRule(storage, GK, eligibleDescription())).toBeUndefined();
+  });
+
+  it("refuses every action while the restricted-data latch is set", () => {
+    let storage = makeStorage();
+    enableRule(storage);
+    enableRule(storage, "edit", GK + 1);
+    storage.containsRestrictedData.put(true);
+    // The latch is workspace-wide: every action submitAction lets pend must be read by a human,
+    // on every gatekeeper.
+    expect(autoApprovalRule(storage, GK, eligibleDescription())).toBeUndefined();
+    expect(autoApprovalRule(storage, GK + 1, eligibleDescription())).toBeUndefined();
   });
 });

--- a/packages/workshop-backend/__tests__/git-push-actions.test.ts
+++ b/packages/workshop-backend/__tests__/git-push-actions.test.ts
@@ -27,10 +27,24 @@ declare module "cloudflare:workers" {
 const GATEKEEPER = 7;
 const USER = { type: "user" as const, id: "alice@example.com", name: "Alice" };
 
+// Every scenario starts with the gatekeeper's record in place: submitAction refuses an action
+// naming a connection the workspace no longer has.
 async function inOverseer(name: string, fn: (impl: any) => Promise<void>): Promise<void> {
   let stub = env.TEST_OVERSEER.getByName(name);
   await runInDurableObject(stub, async (instance: OverseerDurableObject) => {
-    await fn((instance as unknown as { impl: any }).impl);
+    let impl = (instance as unknown as { impl: any }).impl;
+    impl.storage.gatekeepers.put({
+      id: GATEKEEPER,
+      resourceTitle: "Remote repository",
+      class: {} as any,
+      creationSpec: {
+        type: "gatekeeper",
+        vendorId: "testvendor",
+        resourceUrl: "https://example.com/repo",
+        typeUrlPattern: "https://*",
+      },
+    });
+    await fn(impl);
   });
 }
 

--- a/packages/workshop-backend/__tests__/restricted-actions.test.ts
+++ b/packages/workshop-backend/__tests__/restricted-actions.test.ts
@@ -1,0 +1,67 @@
+// submitAction refuses an action on a removed connection outright. Runs against a real
+// OverseerDurableObject (the TEST_OVERSEER binding); records are seeded directly through the impl.
+
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import type { OverseerDurableObject } from "../src/overseer.js";
+import type { ActionDescription } from "@gadgets/workshop-shared/gatekeeper";
+
+declare module "cloudflare:workers" {
+  interface ProvidedEnv {
+    TEST_OVERSEER: DurableObjectNamespace<OverseerDurableObject>;
+  }
+}
+
+const CALLER = { from: "user" } as const;
+
+function getImpl(instance: OverseerDurableObject): any {
+  return (instance as unknown as { impl: any }).impl;
+}
+
+function seedGatekeeper(impl: any, id: number): void {
+  impl.storage.gatekeepers.put({
+    id,
+    resourceTitle: `Connection ${id}`,
+    class: {} as any,
+    creationSpec: {
+      type: "gatekeeper",
+      vendorId: "testvendor",
+      resourceUrl: `https://example.com/${id}`,
+      typeUrlPattern: "https://*",
+    },
+  });
+}
+
+function pokeDescription(autoApprovable = false): ActionDescription {
+  return {
+    title: "Poke the thing",
+    description: "The test poked the thing.",
+    implementsRevert: false,
+    actionKind: { tag: "poke", label: "Pokes" },
+    ...(autoApprovable ? { autoApprovable: true } : {}),
+  };
+}
+
+function actionStates(impl: any): Array<{ gatekeeperId: number; state: string }> {
+  return [...impl.storage.actions.list()]
+      .filter((rec: any) => rec.type === "action")
+      .map((rec: any) => ({ gatekeeperId: rec.gatekeeperId, state: rec.state }));
+}
+
+describe("submitAction", () => {
+  it("refuses an action on a removed connection, writing no record", async () => {
+    let stub = env.TEST_OVERSEER.getByName("restricted-actions-removed");
+    await runInDurableObject(stub, async (instance: OverseerDurableObject) => {
+      let impl = getImpl(instance);
+      seedGatekeeper(impl, 1);
+      impl.storage.gatekeepers.delete(1);
+      let nextActionId = impl.storage.nextActionId.get();
+
+      await expect(impl.submitAction(1, 0, pokeDescription(), CALLER))
+          .rejects.toThrow(/has been removed from this workspace/i);
+      expect(actionStates(impl)).toEqual([]);
+      expect(impl.storage.nextActionId.get()).toBe(nextActionId);
+    });
+  });
+});

--- a/packages/workshop-backend/__tests__/restricted-actions.test.ts
+++ b/packages/workshop-backend/__tests__/restricted-actions.test.ts
@@ -1,5 +1,7 @@
-// submitAction refuses an action on a removed connection outright. Runs against a real
-// OverseerDurableObject (the TEST_OVERSEER binding); records are seeded directly through the impl.
+// submitAction under the restricted-data latch: every action pends for manual approval, on any
+// connection, and is never auto-approved; an action on a removed connection is refused outright.
+// Runs against a real OverseerDurableObject (the TEST_OVERSEER binding); records are seeded
+// directly through the impl.
 
 import { describe, expect, it } from "vitest";
 import { env } from "cloudflare:workers";
@@ -14,6 +16,7 @@ declare module "cloudflare:workers" {
 }
 
 const CALLER = { from: "user" } as const;
+const USER = { type: "user", id: "alice", name: "Alice" } as const;
 
 function getImpl(instance: OverseerDurableObject): any {
   return (instance as unknown as { impl: any }).impl;
@@ -33,6 +36,26 @@ function seedGatekeeper(impl: any, id: number): void {
   });
 }
 
+// A restricted observation attributed to `gatekeeperId` plus the latch, as authorizeObservation
+// writes them.
+function seedRestrictedObservation(impl: any, gatekeeperId: number, actionId: number): void {
+  impl.storage.actions.put({
+    id: actionId,
+    gatekeeperId,
+    caller: CALLER,
+    createdAt: new Date(),
+    state: "approved",
+    type: "observation",
+    description: {
+      title: "Read a thing",
+      description: "The test read a thing.",
+      containsRestrictedData: true,
+    },
+  });
+  impl.storage.nextActionId.put(actionId + 1);
+  impl.storage.containsRestrictedData.put(true);
+}
+
 function pokeDescription(autoApprovable = false): ActionDescription {
   return {
     title: "Poke the thing",
@@ -49,7 +72,55 @@ function actionStates(impl: any): Array<{ gatekeeperId: number; state: string }>
       .map((rec: any) => ({ gatekeeperId: rec.gatekeeperId, state: rec.state }));
 }
 
-describe("submitAction", () => {
+describe("submitAction under the restricted-data latch", () => {
+  it("pends a latched action on any connection, never auto-approved", async () => {
+    let stub = env.TEST_OVERSEER.getByName("restricted-actions-pend");
+    await runInDurableObject(stub, async (instance: OverseerDurableObject) => {
+      let impl = getImpl(instance);
+      seedGatekeeper(impl, 1);
+      seedGatekeeper(impl, 2);
+      seedRestrictedObservation(impl, 1, 100);
+      // A rule that would auto-approve the action on connection 2 were the workspace not latched.
+      impl.storage.autoApproveTags.put({
+        gatekeeperId: 2,
+        actionKind: { tag: "poke", label: "Pokes" },
+        enabledBy: USER,
+      });
+
+      await impl.submitAction(2, 0, pokeDescription(/* autoApprovable */ true), CALLER);
+      await impl.submitAction(1, 0, pokeDescription(), CALLER);
+      expect(actionStates(impl)).toEqual([
+        { gatekeeperId: 2, state: "pending" },
+        { gatekeeperId: 1, state: "pending" },
+      ]);
+
+      // Not auto-approved even by an explicit drain: every action stays a manual gate.
+      await impl.drainAutoApprovals(2);
+      expect(actionStates(impl)).toEqual([
+        { gatekeeperId: 2, state: "pending" },
+        { gatekeeperId: 1, state: "pending" },
+      ]);
+    });
+  });
+
+  it("applies a pre-latch pending action once approved", async () => {
+    let stub = env.TEST_OVERSEER.getByName("restricted-actions-pre-latch");
+    await runInDurableObject(stub, async (instance: OverseerDurableObject) => {
+      let impl = getImpl(instance);
+      seedGatekeeper(impl, 1);
+      seedGatekeeper(impl, 2);
+
+      // Queued while unlatched, on a connection the restricted data never came through.
+      await impl.submitAction(2, 0, pokeDescription(), CALLER);
+      seedRestrictedObservation(impl, 1, 100);
+
+      let record = [...impl.storage.actions.list()].find((rec: any) => rec.type === "action");
+      impl.getGatekeeperFacet = () => ({ async applyAction() {} });
+      await impl.applyPendingAction(record, USER, false);
+      expect(actionStates(impl)).toEqual([{ gatekeeperId: 2, state: "approved" }]);
+    });
+  });
+
   it("refuses an action on a removed connection, writing no record", async () => {
     let stub = env.TEST_OVERSEER.getByName("restricted-actions-removed");
     await runInDurableObject(stub, async (instance: OverseerDurableObject) => {

--- a/packages/workshop-backend/src/auto-approval.ts
+++ b/packages/workshop-backend/src/auto-approval.ts
@@ -3,8 +3,9 @@
 // concurrent drains (the DO's input gate is open across the apply await) can't double-apply the
 // same action. The apply is injected, keeping this constructible over a mock storage in tests.
 
-import type { Collection, NonUniqueIndex } from "@gadgets/typed-storage";
+import type { Collection, NonUniqueIndex, Singleton } from "@gadgets/typed-storage";
 import type { AiChatAuthorInfo } from "@gadgets/workshop-shared/api";
+import type { ActionDescription } from "@gadgets/workshop-shared/gatekeeper";
 import { createWorkshopLogger } from "./observability";
 import type { ActionRecord, AutoApproveTagRecord } from "./overseer.js";
 
@@ -14,6 +15,24 @@ export interface AutoApprovalStorage {
   actions: Collection<ActionRecord, number>
       & { pendingByGatekeeper: NonUniqueIndex<ActionRecord, number> };
   autoApproveTags: Collection<AutoApproveTagRecord>;
+
+  /** The restricted-data latch (see makeOverseerStorage). While set, nothing auto-approves. */
+  containsRestrictedData: Singleton<boolean>;
+}
+
+/**
+ * The single authority on whether an action may be applied without a human: the enabling rule if
+ * the author marked the action `autoApprovable`, the user enabled a rule for its `actionKind` on
+ * this gatekeeper, and the workspace has not latched restricted mode; else undefined.
+ */
+export function autoApprovalRule(
+    storage: AutoApprovalStorage, gatekeeperId: number, description: ActionDescription)
+    : AutoApproveTagRecord | undefined {
+  if (description.autoApprovable !== true) return undefined;
+  let tag = description.actionKind?.tag;
+  if (tag === undefined) return undefined;
+  if (storage.containsRestrictedData.get()) return undefined;
+  return storage.autoApproveTags.get(`${gatekeeperId}:${tag}`);
 }
 
 /**
@@ -56,8 +75,8 @@ export class AutoApprovalDrainer {
   // applying -- it is never skipped ahead of. This preserves in-order application and the
   // invariant that nothing is silently applied past a human gate.
   //
-  // Eligibility requires BOTH signals: the author's `autoApprovable` verdict on the action AND a
-  // user-enabled rule for the action's type on this gatekeeper.
+  // Eligibility is `autoApprovalRule()`: the author's `autoApprovable` verdict, a user-enabled
+  // rule for the action's kind, and no restricted-data latch.
   async #drainOnce(gatekeeperId: number): Promise<void> {
     // Materialize before applying: the index yields lazily in ascending id order, and applying
     // mutates it mid-iteration. Actions created after this snapshot trigger their own drain(),
@@ -67,11 +86,8 @@ export class AutoApprovalDrainer {
     for (let record of pending) {
       if (record.type !== "action") continue;
 
-      let tag = record.description.actionKind?.tag;
-      let rule = tag !== undefined
-          ? this.storage.autoApproveTags.get(`${gatekeeperId}:${tag}`)
-          : undefined;
-      if (record.description.autoApprovable !== true || rule === undefined) {
+      let rule = autoApprovalRule(this.storage, gatekeeperId, record.description);
+      if (rule === undefined) {
         // A manual gate. Stop rather than skipping ahead to any later auto-eligible action.
         return;
       }

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -49,7 +49,7 @@ import { completeAgentCatalogSnapshot, normalizeAgentCatalog } from "./agent-cat
 import { refreshCachedBalance } from "./ai-gateway-billing/cloudflare/connection-service";
 import { SharingManager, SharingCaller, CollaboratorRecord, ShareKeyRecord, roleRank }
     from "./sharing";
-import { AutoApprovalDrainer } from "./auto-approval";
+import { AutoApprovalDrainer, autoApprovalRule } from "./auto-approval";
 import { collectSlashCommands, invokeSlashCommand } from "./slash-commands";
 import { createWorkshopLogger, obsContext, traced } from "./observability";
 import { retryOnDoReset, wrapDoStubForTelemetry } from "./do-retry";
@@ -1154,7 +1154,9 @@ export function makeOverseerStorage(storage: DurableObjectStorage) {
       deadWorktreeIds: <WorkpieceId[]>[],
 
       // True if any past observation was authorized that had the `containsRestrictedData` flag
-      // set in its `ObservationDescription`. The key on disk predates the flag's rename.
+      // set in its `ObservationDescription`. While set, public-web fetches are refused and every
+      // action pends for manual approval (autoApprovalRule never fires); the approver checks the
+      // action text for restricted data. The key on disk predates the flag's rename.
       containsRestrictedData: singleton(false, {storageKey: "prohibitAllSharing"}),
     },
 
@@ -5790,12 +5792,6 @@ class OverseerImpl implements AgentHooks {
           "removed from this workspace.");
     }
 
-    if (this.storage.containsRestrictedData.get()) {
-      throw new Error(
-          "This workspace has observed sensitive data. To prevent leaks, the workspace is prohibited " +
-          "from performing actions.");
-    }
-
     // Push authorization (see ActionDescription.pushedCommits): before anything is queued,
     // verify that every declared head's ancestry reaches a commit proven on this gatekeeper's
     // remote. This is the chokepoint that makes an accidental push to an unrelated remote fail
@@ -5832,10 +5828,9 @@ class OverseerImpl implements AgentHooks {
     });
     this.#associateAction(caller, actionId);
 
-    // Same auto-approval gate as before, named because awaitDecision uses it too. The drain is
-    // deferred because applying calls back into the gatekeeper facet still awaiting submitAction.
-    let willAutoApprove = !!(description.autoApprovable && description.actionKind &&
-        this.storage.autoApproveTags.get(`${gatekeeperId}:${description.actionKind.tag}`) !== undefined);
+    // Same auto-approval gate the drainer uses, named because awaitDecision uses it too. The drain
+    // is deferred because applying calls back into the gatekeeper facet still awaiting submitAction.
+    let willAutoApprove = autoApprovalRule(this.storage, gatekeeperId, description) !== undefined;
 
     // Only agent turns suspend on awaitDecision, and only when a manual decision is pending.
     // Auto-approved actions keep the seamless behavior the user opted into.

--- a/packages/workshop-backend/src/overseer.ts
+++ b/packages/workshop-backend/src/overseer.ts
@@ -5781,6 +5781,15 @@ class OverseerImpl implements AgentHooks {
   async submitAction(gatekeeperId: number, action: number,
                      description: ActionDescription, caller: GatekeeperCaller)
       : Promise<void> {
+    // An in-flight facet RPC can outlive removeGatekeeper, and a pending action on a removed
+    // connection could never be approved or rejected (both dereference the facet).
+    let gatekeeper = this.storage.gatekeepers.get(gatekeeperId);
+    if (!gatekeeper) {
+      throw new Error(
+          "This action was blocked because the connection it was submitted through has been " +
+          "removed from this workspace.");
+    }
+
     if (this.storage.containsRestrictedData.get()) {
       throw new Error(
           "This workspace has observed sensitive data. To prevent leaks, the workspace is prohibited " +
@@ -5799,14 +5808,12 @@ class OverseerImpl implements AgentHooks {
     let actionId = this.storage.nextActionId.get();
     this.storage.nextActionId.put(actionId + 1);
 
-    let gatekeeper = this.storage.gatekeepers.get(gatekeeperId);
-
     let record: ActionRecord = {
       id: actionId,
       gatekeeperId,
       caller,
-      resourceTitle: gatekeeper?.resourceTitle,
-      resourceUrl: gatekeeper?.resourceUrl,
+      resourceTitle: gatekeeper.resourceTitle,
+      resourceUrl: gatekeeper.resourceUrl,
       action,
       createdAt: new Date(),
       state: "pending",

--- a/packages/workshop-frontend/src/Activity.tsx
+++ b/packages/workshop-frontend/src/Activity.tsx
@@ -19,6 +19,7 @@ import { useVendorBranding } from './useVendorBranding'
 import { useResolveAction } from './useResolveAction'
 import { safeExternalUrl } from './utils/safeExternalUrl'
 import AutoApproveConfirmDialog from './components/AutoApproveConfirmDialog'
+import { RestrictedApprovalNotice } from './components/RestrictedApprovalNotice'
 
 export type ActivityView = 'review' | 'history' | 'auto'
 
@@ -252,6 +253,7 @@ export default function Activity({
                 <ReviewRequest
                   key={record.id}
                   record={record}
+                  restricted={restricted}
                   expanded={expandedActionId === record.id}
                   processing={processingActions.has(record.id)}
                   onToggle={() => toggleExpanded(record.id)}
@@ -617,6 +619,7 @@ function AutoApprovalPanel({
 
 function ReviewRequest({
   record,
+  restricted,
   expanded,
   processing,
   onToggle,
@@ -625,6 +628,9 @@ function ReviewRequest({
   onAlwaysApprove,
 }: {
   record: ActionLogEntry
+  // While restricted the approver is the leak check, so the request is shown in full with a
+  // notice saying so.
+  restricted?: boolean
   expanded: boolean
   processing: boolean
   onToggle: () => void
@@ -675,8 +681,10 @@ function ReviewRequest({
         </div>
       </div>
 
+      {restricted && <RestrictedApprovalNotice className="mt-2 max-w-2xl" />}
+
       {record.description.description && (
-        <p className={`mt-1.5 max-w-2xl whitespace-pre-wrap text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle ${expanded ? '' : 'line-clamp-2'}`}>
+        <p className={`mt-1.5 max-w-2xl whitespace-pre-wrap text-[13px] leading-[18px] tracking-[-0.25px] text-kumo-subtle ${restricted || expanded ? '' : 'line-clamp-2'}`}>
           {record.description.description}
         </p>
       )}

--- a/packages/workshop-frontend/src/Activity.tsx
+++ b/packages/workshop-frontend/src/Activity.tsx
@@ -26,6 +26,10 @@ const PANE_BAR = 'flex h-9 flex-shrink-0 items-center border-b border-kumo-line'
 
 interface ActivityProps {
   overseer: RpcStub<Overseer>
+  // True once the workspace has read restricted data (GadgetMetadata.containsRestrictedData).
+  // Latched actions are never auto-approved, so the always-approve affordance is hidden and
+  // existing rules are shown as suspended but stay revocable.
+  restricted?: boolean
   view: ActivityView
   onViewChange: (view: ActivityView) => void
   onAutoApproveChange?: () => void
@@ -152,6 +156,7 @@ function ActivityNotice({ icon, title, description, children }: {
 
 export default function Activity({
   overseer,
+  restricted,
   view,
   onViewChange,
   onAutoApproveChange,
@@ -169,6 +174,11 @@ export default function Activity({
     actionKind: ActionKind
     actionLabel: string
   } | null>(null)
+
+  // The workspace latched: the affordance is gone and confirming could only error.
+  useEffect(() => {
+    if (restricted) setConfirmAutoApprove(null)
+  }, [restricted])
   const toasts = useKumoToastManager()
 
   const history = useActionHistory(overseer, historyFilter, view === 'history')
@@ -225,6 +235,8 @@ export default function Activity({
           <div className="min-h-0 flex-1 overflow-auto">
             {pendingActions.map(record => {
               const autoApproveTarget =
+                // Never auto-approved while restricted, so no rule is offered.
+                !restricted &&
                 record.type === 'action' && record.gatekeeperId !== undefined &&
                 record.description.actionKind !== undefined &&
                 record.description.autoApprovable === true
@@ -423,7 +435,13 @@ export default function Activity({
           </>
         )
       case 'auto':
-        return <AutoApprovalPanel overseer={overseer} reloadTrigger={autoApproveReloadTrigger} />
+        return (
+          <AutoApprovalPanel
+            overseer={overseer}
+            restricted={restricted}
+            reloadTrigger={autoApproveReloadTrigger}
+          />
+        )
     }
   }
 
@@ -452,9 +470,11 @@ export default function Activity({
 
 function AutoApprovalPanel({
   overseer,
+  restricted,
   reloadTrigger,
 }: {
   overseer: RpcStub<Overseer>
+  restricted?: boolean
   reloadTrigger?: number
 }) {
   const { entries, isLoading, loadError, pending, refresh, setEnabled } = useAutoApproval(overseer)
@@ -567,17 +587,21 @@ function AutoApprovalPanel({
                       {entry.actionKind.label}
                     </span>
                     <span className="mt-0.5 block text-[12px] leading-4 tracking-[-0.2px] text-kumo-inactive">
-                      {entry.orphaned
-                        ? 'This connection no longer offers this action; the rule still applies.'
-                        : entry.enabled
-                          ? 'Applied without asking'
-                          : 'Waits for your approval'}
+                      {restricted
+                        // Rules don't apply while restricted; say so, but keep them revocable.
+                        ? "Won't apply: this workspace has read sensitive data, so actions always require manual approval."
+                        : entry.orphaned
+                          ? 'This connection no longer offers this action; the rule still applies.'
+                          : entry.enabled
+                            ? 'Applied without asking'
+                            : 'Waits for your approval'}
                     </span>
                   </span>
                   <Switch
                     size="sm"
                     checked={entry.enabled}
-                    disabled={busy}
+                    // Enabling would only error while restricted; disabling must stay possible.
+                    disabled={busy || (restricted === true && !entry.enabled)}
                     aria-label={`${entry.enabled ? 'Disable' : 'Enable'} auto-approval for ${entry.actionKind.label}`}
                     onCheckedChange={enabled => void setEnabled(entry, enabled)}
                   />

--- a/packages/workshop-frontend/src/ActivityNotifications.test.tsx
+++ b/packages/workshop-frontend/src/ActivityNotifications.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+/* eslint-disable react/react-in-jsx-scope */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@cloudflare/kumo', async (importOriginal) => {
+  const actual = await importOriginal() as typeof import('@cloudflare/kumo')
+  // Render the popover inline (open or not) so its content is in the DOM to assert on.
+  const Pass = ({ children }: { children?: React.ReactNode }) => children ?? null
+  const parts = new Proxy(Pass, { get: () => Pass })
+  const toasts = { add: vi.fn<(options: unknown) => void>() }
+  return { ...actual, Popover: parts, useKumoToastManager: () => toasts }
+})
+
+import { entry, flushFrames, makeOverseer, makeTestRoot } from './action-test-harness'
+import ActivityNotifications from './ActivityNotifications'
+import { RESTRICTED_APPROVAL_COPY } from './components/RestrictedApprovalNotice'
+
+const view = makeTestRoot()
+
+afterEach(() => {
+  view.cleanup()
+  vi.restoreAllMocks()
+})
+
+const longDescription = [
+  'Send the following email to alice@example.com:',
+  'Hi Alice, attached are the quarterly numbers you asked for.',
+  'Regards, the workspace.',
+].join('\n\n')
+
+// Renders the popover with one pending request and returns the span carrying its description.
+async function renderPending(restricted?: boolean): Promise<HTMLElement> {
+  const server = makeOverseer()
+  await view.render(
+    <ActivityNotifications overseer={server.overseer} onViewActivity={() => {}} restricted={restricted} />,
+  )
+  await server.resolveSubscription()
+  await server.resolvePendingQuery({
+    entries: [entry(1, {
+      description: { title: 'Send email', description: longDescription, implementsRevert: false },
+    })],
+  })
+  flushFrames()
+  const description = [...document.querySelectorAll('span')]
+      .find(span => span.textContent === longDescription)
+  if (!description) throw new Error('The pending request description was not rendered')
+  return description
+}
+
+describe('ActivityNotifications', () => {
+  it('shows the review notice and the untruncated request while restricted', async () => {
+    const description = await renderPending(true)
+    expect(document.body.textContent).toContain(RESTRICTED_APPROVAL_COPY)
+    expect(description.classList.contains('line-clamp-2')).toBe(false)
+  })
+
+  it('clamps the request and shows no notice when not restricted', async () => {
+    const description = await renderPending()
+    expect(document.body.textContent).not.toContain(RESTRICTED_APPROVAL_COPY)
+    expect(description.classList.contains('line-clamp-2')).toBe(true)
+  })
+})

--- a/packages/workshop-frontend/src/ActivityNotifications.tsx
+++ b/packages/workshop-frontend/src/ActivityNotifications.tsx
@@ -5,6 +5,7 @@ import type { RpcStub } from 'capnweb'
 import type { Overseer } from '@gadgets/workshop-shared/api'
 import { CountBadge } from './components/CountBadge'
 import { ResolveButton } from './components/ResolveButton'
+import { RestrictedApprovalNotice } from './components/RestrictedApprovalNotice'
 import {
   formatRelativeTime,
   PENDING_CHECKING_COPY,
@@ -17,6 +18,9 @@ import { useResolveAction } from './useResolveAction'
 interface ActivityNotificationsProps {
   overseer: RpcStub<Overseer>
   onViewActivity: (view: ActivityView) => void
+  // True once the workspace has read restricted data (GadgetMetadata.containsRestrictedData):
+  // the approver is the leak check, so each request is shown in full with a notice saying so.
+  restricted?: boolean
 }
 
 const PREVIEW_LIMIT = 3
@@ -24,6 +28,7 @@ const PREVIEW_LIMIT = 3
 export default function ActivityNotifications({
   overseer,
   onViewActivity,
+  restricted,
 }: ActivityNotificationsProps) {
   const [open, setOpen] = useState(false)
   const [processing, setProcessing] = useState<Set<number>>(new Set())
@@ -76,6 +81,7 @@ export default function ActivityNotifications({
           </p>
         ) : (
           <div className="max-h-[min(58vh,420px)] overflow-y-auto pb-1">
+            {restricted && <RestrictedApprovalNotice className="mx-3.5 mb-1 mt-0.5 px-2.5 py-2" />}
             {pending.slice(0, PREVIEW_LIMIT).map((action, index) => {
               const isProcessing = processing.has(action.id)
               return (
@@ -97,7 +103,7 @@ export default function ActivityNotifications({
                         <span className="px-1">·</span>
                         {formatRelativeTime(action.createdAt)}
                       </span>
-                      <span className="mt-1.5 block line-clamp-2 text-[12.5px] leading-[18px] tracking-[-0.2px] text-kumo-subtle">
+                      <span className={`mt-1.5 block whitespace-pre-wrap text-[12.5px] leading-[18px] tracking-[-0.2px] text-kumo-subtle ${restricted ? '' : 'line-clamp-2'}`}>
                         {action.description.description}
                       </span>
                     </button>

--- a/packages/workshop-frontend/src/ChatInterface.actions.test.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.actions.test.tsx
@@ -4,12 +4,16 @@
 import { act } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { RpcStub } from 'capnweb'
-import type { AiChatMessage, AiChatSubscriber, Overseer } from '@gadgets/workshop-shared/api'
+import type {
+  ActionLogEntry, AiChatMessage, AiChatMetadata, AiChatSubscriber, Overseer,
+} from '@gadgets/workshop-shared/api'
 
 vi.stubGlobal('ResizeObserver', class {
   observe() {}
   disconnect() {}
 })
+// jsdom lays nothing out; the message list scrolls itself to the bottom on every render.
+Element.prototype.scrollTo = () => {}
 
 vi.mock('@cloudflare/kumo', async (importOriginal) => {
   const actual = await importOriginal() as typeof import('@cloudflare/kumo')
@@ -42,6 +46,7 @@ vi.mock('./AuthContext', () => {
 
 import { entry, makeOverseer, makeTestRoot } from './action-test-harness'
 import ChatInterface from './ChatInterface'
+import { RESTRICTED_APPROVAL_COPY } from './components/RestrictedApprovalNotice'
 import { linkActionLog } from './useActions'
 
 const testRoot = makeTestRoot()
@@ -54,11 +59,13 @@ afterEach(() => {
 function withChatApi(
   server: ReturnType<typeof makeOverseer>,
   getChatMessage = vi.fn<(chatId: number, sequence: number) => Promise<AiChatMessage | null>>(),
+  chats: AiChatMetadata[] = [],
 ) {
   let subscriber: AiChatSubscriber | undefined
   Object.assign(server.overseer as object, {
     getChatMessage,
-    listChats: async () => [],
+    getChatHistory: async () => ({ messages: [] }),
+    listChats: async () => chats,
     listModels: async () => [],
     onRpcBroken: () => {},
     subscribeToChat: (next: AiChatSubscriber) => {
@@ -74,12 +81,16 @@ function withChatApi(
   }
 }
 
-function renderChat(overseer: RpcStub<Overseer>) {
+function renderChat(
+  overseer: RpcStub<Overseer>,
+  props: { restricted?: boolean, selectedChatId?: number } = {},
+) {
   return testRoot.render(
     <ChatInterface
       workspaceId="workspace"
       overseer={overseer}
-      selectedChatId={null}
+      restricted={props.restricted}
+      selectedChatId={props.selectedChatId ?? null}
       onNavigateToChat={() => {}}
       pendingConsoleLogCount={0}
       consoleLogPreview=""
@@ -137,5 +148,58 @@ describe('ChatInterface action refresh', () => {
     await second.resolveSubscription()
     await second.resolvePendingQuery({ entries: [entry(1)] })
     expect(secondChat.getChatMessage).not.toHaveBeenCalled()
+  })
+})
+
+// A pending action whose description runs to several paragraphs: what the approver has to read
+// in full when the workspace is restricted.
+const longDescription = [
+  'Send the following email to alice@example.com:',
+  'Hi Alice, attached are the quarterly numbers you asked for.',
+  'Regards, the workspace.',
+].join('\n\n')
+
+function pendingLog(over: Partial<Record<string, unknown>> = {}) {
+  return entry(1, {
+    description: { title: 'Send email', description: longDescription, implementsRevert: false, ...over },
+  })
+}
+
+// Renders chat 1 selected, so its messages -- and the action card for `log` -- are actually on
+// screen.
+async function renderPendingCard(log: ActionLogEntry, props: { restricted?: boolean } = {}) {
+  const server = makeOverseer()
+  const chat = withChatApi(server, undefined, [
+    { id: 1, title: 'Chat', started: new Date(), lastActive: new Date() },
+  ])
+  await renderChat(server.overseer, { ...props, selectedChatId: 1 })
+  await server.resolveSubscription()
+  await server.resolvePendingQuery({ entries: [log] })
+  chat.emitMessage({ ...actionMessage, actionLog: log } as AiChatMessage)
+}
+
+const clampedDescription = () => document.querySelector('[class*="max-h-[200px]"]')
+
+describe('restricted approval', () => {
+  it('shows the notice and the full request on a pending card while restricted', async () => {
+    await renderPendingCard(pendingLog(), { restricted: true })
+
+    expect(document.body.textContent).toContain(RESTRICTED_APPROVAL_COPY)
+    expect(document.body.textContent).toContain('Regards, the workspace.')
+    expect(clampedDescription()).toBeNull()
+  })
+
+  it('shows the notice and the full request on a blocking card while restricted', async () => {
+    await renderPendingCard(pendingLog({ awaitDecision: true }), { restricted: true })
+
+    expect(document.body.textContent).toContain(RESTRICTED_APPROVAL_COPY)
+    expect(clampedDescription()).toBeNull()
+  })
+
+  it('keeps the scrolling description and no notice when not restricted', async () => {
+    await renderPendingCard(pendingLog())
+
+    expect(document.body.textContent).not.toContain(RESTRICTED_APPROVAL_COPY)
+    expect(clampedDescription()).not.toBeNull()
   })
 })

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -2384,6 +2384,9 @@ function fallbackToStoredModelSelection(
 interface ChatInterfaceProps {
   workspaceId: string | undefined;
   overseer: RpcStub<Overseer>;
+  // True once the workspace has read restricted data (GadgetMetadata.containsRestrictedData).
+  // Latched actions are never auto-approved, so the always-approve affordance is hidden.
+  restricted?: boolean;
   selectedChatId: number | null;
   onNavigateToChat: (
     chatId: number | null,
@@ -2587,6 +2590,7 @@ function getOrCreateProvisionalToolCall(
 function ChatInterface({
   workspaceId,
   overseer,
+  restricted,
   selectedChatId,
   onNavigateToChat,
   onChatChangesChange,
@@ -4280,6 +4284,11 @@ function ChatInterface({
       actionKind: ActionKind; actionLabel: string } | null
   >(null);
 
+  // The workspace latched: the affordance is gone and confirming could only error.
+  useEffect(() => {
+    if (restricted) setAutoApproveConfirm(null);
+  }, [restricted]);
+
   // Enable auto-approval of an action tag on its connection (gated by the confirm dialog). The
   // server applies the now-eligible pending action(s) via its drain, and the action state flips to
   // "approved" through the actions subscription -- so we don't optimistically mutate it here.
@@ -4870,8 +4879,10 @@ function ChatInterface({
     // Auto-approval target: offer "Always approve this type" only when enabling a rule would
     // actually apply this action -- a tagged action on a connection that the gatekeeper marked
     // auto-approvable. (A non-auto-approvable action stays a manual gate even with a rule; an
-    // auto-approvable action with an existing rule wouldn't still be pending.)
+    // auto-approvable action with an existing rule wouldn't still be pending.) Not offered while
+    // restricted.
     const autoApproveTarget =
+      !restricted &&
       log.gatekeeperId !== undefined && log.description.actionKind !== undefined &&
       log.description.autoApprovable === true
         ? {

--- a/packages/workshop-frontend/src/ChatInterface.tsx
+++ b/packages/workshop-frontend/src/ChatInterface.tsx
@@ -97,6 +97,7 @@ import { HookToggle } from "./components/HookToggle";
 import DeleteConfirmationDialog from "./components/DeleteConfirmationDialog";
 import AutoApproveConfirmDialog from "./components/AutoApproveConfirmDialog";
 import { AlwaysApproveButton, ResolveButton } from "./components/ResolveButton";
+import { RestrictedApprovalNotice } from "./components/RestrictedApprovalNotice";
 import { WorkshopButton, WorkshopIconButton, WorkshopInput } from "./components/WorkshopControls";
 import { actionLogResumed, useActionEntries } from "./useActions";
 import { useAlwaysApproveTag } from "./useAlwaysApproveTag";
@@ -4963,7 +4964,8 @@ function ChatInterface({
                   </span>
                   {resourceMeta}
                 </div>
-                <div className={`chat-panel mt-1 max-h-[200px] overflow-y-auto pr-1 text-[13px] leading-[18px] text-kumo-subtle ${styles.markdownContent}`}>
+                {restricted && <RestrictedApprovalNotice className="mt-2" />}
+                <div className={`chat-panel mt-1 pr-1 text-[13px] leading-[18px] text-kumo-subtle ${restricted ? "" : "max-h-[200px] overflow-y-auto"} ${styles.markdownContent}`}>
                   <MarkdownMessage message={log.description.description} />
                 </div>
               </div>
@@ -5023,7 +5025,8 @@ function ChatInterface({
         )}
         {showDescription && (
           <div className="themed-surface-inset ml-8 mt-1 space-y-1.5 rounded-2xl border border-kumo-line/70 bg-kumo-elevated/45 p-3 text-[13px] leading-[19px] tracking-[-0.25px] text-kumo-subtle">
-            <div className={`chat-panel max-h-[200px] overflow-y-auto pr-1 ${styles.markdownContent}`}>
+            {restricted && isPending && <RestrictedApprovalNotice />}
+            <div className={`chat-panel pr-1 ${restricted && isPending ? "" : "max-h-[200px] overflow-y-auto"} ${styles.markdownContent}`}>
               <MarkdownMessage message={log.description.description} />
             </div>
             {resourceMeta}

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -1478,7 +1478,11 @@ export default function GadgetEditor() {
             </span>
           )}
 
-          <ActivityNotifications overseer={overseer.stub} onViewActivity={openActivity} />
+          <ActivityNotifications
+            overseer={overseer.stub}
+            onViewActivity={openActivity}
+            restricted={metadata?.containsRestrictedData === true}
+          />
 
           {showReconnecting && <ReconnectingChip />}
 

--- a/packages/workshop-frontend/src/GadgetEditor.tsx
+++ b/packages/workshop-frontend/src/GadgetEditor.tsx
@@ -1667,6 +1667,7 @@ export default function GadgetEditor() {
                   key={id}
                   workspaceId={id}
                   overseer={overseer.stub}
+                  restricted={metadata?.containsRestrictedData === true}
                   selectedChatId={effectiveSelectedChatId}
                   onNavigateToChat={navigateToChat}
                   onChatChangesChange={setChatChanges}
@@ -1827,6 +1828,7 @@ export default function GadgetEditor() {
               <div className="min-h-0 flex-1">
                 <Activity
                   overseer={overseer.stub}
+                  restricted={metadata?.containsRestrictedData === true}
                   view={activityView}
                   onViewChange={setActivityView}
                   onAutoApproveChange={() => setAutoApproveReloadTrigger(t => t + 1)}

--- a/packages/workshop-frontend/src/components/RestrictedApprovalNotice.tsx
+++ b/packages/workshop-frontend/src/components/RestrictedApprovalNotice.tsx
@@ -1,0 +1,30 @@
+import { ShieldWarning } from '@phosphor-icons/react'
+
+/**
+ * What an approver is told before approving an action in a workspace that has read restricted
+ * data: the kernel does not check the action for that data, the approver does.
+ */
+export const RESTRICTED_APPROVAL_COPY =
+  'This workspace has read sensitive data. Read the full request below before approving — you ' +
+  'are responsible for making sure it contains none of that data.'
+
+/**
+ * Shown above a pending action's description on every approve surface (Activity review pane,
+ * chat card, notifications popover) while the workspace is restricted. The surfaces render the
+ * description untruncated alongside it, since the notice asks the approver to read all of it.
+ */
+export function RestrictedApprovalNotice({ className = '' }: { className?: string }) {
+  return (
+    <div
+      role="note"
+      className={`flex items-start gap-2.5 rounded-2xl bg-kumo-warning-tint px-3 py-2.5 ${className}`}
+    >
+      <div className="grid h-6 w-6 shrink-0 place-items-center text-kumo-warning">
+        <ShieldWarning size={18} weight="duotone" />
+      </div>
+      <p className="m-0 text-[12px] leading-[18px] tracking-[-0.1px] text-kumo-default">
+        {RESTRICTED_APPROVAL_COPY}
+      </p>
+    </div>
+  )
+}

--- a/packages/workshop-shared/src/api.ts
+++ b/packages/workshop-shared/src/api.ts
@@ -1338,7 +1338,8 @@ export type GadgetMetadata = {
   /**
    * True when the gadget has observed data marked `containsRestrictedData` (see
    * `ObservationDescription`). It can still be shared, with collaborators verified per
-   * gatekeeper, but can no longer perform actions or fetch from the public web.
+   * gatekeeper, but can no longer fetch from the public web, and every action requires manual
+   * approval.
    */
   containsRestrictedData?: boolean;
 

--- a/packages/workshop-shared/src/gatekeeper.ts
+++ b/packages/workshop-shared/src/gatekeeper.ts
@@ -1198,12 +1198,15 @@ export type ObservationDescription = {
    * - Every collaborator must pass this gatekeeper's `addObserver()` to open the gadget, so a
    *   gatekeeper whose `addObserver()` always throws makes the gadget effectively unshareable
    *   once it has made one of these observations.
-   * - Once observed, the gadget enters a restricted mode: no more actions or public-web fetches,
-   *   only observations, so the gadget cannot leak the data through other gatekeepers.
+   * - Once observed, the gadget enters a restricted mode: no public-web fetches, and every action
+   *   requires manual approval -- auto-approval rules are suspended. The approver is shown the
+   *   action's full `description` and is responsible for checking it contains none of the
+   *   restricted data; the kernel does not restrict which connections may be acted on.
    *
    * TODO(someday): The restricted mode is a blunt instrument. It should be possible to perform
-   *   actions whose visibility is limited to people verified to have access to the same data,
-   *   but this requires a more complex policy framework to compute.
+   *   actions whose visibility is limited to people verified to have access to the same data: an
+   *   action should declare who can see its effects, and each restricted producer verify that
+   *   every such person can already see the data.
    */
   containsRestrictedData?: boolean;
 
@@ -1254,7 +1257,10 @@ export type ActionDescription = {
   /**
    * A complete description of the action to be taken, in Markdown-formatted natural language.
    * This will be displayed to the approver. It must include all details that might be relevant to
-   * consider before approving.
+   * consider before approving. This is the only text an approver sees. In a workspace that has
+   * read restricted data they rely on it to check that nothing sensitive leaves, so include the
+   * complete content the action will write or send (message bodies, comments, field values), not
+   * a summary of it.
    */
   description: string;
 


### PR DESCRIPTION
Supersedes #310

Once a workspace has read data marked `containsRestrictedData`, `main` refuses every action outright. This replaces that with a stop-gap which leans heavily on human approvals. 

For gatekeepers that have observed restricted, every action pends for manual approval and can never be auto-approved, and the approver is shown the action's full text with a notice that they are responsible for checking it contains no restricted data.

Also tested in this [preview](https://maximo-preview-restricted-ma-0d8c0d99-gadgets.gadgets-staging.workers.dev/workspace/a5986fa5ba2f41348ad27b0a1475454c545181087764f6dd7529c6b6652da318#share=4297db52d5b3e2cb6103434b69a1cd65)